### PR TITLE
record events in the database

### DIFF
--- a/codalab/client/local_bundle_client.py
+++ b/codalab/client/local_bundle_client.py
@@ -1076,3 +1076,6 @@ class LocalBundleClient(BundleClient):
             raise UsageError('Cannot modify the public group %s.' % group_spec)
 
         return group_info
+
+    def get_events_log_info(self, query_info, offset, limit):
+        return self.model.get_events_log_info(query_info, offset, limit)

--- a/codalab/model/tables.py
+++ b/codalab/model/tables.py
@@ -14,6 +14,8 @@ from sqlalchemy.types import (
   String,
   Text,
   Boolean,
+  DateTime,
+  Float,
 )
 
 db_metadata = MetaData()
@@ -168,3 +170,26 @@ group_object_permission = Table(
 GROUP_OBJECT_PERMISSION_NONE = 0x00
 GROUP_OBJECT_PERMISSION_READ = 0x01
 GROUP_OBJECT_PERMISSION_ALL = 0x02
+
+# Keep track of events that happen.
+event = Table(
+  'event',
+  db_metadata,
+  Column('id', Integer, primary_key=True, nullable=False),
+  Column('date', String(63), nullable=False),  # Deterministic function (e.g., 2015-09-11) of the start_time
+  Column('start_time', DateTime, nullable=False),  # When did this event start?
+  Column('end_time', DateTime, nullable=False),  # When did this event end?
+  Column('duration', Float, nullable=False),  # How much time did this event take?
+  Column('user_id', String(63), nullable=True),  # Who did it?
+  Column('user_name', String(63), nullable=True),  # Who did it?
+  Column('command', String(63), nullable=False),  # The command (gotten in bundle_rpc_server)
+  Column('args', Text, nullable=False),  # JSON string
+  Column('uuid', String(63), nullable=True),  # Either bundle or worksheet id (no ForeignKey because might not be in system anymore)
+  # Indices
+  Index('events_date_index', 'date'),
+  Index('events_user_id_index', 'user_id'),
+  Index('events_user_name_index', 'user_name'),
+  Index('events_command_index', 'command'),
+  Index('events_uuid_index', 'uuid'),
+  sqlite_autoincrement=True,
+)

--- a/codalab/objects/work_manager.py
+++ b/codalab/objects/work_manager.py
@@ -124,7 +124,9 @@ class Worker(object):
                     traceback.print_exc()
             else:  # MakeBundle
                 started = True
-            if started: print '-- START BUNDLE: %s' % (bundle,)
+            if started:
+                print '-- START BUNDLE: %s' % (bundle,)
+                self._update_events_log('start_bundle', bundle, (bundle.uuid,))
 
             # If we have a MakeBundle, then just process it immediately.
             if isinstance(bundle, MakeBundle):
@@ -284,6 +286,7 @@ class Worker(object):
             db_update['state'] = state
             print '-- END BUNDLE: %s [%s]' % (bundle, state)
             print ''
+            self._update_events_log('finalize_bundle', bundle, (bundle.uuid, state, metadata))
 
         # Update database!
         self.model.update_bundle(bundle, db_update)
@@ -388,3 +391,11 @@ class Worker(object):
             else:
                 # Advance counter only if something interesting happened
                 iteration += 1
+
+    def _update_events_log(self, command, bundle, args):
+      self.model.update_events_log(
+        user_id=bundle.owner_id,
+        user_name=None,  # Don't know
+        command=command,
+        args=args,
+        uuid=bundle.uuid)

--- a/test-cli.py
+++ b/test-cli.py
@@ -302,6 +302,16 @@ def test():
     run_command([cl, 'help'])
 add_test('status', test)
 
+def test():
+    run_command([cl, 'events'])
+    run_command([cl, 'events', '-n'])
+    run_command([cl, 'events', '-g', 'user'])
+    run_command([cl, 'events', '-g', 'user', '-n'])
+    run_command([cl, 'events', '-g', 'command'])
+    run_command([cl, 'events', '-o', '1', '-l', '2'])
+    run_command([cl, 'events', '-a', '%true%', '-n'])
+add_test('events', test)
+
 if len(sys.argv) == 1:
     print 'Usage: python %s <module> ... <module>' % sys.argv[0]
     print 'Note that this will modify your current worksheet, but should restore it.'


### PR DESCRIPTION
Adds a new database table to keep track of all the events in the system and support for basic queries.  For example:

```
cl events -n # number of events
cl events --uuid <...> # events involving the given uuid
```
