### PR TITLE
improvements, features, fixes to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -780,6 +780,13 @@ To compare two worksheets:
 
     vimdiff <(cl print -r worksheet1) <(cl print -r worksheet2)
 
+To replace the contents of worksheet2 with worksheet1 (be careful when we do
+this, since all the contents of worksheet1 are removed, although the bundles
+themselves are not removed and will be orphaned):
+
+    cl wedit -f /dev/null -w worksheet2
+    cl wcp worksheet1 worksheet2
+
 ## Editing worksheets
 
 By default, you will use `cl wedit` to edit worksheets.  However, it is

--- a/codalab/bundles/make_bundle.py
+++ b/codalab/bundles/make_bundle.py
@@ -11,9 +11,11 @@ from codalab.common import (
   UsageError,
 )
 from codalab.lib import spec_util, path_util
+from codalab.objects.metadata_spec import MetadataSpec
 
 class MakeBundle(NamedBundle):
     BUNDLE_TYPE = 'make'
+    METADATA_SPECS = list(NamedBundle.METADATA_SPECS)
 
     @classmethod
     def construct(cls, targets, command, metadata, owner_id, uuid=None, data_hash=None, state=State.CREATED):

--- a/codalab/bundles/make_bundle.py
+++ b/codalab/bundles/make_bundle.py
@@ -21,12 +21,12 @@ class MakeBundle(NamedBundle):
     def construct(cls, targets, command, metadata, owner_id, uuid=None, data_hash=None, state=State.CREATED):
         if not uuid: uuid = spec_util.generate_uuid()
         # Check that targets does not include both keyed and anonymous targets.
-        if len(targets) > 1 and '' in targets:
+        if len(targets) > 1 and any(key == '' for key, value in targets):
             raise UsageError('Must specify keys when packaging multiple targets!')
 
         # List the dependencies of this bundle on its targets.
         dependencies = []
