### PR TITLE
codalab issue #1242 fix: return None when file not exist.

### DIFF
--- a/codalab/client/local_bundle_client.py
+++ b/codalab/client/local_bundle_client.py
@@ -843,7 +843,7 @@ class LocalBundleClient(BundleClient):
             elif mode == 'contents':
                 info = self.get_target_info(data, 1)
                 if 'type' not in info:
-                    pass
+                    data = None
                 elif info['type'] == 'file':
                     data = self.head_target(data, int(properties.get('maxlines', 10)))
             elif mode == 'html':


### PR DESCRIPTION
When the contents of a specific file are displayed (using % display contents directive) but the file does not exist, an internal 500 error is thrown. This happens because the local_bundle_file did not return a None when the file was not found, which crashes `map.decode` functionality.

This fix resolves that issue and the None is converted to 'MISSING' in the web-interface (bundles.py file) (see issue #1242 in Codalab repo)
#### Testing
##### Unit-tests

```
$ nosetests
 BundleStore.upload: moving test_root/temp/abloogywoogywu to test_root/data/0xdirectory-hash
.....................
----------------------------------------------------------------------
Ran 28 tests in 4.460s

OK

```
