### PR TITLE
issue #95 if cannot connect to the server, keep on trying

### DIFF
--- a/codalab/client/remote_bundle_client.py
+++ b/codalab/client/remote_bundle_client.py
@@ -133,24 +133,31 @@ class RemoteBundleClient(BundleClient):
         self.proxy = xmlrpclib.ServerProxy(host, transport=transport, allow_none=True)
         def do_command(command):
             def inner(*args, **kwargs):
-                try:
-                    if self.verbose >= 2:
-                        print 'remote_bundle_client: %s %s %s' % (command, args, kwargs)
-                    return getattr(self.proxy, command)(*args, **kwargs)
-                except xmlrpclib.ProtocolError, e:
-                    raise UsageError("Could not authenticate on %s: %s" % (host, e))
-                except xmlrpclib.Fault, e:
-                    # Transform server-side UsageErrors into client-side UsageErrors.
-                    if 'codalab.common.UsageError' in e.faultString:
-                        index = e.faultString.find(':')
-                        raise UsageError(e.faultString[index + 1:])
-                    elif 'codalab.common.PermissionError' in e.faultString:
-                        index = e.faultString.find(':')
-                        raise PermissionError(e.faultString[index + 1:])
-                    else:
-                        raise
-                except socket.error, e:
-                    raise UsageError('Failed to connect to %s: %s' % (host, e))
+                import time
+                time_delay = 1
+                if self.verbose >= 2:
+                    print 'remote_bundle_client: %s %s %s' % (command, args, kwargs)
+                while True:
+                    try:
+                        return getattr(self.proxy, command)(*args, **kwargs)
+                    except xmlrpclib.ProtocolError, e:
+                        raise UsageError("Could not authenticate on %s: %s" % (host, e))
+                    except xmlrpclib.Fault, e:
+                        # Transform server-side UsageErrors into client-side UsageErrors.
+                        if 'codalab.common.UsageError' in e.faultString:
+                            index = e.faultString.find(':')
+                            raise UsageError(e.faultString[index + 1:])
+                        elif 'codalab.common.PermissionError' in e.faultString:
+                            index = e.faultString.find(':')
+                            raise PermissionError(e.faultString[index + 1:])
+                        else:
+                            raise
+                    except socket.error, e:
+                        print "Failed to connect to %s: %s. Trying to reconnect in %s seconds..." % (host, e, time_delay)
+                        time.sleep(time_delay)
+                        time_delay *= 2
+                        if time_delay > 512:
+                            raise UsageError('Failed to connect to %s: %s' % (host, e))
             return inner
         for command in self.COMMANDS:
             setattr(self, command, do_command(command))


### PR DESCRIPTION
### Testing
#### Manual-testing

Earlier, if could not connect to the server, a UsageError was thrown

```
$ cl work localhost::
UsageError: Failed to connect to http://localhost:2800: [Errno 111] Connection refused
```

Now, if cannot connect to the server, it keeps on trying to reconnect:

```
$ cl work localhost::
Failed to connect to http://localhost:2800: [Errno 111] Connection refused. Trying to reconnect in 1 seconds...
Failed to connect to http://localhost:2800: [Errno 111] Connection refused. Trying to reconnect in 2 seconds...
Failed to connect to http://localhost:2800: [Errno 111] Connection refused. Trying to reconnect in 4 seconds...
Failed to connect to http://localhost:2800: [Errno 111] Connection refused. Trying to reconnect in 8 seconds...

```

and if the connection is successfully established, then the loop breaks and normal execution continues to happen:

```
$ cl work localhost::
Failed to connect to http://localhost:2800: [Errno 111] Connection refused. Trying to reconnect in 1 seconds...
Failed to connect to http://localhost:2800: [Errno 111] Connection refused. Trying to reconnect in 2 seconds...
Switched to worksheet http://localhost:2800::codalab(0xc6ced1a2408f4f12b019eaf94e4b0b7b).

```
#### Unit-testing

```
$ nosetests
 BundleStore.upload: moving test_root/temp/abloogywoogywu to test_root/data/0xdirectory-hash
.....................
----------------------------------------------------------------------
Ran 28 tests in 4.110s


```
