### PR TITLE
refactor worker system

### DIFF
--- a/codalab/lib/bundle_store.py
+++ b/codalab/lib/bundle_store.py
@@ -78,8 +78,12 @@ class BundleStore(object):
         keys to precomputed statistics about the new data directory.
         '''
         # Create temporary directory as a staging area.
-        temp_directory = uuid.uuid4().hex
-        temp_path = os.path.join(self.temp, temp_directory)
+        # If |path| is already temporary, then we use that directly
+        # (with the understanding that |path| will be moved)
+        if path.startswith(self.temp):
+            temp_path = path
+        else:
+            temp_path = os.path.join(self.temp, uuid.uuid4().hex)
 
         if path_util.path_is_url(path):
             # Have to be careful.  Want to make sure if we're fetching a URL
@@ -94,7 +98,7 @@ class BundleStore(object):
             # Download |path| if it is a URL.
             print >>sys.stderr, 'BundleStore.upload: downloading %s to %s' % (path, temp_path)
             file_util.download_url(path, temp_path, print_status=True)
-        else:
+        elif path != temp_path:
             # Copy |path| into the temp_path.
             if isinstance(path, list):
                 absolute_path = [path_util.normalize(p) for p in path]

--- a/codalab/lib/codalab_manager.py
+++ b/codalab/lib/codalab_manager.py
@@ -77,16 +77,11 @@ class CodaLabManager(object):
                     'localhost': 'http://localhost:2800',
                 },
                 'workers': {
-                    'local': {
-                        'type': 'local'
-                    },
-                    # By default, just ssh into the current machine (only for testing)
-                    'localhost': {
+                    'q': {
                         'type': 'remote',
-                        'host': 'localhost',
-                        'user': os.getenv('USER'),
-                        'working_directory': os.path.join(self.codalab_home(), 'worker_scratch'),
                         'verbose': 1,
+                        'max_instances': 10,
+                        'dispatch_command': "python (fill in)/codalab-cli/scripts/dispatch-q.py",
                     }
                 }
             }, config_path)

--- a/codalab/machines/remote_machine.py
+++ b/codalab/machines/remote_machine.py
@@ -3,6 +3,7 @@ import subprocess
 import json
 import tempfile
 import time
+import sys
 
 from codalab.lib import (
   canonicalize,
@@ -12,7 +13,22 @@ from codalab.lib import (
 from codalab.objects.machine import Machine
 
 '''