-        for (child_path, (parent_uuid, parent_path)) in targets.iteritems():
+        for (child_path, (parent_uuid, parent_path)) in targets:
             dependencies.append({
               'child_uuid': uuid,
               'child_path': child_path,

--- a/codalab/bundles/named_bundle.py
+++ b/codalab/bundles/named_bundle.py
@@ -17,7 +17,7 @@ class NamedBundle(Bundle):
     METADATA_SPECS = (
       MetadataSpec('name', basestring, 'short variable name (not necessarily unique); must conform to ' + spec_util.NAME_REGEX.pattern, short_key='n'),
       MetadataSpec('description', basestring, 'full description of the bundle'),
-      MetadataSpec('tags', set, 'space-separated list of tags used for search (e.g., machine-learning)', metavar='TAG'),
+      MetadataSpec('tags', list, 'space-separated list of tags used for search (e.g., machine-learning)', metavar='TAG'),
       MetadataSpec('created', int, 'time when this bundle was created', generated=True, formatting='date'),
       MetadataSpec('data_size', int, 'size of this bundle (in bytes)', generated=True, formatting='size'),
       MetadataSpec('failure_message', basestring, 'error message if bundle failed', generated=True),
@@ -36,9 +36,6 @@ class NamedBundle(Bundle):
         if not self.metadata.name:
             raise UsageError('%ss must have non-empty names' % (bundle_type,))
         spec_util.check_name(self.metadata.name)
-        # Too strict
-        #if not self.metadata.description:
-        #    raise UsageError('%ss must have non-empty descriptions' % (bundle_type,))
 
     def __repr__(self):
         return '%s(uuid=%r, name=%r)' % (

--- a/codalab/bundles/program_bundle.py
+++ b/codalab/bundles/program_bundle.py
@@ -11,5 +11,5 @@ from codalab.objects.metadata_spec import MetadataSpec
 class ProgramBundle(UploadedBundle):
     BUNDLE_TYPE = 'program'
     METADATA_SPECS = list(UploadedBundle.METADATA_SPECS)
-    METADATA_SPECS.append(MetadataSpec('architectures', set, 'viable architectures'))
-    METADATA_SPECS.append(MetadataSpec('language', set, 'which programming language was used'))
+    METADATA_SPECS.append(MetadataSpec('architectures', list, 'viable architectures'))
+    METADATA_SPECS.append(MetadataSpec('language', list, 'which programming language was used'))

--- a/codalab/bundles/run_bundle.py
+++ b/codalab/bundles/run_bundle.py
@@ -37,7 +37,7 @@ class RunBundle(NamedBundle):
     METADATA_SPECS.append(MetadataSpec('request_gpus', int, 'number of GPUs allowed for this run'))
     METADATA_SPECS.append(MetadataSpec('request_queue', basestring, 'submit job to this queue'))
 
-    METADATA_SPECS.append(MetadataSpec('actions', set, 'actions performed on this run', generated=True))
+    METADATA_SPECS.append(MetadataSpec('actions', list, 'actions performed on this run', generated=True))
 
     METADATA_SPECS.append(MetadataSpec('time', float, 'amount of time (seconds) used by this run (total)', generated=True, formatting='duration'))
     METADATA_SPECS.append(MetadataSpec('time_user', float, 'amount of time (seconds) by user', generated=True, formatting='duration'))

--- a/codalab/bundles/run_bundle.py
+++ b/codalab/bundles/run_bundle.py
@@ -57,14 +57,14 @@ class RunBundle(NamedBundle):
     def construct(cls, targets, command, metadata, owner_id, uuid=None, data_hash=None, state=State.CREATED):
         if not uuid: uuid = spec_util.generate_uuid()
         # Check that targets does not include both keyed and anonymous targets.
-        if len(targets) > 1 and '' in targets:
+        if len(targets) > 1 and any(key == '' for key, value in targets):
             raise UsageError('Must specify keys when packaging multiple targets!')
         if not isinstance(command, basestring):
             raise UsageError('%r is not a valid command!' % (command,))
 
         # List the dependencies of this bundle on its targets.
         dependencies = []
-        for (child_path, (parent_uuid, parent_path)) in targets.iteritems():
+        for (child_path, (parent_uuid, parent_path)) in targets:
             dependencies.append({
               'child_uuid': uuid,
               'child_path': child_path,

--- a/codalab/client/local_bundle_client.py
+++ b/codalab/client/local_bundle_client.py
@@ -175,10 +175,12 @@ class LocalBundleClient(BundleClient):
             self.validate_user_metadata(bundle_subclass, metadata)
 
         # Upload the given path and record additional metadata from the upload.
-        (data_hash, bundle_store_metadata) = self.bundle_store.upload(path, follow_symlinks=follow_symlinks)
-        metadata.update(bundle_store_metadata)
-        # TODO: check that if the data hash already exists, it's the same as before.
-        construct_args['data_hash'] = data_hash
+        if path:
+            (data_hash, bundle_store_metadata) = self.bundle_store.upload(path, follow_symlinks=follow_symlinks)
+            metadata.update(bundle_store_metadata)
+            precondition(construct_args['data_hash'] == data_hash, \
+                'Provided data_hash doesn\'t match: %s versus %s' % (construct_args['data_hash'], data_hash))
+            construct_args['data_hash'] = data_hash
         # Set the owner
         construct_args['owner_id'] = self._current_user_id()
         bundle = bundle_subclass.construct(**construct_args)

--- a/codalab/client/local_bundle_client.py
+++ b/codalab/client/local_bundle_client.py
@@ -178,8 +178,8 @@ class LocalBundleClient(BundleClient):
         if path:
             (data_hash, bundle_store_metadata) = self.bundle_store.upload(path, follow_symlinks=follow_symlinks)
             metadata.update(bundle_store_metadata)
-            precondition(construct_args['data_hash'] == data_hash, \
-                'Provided data_hash doesn\'t match: %s versus %s' % (construct_args['data_hash'], data_hash))
+            precondition(construct_args.get('data_hash', data_hash) == data_hash, \
+                'Provided data_hash doesn\'t match: %s versus %s' % (construct_args.get('data_hash'), data_hash))
             construct_args['data_hash'] = data_hash
         # Set the owner
         construct_args['owner_id'] = self._current_user_id()

--- a/codalab/client/local_bundle_client.py
+++ b/codalab/client/local_bundle_client.py
@@ -607,6 +607,7 @@ class LocalBundleClient(BundleClient):
         for item in interpreted_items:
             mode = item['mode']
             data = item['interpreted']
+            properties = item.get('properties', {})
             is_newline = (data == '')
             # if's in order of most frequent
             if mode == 'markup':
@@ -627,7 +628,7 @@ class LocalBundleClient(BundleClient):
                 if 'type' not in info:
                     pass
                 elif info['type'] == 'file':
-                    data = self.head_target(data, 10)
+                    data = self.head_target(data, int(properties.get('maxlines', 10)))
             elif mode == 'html':
                 data = self.head_target(data, None)
             elif mode == 'image':

--- a/codalab/client/local_bundle_client.py
+++ b/codalab/client/local_bundle_client.py
@@ -253,8 +253,15 @@ class LocalBundleClient(BundleClient):
                 ))
             relevant_uuids = uuids
         check_has_all_permission_on_bundles(self.model, self._current_user(), relevant_uuids)
+
+        # Get data hashes
+        relevant_data_hashes = set(bundle.data_hash for bundle in self.model.batch_get_bundles(uuid=relevant_uuids) if bundle.data_hash)
+
         if not dry_run:
             self.model.delete_bundles(relevant_uuids)
+        # Clean out data from bundle store!
+        for data_hash in relevant_data_hashes:
+            self.bundle_store.cleanup(self.model, data_hash, dry_run)
         return relevant_uuids
 
     def get_bundle_info(self, uuid, get_children=False, get_host_worksheets=False):

--- a/codalab/client/local_bundle_client.py
+++ b/codalab/client/local_bundle_client.py
@@ -86,7 +86,7 @@ class LocalBundleClient(BundleClient):
         }
         for dep in result['dependencies']:
             uuid = dep['parent_uuid']
-            dep['parent_name'] = self.model.get_bundle_names([uuid])[uuid]
+            dep['parent_name'] = self.model.get_bundle_names([uuid]).get(uuid)
 
         return result
 

--- a/codalab/client/local_bundle_client.py
+++ b/codalab/client/local_bundle_client.py
@@ -591,19 +591,17 @@ class LocalBundleClient(BundleClient):
         target_cache = {}
         responses = []
         for (bundle_uuid, genpath, post) in requests:
-            value = worksheet_util.interpret_file_genpath(self, target_cache, bundle_uuid, genpath)
+            value = worksheet_util.interpret_file_genpath(self, target_cache, bundle_uuid, genpath, post)
             #print 'interpret_file_genpaths', bundle_uuid, genpath, value
-            value = worksheet_util.apply_func(post, value)
             responses.append(value)
         return responses
 
     def resolve_interpreted_items(self, interpreted_items):
         """
-        Helper function.
-        Takes a list of interpreted worksheet items loops through them and depending
-        on the type will find genpath for bundle info being requested.
-
-        Returns as a full interpeted_items lists which can be easialy json or rpc
+        Called by the web interface.  Takes a list of interpreted worksheet
+        items (returned by worksheet_util.interpret_items) and fetches the
+        appropriate information, replacing the 'interpreted' field in each item.
+        The result can be serialized via JSON.
         """
         is_last_newline = False
         for item in interpreted_items:
@@ -634,13 +632,11 @@ class LocalBundleClient(BundleClient):
                 data = self.head_target(data, None)
             elif mode == 'image':
                 path = self.get_target_path(data)
-                encoded = path_util.base64_encode(path)
-                data = encoded
+                data = path_util.base64_encode(path)
             elif mode == 'search':
                 search_interpreted = worksheet_util.interpret_search(client, worksheet_info['uuid'], data)
                 data = search_interpreted
             elif mode == 'worksheet':
-                #placeholder
                 pass
             else:
                 raise UsageError('Invalid display mode: %s' % mode)

--- a/codalab/client/local_bundle_client.py
+++ b/codalab/client/local_bundle_client.py
@@ -142,8 +142,8 @@ class LocalBundleClient(BundleClient):
             construct_args = {'metadata': info['metadata'], 'uuid': info['uuid'],
                               'data_hash': info['data_hash']}
         elif bundle_type == 'make' or bundle_type == 'run':
-            targets = { item['child_path'] : (item['parent_uuid'], item['parent_path'])
-                        for item in info['dependencies'] }
+            targets = [(item['child_path'], (item['parent_uuid'], item['parent_path']))
+                        for item in info['dependencies']]
             construct_args = {'targets': targets, 'command': info['command'],
                               'metadata': info['metadata'], 'uuid': info['uuid'],
                               'data_hash': info['data_hash'], 'state': info['state']}
@@ -488,9 +488,7 @@ class LocalBundleClient(BundleClient):
                         new_metadata.pop(spec.key)
 
                 # Set the targets
-                targets = {}
-                for dep in new_dependencies:
-                    targets[dep['child_path']] = (dep['parent_uuid'], dep['parent_path'])
+                targets = [(dep['child_path'], (dep['parent_uuid'], dep['parent_path'])) for dep in new_dependencies]
 
                 if dry_run:
                     new_bundle_uuid = None

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -759,7 +759,7 @@ class BundleCLI(object):
                 # Display a single field (arbitrary genpath)
                 genpath = args.field
                 if worksheet_util.is_file_genpath(genpath):
-                    value = worksheet_util.interpret_file_genpath(client, {}, bundle_uuid, genpath)
+                    value = worksheet_util.interpret_file_genpath(client, {}, bundle_uuid, genpath, None)
                 else:
                     value = worksheet_util.interpret_genpath(info, genpath)
                 print value

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -1412,9 +1412,10 @@ class BundleCLI(object):
         '''
         Removes data hash directories which are not used by any bundle.
         '''
-        parser.parse_args(argv)
+        parser.add_argument('-i', '--dry-run', action='store_true', help='don\'t actually do it, but see what the command would do')
+        args = parser.parse_args(argv)
         client = self.manager.current_client()
-        client.bundle_store.full_cleanup(client.model)
+        client.bundle_store.full_cleanup(client.model, args.dry_run)
 
     def do_reset_command(self, argv, parser):
         # This command only works if client is a LocalBundleClient.

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -207,7 +207,7 @@ class BundleCLI(object):
         '''
         Helper: items is a list of strings which are [<key>]:<target>
         '''
-        targets = {}
+        targets = []
         # Turn targets into a dict mapping key -> (uuid, subpath)) tuples.
         for item in items:
             if ':' in item:
@@ -221,7 +221,7 @@ class BundleCLI(object):
                     raise UsageError('Duplicate key: %s' % (key,))
                 else:
                     raise UsageError('Must specify keys when packaging multiple targets!')
-            targets[key] = self.parse_target(client, worksheet_uuid, target)
+            targets.append((key, self.parse_target(client, worksheet_uuid, target)))
         return targets
 
     def print_table(self, columns, row_dicts, post_funcs={}, justify={}, show_header=True, indent=''):
@@ -582,7 +582,8 @@ class BundleCLI(object):
         while True:
             m = pattern.match(command)
             if not m: break
-            i = str(len(target_spec)+1)
+            # Call bundles b1, b2, b3 by default.
+            i = 'b' + str(len(target_spec)+1)
             if ':' in m.group(2):
                 i, val = m.group(2).split(':', 1)
                 if i == '': i = val
@@ -827,7 +828,7 @@ class BundleCLI(object):
         # Dependencies (both hard dependencies and soft)
         def display_dependencies(label, deps):
             lines.append(label + ':')
-            for dep in sorted(deps, key=lambda dep: dep['child_path']):
+            for dep in deps:
                 child = dep['child_path']
                 parent = path_util.safe_join((dep['parent_name'] or 'MISSING') + '(' + dep['parent_uuid'] + ')', dep['parent_path'])
                 lines.append('  %s: %s' % (child, parent))

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -651,6 +651,7 @@ class BundleCLI(object):
         parser.add_argument('bundle_spec', help=self.BUNDLE_SPEC_FORMAT, nargs='+')
         parser.add_argument('-f', '--force', action='store_true', help='delete bundle (DANGEROUS - breaking dependencies!)')
         parser.add_argument('-r', '--recursive', action='store_true', help='delete all bundles downstream that depend on this bundle')
+        parser.add_argument('-d', '--data-only', action='store_true', help='keep the bundle metadata, but remove the bundle contents')
         parser.add_argument('-i', '--dry-run', action='store_true', help='delete all bundles downstream that depend on this bundle')
         parser.add_argument('-w', '--worksheet_spec', help='operate on this worksheet (%s)' % self.WORKSHEET_SPEC_FORMAT, nargs='?')
         args = parser.parse_args(argv)
@@ -660,7 +661,7 @@ class BundleCLI(object):
         # Resolve all the bundles first, then delete (this is important since
         # some of the bundle specs are relative).
         bundle_uuids = [worksheet_util.get_bundle_uuid(client, worksheet_uuid, bundle_spec) for bundle_spec in args.bundle_spec]
-        deleted_uuids = client.delete_bundles(bundle_uuids, args.force, args.recursive, args.dry_run)
+        deleted_uuids = client.delete_bundles(bundle_uuids, args.force, args.recursive, args.data_only, args.dry_run)
         if args.dry_run:
             print 'This command would permanently remove the following bundles (not doing so yet):'
             bundle_infos = client.get_bundle_infos(deleted_uuids)

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -854,13 +854,13 @@ class BundleCLI(object):
         self.print_target_info(client, target, decorate=False)
 
     # Helper: shared between info and cat
-    def print_target_info(self, client, target, decorate):
+    def print_target_info(self, client, target, decorate, maxlines=10):
         info = client.get_target_info(target, 1)
         if 'type' not in info:
             self.exit('Target doesn\'t exist: %s/%s' % target)
         if info['type'] == 'file':
             if decorate:
-                for line in client.head_target(target, 10):
+                for line in client.head_target(target, maxlines):
                     print line,
             else:
                 client.cat_target(target, sys.stdout)
@@ -1177,6 +1177,7 @@ class BundleCLI(object):
         for item in interpreted['items']:
             mode = item['mode']
             data = item['interpreted']
+            properties = item.get('properties', {})
             is_newline = (data == '')
             if mode == 'link' or mode == 'inline' or mode == 'markup' or mode == 'contents':
                 if not (is_newline and is_last_newline):
@@ -1185,7 +1186,7 @@ class BundleCLI(object):
                             data = client.interpret_file_genpaths([data])[0]
                         print '[' + str(data) + ']'
                     elif mode == 'contents':
-                        self.print_target_info(client, data, decorate=True)
+                        self.print_target_info(client, data, decorate=True, maxlines=int(properties.get('maxlines')))
                     else:
                         print data
             elif mode == 'record' or mode == 'table':

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -640,7 +640,6 @@ class BundleCLI(object):
         parser.add_argument('bundle_spec', help=self.BUNDLE_SPEC_FORMAT)
         parser.add_argument('-n', '--name', help='new name: ' + spec_util.NAME_REGEX.pattern, nargs='?')
         parser.add_argument('-w', '--worksheet_spec', help='operate on this worksheet (%s)' % self.WORKSHEET_SPEC_FORMAT, nargs='?')
-        self.add_wait_args(parser)
         args = parser.parse_args(argv)
 
         client, worksheet_uuid = self.parse_client_worksheet_uuid(args.worksheet_spec)
@@ -1074,6 +1073,7 @@ class BundleCLI(object):
 
     def do_new_command(self, argv, parser):
         parser.add_argument('name', help='name: ' + spec_util.NAME_REGEX.pattern)
+        parser.add_argument('-r', '--raw', action='store_true', help='print out the worksheet uuid')
         parser.add_argument('-w', '--worksheet_spec', help='operate on this worksheet (%s)' % self.WORKSHEET_SPEC_FORMAT, nargs='?')
         args = parser.parse_args(argv)
 
@@ -1083,7 +1083,10 @@ class BundleCLI(object):
         client.add_worksheet_item(uuid, worksheet_util.markup_item('Parent:'))  # Backpointer
         client.add_worksheet_item(uuid, worksheet_util.subworksheet_item(worksheet_uuid))  # Backpointer
         worksheet_info = client.get_worksheet_info(uuid, False)
-        print 'Created worksheet %s.' % (self.worksheet_str(worksheet_info))
+        if args.raw:
+            print worksheet_info['uuid']
+        else:
+            print 'Created worksheet %s.' % (self.worksheet_str(worksheet_info))
 
     def do_add_command(self, argv, parser):
         parser.add_argument('bundle_spec', help=self.BUNDLE_SPEC_FORMAT, nargs='*')
@@ -1103,6 +1106,7 @@ class BundleCLI(object):
                 client.add_worksheet_item(worksheet_uuid, worksheet_util.markup_item(args.message))
 
     def do_work_command(self, argv, parser):
+        parser.add_argument('-r', '--raw', action='store_true', help='print out the worksheet uuid')
         parser.add_argument('worksheet_spec', help=self.WORKSHEET_SPEC_FORMAT, nargs='?')
         args = parser.parse_args(argv)
 
@@ -1110,10 +1114,16 @@ class BundleCLI(object):
         worksheet_info = client.get_worksheet_info(worksheet_uuid, False)
         if args.worksheet_spec:
             self.manager.set_current_worksheet_uuid(client, worksheet_uuid)
-            print 'Switched to worksheet %s.' % (self.worksheet_str(worksheet_info))
+            if args.raw:
+                print worksheet_info['uuid']
+            else:
+                print 'Switched to worksheet %s.' % (self.worksheet_str(worksheet_info))
         else:
             if worksheet_info:
-                print 'Currently on worksheet %s.' % (self.worksheet_str(worksheet_info))
+                if args.raw:
+                    print worksheet_info['uuid']
+                else:
+                    print 'Currently on worksheet %s.' % (self.worksheet_str(worksheet_info))
             else:
                 print 'Not on any worksheet. Use `cl new` or `cl work` to switch to one.'
 

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -148,6 +148,7 @@ class BundleCLI(object):
         'p': 'print',
         'i': 'info',
         'e': 'edit',
+        's': 'search',
         'st': 'status',
     }
 

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -1177,7 +1177,7 @@ class BundleCLI(object):
         for item in interpreted['items']:
             mode = item['mode']
             data = item['interpreted']
-            properties = item.get('properties', {})
+            properties = item['properties']
             is_newline = (data == '')
             if mode == 'link' or mode == 'inline' or mode == 'markup' or mode == 'contents':
                 if not (is_newline and is_last_newline):
@@ -1186,7 +1186,10 @@ class BundleCLI(object):
                             data = client.interpret_file_genpaths([data])[0]
                         print '[' + str(data) + ']'
                     elif mode == 'contents':
-                        self.print_target_info(client, data, decorate=True, maxlines=int(properties.get('maxlines')))
+                        maxlines = properties.get('maxlines')
+                        if maxlines:
+                            maxlines = int(maxlines)
+                        self.print_target_info(client, data, decorate=True, maxlines=maxlines)
                     else:
                         print data
             elif mode == 'record' or mode == 'table':

--- a/codalab/lib/bundle_store.py
+++ b/codalab/lib/bundle_store.py
@@ -132,7 +132,7 @@ class BundleStore(object):
             final_path_exists = True
         except OSError, e:
             if e.errno == errno.ENOENT:
-                print 'BundleStore.upload: moving %s to %s' % (temp_path, final_path)
+                print >>sys.stderr, 'BundleStore.upload: moving %s to %s' % (temp_path, final_path)
                 path_util.rename(temp_path, final_path)
             else:
                 raise

--- a/codalab/lib/bundle_store.py
+++ b/codalab/lib/bundle_store.py
@@ -143,12 +143,13 @@ class BundleStore(object):
         assert(os.path.exists(final_path)), 'Uploaded to %s failed!' % (final_path,)
         return (data_hash, {'data_size': data_size})
 
-    def cleanup(self, model, data_hash, dry_run):
+    def cleanup(self, model, data_hash, except_bundle_uuids, dry_run):
         '''
-        If the given data hash is not needed for any bundle, delete its data.
+        If the given data hash is not needed by any bundle (not in
+        except_bundle_uuids), delete the data.
         '''
         bundles = model.batch_get_bundles(data_hash=data_hash)
-        if not bundles:
+        if all(bundle.uuid in except_bundle_uuids for bundle in bundles):
             absolute_path = self.get_location(data_hash)
             print >>sys.stderr, "cleanup: data %s" % absolute_path
             if not dry_run:
@@ -161,7 +162,7 @@ class BundleStore(object):
         '''
         old_data_files = self.list_old_files(self.data, self.DATA_CLEANUP_TIME)
         for data_hash in old_data_files:
-            self.cleanup(model, data_hash, dry_run)
+            self.cleanup(model, data_hash, [], dry_run)
         old_temp_files = self.list_old_files(self.temp, self.TEMP_CLEANUP_TIME)
         for temp_file in old_temp_files:
             temp_path = os.path.join(self.temp, temp_file)

--- a/codalab/lib/canonicalize.py
+++ b/codalab/lib/canonicalize.py
@@ -75,7 +75,7 @@ def get_bundle_uuid(model, user_id, worksheet_uuid, bundle_spec):
         message = "name pattern '%s'" % (bundle_spec,)
     # Take the last bundle
     if last_index <= 0 or last_index > len(bundle_uuids):
-        raise UsageError('Index %d out of range, only %d bundles matched' % (last_index, len(bundle_uuids)))
+        raise UsageError('bundle spec %s doesn\'t match (want index %d out of %d bundles)' % (bundle_spec, last_index, len(bundle_uuids)))
     return bundle_uuids[last_index - 1]
 
 def get_current_location(bundle_store, uuid):

--- a/codalab/lib/worksheet_util.py
+++ b/codalab/lib/worksheet_util.py
@@ -285,7 +285,7 @@ def interpret_genpath(bundle_info, genpath):
 
     # Special cases
     if genpath == 'dependencies':
-        return ','.join(sorted(dep['parent_name'] for dep in bundle_info[genpath]))
+        return ','.join(sorted(dep['child_path'] + ':' + dep['parent_name'] for dep in bundle_info[genpath]))
     elif genpath.startswith('dependencies/'):
         # Look up the particular dependency
         _, name = genpath.split('/', 1)

--- a/codalab/lib/worksheet_util.py
+++ b/codalab/lib/worksheet_util.py
@@ -200,6 +200,7 @@ def get_bundle_uuid(client, worksheet_uuid, bundle_spec):
     a uuid, then just return it directly.  This avoids an extra call to the
     client.
     '''
+    bundle_spec = bundle_spec.strip()
     if spec_util.UUID_REGEX.match(bundle_spec):
         bundle_uuid = bundle_spec  # Already uuid, don't need to look up specification
     else:
@@ -214,6 +215,7 @@ def get_worksheet_uuid(client, base_worksheet_uuid, worksheet_spec):
     '''
     Same thing as get_bundle_uuid, but for worksheets.
     '''
+    worksheet_spec = worksheet_spec.strip()
     if spec_util.UUID_REGEX.match(worksheet_spec):
         worksheet_uuid = worksheet_spec  # Already uuid, don't need to look up specification
     else:

--- a/codalab/lib/worksheet_util.py
+++ b/codalab/lib/worksheet_util.py
@@ -203,6 +203,10 @@ def get_bundle_uuid(client, worksheet_uuid, bundle_spec):
     if spec_util.UUID_REGEX.match(bundle_spec):
         bundle_uuid = bundle_spec  # Already uuid, don't need to look up specification
     else:
+        if '/' in bundle_spec:  # <worksheet_spec>/<bundle_spec>
+            # Shift to new worksheet
+            worksheet_spec, bundle_spec = bundle_spec.split('/', 1)
+            worksheet_uuid = get_worksheet_uuid(client, worksheet_uuid, worksheet_spec)
         bundle_uuid = client.get_bundle_uuid(worksheet_uuid, bundle_spec)
     return bundle_uuid
 

--- a/codalab/lib/worksheet_util.py
+++ b/codalab/lib/worksheet_util.py
@@ -496,6 +496,7 @@ def interpret_items(schemas, items):
         # Print out the curent bundles somehow
         mode = current_display_ref[0][0]
         args = current_display_ref[0][1:]
+        properties = {}
         if mode == 'hidden':
             pass
         elif mode == 'link':
@@ -505,6 +506,7 @@ def interpret_items(schemas, items):
                 new_items.append({
                     'mode': mode,
                     'interpreted': '[%s](%s)' % (args[0], bundle_info['uuid']),
+                    'properties': properties,
                     'bundle_info': copy.deepcopy(bundle_info)
                 })
         elif mode == 'inline' or mode == 'contents' or mode == 'image' or mode == 'html':
@@ -515,8 +517,6 @@ def interpret_items(schemas, items):
                 # Properties - e.g., height, width, maxlines (optional)
                 if len(args) > 1:
                     properties = dict(item.split('=') for item in args[1].split(','))
-                else:
-                    properties = None
 
                 if isinstance(interpreted, tuple):  # Not rendered yet
                     bundle_uuid, genpath = interpreted
@@ -550,6 +550,7 @@ def interpret_items(schemas, items):
                 new_items.append({
                     'mode': mode,
                     'interpreted': (header, rows),
+                    'properties': properties,
                     'bundle_info': copy.deepcopy(bundle_info)
                 })
         elif mode == 'table':
@@ -567,6 +568,7 @@ def interpret_items(schemas, items):
             new_items.append({
                     'mode': mode,
                     'interpreted': (header, rows),
+                    'properties': properties,
                     'bundle_info': copy.deepcopy(bundle_infos)
                 })
         else:
@@ -584,6 +586,7 @@ def interpret_items(schemas, items):
         return value_obj[0] if len(value_obj) > 0 else None
     for item in items:
         (bundle_info, subworksheet_info, value_obj, item_type) = item
+        properties = {}
 
         if item_type == TYPE_BUNDLE:
             bundle_infos.append(bundle_info)
@@ -592,6 +595,7 @@ def interpret_items(schemas, items):
             new_items.append({
                 'mode': TYPE_WORKSHEET,
                 'interpreted': subworksheet_info,  # TODO: convert into something more useful?
+                'properties': {},
                 'subworksheet_info': subworksheet_info,
             })
         elif item_type == TYPE_MARKUP:
@@ -599,6 +603,7 @@ def interpret_items(schemas, items):
             new_items.append({
                 'mode': TYPE_MARKUP,
                 'interpreted': value_obj,
+                'properties': {},
             })
         elif item_type == TYPE_DIRECTIVE:
             flush()
@@ -629,6 +634,7 @@ def interpret_items(schemas, items):
                 new_items.append({
                     'mode': mode,
                     'interpreted': data,
+                    'properties': {},
                 })
             else:
                 raise UsageError('Unknown directive command in %s' % value_obj)

--- a/codalab/machines/local_machine.py
+++ b/codalab/machines/local_machine.py
@@ -23,7 +23,7 @@ class LocalMachine(Machine):
         '''
         Start a bundle in the background.
         '''
-        if self.bundle != None: raise InternalError('Bundle already started')
+        if self.bundle != None: return None
         temp_dir = canonicalize.get_current_location(bundle_store, bundle.uuid)
         path_util.make_directory(temp_dir)
 
@@ -45,10 +45,6 @@ class LocalMachine(Machine):
             f.write('(%s) > stdout 2>stderr\n' % bundle.command)
         # Use stdbuf to turn off buffering so we get real-time feedback.
         process = subprocess.Popen("stdbuf -o0 bash " + script_file, shell=True)
-
-        #with path_util.chdir(temp_dir):
-            #with open('stdout', 'wb') as stdout, open('stderr', 'wb') as stderr:
-                #process = subprocess.Popen("stdbuf -o0 " + bundle.command, stdout=stdout, stderr=stderr, shell=True)
 
         self.bundle = bundle
         self.temp_dir = temp_dir

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -115,6 +115,7 @@ class BundleModel(object):
     def get_bundle(self, uuid):
         '''
         Retrieve a bundle from the database given its uuid.
+        Assume it's unique.
         '''
         bundles = self.batch_get_bundles(uuid=uuid)
         if not bundles:
@@ -125,7 +126,8 @@ class BundleModel(object):
 
     def get_bundle_names(self, uuids):
         '''
-        Return the names of the bundles with given uuids.
+        Fetch the bundle names of the given uuids.
+        Return {uuid: name, ...}
         '''
         if len(uuids) == 0:
             return []
@@ -137,43 +139,28 @@ class BundleModel(object):
                 and_(cl_bundle_metadata.c.metadata_key == 'name',
                      cl_bundle_metadata.c.bundle_uuid.in_(uuids))
             )).fetchall()
