### PR TITLE
issue #94 fix: non-existent file directives

### DIFF
--- a/codalab/client/local_bundle_client.py
+++ b/codalab/client/local_bundle_client.py
@@ -45,6 +45,7 @@ from codalab.model.tables import (
     GROUP_OBJECT_PERMISSION_READ,
 )
 
+from codalab.lib.formatting import contents_str
 
 def authentication_required(func):
     def decorate(self, *args, **kwargs):
@@ -808,7 +809,7 @@ class LocalBundleClient(BundleClient):
         target_cache = {}
         responses = []
         for (bundle_uuid, genpath, post) in requests:
-            value = worksheet_util.interpret_file_genpath(self, target_cache, bundle_uuid, genpath, post)
+            value = contents_str(worksheet_util.interpret_file_genpath(self, target_cache, bundle_uuid, genpath, post))
             #print 'interpret_file_genpaths', bundle_uuid, genpath, value
             responses.append(value)
         return responses

--- a/codalab/lib/formatting.py
+++ b/codalab/lib/formatting.py
@@ -5,6 +5,13 @@ Provides basic formatting utilities.
 import datetime
 import sys
 
+def contents_str(input_string):
+    '''
+    input_string: raw string (may be None)
+    Return 'MISSING' if input_string is None.
+    '''
+    return input_string if input_string is not None else 'MISSING'
+
 def size_str(size):
     '''
     size: number of bytes


### PR DESCRIPTION
### Testing
#### Manual-testing

The following worksheet was used for testing:

```
$ cl ls
### Worksheet: local::topological(0x9ed07c2cd708430c98b091ea7feda24c)
### Owner: codalab(0)
### Permissions: public(0x7b9b74):read
ref  uuid      name                          bundle_type  owner       created              data_size  state
-----------------------------------------------------------------------------------------------------------
 ^4  0x440cfb  graph-1.txt                   dataset      codalab(0)  2015-08-27 23:37:49        151  ready
 ^3  0x86e035  graph-2.txt                   dataset      codalab(0)  2015-08-27 23:38:11        161  ready
 ^2  0x440cfb  graph-1.txt                   dataset      codalab(0)  2015-08-27 23:37:49        151  ready
 ^1  0xa38178  topological-sort-run-graph-1  run          codalab(0)  2015-08-27 23:39:51       4.1K  ready
```
##### Testing cl cat

when a valid file is cat-ed, file contents are returned

```
$ cl cat topological-sort-run-graph-1/output
tree ---> coal ---> iron ---> logs ---> nails ---> table-top ---> table-legs ---> chairs ---> table
```

when an invalid file is cat-ed, error is raised

```
$ cl cat topological-sort-run-graph-1/output-1
UsageError: Target doesn't exist: 0xa3817866bf2c4aeeb5f516546270b105/output-1

```
##### Testing cl print

For testing 'cl pint' command, the following worksheet is used:

```
***display table directive***

% schema s1
% add stdout /output
% display table s1
[dataset graph-1.txt]{0x440cfb819ef5412d90bc6e482eef79f1}
[dataset graph-2.txt]{0x86e03564a45d40d6a802482f87e47256}

% display table s1
[run topological-sort-run-graph-1 -- :topological-sort.py,input:graph-1.txt : python topological-sort.py < input > output]{0xa3817866bf2c4aeeb5f516546270b105}


***display content directive***

% display contents /output
[dataset graph-1.txt]{0x440cfb819ef5412d90bc6e482eef79f1}

% display contents /output
[run topological-sort-run-graph-1 -- :topological-sort.py,input:graph-1.txt : python topological-sort.py < input > output]{0xa3817866bf2c4aeeb5f516546270b105}

```

Output of `cl print` command:

```
$ cl print
### Worksheet: local::topological(0x9ed07c2cd708430c98b091ea7feda24c)
### Owner: codalab(0)
### Permissions: public(0x7b9b74):read

***display table directive***

  stdout 
  -------
  MISSING
  MISSING

  stdout                                                                                             
  ---------------------------------------------------------------------------------------------------
  tree ---> coal ---> iron ---> logs ---> nails ---> table-top ---> table-legs ---> chairs ---> table

***display content directive***

MISSING

tree ---> coal ---> iron ---> logs ---> nails ---> table-top ---> table-legs ---> chairs ---> table
```

Now, when something non-existent is shown in a table format, 'MISSING' is shown.
The same is applicable for the `%display content /file` directive.
#### unit tests

all pass

```
$ nosetests
 BundleStore.upload: moving test_root/temp/abloogywoogywu to test_root/data/0xdirectory-hash
.....................
----------------------------------------------------------------------
Ran 28 tests in 4.667s

OK

```
