### PR TITLE
treat symlinks as opaque entities

### DIFF
--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -995,11 +995,13 @@ class BundleCLI(object):
             return t
         if info['type'] == 'directory':
             contents = [
-                {'name': x['name'] + (' -> ' + x['link'] if x['type'] == 'link' else ''), 'size': size(x)}
+                {'name': x['name'] + (' -> ' + x['link'] if x['type'] == 'link' else ''),
+                'size': size(x),
+                'perm': oct(x['perm']) if 'perm' in x else ''}
                 for x in info['contents']
             ]
             contents = sorted(contents, key=lambda r : r['name'])
-            self.print_table(('name', 'size'), contents, justify={'size':1}, indent='')
+            self.print_table(('name', 'perm', 'size'), contents, justify={'size':1}, indent='')
         return info
 
     def do_wait_command(self, argv, parser):

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -989,13 +989,13 @@ class BundleCLI(object):
             else:
                 client.cat_target(target, sys.stdout)
         def size(x):
-            t = x.get('type', 'MISSING')
-            if t == 'file': return formatting.size_str(x['size'])
+            t = x.get('type', '???')
+            if t == 'file' or t == 'link': return formatting.size_str(x['size'])
             if t == 'directory': return 'dir'
             return t
         if info['type'] == 'directory':
             contents = [
-                {'name': x['name'], 'size': size(x)}
+                {'name': x['name'] + (' -> ' + x['link'] if x['type'] == 'link' else ''), 'size': size(x)}
                 for x in info['contents']
             ]
             contents = sorted(contents, key=lambda r : r['name'])

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -539,9 +539,9 @@ class BundleCLI(object):
             print 'Local file/directory', local_dir, 'already exists.'
             return
 
-        # Download first to a local location path.
-        local_path, temp_path = client.download_target(target, True)
-        path_util.copy(local_path, final_path, follow_symlinks=True)
+        # Download first to a local location path.  Note: don't follow symlinks.
+        local_path, temp_path = client.download_target(target, False)
+        path_util.copy(local_path, final_path, follow_symlinks=False)
         if temp_path:
           path_util.remove(temp_path)
         print 'Downloaded %s to %s.' % (self.simple_bundle_str(info), final_path)

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -990,12 +990,12 @@ class BundleCLI(object):
                 client.cat_target(target, sys.stdout)
         def size(x):
             t = x.get('type', '???')