-            names = dict((row.bundle_uuid, row.metadata_value) for row in rows)
-            return [names.get(uuid) for uuid in uuids]
+            return dict((row.bundle_uuid, row.metadata_value) for row in rows)
 
-    def get_parents(self, uuid):
+    def get_children_uuids(self, uuids):
         '''
-        Get all bundles that the bundle with the given uuid depends on.
+        Get all bundles that depend on the bundle with the given uuids.
+        Return {parent_uuid: [child_uuid, ...], ...}
         '''
         with self.engine.begin() as connection:
             rows = connection.execute(select([
-              cl_bundle_dependency.c.parent_uuid
-            ]).where(
-              cl_bundle_dependency.c.child_uuid == uuid
-            )).fetchall()
-        uuids = set([row.parent_uuid for row in rows])
-        return self.batch_get_bundles(uuid=uuids)
-
-    def get_children_uuids(self, uuid):
-        '''
-        Get all bundles that depend on the bundle with the given uuid.
-        uuid may also be a list, set, or tuple, in which case we return all
-        bundles that depend on any bundle in that collection.
-        '''
-        if isinstance(uuid, (list, set, tuple)):
-            clause = cl_bundle_dependency.c.parent_uuid.in_(uuid)
-        else:
-            clause = (cl_bundle_dependency.c.parent_uuid == uuid)
-        with self.engine.begin() as connection:
-            rows = connection.execute(select([
-              cl_bundle_dependency.c.child_uuid
-            ]).where(clause)).fetchall()
-        return set([row.child_uuid for row in rows])
+              cl_bundle_dependency.c.parent_uuid,
+              cl_bundle_dependency.c.child_uuid,
+            ]).where(cl_bundle_dependency.c.parent_uuid.in_(uuids))).fetchall()
+        result = dict((uuid, []) for uuid in uuids)
+        for row in rows:
+            result[row.parent_uuid].append(row.child_uuid)
+        return result
 
     def get_host_worksheet_uuids(self, bundle_uuids):
         '''
         Return list of worksheet uuids that contain the given bundle_uuids.
         bundle_uuids = ['0x12435']
-        Return {'0x12435': [host_worksheet_uuid, ...]}
+        Return {'0x12435': [host_worksheet_uuid, ...], ...}
         '''
         with self.engine.begin() as connection:
             rows = connection.execute(select([
@@ -190,12 +177,19 @@ class BundleModel(object):
         Get all bundles that depend on bundles with the given uuids.
         depth = 1 gets only children
         '''
-        frontier = set(uuids)
-        visited = set(frontier)
+        frontier = uuids
+        visited = list(frontier)
         while len(frontier) > 0 and depth > 0:
-            new_frontier = self.get_children_uuids(frontier)
-            frontier = new_frontier - visited
-            visited.update(frontier)
+            # Get children of all nodes in frontier
+            result = self.get_children_uuids(frontier)
+            new_frontier = []
+            for l in result.values():
+                for uuid in l:
+                    if uuid in visited:
+                        continue
+                    new_frontier.append(uuid)
+                    visited.append(uuid)
+            frontier = new_frontier
             depth -= 1
         return visited
 

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -461,6 +461,10 @@ class BundleModel(object):
                 cl_bundle.c.uuid.in_(uuids)
             ))
 
+    def remove_data_hash_references(self, uuids):
+        with self.engine.begin() as connection:
+            connection.execute(cl_bundle.update().where(cl_bundle.c.uuid.in_(uuids)).values({'data_hash': None}))
+
     #############################################################################
     # Worksheet-related model methods follow!
     #############################################################################

--- a/codalab/objects/bundle.py
+++ b/codalab/objects/bundle.py
@@ -96,6 +96,8 @@ class Bundle(ORMObject):
         def process_dep(dep):
             parent = parent_dict[dep.parent_uuid]
             # Compute an absolute target and check that the dependency exists.
+            if not parent.data_hash:
+                raise UsageError('Parent %s does not have data hash' % parent)
             target = path_util.safe_join(
               bundle_store.get_location(parent.data_hash),
               dep.parent_path,

--- a/codalab/objects/metadata_spec.py
+++ b/codalab/objects/metadata_spec.py
@@ -6,7 +6,7 @@ these objects. For example, if some bundle type should have a string name and
 a list of string tags, then its METADATA_SPECS would be:
   [
     MetadataSpec('name', basestring, 'The bundle name.'),
-    MetadataSpec('tags', set, 'A list of searchable tags.'),
+    MetadataSpec('tags', list, 'A list of searchable tags.'),
   ]
 The description, short_key, and default of a metadata spec are used to produce
 nicely-formatted help strings for bundle creation commands.

--- a/codalab/objects/work_manager.py
+++ b/codalab/objects/work_manager.py
@@ -159,7 +159,7 @@ class Worker(object):
             else:
                 print 'Unknown action: %s' % x.action
 
-            new_actions = getattr(bundle.metadata, 'actions', set()) | set([x.action])
+            new_actions = getattr(bundle.metadata, 'actions', []) + [x.action]
             db_update = {'metadata': {'actions': new_actions}}
             self.model.update_bundle(bundle, db_update)
         return len(bundle_actions) > 0

--- a/codalab/objects/work_manager.py
+++ b/codalab/objects/work_manager.py
@@ -118,8 +118,9 @@ class Worker(object):
                     # (even if it's not the bundle's fault).
                     temp_dir = canonicalize.get_current_location(self.bundle_store, bundle.uuid)
                     path_util.make_directory(temp_dir)
-                    status = {'bundle': bundle, 'success': False, 'failure_message': str(e)}
+                    status = {'bundle': bundle, 'success': False, 'failure_message': str(e), 'temp_dir': temp_dir}
                     print '=== INTERNAL ERROR: %s' % e
+                    started = True  # Force failing
                     traceback.print_exc()
             else:  # MakeBundle
                 started = True
@@ -244,9 +245,8 @@ class Worker(object):
             # we always only need to look back one-level at the dependencies,
             # not recurse.
             try:
-                if isinstance(bundle, MakeBundle):
-                    temp_dir = status.get('temp_dir')
-                else:
+                temp_dir = status.get('temp_dir')
+                if not temp_dir:
                     temp_dir = bundle.metadata.temp_dir
                 copy = isinstance(bundle, MakeBundle)
                 print >>sys.stderr, 'Worker.finalize_bundle: installing dependencies to %s (copy=%s)' % (temp_dir, copy)

--- a/codalab/objects/work_manager.py
+++ b/codalab/objects/work_manager.py
@@ -86,11 +86,10 @@ class Worker(object):
         parent_dict = {parent.uuid: parent for parent in parents}
         return parent_dict
 
-
     def start_bundle(self, bundle):
         '''
         Run the given bundle using an available Machine.
-        Return 
+        Return whether something was started.
         '''
         # Check that we're running a bundle in the RUNNING state.
         state_message = 'Unexpected bundle state: %s' % (bundle.state,)
@@ -101,7 +100,6 @@ class Worker(object):
         # Run the bundle.
         with self.profile('Running bundle...'):
             started = False
-            exception = None
             if isinstance(bundle, RunBundle):
                 try:
                     # Get the username of the bundle
@@ -112,6 +110,9 @@ class Worker(object):
                         username = str(bundle.owner_id)
 
                     status = self.machine.start_bundle(bundle, self.bundle_store, self.get_parent_dict(bundle), username)
+                    if status != None:
+                        started = True
+
                 except Exception as e:
                     # If there's an exception, we just make the bundle fail
                     # (even if it's not the bundle's fault).
@@ -128,11 +129,12 @@ class Worker(object):
             if isinstance(bundle, MakeBundle):
                 temp_dir = canonicalize.get_current_location(self.bundle_store, bundle.uuid)
                 path_util.make_directory(temp_dir)
-                status.update({'success': True})
+                status = {'bundle': bundle, 'success': True, 'temp_dir': temp_dir}
 
             # Update database
-            self.update_running_bundle(status)
-            return True
+            if started:
+                self.update_running_bundle(status)
+            return started
 
     def _safe_get_bundle(self, uuid):
         try:
@@ -157,7 +159,7 @@ class Worker(object):
             else:
                 print 'Unknown action: %s' % x.action
 
-            new_actions = bundle.metadata.actions | set([x.action])
+            new_actions = getattr(bundle.metadata, 'actions', set()) | set([x.action])
             db_update = {'metadata': {'actions': new_actions}}
             self.model.update_bundle(bundle, db_update)
         return len(bundle_actions) > 0
@@ -195,7 +197,7 @@ class Worker(object):
         running_bundles = self.model.batch_get_bundles(state=State.RUNNING)
         for bundle in running_bundles:
             if bundle.uuid in status_bundle_uuids: continue
-            if Command.KILL not in bundle.metadata.actions: continue
+            if Command.KILL not in getattr(bundle.metadata, 'actions', set()): continue
             status = {'state': State.FAILED, 'bundle': bundle}
             print 'work_manager: %s (%s): killing zombie %s' % (bundle.uuid, bundle.state, status)
             self.update_running_bundle(status)
@@ -231,6 +233,8 @@ class Worker(object):
             if value != None:
                 metadata[spec.key] = value
 
+        #print 'update_running_bundle', status
+
         # See if the bundle is completed.
         success = status.get('success')
         if success != None:
@@ -240,7 +244,10 @@ class Worker(object):
             # we always only need to look back one-level at the dependencies,
             # not recurse.
             try:
-                temp_dir = bundle.metadata.temp_dir
+                if isinstance(bundle, MakeBundle):
+                    temp_dir = status.get('temp_dir')
+                else:
+                    temp_dir = bundle.metadata.temp_dir
                 copy = isinstance(bundle, MakeBundle)
                 print >>sys.stderr, 'Worker.finalize_bundle: installing dependencies to %s (copy=%s)' % (temp_dir, copy)
                 bundle.install_dependencies(self.bundle_store, self.get_parent_dict(bundle), temp_dir, copy=copy)
@@ -249,6 +256,8 @@ class Worker(object):
                 db_update['data_hash'] = data_hash
                 metadata.update(new_metadata)
             except Exception as e:
+                print '=== INTERNAL ERROR: %s' % e
+                traceback.print_exc()
                 success = False
                 metadata['failure_message'] = e.message
 

--- a/codalab/server/bundle_rpc_server.py
+++ b/codalab/server/bundle_rpc_server.py
@@ -60,13 +60,17 @@ class BundleRPCServer(FileServer):
         upload the unzipped directory. Return the new bundle's id.
         Note: delete the file_uuid file, because it's temporary!
         '''
-        zip_path = self.file_paths[file_uuid]  # Note: cheat and look at file_server's data
-        precondition(zip_path, 'Unexpected file uuid: %s' % (file_uuid,))
-        container_path = tempfile.mkdtemp()  # Make temporary directory
-        path = zip_util.unzip(zip_path, container_path)  # Unzip
+        if file_uuid:
+            zip_path = self.file_paths[file_uuid]  # Note: cheat and look at file_server's data
+            precondition(zip_path, 'Unexpected file uuid: %s' % (file_uuid,))
+            container_path = tempfile.mkdtemp()  # Make temporary directory
+            path = zip_util.unzip(zip_path, container_path)  # Unzip
+        else:
+            path = None
         result = self.client.upload_bundle(path, construct_args, worksheet_uuid, follow_symlinks)
-        path_util.remove(container_path)  # Remove temporary directory
-        self.finalize_file(file_uuid, True)  # Remove temporary zip
+        if file_uuid:
+            path_util.remove(container_path)  # Remove temporary directory
+            self.finalize_file(file_uuid, True)  # Remove temporary zip
         return result
 
     def open_target(self, target):

--- a/test-cli.py
+++ b/test-cli.py
@@ -1,0 +1,202 @@
+#!/usr/bin/python
+
+import subprocess
+import sys
+import re
+import os
+import shutil
+
+'''
+Tests all the CLI functionality end-to-end.
+
+Things not tested:
+- Interactive modes (cl edit, cl wedit)
+- Permissions
+'''
+
+cl = 'cl'
+
+def run_command(args, expected_exit_code=0):
+    try:
+        output = subprocess.check_output(args)
+        exitcode = 0
+    except subprocess.CalledProcessError, e:
+        output = e.output
+        exitcode = e.returncode
+    print '>> %s (exit code %s, expected %s)\n%s' % (args, exitcode, expected_exit_code, output)
+    if expected_exit_code != exitcode:
+        error('Exit codes don\'t match')
+    return output.rstrip()
+
+def get_info(uuid, key):
+    return run_command([cl, 'info', '-f', key, uuid])
+
+def wait(uuid):
+    run_command([cl, 'wait', uuid])
+
+def error(message):
+    print 'ERROR:', message
+    sys.exit(1)
+
+def check_equals(true_value, pred_value):
+    if true_value != pred_value:
+        error("expected '%s', but got '%s'" % (true_value, pred_value))
+    return pred_value
+
+def check_contains(true_value, pred_value):
+    if isinstance(true_value, list):
+        for v in true_value:
+            check_contains(v, pred_value)
+    else:
+        if not re.search(true_value, pred_value):
+            error("expected something that contains '%s', but got '%s'" % (true_value, pred_value))
+    return pred_value
+
+def check_num_lines(true_value, pred_value):
+    num_lines = len(pred_value.split('\n'))
+    if num_lines != true_value:
+        error("expected %d lines, but got %s" % (true_value, num_lines))
+    return pred_value
+
+tests = []
+def add_test(name, func):
+    tests.append((name, func))
+def run_test(query_name):
+    for name, func in tests:
+        if query_name == 'all' or query_name == name:
+            print '============= ' + name
+            func()
+
+############################################################
+
+def test():
+    # upload
+    uuid = run_command([cl, 'upload', 'dataset', '/etc/hosts', '--description', 'hello', '--tags', 'a', 'b'])
+    check_equals('hosts', get_info(uuid, 'name'))
+    check_equals('hello', get_info(uuid, 'description'))
+    check_equals("[u'a', u'b']", get_info(uuid, 'tags'))
+    check_equals('ready', get_info(uuid, 'state'))
+
+    # edit
+    run_command([cl, 'edit', uuid, '--name', 'hosts2'])
+    check_equals('hosts2', get_info(uuid, 'name'))
+
+    # cat, info
+    check_contains('127.0.0.1', run_command([cl, 'cat', uuid]))
+    check_contains(['bundle_type', 'uuid', 'owner', 'created'], run_command([cl, 'info', uuid]))
+    check_contains('license', run_command([cl, 'info', '--raw', uuid]))
+    check_contains(['host_worksheets', 'contents'], run_command([cl, 'info', '--verbose', uuid]))
+
+    # rm
+    run_command([cl, 'rm', '--dry-run', uuid])
+    check_contains('0x', get_info(uuid, 'data_hash'))
+    run_command([cl, 'rm', '--data-only', uuid])
+    check_equals('None', get_info(uuid, 'data_hash'))
+    run_command([cl, 'rm', uuid])
+add_test('upload', test)
+
+def test():
+    # Upload two files
+    uuid = run_command([cl, 'upload', 'program', '/etc/hosts', '/etc/issue', '--description', 'hello'])
+    check_contains('127.0.0.1', run_command([cl, 'cat', uuid + '/hosts']))
+    # Upload with base
+    uuid2 = run_command([cl, 'upload', 'program', '/etc/hosts', '/etc/issue', '--base', uuid])
+    check_equals('hello', get_info(uuid2, 'description'))
+    # Cleanup
+    run_command([cl, 'rm', uuid, uuid2])
+add_test('upload2', test)
+
+def test():
+    uuid1 = run_command([cl, 'upload', 'dataset', '/etc/hosts'])
+    uuid2 = run_command([cl, 'upload', 'dataset', '/etc/issue'])
+    # make
+    uuid3 = run_command([cl, 'make', 'dep1:'+uuid1, 'dep2:'+uuid2])
+    wait(uuid3)
+    check_equals('ready', run_command([cl, 'info', '-f', 'state', uuid3]))
+    check_contains(['dep1', uuid1, 'dep2', uuid2], run_command([cl, 'info', uuid3]))
+    # anonymous make
+    uuid4 = run_command([cl, 'make', uuid3, '--name', 'foo'])
+    wait(uuid4)
+    check_equals('ready', run_command([cl, 'info', '-f', 'state', uuid4]))
+    check_contains([uuid3], run_command([cl, 'info', uuid3]))
+    # Cleanup
+    run_command([cl, 'rm', uuid1], 1)  # should fail
+    run_command([cl, 'rm', '-f', uuid2])  # force the deletion
+    run_command([cl, 'rm', '-r', uuid1])  # delete things downstream
+add_test('make', test)
+
+def test():
+    name = 'test-hello-run'
+    uuid = run_command([cl, 'run', 'echo hello', '-n', name])
+    wait(uuid)
+    # test search
+    check_contains('hello', run_command([cl, 'search', name]))
+    #check_equals('1', run_command([cl, 'search', name, '--count'])) # TODO: doesn't work
+    check_equals(uuid, run_command([cl, 'search', name, '-u']))
+    run_command([cl, 'search', 'test-hello-run', '--append'])
+    # get info
+    check_equals('ready', run_command([cl, 'info', '-f', 'state', uuid]))
+    check_equals('run "echo hello"', run_command([cl, 'info', '-f', 'args', uuid]))
+    check_equals('hello', run_command([cl, 'cat', uuid+'/stdout']))
+    # block
+    uuid2 = check_contains('hello', run_command([cl, 'run', 'echo hello', '--tail'])).split('\n')[0]
+    # cleanup
+    run_command([cl, 'rm', uuid, uuid2])
+add_test('run', test)
+
+def test():
+    wname = 'test-worksheet'
+    # Create new worksheet
+    orig_wuuid = run_command([cl, 'work', '--raw'])
+    wuuid = run_command([cl, 'new', wname, '--raw'])
+    check_contains(['Switched', wname, wuuid], run_command([cl, 'work', wuuid]))
+    # ls
+    check_equals('', run_command([cl, 'ls', '-u']))
+    uuid = run_command([cl, 'upload', 'dataset', '/etc/hosts'])
+    check_equals(uuid, run_command([cl, 'ls', '-u']))
+    # create worksheet
+    check_contains(uuid[0:5], run_command([cl, 'ls']))
+    run_command([cl, 'add', '-m', 'testing'])
+    run_command([cl, 'add', '-m', '% display contents / maxlines=2'])
+    run_command([cl, 'add', uuid])
+    run_command([cl, 'add', '-m', '%% comment'])
+    run_command([cl, 'add', '-m', '% schema foo'])
+    run_command([cl, 'add', '-m', '% add uuid'])
+    run_command([cl, 'add', '-m', '% add data_hash data_hash s/0x/HEAD'])
+    run_command([cl, 'add', '-m', '% add CREATE created "date | [0:5]"'])
+    run_command([cl, 'add', '-m', '% display table foo'])
+    run_command([cl, 'add', uuid])
+    run_command([cl, 'cp', uuid, wuuid])  # not testing real copying ability
+    run_command([cl, 'wadd', wuuid])
+    check_contains(['Worksheet', 'testing', 'hosts', '127.0.0.1', uuid, 'HEAD', 'CREATE'], run_command([cl, 'print']))
+    run_command([cl, 'wcp', wuuid, wuuid])
+    check_num_lines(8, run_command([cl, 'ls', '-u']))
+    run_command([cl, 'wedit', wuuid, '--name', wname + '2'])
+    run_command([cl, 'wedit', wuuid, '--file', '/dev/null'])  # wipe out worksheet
+    # cleanup
+    run_command([cl, 'rm', uuid])
+    run_command([cl, 'wrm', wuuid])
+    run_command([cl, 'work', orig_wuuid])
+add_test('worksheet', test)
+
+def test():
+    uuid = run_command([cl, 'upload', 'dataset', '/etc/hosts', '/etc/issue'])
+    # download
+    run_command([cl, 'download', uuid, '-o', uuid])
+    run_command(['ls', '-R', uuid])
+    shutil.rmtree(uuid)
+    # cleanup
+    run_command([cl, 'rm', uuid])
+add_test('copy', test)
+
+def test():
+    run_command([cl, 'status'])
+    run_command([cl, 'alias'])
+    run_command([cl, 'help'])
+add_test('status', test)
+
+if len(sys.argv) == 1:
+    print 'Modules:', ' '.join(name for name, func in tests)
+else:
+    for name in sys.argv[1:]:
+        run_test(name)

--- a/test-cli.py
+++ b/test-cli.py
@@ -12,6 +12,7 @@ Tests all the CLI functionality end-to-end.
 Things not tested:
 - Interactive modes (cl edit, cl wedit)
 - Permissions
+- Worker system
 '''
 
 cl = 'cl'
@@ -74,7 +75,7 @@ def test():
     uuid = run_command([cl, 'upload', 'dataset', '/etc/hosts', '--description', 'hello', '--tags', 'a', 'b'])
     check_equals('hosts', get_info(uuid, 'name'))
     check_equals('hello', get_info(uuid, 'description'))
-    check_equals("[u'a', u'b']", get_info(uuid, 'tags'))
+    check_contains(['a', 'b'], get_info(uuid, 'tags'))
     check_equals('ready', get_info(uuid, 'state'))
 
     # edit


### PR DESCRIPTION
Highlights:
- 'cl rm -d' allows you to remove contents of a bundle to save space.
- 'cl cp' and 'cl wcp' works more robustly.
- 'cl mimic' adds worksheet markup to new bundles created.

Need to do a git pull (interface to 'cl rm' changed).
