### PR TITLE
Allow cl to upload URLs

### DIFF
--- a/codalab/client/local_bundle_client.py
+++ b/codalab/client/local_bundle_client.py
@@ -151,6 +151,12 @@ class LocalBundleClient(BundleClient):
         return construct_args
 
     @authentication_required
+    # Called when |path| is a url.
+    # Only used to expose uploading URLs directly to the RemoteBundleClient.
+    def upload_bundle_url(self, path, info, worksheet_uuid, follow_symlinks):
+        return self.upload_bundle(path, info, worksheet_uuid, follow_symlinks)
+
+    @authentication_required
     def upload_bundle(self, path, info, worksheet_uuid, follow_symlinks):
         bundle_type = info['bundle_type']
         if 'uuid' in info:

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -426,7 +426,8 @@ class BundleCLI(object):
 
         # Check that the upload path exists.
         for path in args.path:
-            path_util.check_isvalid(path_util.normalize(path), 'upload')
+            if not path_util.path_is_url(path):
+                path_util.check_isvalid(path_util.normalize(path), 'upload')
 
         # Pull out the upload bundle type from the arguments and validate it.
         if args.bundle_type not in UPLOADED_TYPES:

--- a/codalab/lib/bundle_store.py
+++ b/codalab/lib/bundle_store.py
@@ -7,6 +7,7 @@ folders within this data store. This class provides two main methods:
 import errno
 import os
 import time
+import sys
 import uuid
 
 from codalab.lib import path_util, file_util
@@ -91,6 +92,7 @@ class BundleStore(object):
                     raise UsageError('Not allowed to upload %s (only %s allowed)' % (path_suffix, self.direct_upload_paths))
 
             # Download |path| if it is a URL.
+            print >>sys.stderr, 'BundleStore.upload: downloading %s to %s' % (path, temp_path)
             file_util.download_url(path, temp_path, print_status=True)
         else:
             # Copy |path| into the temp_path.
@@ -103,6 +105,7 @@ class BundleStore(object):
 
             #print 'COPY', absolute_path, temp_path
             # Recursively copy the directory into a new BundleStore temp directory.
+            print >>sys.stderr, 'BundleStore.upload: copying %s to %s' % (absolute_path, temp_path)
             path_util.copy(absolute_path, temp_path, follow_symlinks=follow_symlinks)
 
         # Multiplex between uploading a directory and uploading a file here.
@@ -114,6 +117,7 @@ class BundleStore(object):
 
         # Hash the contents of the temporary directory, and then if there is no
         # data with this hash value, move this directory into the data directory.
+        print >>sys.stderr, 'BundleStore.upload: hashing %s' % (temp_path)
         data_hash = '0x%s' % (path_util.hash_directory(temp_path, dirs_and_files),)
         data_size = path_util.get_size(temp_path, dirs_and_files)
         final_path = os.path.join(self.data, data_hash)

--- a/codalab/lib/bundle_store.py
+++ b/codalab/lib/bundle_store.py
@@ -9,8 +9,7 @@ import os
 import time
 import uuid
 
-from codalab.lib import path_util
-
+from codalab.lib import path_util, file_util
 
 class BundleStore(object):
     DATA_SUBDIRECTORY = 'data'
@@ -71,18 +70,25 @@ class BundleStore(object):
         Return a (data_hash, metadata) pair, where the metadata is a dict mapping
         keys to precomputed statistics about the new data directory.
         '''
-        if isinstance(path, list):
-            absolute_path = [path_util.normalize(p) for p in path]
-            for p in absolute_path: path_util.check_isvalid(p, 'upload')
-        else:
-            absolute_path = path_util.normalize(path)
-            path_util.check_isvalid(absolute_path, 'upload')
-
-        # Recursively copy the directory into a new BundleStore temp directory.
+        # Create temporary directory as a staging area.
         temp_directory = uuid.uuid4().hex
         temp_path = os.path.join(self.temp, temp_directory)
-        #print 'COPY', absolute_path, temp_path
-        path_util.copy(absolute_path, temp_path, follow_symlinks=follow_symlinks)
+
+        if path_util.path_is_url(path):
+            # Download |path| if it is a URL.
+            file_util.download_url(path, temp_path, print_status=True)
+        else:
+            # Copy |path| into the temp_path.
+            if isinstance(path, list):
+                absolute_path = [path_util.normalize(p) for p in path]
+                for p in absolute_path: path_util.check_isvalid(p, 'upload')
+            else:
+                absolute_path = path_util.normalize(path)
+                path_util.check_isvalid(absolute_path, 'upload')
+
+            #print 'COPY', absolute_path, temp_path
+            # Recursively copy the directory into a new BundleStore temp directory.
+            path_util.copy(absolute_path, temp_path, follow_symlinks=follow_symlinks)
 
         # Multiplex between uploading a directory and uploading a file here.
         # All other path_util calls will use these lists of directories and files.

--- a/codalab/lib/codalab_manager.py
+++ b/codalab/lib/codalab_manager.py
@@ -123,7 +123,8 @@ class CodaLabManager(object):
     def bundle_store(self):
         codalab_home = self.codalab_home()
         from codalab.lib.bundle_store import BundleStore
-        return BundleStore(codalab_home)
+        direct_upload_paths = self.config['server'].get('direct_upload_paths', [])
+        return BundleStore(codalab_home, direct_upload_paths)
 
     def apply_alias(self, key):
         return self.config['aliases'].get(key, key)

--- a/codalab/lib/file_util.py
+++ b/codalab/lib/file_util.py
@@ -3,9 +3,11 @@ file_util provides helpers for dealing with file handles in robust,
 memory-efficent ways.
 '''
 BUFFER_SIZE = 2 * 1024 * 1024
