### PR TITLE
several small usability improvements on the CLI side

### DIFF
--- a/README.md
+++ b/README.md
@@ -628,7 +628,7 @@ Install the MySQL server.  On Ubuntu, run:
 
     sudo apt-get install mysql-server
 
-Install the MySQL Python:
+Install the MySQL Python if it hasn't been done already:
 
     venv/bin/pip install MySQL-python
 

--- a/codalab/client/local_bundle_client.py
+++ b/codalab/client/local_bundle_client.py
@@ -555,6 +555,10 @@ class LocalBundleClient(BundleClient):
         # Don't need any permissions to do this.
         worksheet = Worksheet({'name': name, 'items': [], 'owner_id': self._current_user_id()})
         self.model.save_worksheet(worksheet)
+
+        # Make worksheet publicly readable by default
+        self.set_worksheet_perm(worksheet.uuid, self.model.public_group_uuid, 'read')
+
         return worksheet.uuid
 
     def list_worksheets(self):

--- a/codalab/client/local_bundle_client.py
+++ b/codalab/client/local_bundle_client.py
@@ -662,8 +662,11 @@ class LocalBundleClient(BundleClient):
 
     @authentication_required
     def delete_worksheet(self, uuid):
-        worksheet = self.model.get_worksheet(uuid, fetch_items=False)
+        worksheet = self.model.get_worksheet(uuid, fetch_items=True)
         check_has_all_permission(self.model, self._current_user(), worksheet)
+        # Be safe!
+        if len(worksheet.items) > 0:
+            raise UsageError("Can\'t delete worksheet %s because it is not empty" % worksheet.uuid)
         self.model.delete_worksheet(uuid)
 
     def interpret_file_genpaths(self, requests):

--- a/codalab/client/local_bundle_client.py
+++ b/codalab/client/local_bundle_client.py
@@ -261,6 +261,13 @@ class LocalBundleClient(BundleClient):
             relevant_uuids = uuids
         check_has_all_permission_on_bundles(self.model, self._current_user(), relevant_uuids)
 
+        # Make sure that bundles are not referenced in multiple places (otherwise, it's very dangerous)
+        if not force:
+            result = self.model.get_host_worksheet_uuids(relevant_uuids)
+            for uuid, host_worksheet_uuids in result.items():
+                if len(host_worksheet_uuids) > 1:
+                    raise UsageError('Bundle %s appears in multiple worksheets: %s, not deleting' % (uuid, host_worksheet_uuids))
+
         # Get data hashes
         relevant_data_hashes = set(bundle.data_hash for bundle in self.model.batch_get_bundles(uuid=relevant_uuids) if bundle.data_hash)
 

--- a/codalab/client/local_bundle_client.py
+++ b/codalab/client/local_bundle_client.py
@@ -611,7 +611,13 @@ class LocalBundleClient(BundleClient):
         for (bundle_uuid, subworksheet_uuid, value, type) in items:
             bundle_info = bundle_dict.get(bundle_uuid, {'uuid': bundle_uuid}) if bundle_uuid else None
             if subworksheet_uuid:
-                subworksheet_info = self.model.get_worksheet(subworksheet_uuid, fetch_items=False).to_dict()
+                try:
+                    subworksheet_info = self.model.get_worksheet(subworksheet_uuid, fetch_items=False).to_dict()
+                except UsageError, e:
+                    # If can't get the subworksheet, it's probably invalid, so just replace it with an error
+                    type = worksheet_util.TYPE_MARKUP
+                    subworksheet_info = None
+                    value = 'ERROR: non-existent worksheet %s' % subworksheet_uuid
             else:
                 subworksheet_info = None
             value_obj = worksheet_util.string_to_tokens(value) if type == worksheet_util.TYPE_DIRECTIVE else value

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -1086,8 +1086,9 @@ class BundleCLI(object):
         client, worksheet_uuid = self.parse_client_worksheet_uuid(args.worksheet_spec)
         uuid = client.new_worksheet(args.name)
         client.add_worksheet_item(worksheet_uuid, worksheet_util.subworksheet_item(uuid))  # Add new to current
-        client.add_worksheet_item(uuid, worksheet_util.markup_item('Parent:'))  # Backpointer
-        client.add_worksheet_item(uuid, worksheet_util.subworksheet_item(worksheet_uuid))  # Backpointer
+        # Don't need backpointer - looks ugly anyway
+        #client.add_worksheet_item(uuid, worksheet_util.markup_item('Parent:'))  # Backpointer
+        #client.add_worksheet_item(uuid, worksheet_util.subworksheet_item(worksheet_uuid))  # Backpointer
         worksheet_info = client.get_worksheet_info(uuid, False)
         if args.raw:
             print worksheet_info['uuid']

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -79,7 +79,7 @@ class BundleCLI(object):
       'uadd': 'Add a user to a group.',
       'urm': 'Remove a user from a group.',
       'wperm': 'Set a group\'s permissions for a worksheet.',
