### PR TITLE
get search working for bundles and worksheets

### DIFF
--- a/README.md
+++ b/README.md
@@ -690,6 +690,12 @@ Install the MySQL Python if it hasn't been done already:
 
     venv/bin/pip install MySQL-python
 
+Create a user in the `mysql -u root -p` prompt:
+
+    CREATE USER '<username>'@'localhost' IDENTIFIED BY '<password>';
+    CREATE DATABASE codalab_bundles;
+    GRANT ALL ON codalab_bundles.* TO 'codalab'@'localhost';
+
 In the configuration file `.codalab/config.json`,
 change `"class": "SQLiteModel"` to
 
@@ -710,6 +716,10 @@ Once you set up your database, run the following so that future migrations
 start from the right place (this is important!):
 
     venv/bin/alembic stamp head
+
+You can back up the contents of the database:
+
+    mysqldump codalab_bundles > bundles.mysqldump
 
 ## Authentication
 

--- a/README.md
+++ b/README.md
@@ -719,7 +719,7 @@ start from the right place (this is important!):
 
 You can back up the contents of the database:
 
-    mysqldump codalab_bundles > bundles.mysqldump
+    mysqldump -u codalab -p codalab_bundles > bundles.mysql
 
 ## Authentication
 

--- a/README.md
+++ b/README.md
@@ -795,6 +795,7 @@ Some initial examples:
     cl search dependency=0xa11%            # bundles that depends on the given bundle
     cl search worksheet=0xfdd%             # bundles that are on the given worksheet
     cl search owner=codalab                # bundles that are owned by the given user name
+    cl search =%python%                    # match any field
 
 You can combine search terms:
 
@@ -828,6 +829,16 @@ This can be piped into other commands:
 
     cl search .mine .floating -u | xargs cl rm  # delete the floating bundles
     cl search mnist -u | xargs cl add           # add mnist to the current worksheet
+
+We can list and search worksheets in a similar fashion:
+
+    cl wls                       # all worksheets
+    cl wls .mine                 # my worksheet
+    cl wls .last .limit=3        # last worksheets created
+    cl wls name=.sort            # worksheets sorted by name
+    cl wls bundle=0x3bb%         # worksheets containing this bundle
+    cl wls owner=codalab         # worksheets owned by `codalab`
+    cl wls =%Hello%              # worksheets containing 'Hello'
 
 ## Updating CodaLab
 

--- a/codalab/client/bundle_client.py
+++ b/codalab/client/bundle_client.py
@@ -128,10 +128,7 @@ class BundleClient(object):
         This dict will have the following keys:
           uuid: the worksheet uuid
           name: the worksheet name
