### PR TITLE
fix issue 94: non existent file directives

### DIFF
--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -1326,7 +1326,7 @@ class BundleCLI(object):
                         try:
                             self.print_target_info(client, data, decorate=True, maxlines=maxlines)
                         except UsageError, e:
-                            print 'ERROR:', e
+                            print 'MISSING'
                     else:
                         print data
             elif mode == 'record' or mode == 'table':


### PR DESCRIPTION
## How do I know the changes work:
### Manual-testing:

cl print now produces the following:

```
$ cl print
### Worksheet: local::codalab(0xc6ced1a2408f4f12b019eaf94e4b0b7b)
### Owner: codalab(0)
### Permissions: public(0x7b9b74):read
  uuid      name     description                                                          bundle_type  created              dependencies  command  data_size  state
  -----------------------------------------------------------------------------------------------------------------------------------------------------------------
  0xde87df  a.txt    Upload /home/pujun/Desktop/Development/codealab/codalab-cli/a.txt    dataset      2015-08-22 17:12:57                         12         ready
  0xf27b56  sort.py  Upload /home/pujun/Desktop/Development/codealab/codalab-cli/sort.py  program      2015-08-22 17:45:15                         66         ready

[Worksheet topological(0x9ed07c2cd708430c98b091ea7feda24c)]
MISSING
```

while trying to cat a non-existent file still produces the following error:

```
$ cl cat ab.txt
UsageError: bundle spec ab.txt doesn't match (want index 1 out of 0 bundles)

```
### Unit-tests

all passed

```
$ nosetests
 BundleStore.upload: moving test_root/temp/abloogywoogywu to test_root/data/0xdirectory-hash
.....................
----------------------------------------------------------------------
Ran 28 tests in 5.052s

OK
```