-Run commands by ssh'ing into other machines and running docker.
+To execute a run, we do the following:
+
+1) Copy all files to a temp directory (ideally on the local directory of the
+machine we're going to run on, but this is impossible to know in advance).
+
+2) Invoke a designated command (e.g., qsub) to start the job in that temp
+directory.  There needs to be a standard way to specify time, memory, etc.
+This call is non-blocking and will return a job handle.
+
+3) If we want to kill the process, then we can call a designated command to
+kill that job with the handle.
+
+4) When constantly poll to see if the job has finished.
+
+The above steps depend on a dispatch_command, which is set in the config.json.
+
 Convention: command is a string, args is a list of arguments
 '''
 class RemoteMachine(Machine):
@@ -20,23 +36,13 @@ class RemoteMachine(Machine):
         self.user = config.get('user')
         self.host = config['host']
         self.verbose = config.get('verbose', 1)
-        self.docker_image = config.get('docker_image', '5a76b45a534f')  # codalab/ubuntu
-        self.remote_directory = config.get('working_directory', '/tmp/codalab')  # This is the base directory where bundles are stored
+        self.dispatch_command = config['dispatch_command']
+
         # State
-        self.bundle = None
-        self.container = None  # id of the container that's running
-        self.created_local_dir = False
-        self.created_remote_dir = False
-
-    def get_host_string(self):
-        return (self.user + '@' if self.user else '') + self.host
-    def get_remote_dir(self):
-        return os.path.join(self.remote_directory, self.bundle.uuid)
-    def get_remote_sh_file(self):
-        return self.get_remote_dir() + '.sh'
-
-    def get_ssh_args(self):
-        return ['ssh', '-x', self.get_host_string()]
+        self.bundle = None  # Bundle 
+        self.temp_dir = None  # Where the job is being run.
+        self.script_file = None  # Script file to invoke the run.
+        self.handle = None  # Handle from the dispatcher.
 
     def run_command(self, args):
         if self.verbose >= 3: print "=== run_command: %s" % (args,)
@@ -58,150 +64,49 @@ class RemoteMachine(Machine):
             raise SystemError('Command failed (exitcode = %s): %s' % (exit_code, args))
         return stdout
 
-    def make_remote_dir(self):
-        command = 'mkdir -p %s' % self.get_remote_dir()
-        self.run_command(self.get_ssh_args() + [command])
-
-    def remove_remote_dir(self):
-        command = 'rm -rf %s %s' % (self.get_remote_dir(), self.get_remote_sh_file())
-        self.run_command(self.get_ssh_args() + [command])
-
-    def rsync(self, source, dest):
-        # Copy the contents of source into the contents of dest (assume both exist).
-        flags = '-az'
-        if self.verbose >= 10: flags += 'v'
-        args = ["rsync", flags, '--delete', '--exclude', '.nfs*', '-e', 'ssh -x', source, dest]
-        self.run_command(args)
-
-    def copy_local_to_remote(self):
-        source = os.path.join(self.temp_dir, '')
-        dest = self.get_host_string() + ':' + self.get_remote_dir()
-        self.rsync(source, dest)
-        # Need to give global permissions so these files can be accessed inside docker
-        # TODO: combine this with the rsync command
-        self.run_command(self.get_ssh_args() + ['chmod -R go=u ' + self.get_remote_dir()])
-
-    def copy_remote_to_local(self, copy_all):
-        if copy_all:
-            files = ''
-        else:
-            # Come up with more systematic way to figure out which files to copy back
-            # Punt on this because this is too annoying.
-            #files = '{stdout,stderr,exec/stats,exec/options.map,exec/output.map}'
-            files = ''
-
-        # Copy from remote directory to the local directory
-        source = os.path.join(self.get_host_string() + ':' + self.get_remote_dir(), files)
-        dest = self.temp_dir
-        try:
-            self.rsync(source, dest)
-        except:
-            # Need to do this because some of the files created by docker
-            # aren't accessible by the outside.
-            print 'WARNING: rsync failed, but ignoring (files might be missing)'
-            pass
-
     # Sets up remote environment, starts bundle command
     def start_bundle(self, bundle, bundle_store, parent_dict):
         if self.bundle != None: raise InternalError('Bundle already started')
-        self.bundle = bundle
-        self.temp_dir = canonicalize.get_current_location(bundle_store, bundle.uuid)
+        temp_dir = canonicalize.get_current_location(bundle_store, bundle.uuid)
+        path_util.make_directory(temp_dir)
 
-        # TODO: rsync bundles in the bundle store to remote directly; remote keeps own bundle store
-
-        # Copy to temp directory
-        if self.verbose >= 1:
-            print '=== start_bundle(): preparing temporary directory %s' % self.temp_dir
-        path_util.make_directory(self.temp_dir)
-        self.created_local_dir = True
-        pairs = bundle.get_dependency_paths(bundle_store, parent_dict, self.temp_dir)
+        pairs = bundle.get_dependency_paths(bundle_store, parent_dict, temp_dir)
+        print >>sys.stderr, 'RemoteMachine.start_bundle: copying dependencies of %s to %s' % (bundle.uuid, temp_dir)
         for (source, target) in pairs:
-            # Don't follow random symlinks because people could link to random
-            # files on the system and also we need to preserve the local
-            # symlink structure.
             path_util.copy(source, target, follow_symlinks=False)
 
-        # Copy from temp directory to remote
-        if self.verbose >= 1:
-            print '=== start_bundle(): copying to remote %s:%s' % (self.get_host_string(), self.get_remote_dir())
-        self.make_remote_dir()
-        self.created_remote_dir = True
-        self.copy_local_to_remote()
-
-        # Write the command to be executed and copy it as a .sh file
-        # This way, we avoid annoying quoting issues
-        fd, path = tempfile.mkstemp()
-        os.close(fd)
-        with open(path, 'w') as f:
-            f.write("cd %s &&\n" % self.bundle.uuid)
-            f.write('(%s) > stdout 2>stderr\n' % self.bundle.command)
+        # Write the command to be executed.
+        script_file = os.path.join(temp_dir + '.sh')
+        with open(script_file, 'w') as f:
+            f.write("cd %s &&\n" % temp_dir)
+            f.write('(%s) > stdout 2>stderr\n' % bundle.command)
             f.close()
-        # Copy the script over
-        remote_sh_file = self.get_remote_sh_file()
-        container_sh_file = os.path.basename(remote_sh_file)
-        if self.verbose >= 10:
-            print '---', container_sh_file, '---'
-            print open(path).read()
-        self.rsync(path, self.get_host_string() + ":" + remote_sh_file)
-        os.unlink(path)
 
-        # Create the command to ssh into the machine and run the docker command
-        # (-d detaches, -v sets up mount points)
-        args = self.get_ssh_args() + ['docker', 'run', '-d']
-        args += ['-v',  remote_sh_file + ':/' + container_sh_file + ':ro']
-        args += ['-v', self.get_remote_dir() + ':/' + bundle.uuid]
-        args += [self.docker_image, 'bash', container_sh_file]
-
-        # Run the command
+        # Start the command.
+        args = self.dispatch_command.split() + ['start', script_file]
         if self.verbose >= 1: print '=== start_bundle(): running %s' % args
-        stdout = self.run_command_get_stdout(args)
+        result = json.loads(self.run_command_get_stdout(args))
+        if self.verbose >= 1: print '=== start_bundle(): got %s' % result
 
-        self.container = stdout.strip()
-        if self.verbose >= 2: print '=== start_bundle(): container = %s' % self.container
+        self.bundle = bundle
+        self.temp_dir = temp_dir
+        self.script_file = script_file
+        self.handle = result['handle']
         return True
 
-    def cleanup(self):
-        if self.verbose >= 1: print '=== cleanup(%s)' % self.bundle.uuid
-        # Remove local
-        if self.created_local_dir:
-            path_util.remove(self.temp_dir)
-            self.created_local_dir = False
-        # Remove remote
-        if self.created_remote_dir:
-            # Might not have enough permissions to do this since files created
-            # in docker are owned by root, so have to run docker to delete the file
-            #self.remove_remote_dir()
-            args = self.get_ssh_args() + ['docker', 'run', '--rm']
-            args += ['-v', self.remote_directory + ':/scratch']
-            args += [self.docker_image, 'rm', '-r', '/scratch/' + self.bundle.uuid]
-            self.run_command(args)
-            self.created_remote_dir = False
-        # Remove container
-        if self.container:
-            stdout = self.run_command_get_stdout(self.get_ssh_args() + ['docker', 'rm', self.container])
-            self.container = None
-        self.bundle = None
-        self.temp_dir = None
-
     def poll(self):
-        if not self.container: return None
+        if not self.handle: return None
         exception = None
         exitcode = -1
+        result = {}
         try:
             # Get status
-            stdout = self.run_command_get_stdout(self.get_ssh_args() + ['docker', 'inspect', self.container])
-            contents = json.loads(stdout)
-            state = contents[0]['State']
-            if state['Running']:
-                # Still running: don't need to copy everything back
-                self.copy_remote_to_local(copy_all=False)
-                return None
-            else:
-                # Done: copy all files back
-                self.copy_remote_to_local(copy_all=True)
-                exitcode = state['ExitCode']
-
-                if self.verbose >= 1: print '=== poll(%s): exitcode = %s' % (self.bundle.uuid, exitcode)
+            args = self.dispatch_command.split() + ['info', self.handle]
+            result = json.loads(self.run_command_get_stdout(args))
+            exitcode = result.get('exitcode')
+            if exitcode == None:
+                return None  # Not done yet
+            if self.verbose >= 1: print '=== poll(%s): %s' % (self.bundle.uuid, result)
         except Exception as e:
             exception = e
 
@@ -211,8 +116,8 @@ class RemoteMachine(Machine):
             'success': exitcode == 0,
             'temp_dir': self.temp_dir,
             'exitcode': exitcode,
-            'docker_image': self.docker_image,
-            'remote': self.get_host_string() + ':' + self.get_remote_dir()
+            'docker_image': result.get('docker_image', ''),
+            'remote': result.get('hostname', '?') + ':' + self.temp_dir,
         }
         if exception:
             result['internal_error'] = str(exception)
@@ -220,14 +125,25 @@ class RemoteMachine(Machine):
 
     def kill_bundle(self, uuid):
         if not self.bundle or self.bundle.uuid != uuid: return False
-        if self.verbose >= 1: print '=== kill_bundle(%s): container = %s' % (uuid, self.container)
+        if self.verbose >= 1: print '=== kill_bundle(%s)' % (uuid)
         try:
-            self.run_command(self.get_ssh_args() + ['docker', 'kill', self.container])
+            args = self.dispatch_command.split() + ['kill', self.handle]
+            result = json.loads(self.run_command_get_stdout(args))
             return True
         except:
             return False
 
     def finalize_bundle(self, uuid):
         if not self.bundle or self.bundle.uuid != uuid: return False
-        self.cleanup()
+        if self.verbose >= 1: print '=== finalize_bundle(%s)' % self.bundle.uuid
+
+        args = self.dispatch_command.split() + ['cleanup', self.handle]
+        result = json.loads(self.run_command_get_stdout(args))
+        path_util.remove(self.script_file)
+
+        self.bundle = None
+        self.temp_dir = None
+        self.script_file = None
+        self.handle = None
+
         return True

--- a/codalab/machines/remote_machine.py
+++ b/codalab/machines/remote_machine.py
@@ -33,8 +33,6 @@ Convention: command is a string, args is a list of arguments
 '''
 class RemoteMachine(Machine):
     def __init__(self, config):
