### PR TITLE
fix#1242 in cli

### DIFF
--- a/codalab/client/local_bundle_client.py
+++ b/codalab/client/local_bundle_client.py
@@ -837,7 +837,7 @@ class LocalBundleClient(BundleClient):
         target_cache = {}
         responses = []
         for (bundle_uuid, genpath, post) in requests:
-            value = contents_str(worksheet_util.interpret_file_genpath(self, target_cache, bundle_uuid, genpath, post))
+            value = worksheet_util.interpret_file_genpath(self, target_cache, bundle_uuid, genpath, post)
             #print 'interpret_file_genpaths', bundle_uuid, genpath, value
             responses.append(value)
         return responses

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -250,7 +250,7 @@ class BundleCLI(object):
                 cell = row_dict.get(col)
                 func = post_funcs.get(col)
                 if func: cell = worksheet_util.apply_func(func, cell)
-                if cell == None: cell = ''
+                if cell == None: cell = 'MISSING'
                 row.append(cell)
             rows.append(row)
 


### PR DESCRIPTION
If worksheet contains `% display contents output-1` directive that refers to a non-existent file or a column that refers to a non-existent file (using `add output-1 output-1`) , this fix will enable display 'MISSING' in worksheet cl print or cl info.  