-      'chown': 'Set the owner of bundles/worksheets.',
+      'chown': 'Set the owner of bundles.',
       # Commands that can only be executed on a LocalBundleClient.
       'help': 'Show a usage message for cl or for a particular command.',
       'status': 'Show current client status.',

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -879,7 +879,7 @@ class BundleCLI(object):
     def print_target_info(self, client, target, decorate, maxlines=10):
         info = client.get_target_info(target, 1)
         if 'type' not in info:
-            self.exit('Target doesn\'t exist: %s/%s' % target)
+            raise UsageError('Target doesn\'t exist: %s/%s' % target)
         if info['type'] == 'file':
             if decorate:
                 for line in client.head_target(target, maxlines):
@@ -1222,7 +1222,10 @@ class BundleCLI(object):
                         maxlines = properties.get('maxlines')
                         if maxlines:
                             maxlines = int(maxlines)
-                        self.print_target_info(client, data, decorate=True, maxlines=maxlines)
+                        try:
+                            self.print_target_info(client, data, decorate=True, maxlines=maxlines)
+                        except UsageError, e:
+                            print 'ERROR:', e
                     else:
                         print data
             elif mode == 'record' or mode == 'table':

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -148,6 +148,7 @@ class BundleCLI(object):
         'p': 'print',
         'i': 'info',
         'e': 'edit',
+        'we': 'wedit',
         's': 'search',
         'st': 'status',
     }

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -1150,7 +1150,7 @@ class BundleCLI(object):
         else:
             # Either get a list of lines from the given file or request it from the user in an editor.
             if args.file:
-                lines = [line.strip() for line in open(args.file).readlines()]
+                lines = [line.rstrip() for line in open(args.file).readlines()]
             else:
                 lines = worksheet_util.request_lines(worksheet_info, client)
 

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -746,7 +746,7 @@ class BundleCLI(object):
                 else:
                     return info.get(col, info['metadata'].get(col))
                     