-        self.user = config.get('user')
-        self.host = config['host']
         self.verbose = config.get('verbose', 1)
         self.dispatch_command = config['dispatch_command']
 

--- a/codalab/objects/work_manager.py
+++ b/codalab/objects/work_manager.py
@@ -180,7 +180,9 @@ class Worker(object):
         # back one-level at the dependencies, not recurse.
         try:
             copy = isinstance(bundle, MakeBundle)
+            print >>sys.stderr, 'Worker.finalize_bundle: installing dependencies to %s (copy=%s)' % (temp_dir, copy)
             bundle.install_dependencies(self.bundle_store, parent_dict, temp_dir, copy=copy)
+            # Note: uploading will move temp_dir to the bundle store.
             (data_hash, metadata) = self.bundle_store.upload(temp_dir)
         except Exception as e:
             (data_hash, metadata) = (None, {})
@@ -206,11 +208,9 @@ class Worker(object):
         with self.profile('Setting 1 bundle to %s...' % (state.upper(),)):
             self.model.update_bundle(bundle, update)
 
-        # Remove temporary data
+        # Clean up any state for RunBundles.
         if isinstance(bundle, RunBundle):
             self.machine.finalize_bundle(bundle.uuid)
-        else:
-            path_util.remove(temp_dir)
 
         print '-- END BUNDLE: %s [%s]' % (bundle, state)
         print ''