+#BUFFER_SIZE = 256 * 10240
 
 import sys
 import formatting
+import urllib2
 
 def copy(source, dest, autoflush=True, print_status=False):
     '''
@@ -24,4 +26,26 @@ def copy(source, dest, autoflush=True, print_status=False):
             print >>sys.stderr, "\rCopied %s" % formatting.size_str(n),
             sys.stderr.flush()
     if print_status:
-        print >>sys.stderr, "\rCopied %s" % formatting.size_str(n)
+        print >>sys.stderr, "\rCopied %s [done]" % formatting.size_str(n)
+
+def download_url(source_url, target_path, print_status=False):
+    '''
+    Download the file at |source_url| and write it to |target_path|.
+    '''
+    in_file = urllib2.urlopen(source_url)
+    total_bytes = int(in_file.info().getheader('Content-Length').strip())
+
+    num_bytes = 0
+    out_file = open(target_path, 'wb')
+    def status_str():
+        return 'Downloaded %s/%s (%d%%)' % (formatting.size_str(num_bytes), formatting.size_str(total_bytes), 100.0 * num_bytes / total_bytes)
+    while True:
+        s = in_file.read(BUFFER_SIZE)
+        if not s: break
+        out_file.write(s)
+        num_bytes += len(s)
+        if print_status:
+            print >>sys.stderr, '\r' + status_str(),
+            sys.stderr.flush()
+    if print_status:
+        print >>sys.stderr, '\r' + status_str() + ' [done]'

--- a/codalab/lib/file_util.py
+++ b/codalab/lib/file_util.py
@@ -8,6 +8,7 @@ BUFFER_SIZE = 2 * 1024 * 1024
 import sys
 import formatting
 import urllib2
+from codalab.common import UsageError
 
 def copy(source, dest, autoflush=True, print_status=False):
     '''
@@ -33,12 +34,17 @@ def download_url(source_url, target_path, print_status=False):
     Download the file at |source_url| and write it to |target_path|.
     '''
     in_file = urllib2.urlopen(source_url)
-    total_bytes = int(in_file.info().getheader('Content-Length').strip())
+    total_bytes = in_file.info().getheader('Content-Length')
+    if total_bytes:
+        total_bytes = int(total_bytes)
 
     num_bytes = 0
     out_file = open(target_path, 'wb')
     def status_str():
-        return 'Downloaded %s/%s (%d%%)' % (formatting.size_str(num_bytes), formatting.size_str(total_bytes), 100.0 * num_bytes / total_bytes)
+        if total_bytes:
+            return 'Downloaded %s/%s (%d%%)' % (formatting.size_str(num_bytes), formatting.size_str(total_bytes), 100.0 * num_bytes / total_bytes)
+        else:
+            return 'Downloaded %s' % (formatting.size_str(num_bytes))
     while True:
         s = in_file.read(BUFFER_SIZE)
         if not s: break

--- a/codalab/lib/metadata_defaults.py
+++ b/codalab/lib/metadata_defaults.py
@@ -55,11 +55,6 @@ class MetadataDefaults(object):
         if bundle_subclass.BUNDLE_TYPE in UPLOADED_TYPES:
             description = ' '.join(path_util.normalize(path) for path in args.path)
             return 'Upload %s' % (description,)
-        # This is almost redundant with other metadata, so it can just be re-generated.
-        #elif bundle_subclass is MakeBundle:
-        #    return 'Make {%s}' % (', '.join(args.target_spec))
-        #elif bundle_subclass is RunBundle:
-        #    return 'Run {%s}[%s]' % (', '.join(args.target_spec), args.command)
         return ''
 
     @staticmethod

--- a/codalab/lib/path_util.py
+++ b/codalab/lib/path_util.py
@@ -416,4 +416,7 @@ def set_permissions(path, permissions, dirs_and_files=None):
                 raise
 
 def path_is_url(path):
-    return path.startswith('http://') or path.startswith('https://') or path.startswith('ftp://')
+    for prefix in ['http', 'https', 'ftp', 'file']:
+        if path.startswith(prefix + '://'):
+            return True
+    return False

--- a/codalab/lib/path_util.py
+++ b/codalab/lib/path_util.py
@@ -80,6 +80,7 @@ def normalize(path):
     This path is returned in a "canonical form", without ~'s, .'s, ..'s.
     '''
     if path == '-': return '/dev/stdin'
+    if path_is_url(path): return path
     return os.path.abspath(os.path.expanduser(path))
 
 

--- a/codalab/lib/path_util.py
+++ b/codalab/lib/path_util.py
@@ -414,3 +414,6 @@ def set_permissions(path, permissions, dirs_and_files=None):
             # chmod-ing a broken symlink will raise ENOENT, so we pass on this case.
             if not (e.errno == errno.ENOENT and os.path.islink(subpath)):
                 raise
+
+def path_is_url(path):
+    return path.startswith('http://') or path.startswith('https://') or path.startswith('ftp://')

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -982,7 +982,7 @@ class BundleModel(object):
             ]).where(cl_bundle.c.uuid.in_(bundle_uuids))).fetchall()
             for r in rows:
                 if r.owner_id == user_id:
-                    permissions[i] = max(permissions[i], GROUP_OBJECT_PERMISSION_ALL)
+                    permissions[r.uuid] = max(permissions[r.uuid], GROUP_OBJECT_PERMISSION_ALL)
 
         return [permissions[uuid] for uuid in bundle_uuids]
 


### PR DESCRIPTION
Now, we can do:
cl upload dataset http://www.example.com/bigdata.zip
or
cl upload dataset file:///tmp/bigdata.zip

This is especially useful when talking to a remote and we don't want the server to fetch the data directly rather than actually uploading it.