-          items: an list of (bundle_info, value) pairs, where bundle_info is either:
-                  - a bundle info dict
-                  - a dict mapping 'uuid' to a bundle_uuid, if the uuid is orphaned
-                  - None (for non-bundle rows)
+          items: an list of worksheet items
           last_item_id: the last database id of any item in the list
         '''
         raise NotImplementedError

--- a/codalab/client/local_bundle_client.py
+++ b/codalab/client/local_bundle_client.py
@@ -101,7 +101,7 @@ class LocalBundleClient(BundleClient):
             m = re.match('owner=(.+)', keyword)
             if not m:
                 return keyword
-            return 'owner_id=' + self._user_name_to_id(m.group(1))
+            return 'owner_id=%s' % self._user_name_to_id(m.group(1))
         return map(resolve, keywords)
 
     def search_bundle_uuids(self, worksheet_uuid, keywords):
@@ -677,7 +677,7 @@ class LocalBundleClient(BundleClient):
 
     def _user_name_to_id(self, user_name):
         results = self.auth_handler.get_users('names', [user_name])
-        if user_name not in results:
+        if not results[user_name]:
             raise UsageError('Unknown user: %s' % user_name)
         return results[user_name].unique_id
         

--- a/codalab/client/local_bundle_client.py
+++ b/codalab/client/local_bundle_client.py
@@ -635,9 +635,12 @@ class LocalBundleClient(BundleClient):
 
         return worksheet.uuid
 
-    def list_worksheets(self, keywords):
+    def list_worksheets(self):
+        return self.search_worksheets([])
+
+    def search_worksheets(self, keywords):
         keywords = self.resolve_owner_in_keywords(keywords)
-        results = self.model.list_worksheets(self._current_user_id(), keywords)
+        results = self.model.search_worksheets(self._current_user_id(), keywords)
         self._set_owner_names(results)
         return results
 

--- a/codalab/client/remote_bundle_client.py
+++ b/codalab/client/remote_bundle_client.py
@@ -83,6 +83,7 @@ class RemoteBundleClient(BundleClient):
       # Worksheet-related commands all have JSON-able inputs and outputs.
       'new_worksheet',
       'list_worksheets',
+      'search_worksheets',
       'get_worksheet_uuid',
       'get_worksheet_info',
       'add_worksheet_item',

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -1314,7 +1314,7 @@ class BundleCLI(object):
         else:
             client = self.manager.current_client()
 
-        worksheet_dicts = client.list_worksheets(args.keywords)
+        worksheet_dicts = client.search_worksheets(args.keywords)
         if args.uuid_only:
             for row in worksheet_dicts:
                 print row['uuid']

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -190,7 +190,7 @@ class BundleCLI(object):
 
     def get_worksheet_bundles(self, worksheet_info):
         '''
-        Return list of info dicts of distinct, non-orphaned bundles in the worksheet.
+        Return list of info dicts of distinct bundles in the worksheet.
         '''
         result = []
         for (bundle_info, subworksheet_info, value_obj, item_type) in worksheet_info['items']:

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -53,7 +53,7 @@ class BundleCLI(object):
       'edit': "Edit an existing bundle's metadata.",
       'hide': 'Hide a bundle from this worksheet, but doesn\'t remove the bundle.',
       'rm': 'Remove a bundle (permanent!).',
-      'search': 'Search for bundles in the system',
+      'search': 'Search for bundles in the system.',
       'ls': 'List bundles in a worksheet.',
       'info': 'Show detailed information for a bundle.',
       'cat': 'Print the contents of a file/directory in a bundle.',
@@ -1303,7 +1303,8 @@ class BundleCLI(object):
             is_last_newline = is_newline
 
     def do_wls_command(self, argv, parser):
-        parser.add_argument('address', help=self.ADDRESS_SEPC_FORMAT, nargs='?')
+        parser.add_argument('keywords', help='keywords to search for', nargs='*')
+        parser.add_argument('-a', '--address', help=self.ADDRESS_SEPC_FORMAT, nargs='?')
         parser.add_argument('-u', '--uuid-only', help='only print uuids', action='store_true')
         args = parser.parse_args(argv)
 
@@ -1313,7 +1314,7 @@ class BundleCLI(object):
         else:
             client = self.manager.current_client()
 
-        worksheet_dicts = client.list_worksheets()
+        worksheet_dicts = client.list_worksheets(args.keywords)
         if args.uuid_only:
             for row in worksheet_dicts:
                 print row['uuid']
@@ -1324,8 +1325,6 @@ class BundleCLI(object):
                     row['permissions'] = group_permissions_str(row['group_permissions'])
                 post_funcs = {'uuid': self.UUID_POST_FUNC}
                 self.print_table(('uuid', 'name', 'owner', 'permissions'), worksheet_dicts, post_funcs)
-            else:
-                print 'No worksheets found.'
 
     def do_wadd_command(self, argv, parser):
         parser.add_argument('subworksheet_spec', help='worksheets to add (%s)' % self.WORKSHEET_SPEC_FORMAT, nargs='+')

--- a/codalab/lib/bundle_store.py
+++ b/codalab/lib/bundle_store.py
@@ -16,8 +16,11 @@ from codalab.common import UsageError
 class BundleStore(object):
     DATA_SUBDIRECTORY = 'data'
     TEMP_SUBDIRECTORY = 'temp'
-    # The amount of time an orphaned folder can live in the data and temp
+
+    # The amount of time a folder can live in the data and temp
     # directories before it is garbage collected by full_cleanup.
+    # Note: this is not used right now since we clear out the bundle store
+    # immediately.
     DATA_CLEANUP_TIME = 60
     TEMP_CLEANUP_TIME = 60*60
 

--- a/codalab/machines/local_machine.py
+++ b/codalab/machines/local_machine.py
@@ -60,6 +60,7 @@ class LocalMachine(Machine):
 
     def kill_bundle(self, bundle):
         if not self.bundle or self.bundle.uuid != bundle.uuid: return False
+        print >>sys.stderr, 'LocalMachine.kill_bundle %s' % (bundle.uuid)
         self.process.kill()
         return True
 

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -704,7 +704,7 @@ class BundleModel(object):
                 worksheet_values[item_row.worksheet_uuid]['items'].append(item_row)
         return [Worksheet(value) for value in worksheet_values.itervalues()]
 
-    def list_worksheets(self, user_id, keywords):
+    def search_worksheets(self, user_id, keywords):
         '''
         Return a list of row dicts, one per worksheet. These dicts do NOT contain
         ALL worksheet items; this method is meant to make it easy for a user to see

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -486,7 +486,7 @@ class BundleModel(object):
             uuids = set(bundle_row.uuid for bundle_row in bundle_rows)
             dependency_rows = connection.execute(cl_bundle_dependency.select().where(
               cl_bundle_dependency.c.child_uuid.in_(uuids)
-            )).fetchall()
+            ).order_by(cl_bundle_dependency.c.id)).fetchall()
             metadata_rows = connection.execute(cl_bundle_metadata.select().where(
               cl_bundle_metadata.c.bundle_uuid.in_(uuids)
             )).fetchall()

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -416,7 +416,7 @@ class BundleModel(object):
 
         # Count
         if count:
-            query = query.count()
+            query = alias(query).count()
 
         #print 'QUERY', self._render_query(query)
         result = self._execute_query(query)

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -766,8 +766,17 @@ class BundleModel(object):
                 clause = make_condition(cl_worksheet.c.name, value)
             elif key == 'owner_id':
                 clause = make_condition(cl_worksheet.c.owner_id, value)
-            elif key == 'bundle':
+            elif key == 'bundle':  # contains bundle?
                 condition = make_condition(cl_worksheet_item.c.bundle_uuid, value)
+                if condition == true():  # top-level
+                    clause = and_(
+                        cl_worksheet_item.c.worksheet_uuid == cl_worksheet.c.uuid,  # Join constraint
+                        condition,
+                    )
+                else:
+                    clause = cl_worksheet.c.uuid.in_(alias(select([cl_worksheet_item.c.worksheet_uuid]).where(condition)))
+            elif key == 'worksheet':  # contains worksheet?
+                condition = make_condition(cl_worksheet_item.c.subworksheet_uuid, value)
                 if condition == true():  # top-level
                     clause = and_(
                         cl_worksheet_item.c.worksheet_uuid == cl_worksheet.c.uuid,  # Join constraint

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -713,7 +713,7 @@ class BundleModel(object):
         '''
         clauses = []
         offset = 0
-        limit = 10
+        limit = 1000
         sort_key = [cl_worksheet.c.name]
 
         # Number nested subqueries

--- a/codalab/model/tables.py
+++ b/codalab/model/tables.py
@@ -54,7 +54,9 @@ bundle_dependency = Table(
   Column('id', Integer, primary_key=True, nullable=False),
   Column('child_uuid', String(63), ForeignKey(bundle.c.uuid), nullable=False),
   Column('child_path', Text, nullable=False),
-  Column('parent_uuid', String(63), ForeignKey(bundle.c.uuid), nullable=False),
+  # Deliberately omit ForeignKey(bundle.c.uuid), because bundles can have
+  # dependencies to bundles not (yet) in the system.
+  Column('parent_uuid', String(63), nullable=False),
   Column('parent_path', Text, nullable=False),
   sqlite_autoincrement=True,
 )

--- a/codalab/objects/work_manager.py
+++ b/codalab/objects/work_manager.py
@@ -146,6 +146,7 @@ class Worker(object):
     def check_killed_bundles(self):
         '''
         For bundles that need to be killed, tell the machine to kill it.
+        If unable to kill, still discard the action.
         '''
         bundle_actions = self.model.pop_bundle_actions()
         if self.verbose >= 2: print 'bundle_actions:', bundle_actions

--- a/rc
+++ b/rc
@@ -1,4 +1,4 @@
-# Handy macros for the CodaLab CLI.
+# Handy macros the CodaLab CLI.
 
 # Usage: clhist <bundle>
 # Put the command used to create the bundle in the history.

--- a/scripts/sqlite_to_mysql.py
+++ b/scripts/sqlite_to_mysql.py
@@ -7,6 +7,9 @@ import fileinput
 # Adapted from http://paulasmuth.com/blog/migrate_sqlite_to_mysql/
 # Reads from stdin (output of sqlite3 <db> .dump), writes to stdout.
 
+# Suppress errors when record contains invalid foreign key.
+print 'SET FOREIGN_KEY_CHECKS=0;'
+
 for line in fileinput.input():
     line = line.strip()
     line = line.replace("\"", "`").replace("\\''", "\\'")
@@ -25,3 +28,5 @@ for line in fileinput.input():
     if line.startswith('CREATE INDEX'):
         line = line.replace('metadata_value', 'metadata_value(255)')
     print line
+
+print 'SET FOREIGN_KEY_CHECKS=1;'

--- a/scripts/sqlite_to_mysql.py
+++ b/scripts/sqlite_to_mysql.py
@@ -7,8 +7,9 @@ import fileinput
 # Adapted from http://paulasmuth.com/blog/migrate_sqlite_to_mysql/
 # Reads from stdin (output of sqlite3 <db> .dump), writes to stdout.
 
-# Suppress errors when record contains invalid foreign key.
-print 'SET FOREIGN_KEY_CHECKS=0;'
+# Suppress errors when record contains invalid foreign key.  This is here
+# because sqlite is less strict than mysql, but avoid doing this.
+#print 'SET FOREIGN_KEY_CHECKS=0;'
 
 for line in fileinput.input():
     line = line.strip()
@@ -29,4 +30,4 @@ for line in fileinput.input():
         line = line.replace('metadata_value', 'metadata_value(255)')
     print line
 
-print 'SET FOREIGN_KEY_CHECKS=1;'
+#print 'SET FOREIGN_KEY_CHECKS=1;'

--- a/test-cli.py
+++ b/test-cli.py
@@ -5,6 +5,8 @@ import sys
 import re
 import os
 import shutil
+import random
+import time
 
 '''
 Tests all the CLI functionality end-to-end.
@@ -20,6 +22,9 @@ Things not tested:
 '''
 
 cl = 'cl'
+
+def random_name():
+    return 'test-cli-' + str(random.randint(0, 1000000))
 
 def run_command(args, expected_exit_code=0):
     try:
@@ -142,7 +147,7 @@ def test():
 add_test('make', test)
 
 def test():
-    name = 'test-hello-run'
+    name = random_name()
     uuid = run_command([cl, 'run', 'echo hello', '-n', name])
     wait(uuid)
     # test search
@@ -156,11 +161,11 @@ def test():
     # block
     uuid2 = check_contains('hello', run_command([cl, 'run', 'echo hello', '--tail'])).split('\n')[0]
     # cleanup
-    run_command([cl, 'rm', '-f', uuid, uuid2])  # force because bundle shows up twice
+    run_command([cl, 'rm', uuid, uuid2])  # force because bundle shows up twice
 add_test('run', test)
 
 def test():
-    wname = 'test-worksheet'
+    wname = random_name()
     # Create new worksheet
     orig_wuuid = run_command([cl, 'work', '--raw'])
     wuuid = run_command([cl, 'new', wname, '--raw'])
@@ -210,15 +215,15 @@ def test():
     run_command([cl, 'add', uuid1])
     run_command([cl, 'add', uuid2])
     # State after the above: 1 2 1 2
-    run_command([cl, 'hide', uuid1], 1) # multiple indices
-    run_command([cl, 'hide', uuid1, '-n', '3'], 1) # indes out of range
-    run_command([cl, 'hide', uuid2, '-n', '2']) # State: 1 1 2
+    run_command([cl, 'detach', uuid1], 1) # multiple indices
+    run_command([cl, 'detach', uuid1, '-n', '3'], 1) # indes out of range
+    run_command([cl, 'detach', uuid2, '-n', '2']) # State: 1 1 2
     check_equals(get_info('^', 'uuid'), uuid2)
-    run_command([cl, 'hide', uuid2]) # State: 1 1
+    run_command([cl, 'detach', uuid2]) # State: 1 1
     check_equals(get_info('^', 'uuid'), uuid1)
     # Cleanup
     run_command([cl, 'rm', uuid1, uuid2])
-add_test('hide', test)
+add_test('detach', test)
 
 def test():
     uuid = run_command([cl, 'upload', 'dataset', '/etc/hosts'])
@@ -230,7 +235,7 @@ def test():
 add_test('perm', test)
 
 def test():
-    name = 'test-123'
+    name = random_name()
     uuid1 = run_command([cl, 'upload', 'dataset', '/etc/hosts', '-n', name])
     uuid2 = run_command([cl, 'upload', 'dataset', '/etc/issue', '-n', name])
     check_equals(uuid1, run_command([cl, 'search', uuid1, '-u']))
@@ -242,11 +247,18 @@ def test():
     check_equals(uuid1 + '\n' + uuid2, run_command([cl, 'search', 'name='+name, 'id=.sort', '-u']))
     check_equals(uuid2 + '\n' + uuid1, run_command([cl, 'search', 'name='+name, 'id=.sort-', '-u']))
     check_equals('2', run_command([cl, 'search', 'name='+name, '.count']))
-    size1 = int(run_command([cl, 'info', '-f', 'data_size', uuid1]))
-    size2 = int(run_command([cl, 'info', '-f', 'data_size', uuid2]))
-    check_equals(str(size1 + size2), run_command([cl, 'search', 'name='+name, 'data_size=.sum']))
+    size1 = float(run_command([cl, 'info', '-f', 'data_size', uuid1]))
+    size2 = float(run_command([cl, 'info', '-f', 'data_size', uuid2]))
+    check_equals(size1 + size2, float(run_command([cl, 'search', 'name='+name, 'data_size=.sum'])))
     run_command([cl, 'rm', uuid1, uuid2])
 add_test('search', test)
+
+def test():
+    uuid = run_command([cl, 'run', 'sleep 1000'])
+    time.sleep(2)
+    check_equals(uuid, run_command([cl, 'kill', uuid]))
+    run_command([cl, 'wait', uuid], 1)
+add_test('kill', test)
 
 def test():
     run_command([cl, 'status'])

--- a/test-cli.py
+++ b/test-cli.py
@@ -258,6 +258,7 @@ def test():
     time.sleep(2)
     check_equals(uuid, run_command([cl, 'kill', uuid]))
     run_command([cl, 'wait', uuid], 1)
+    run_command([cl, 'rm', uuid])
 add_test('kill', test)
 
 def test():


### PR DESCRIPTION
The main functionality added is full search for bundles and worksheets.
Interface change: 'cl wls' uses search_worksheets(keywords).
Revamped the documentation.
Main fix: allow parent_uuid in bundle_dependency to not be a valid bundle uuid in the system (should fix #34).