--- a/codalab/objects/work_manager.py
+++ b/codalab/objects/work_manager.py
@@ -120,7 +120,8 @@ class Worker(object):
                     # (even if it's not the bundle's fault).
                     started = True
                     exception = e
-                    print 'INTERNAL ERROR: %s' % e
+                    print '=== INTERNAL ERROR: %s' % e
+                    traceback.print_exc()
             else:
                 started = True
             if started: print '-- START BUNDLE: %s' % (bundle,)

--- a/scripts/dispatch-q.py
+++ b/scripts/dispatch-q.py
@@ -1,0 +1,63 @@
+#!/usr/bin/python
+
+# Wrapper for fig's simple workqueue system.
+# https://github.com/percyliang/fig/blob/master/bin/q
+# Each command outputs JSON.
+
+import sys, os, json, re
+import subprocess
+
+def system(command):
+    print command
+    if not os.system(command):
+        sys.exit(1)
+
+if len(sys.argv) <= 1:
+    print 'Usage:'
+    print '  start [-mem 5g] [-time 10h] <script>'
+    print '    => {handle: ...}'
+    print '  info <handle>'
+    print '    => {handle: ..., remote: ..., memory: ..., raw: ...}'
+    print '  kill <handle>'
+    print '    => {handle: ...}'
+    print '  cleanup <handle>'
+    print '    => {handle: ...}'
+    sys.exit(1)
+
+result = {}
+handle = None
+
+mode = sys.argv[1]
+if mode == 'start':
+    script = sys.argv[2]
+    stdout = subprocess.check_output('q -shareWorkingPath -add bash %s' % script, shell=True)
+    m = re.match(r'Job (J-.+) added successfully', stdout)
+    if m:
+        handle = m.group(1)
+elif mode == 'info':
+    handle = sys.argv[2]
+    stdout = subprocess.check_output('q -list %s -tabs' % handle, shell=True)
+    # Example output
+    # handle	worker	status	exitcode	time	mem	disk	outName	command
+    # J-ifnrj9	mazurka-37 mazurka	done	0	1m40s	1m	-1m		sleep 100
+    tokens = stdout.strip().split("\t")
+    hostname = tokens[1].split()
+    if len(hostname) > 1: hostname = hostname[-1]
+    result['hostname'] = hostname
+    exitcode = tokens[3]
+    if exitcode != '':
+        result['exitcode'] = int(exitcode)
+elif mode == 'kill':
+    handle = sys.argv[2]
+    stdout = subprocess.check_output('q -kill %s' % handle, shell=True)
+elif mode == 'cleanup':
+    handle = sys.argv[2]
+    stdout = subprocess.check_output('q -del %s' % handle, shell=True)
+else:
+    print 'Invalid mode: %s' % mode
+    sys.exit(1)
+
+result['handle'] = handle
+result['raw'] = stdout
+
+print json.dumps(result)


### PR DESCRIPTION
Now, most of the worker code is not in CodaLab itself, but in the scripts/dispatch-*.py scripts.
The actual CodaLab worker will just create a directory and a script, and call the dispatcher with start, kill, info, cleanup commands.  Two dispatchers are supported right now (for Torque and q).