-            columns = (('ref',) if print_ref else ()) + ('uuid', 'name', 'bundle_type', 'created', 'data_size', 'state')
+            columns = (('ref',) if print_ref else ()) + ('uuid', 'name', 'bundle_type', 'owner', 'created', 'data_size', 'state')
             post_funcs = {'uuid': self.UUID_POST_FUNC, 'created': 'date', 'data_size': 'size'}
             justify = {'data_size': 1, 'ref': 1}
             bundle_dicts = [
@@ -772,13 +772,15 @@ class BundleCLI(object):
                 raise UsageError('Invalid bundle uuid: %s' % bundle_uuid)
 
             if args.field:
-                # Display a single field (arbitrary genpath)
-                genpath = args.field
-                if worksheet_util.is_file_genpath(genpath):
-                    value = worksheet_util.interpret_file_genpath(client, {}, bundle_uuid, genpath, None)
-                else:
-                    value = worksheet_util.interpret_genpath(info, genpath)
-                print value
+                # Display individual fields (arbitrary genpath)
+                values = []
+                for genpath in args.field.split(','):
+                    if worksheet_util.is_file_genpath(genpath):
+                        value = worksheet_util.interpret_file_genpath(client, {}, bundle_uuid, genpath, None)
+                    else:
+                        value = worksheet_util.interpret_genpath(info, genpath)
+                    values.append(value)
+                print '\t'.join(map(str, values))
             else:
                 # Display all the fields
                 if i > 0:

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -281,7 +281,11 @@ class BundleCLI(object):
         return (self.manager.client(address), spec)
 
     def parse_client_worksheet_uuid(self, spec):
-        if not spec:
+        '''
+        Return the worksheet referred to by |spec|.
+        '''
+        if not spec or spec == '.':
+            # Empty spec, just return current worksheet.
             client, worksheet_uuid = self.manager.get_current_worksheet_uuid()
         else:
             client_is_explicit = spec_util.client_is_explicit(spec)
@@ -1399,8 +1403,8 @@ class BundleCLI(object):
         '''
         Change the owner of bundles.
         '''
-        parser.add_argument('bundle_spec', help=self.BUNDLE_SPEC_FORMAT, nargs='+')
         parser.add_argument('user_spec', help='username')
+        parser.add_argument('bundle_spec', help=self.BUNDLE_SPEC_FORMAT, nargs='+')
         parser.add_argument('-w', '--worksheet_spec', help='operate on this worksheet (%s)' % self.WORKSHEET_SPEC_FORMAT, nargs='?')
         args = parser.parse_args(argv)
         args.bundle_spec = spec_util.expand_specs(args.bundle_spec)

--- a/codalab/lib/codalab_manager.py
+++ b/codalab/lib/codalab_manager.py
@@ -36,8 +36,8 @@ import psutil
 
 from codalab.client import is_local_address
 from codalab.common import UsageError, PermissionError
-from codalab.server.auth import ROOT_USER_NAME
 from codalab.objects.worksheet import Worksheet
+from codalab.server.auth import User
 
 def cached(fn):
     def inner(self):
@@ -178,33 +178,51 @@ class CodaLabManager(object):
         Return a model.  Called by the server.
         '''
         model_class = self.config['server']['class']
+        model = None
         if model_class == 'MySQLModel':
             from codalab.model.mysql_model import MySQLModel
-            return MySQLModel(engine_url=self.config['server']['engine_url'])
-        if model_class == 'SQLiteModel':
+            model = MySQLModel(engine_url=self.config['server']['engine_url'])
+        elif model_class == 'SQLiteModel':
             codalab_home = self.codalab_home()
             from codalab.model.sqlite_model import SQLiteModel
-            return SQLiteModel(codalab_home)
+            model = SQLiteModel(codalab_home)
         else:
             raise UsageError('Unexpected model class: %s, expected MySQLModel or SQLiteModel' % (model_class,))
+        model.root_user_id = self.root_user_id()
+        return model
 
-    @cached
-    def auth_handler(self):
+    def auth_handler(self, mock=False):
         '''
         Returns a class to authenticate users on the server-side.  Called by the server.
         '''
         auth_config = self.config['server']['auth']
         handler_class = auth_config['class']
 
+        if mock or handler_class == 'MockAuthHandler':
+            return self.mock_auth_handler()
         if handler_class == 'OAuthHandler':
-            arguments = ('address', 'app_id', 'app_key')
-            kwargs = {arg: auth_config[arg] for arg in arguments}
-            from codalab.server.auth import OAuthHandler
-            return OAuthHandler(**kwargs)
-        if handler_class == 'MockAuthHandler':
-            from codalab.server.auth import MockAuthHandler
-            return MockAuthHandler()
+            return self.oauth_handler()
         raise UsageError('Unexpected auth handler class: %s, expected OAuthHandler or MockAuthHandler' % (handler_class,))
+
+    @cached
+    def mock_auth_handler(self):
+        from codalab.server.auth import MockAuthHandler
+        # Just create one user corresponding to the root
+        users = [User(self.root_user_name(), self.root_user_id())]
+        return MockAuthHandler(users)
+
+    @cached
+    def oauth_handler(self):
+        arguments = ('address', 'app_id', 'app_key')
+        auth_config = self.config['server']['auth']
+        kwargs = {arg: auth_config[arg] for arg in arguments}
+        from codalab.server.auth import OAuthHandler
+        return OAuthHandler(**kwargs)
+
+    def root_user_name(self):
+        return self.config['server'].get('root_user_name', 'codalab')
+    def root_user_id(self):
+        return self.config['server'].get('root_user_id', '0')
 
     def local_client(self):
         return self.client('local')
@@ -223,14 +241,9 @@ class CodaLabManager(object):
             return self.clients[address]
         # if local force mockauth or if locl server use correct auth
         if is_local_address(address):
-            from codalab.server.auth import MockAuthHandler
             bundle_store = self.bundle_store()
             model = self.model()
-
-            if is_cli:  # we are local and cli, we only need mock
-                auth_handler = MockAuthHandler()
-            else: # server
-                auth_handler = self.auth_handler()
+            auth_handler = self.auth_handler(mock=is_cli)
 
             from codalab.client.local_bundle_client import LocalBundleClient
             client = LocalBundleClient(address, bundle_store, model, auth_handler, self.cli_verbose)
@@ -296,7 +309,7 @@ class CodaLabManager(object):
         username = None
         # For a local client with mock credentials, use the default username.
         if is_local_address(client.address):
-            username = ROOT_USER_NAME
+            username = self.root_user_name()
             password = ''
         if not username:
             print 'Requesting access at %s' % address

--- a/codalab/lib/codalab_manager.py
+++ b/codalab/lib/codalab_manager.py
@@ -35,7 +35,7 @@ import time
 import psutil
 
 from codalab.client import is_local_address
-from codalab.common import UsageError
+from codalab.common import UsageError, PermissionError
 from codalab.server.auth import ROOT_USER_NAME
 from codalab.objects.worksheet import Worksheet
 
@@ -306,7 +306,7 @@ class CodaLabManager(object):
 
         token_info = client.login('credentials', username, password)
         if token_info is None:
-            raise UsageError("Invalid username or password")
+            raise PermissionError("Invalid username or password.")
         return _cache_token(token_info, username)
 
     def get_current_worksheet_uuid(self):

--- a/codalab/lib/worksheet_util.py
+++ b/codalab/lib/worksheet_util.py
@@ -157,7 +157,7 @@ def get_worksheet_lines(worksheet_info):
         elif type == TYPE_BUNDLE:
             if 'metadata' not in bundle_info:
                 # This happens when we add bundles by uuid and don't actually make sure they exist
-                lines.append('Non-existent bundle: %s' % bundle_info['uuid'])
+                lines.append('ERROR: non-existent bundle %s' % bundle_info['uuid'])
                 continue
             metadata = bundle_info['metadata']
             description = bundle_info['bundle_type']

--- a/codalab/lib/worksheet_util.py
+++ b/codalab/lib/worksheet_util.py
@@ -114,8 +114,9 @@ def get_worksheet_lines(worksheet_info):
     Generator that returns pretty-printed lines of text for the given worksheet.
     '''
     header = '''
-// Editing for worksheet %s.  The coments (//) are simply instructions
-// to you and not part of the actual worksheet.  You can enter:
+// Editing worksheet %s(%s).
+// The coments (//) are simply instructions to you and not part of the actual
+// worksheet.  You can enter:
 // - Arbitrary Markdown (see http://daringfireball.net/projects/markdown/syntax)
 // - References to bundles: {<bundle_spec>}
 // - Directives (%% title|schema|add|display)
@@ -144,7 +145,7 @@ def get_worksheet_lines(worksheet_info):
 // %% display table s1
 // %% {run1}
 // %% {run2}
-    '''.strip() % (worksheet_info['name'],)
+    '''.strip() % (worksheet_info['name'], worksheet_info['uuid'],)
     lines = header.split('\n')
 
     for (bundle_info, subworksheet_info, value_obj, type) in worksheet_info['items']:

--- a/codalab/lib/worksheet_util.py
+++ b/codalab/lib/worksheet_util.py
@@ -289,7 +289,13 @@ def interpret_genpath(bundle_info, genpath):
     deps = bundle_info['dependencies']
     anonymous = len(deps) == 1 and deps[0]['child_path'] == ''
     def render_dep(dep, show_key=True, show_uuid=False):
-        a = dep['child_path'] + ':' if not anonymous and show_key else ''
+        if show_key and not anonymous:
+            if show_uuid or dep['child_path'] != dep['parent_name']:
+                a = dep['child_path'] + ':'
+            else:
+                a = ':'
+        else:
+            a = ''
         b = dep['parent_uuid'] if show_uuid else dep['parent_name']
         c = '/' + dep['parent_path'] if dep['parent_path'] else ''
         return a + b + c

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -733,9 +733,6 @@ class BundleModel(object):
             group_dict = groups[0]
         self.public_group_uuid = group_dict['uuid']
 
-        # TODO: find a more systematic way of doing this.
-        self.root_user_id = '0'
-
     def list_groups(self, owner_id):
         '''
         Return a list of row dicts --one per group-- for the given owner.

--- a/codalab/objects/bundle.py
+++ b/codalab/objects/bundle.py
@@ -121,9 +121,8 @@ class Bundle(ORMObject):
 
     def install_dependencies(self, bundle_store, parent_dict, dest_path, copy):
         '''
-        Symlink this bundle's dependencies into the directory at dest_path.
+        Symlink or copy this bundle's dependencies into the directory at dest_path.
         The caller is responsible for cleaning up this directory.
-        rel: whether to use relative symlinks
         '''
         precondition(os.path.isabs(dest_path), '%s is a relative path!' % (dest_path,))
         pairs = self.get_dependency_paths(bundle_store, parent_dict, dest_path, relative_symlinks=not copy)
@@ -136,3 +135,14 @@ class Bundle(ORMObject):
                 path_util.copy(target, link_path, follow_symlinks=False)
             else:
                 os.symlink(target, link_path)
+
+    def remove_dependencies(self, bundle_store, parent_dict, dest_path):
+        '''
+        Remove dependencies (for RunBundles).
+        '''
+        precondition(os.path.isabs(dest_path), '%s is a relative path!' % (dest_path,))
+        pairs = self.get_dependency_paths(bundle_store, parent_dict, dest_path, relative_symlinks=False)
+        for (target, link_path) in pairs:
+            # If the dependency already exists, remove it (this happens when we are reinstalling)
+            if os.path.exists(link_path):
+                path_util.remove(link_path)

--- a/codalab/server/auth.py
+++ b/codalab/server/auth.py
@@ -9,9 +9,6 @@ from base64 import encodestring
 
 from codalab.common import UsageError, PermissionError
 
-ROOT_USER_NAME = 'codalab'
-ROOT_USER_ID = '0'
-
 class User(object):
     '''
     Defines a registered user with a unique name and a unique (int) identifier.
@@ -27,9 +24,7 @@ class MockAuthHandler(object):
     authentication is required.  There is exactly one root user with no
     password.
     '''
-    def __init__(self, users=None):
-        if users == None:
-            users = [User(ROOT_USER_NAME, ROOT_USER_ID)]
+    def __init__(self, users):
         self.users = users
         self._user = users[0]
 

--- a/codalab/server/auth.py
+++ b/codalab/server/auth.py
@@ -7,7 +7,7 @@ import urllib
 import urllib2
 from base64 import encodestring
 
-from codalab.common import UsageError
+from codalab.common import UsageError, PermissionError
 
 ROOT_USER_NAME = 'codalab'
 ROOT_USER_ID = '0'
@@ -158,7 +158,7 @@ class OAuthHandler(object):
         '''
         if grant_type == 'credentials':
             if len(username) < self.min_username_length or len(key) < self.min_key_length:
-                raise UsageError("Invalid username or password.")
+                raise PermissionError("Invalid username or password.")
             return self._generate_new_token(username, key)
         if grant_type == 'refresh_token':
             return self._refresh_token(username, key)

--- a/setup.sh
+++ b/setup.sh
@@ -21,7 +21,7 @@ if [ ! -e $env ]; then
 fi
 
 echo "=== Install Python packages into $env..."
-$env/bin/pip install sqlalchemy alembic pyyaml watchdog || exit 1
+$env/bin/pip install sqlalchemy alembic pyyaml MySQL-python watchdog || exit 1
 
 ( # try
     $env/bin/pip install psutil || exit 1

--- a/test-cli.py
+++ b/test-cli.py
@@ -95,7 +95,7 @@ def test():
     run_command([cl, 'rm', '--data-only', uuid])
     check_equals('None', get_info(uuid, 'data_hash'))
     run_command([cl, 'rm', uuid])
-add_test('upload', test)
+add_test('upload1', test)
 
 def test():
     # Upload two files
@@ -107,6 +107,13 @@ def test():
     # Cleanup
     run_command([cl, 'rm', uuid, uuid2])
 add_test('upload2', test)
+
+def test():
+    uuid = run_command([cl, 'upload', 'dataset', '/etc/hosts'])
+    run_command([cl, 'cp', uuid, '.'])  # Duplicate
+    run_command([cl, 'rm', uuid], 1)  # should fail
+    run_command([cl, 'rm', '-f', uuid])  # force it
+add_test('rm', test)
 
 def test():
     uuid1 = run_command([cl, 'upload', 'dataset', '/etc/hosts'])

--- a/test-cli.py
+++ b/test-cli.py
@@ -9,6 +9,10 @@ import shutil
 '''
 Tests all the CLI functionality end-to-end.
 
+Currently, the tests will operate on your current worksheet.  In theory, it
+shouldn't mutate anything, but this is not guaranteed, and you should run this
+command in an unimportant CodaLab account.
+
 Things not tested:
 - Interactive modes (cl edit, cl wedit)
 - Permissions
@@ -150,7 +154,7 @@ def test():
     # block
     uuid2 = check_contains('hello', run_command([cl, 'run', 'echo hello', '--tail'])).split('\n')[0]
     # cleanup
-    run_command([cl, 'rm', uuid, uuid2])
+    run_command([cl, 'rm', '-f', uuid, uuid2])  # force because bundle shows up twice
 add_test('run', test)
 
 def test():

--- a/test-cli.py
+++ b/test-cli.py
@@ -77,6 +77,7 @@ def test():
     check_equals('hello', get_info(uuid, 'description'))
     check_contains(['a', 'b'], get_info(uuid, 'tags'))
     check_equals('ready', get_info(uuid, 'state'))
+    check_equals('ready\thello', get_info(uuid, 'state,description'))
 
     # edit
     run_command([cl, 'edit', uuid, '--name', 'hosts2'])


### PR DESCRIPTION
Main differences in behavior:
- Use '.' to refer to current worksheet
- Can't delete worksheet unless empty
- Can't delete bundle used in multiple worksheets
- Make worksheets public by default
- RunBundles don't contain symlinks to dependencies