-            if t == 'file' or t == 'link': return formatting.size_str(x['size'])
+            if t == 'file': return formatting.size_str(x['size'])
             if t == 'directory': return 'dir'
             return t
         if info['type'] == 'directory':
             contents = [
-                {'name': x['name'] + (' -> ' + x['link'] if x['type'] == 'link' else ''),
+                {'name': x['name'] + (' -> ' + x['link'] if 'link' in x else ''),
                 'size': size(x),
                 'perm': oct(x['perm']) if 'perm' in x else ''}
                 for x in info['contents']

--- a/codalab/lib/canonicalize.py
+++ b/codalab/lib/canonicalize.py
@@ -95,15 +95,14 @@ def get_target_path(bundle_store, model, target):
     (uuid, path) = target
     bundle = model.get_bundle(uuid)
     if not bundle.data_hash:
-        # Note that the bundle might not be done, but return the location anyway to the temporary directory
+        # Note that the bundle might not be ready, but return the location anyway to the temporary directory.
         bundle_root = get_current_location(bundle_store, uuid)
     else:
         bundle_root = bundle_store.get_location(bundle.data_hash)
     final_path = path_util.safe_join(bundle_root, path)
 
-    # This is too restrictive because it means we can't follow any of the
-    # components of a make bundle.
-    #path_util.check_under_path(final_path, bundle_root)
+    # Make sure that we're not following symlinks to some crazy place.
+    path_util.check_under_path(final_path, bundle_root)
 
     result = path_util.TargetPath(final_path)
     result.target = target

--- a/codalab/lib/path_util.py
+++ b/codalab/lib/path_util.py
@@ -204,7 +204,6 @@ def cat(path, out):
     '''
     Copy data from the file at the given path to the file descriptor |out|.
     '''
-    if os.path.islink(path): return None  # Don't follow symlinks
     if not os.path.isfile(path): return None
     with open(path, 'rb') as file_handle:
         file_util.copy(file_handle, out)
@@ -213,7 +212,6 @@ def read_lines(path, num_lines=None):
     '''
     Return list of lines (up to num_lines).
     '''
-    if os.path.islink(path): return None  # Don't follow symlinks
     if not os.path.isfile(path): return None
     with open(path, 'rb') as file_handle:
         if num_lines == None:
@@ -260,10 +258,8 @@ def get_info(path, depth):
     result = {}
     result['name'] = os.path.basename(path)
     if os.path.islink(path):
-        result['type'] = 'link'
         result['link'] = os.readlink(path)
-        result['size'] = get_size(path)
-    elif os.path.isfile(path):
+    if os.path.isfile(path):
         result['type'] = 'file'
         result['size'] = get_size(path)
     elif os.path.isdir(path):

--- a/codalab/lib/path_util.py
+++ b/codalab/lib/path_util.py
@@ -204,7 +204,8 @@ def cat(path, out):
     '''
     Copy data from the file at the given path to the file descriptor |out|.
     '''
-    check_isfile(path, 'cat')
+    if os.path.islink(path): return None  # Don't follow symlinks
+    if not os.path.isfile(path): return None
     with open(path, 'rb') as file_handle:
         file_util.copy(file_handle, out)
 
@@ -212,8 +213,8 @@ def read_lines(path, num_lines=None):
     '''
     Return list of lines (up to num_lines).
     '''
+    if os.path.islink(path): return None  # Don't follow symlinks
     if not os.path.isfile(path): return None
-    #check_isfile(path, 'read_lines')
     with open(path, 'rb') as file_handle:
         if num_lines == None:
             return file_handle.readlines()
@@ -258,6 +259,10 @@ def get_info(path, depth):
     '''
     result = {}
     result['name'] = os.path.basename(path)
+    if os.path.islink(path):
+        result['type'] = 'link'
+        result['link'] = os.path.realpath(path)
+        result['size'] = get_size(path)
     if os.path.isfile(path):
         result['type'] = 'file'
         result['size'] = get_size(path)

--- a/codalab/lib/path_util.py
+++ b/codalab/lib/path_util.py
@@ -261,15 +261,17 @@ def get_info(path, depth):
     result['name'] = os.path.basename(path)
     if os.path.islink(path):
         result['type'] = 'link'
-        result['link'] = os.path.realpath(path)
+        result['link'] = os.readlink(path)
         result['size'] = get_size(path)
-    if os.path.isfile(path):
+    elif os.path.isfile(path):
         result['type'] = 'file'
         result['size'] = get_size(path)
     elif os.path.isdir(path):
         result['type'] = 'directory'
         if depth > 0:
             result['contents'] = [get_info(os.path.join(path, file_name), depth-1) for file_name in os.listdir(path)]
+    if os.path.exists(path):
+        result['perm'] = os.stat(path).st_mode & 0777
     return result
 
 def hash_directory(path, dirs_and_files=None):

--- a/codalab/machines/remote_machine.py
+++ b/codalab/machines/remote_machine.py
@@ -159,14 +159,15 @@ class RemoteMachine(Machine):
                     resource_args += ' -m %s' % int(formatting.parse_size(bundle.metadata.request_memory))
                 # TODO: would constrain --cpuset=0, but difficult because don't know the CPU ids
 
-                f.write("docker run%s --rm --cidfile %s -u %s -v %s:/%s -v %s:/%s %s bash %s & wait $!\n" % (
+                f.write("docker run%s --rm --cidfile %s -u %s -v %s:/%s -v %s:/%s %s bash %s >%s/stdout 2>%s/stderr & wait $!\n" % (
                     resource_args,
                     ptr_container_file,
                     os.geteuid(),
                     ptr_temp_dir, docker_temp_dir,
                     ptr_internal_script_file, docker_internal_script_file,
                     docker_image,
-                    docker_internal_script_file))
+                    docker_internal_script_file,
+                    ptr_temp_dir, ptr_temp_dir))
 
             # 2) internal_script_file runs the actual command inside the docker container
             with open(internal_script_file, 'w') as f:
@@ -178,13 +179,13 @@ class RemoteMachine(Machine):
                 # Go into the temp directory
                 f.write("cd %s &&\n" % docker_temp_dir)
                 # Run the actual command
-                f.write('(%s) > stdout 2>stderr\n' % bundle.command)
+                f.write('(%s) >>stdout 2>>stderr\n' % bundle.command)
         else:
             # Just run the command regularly without docker
             with open(script_file, 'w') as f:
                 f.write(set_temp_dir_header)
                 f.write("cd %s &&\n" % ptr_temp_dir)
-                f.write('(%s) > stdout 2>stderr\n' % bundle.command)
+                f.write('(%s) >stdout 2>stderr\n' % bundle.command)
 
         # Determine resources to request
         resource_args = []


### PR DESCRIPTION
Don't follow them on cat, head, ls, or download.
Improve rendering of file listing.
