### PR TITLE
Refactor test-cli.py

### DIFF
--- a/test-cli.py
+++ b/test-cli.py
@@ -1,13 +1,4 @@
 #!/usr/bin/env python
-
-import subprocess
-import sys
-import re
-import os
-import shutil
-import random
-import time
-
 '''
 Tests all the CLI functionality end-to-end.
 
@@ -20,6 +11,16 @@ Things not tested:
 - Permissions
 - Worker system
 '''
+
+import subprocess
+import sys
+import re
+import os
+import shutil
+import random
+import time
+import traceback
+from collections import OrderedDict
 
 cl = 'cl'
 
@@ -60,32 +61,116 @@ def check_num_lines(true_value, pred_value):
     assert num_lines == true_value, "expected %d lines, but got %s" % (true_value, num_lines)
     return pred_value
 
-tests = []
-def add_test(name, func):
-    tests.append((name, func))
-def run_test(query_name):
-    failed = []
-    for name, func in tests:
-        if query_name == 'all' or query_name == name:
-            print '============= ' + name
-            try:
-                func()
-            except AssertionError as e:
-                print "ERROR: %s" % e.message
-                failed.append(name)
+class ModuleContext(object):
+    def __init__(self):
+        self.worksheets = []
+        self.bundles = []
+        self.error = None
 
-    if failed:
-        print "Tests failed: %s" % ', '.join(failed)
-    else:
-        print "All tests passed."
+    def __enter__(self):
+        print 'SWITCHING TO TEMPORARY WORKSHEET'
+        print
+
+        self.original_worksheet = run_command([cl, 'work', '-u'])
+        temp_worksheet = run_command([cl, 'new', random_name()])
+        self.worksheets.append(temp_worksheet)
+        run_command([cl, 'work', temp_worksheet])
+
+        print 'BEGIN TEST'
+        print
+
+        return self
+
+    def __exit__(self, exc_type, exc_value, tb):
+        if exc_type is not None:
+            self.error = (exc_type, exc_value, tb)
+            if exc_type is AssertionError:
+                print 'ERROR: %s' % exc_value.message
+            else:
+                print 'ERROR: Test raised an exception!'
+                traceback.print_exception(exc_type, exc_value, tb)
+        else:
+            print 'TEST PASSED'
+        print
+
+        # Clean up and restore original worksheet
+        print 'CLEANING UP'
+        print
+        run_command([cl, 'work', self.original_worksheet])
+        for worksheet in self.worksheets:
+            self.bundles.extend(run_command([cl, 'ls', worksheet, '-u']).split())
+            run_command([cl, 'wrm', '--force', worksheet])
+
+        for bundle in self.bundles:
+            run_command([cl, 'rm', '--force', bundle])
+
+        # Do not reraise exception
+        return True
+
+    def collect_worksheet(self, uuid):
+        self.worksheets.append(uuid)
+
+    def collect_bundle(self, uuid):
+        self.bundles.append(uuid)
+
+class TestModule(object):
+    modules = OrderedDict()
+
+    def __init__(self, name, func, description):
+        self.name = name
+        self.func = func
+        self.description = description
+
+    @classmethod
+    def register(cls, name):
+        def add_module(func):
+            cls.modules[name] = TestModule(name, func, func.__doc__)
+        return add_module
+
+    @classmethod
+    def run(cls, query):
+        modules_to_run = []
+        for name in query:
+            if name == 'all':
+                modules_to_run.extend(cls.modules.values())
+            elif name in cls.modules:
+                modules_to_run.append(cls.modules[name])
+            else:
+                print 'Could not find module %s' % name
+                print 'Modules: all ' + ' '.join(cls.modules.keys())
+                sys.exit(1)
+
+        print 'Running modules ' + ' '.join([m.name for m in modules_to_run])
+        print
+
+        failed = []
+        for module in modules_to_run:
+            print '============= BEGIN MODULE: ' + module.name
+            if module.description is not None:
+                print 'DESCRIPTION: ' + module.description
+            print
+
+            with ModuleContext() as ctx:
+                module.func(ctx)
+
+            if ctx.error:
+                failed.append(module.name)
+
+        print '============= SUMMARY'
+        if failed:
+            print 'Tests failed: %s' % ', '.join(failed)
+        else:
+            print 'All tests passed.'
 
 ############################################################
 
-def test():
+@TestModule.register('unittest')
+def test(ctx):
+    '''Run nose unit tests'''
     run_command(['venv/bin/nosetests'])
-add_test('unittest', test)
 
-def test():
+@TestModule.register('upload1')
+def test(ctx):
     # upload
     uuid = run_command([cl, 'upload', 'dataset', '/etc/hosts', '--description', 'hello', '--tags', 'a', 'b'])
     check_equals('hosts', get_info(uuid, 'name'))
@@ -110,9 +195,9 @@ def test():
     run_command([cl, 'rm', '--data-only', uuid])
     check_equals('None', get_info(uuid, 'data_hash'))
     run_command([cl, 'rm', uuid])
-add_test('upload1', test)
 
-def test():
+@TestModule.register('upload2')
+def test(ctx):
     # Upload two files
     uuid = run_command([cl, 'upload', 'program', '/etc/hosts', '/etc/group', '--description', 'hello'])
     check_contains('127.0.0.1', run_command([cl, 'cat', uuid + '/hosts']))
@@ -121,21 +206,21 @@ def test():
     check_equals('hello', get_info(uuid2, 'description'))
     # Cleanup
     run_command([cl, 'rm', uuid, uuid2])
-add_test('upload2', test)
 
-def test():
+@TestModule.register('upload3')
+def test(ctx):
     uuid = run_command([cl, 'upload', 'dataset', '-c', 'hello'])
     check_equals('hello', run_command([cl, 'cat', uuid]))
     run_command([cl, 'rm', uuid])
-add_test('upload3', test)
 
-def test():
+@TestModule.register('rm')
+def test(ctx):
     uuid = run_command([cl, 'upload', 'dataset', '/etc/hosts'])
     run_command([cl, 'cp', uuid, '.'])  # Duplicate
     run_command([cl, 'rm', uuid])  # Can delete even though it exists twice on the same worksheet
-add_test('rm', test)
 
-def test():
+@TestModule.register('make')
+def test(ctx):
     uuid1 = run_command([cl, 'upload', 'dataset', '/etc/hosts'])
     uuid2 = run_command([cl, 'upload', 'dataset', '/etc/group'])
     # make
@@ -152,9 +237,9 @@ def test():
     run_command([cl, 'rm', uuid1], 1)  # should fail
     run_command([cl, 'rm', '--force', uuid2])  # force the deletion
     run_command([cl, 'rm', '-r', uuid1])  # delete things downstream
-add_test('make', test)
 
-def test():
+@TestModule.register('run')
+def test(ctx):
     name = random_name()
     uuid = run_command([cl, 'run', 'echo hello', '-n', name])
     wait(uuid)
@@ -170,13 +255,13 @@ def test():
     uuid2 = check_contains('hello', run_command([cl, 'run', 'echo hello', '--tail'])).split('\n')[0]
     # cleanup
     run_command([cl, 'rm', uuid, uuid2])
-add_test('run', test)
 
-def test():
+@TestModule.register('worksheet')
+def test(ctx):
     wname = random_name()
     # Create new worksheet
-    orig_wuuid = run_command([cl, 'work', '-u'])
     wuuid = run_command([cl, 'new', wname])
+    ctx.collect_worksheet(wuuid)
     check_contains(['Switched', wname, wuuid], run_command([cl, 'work', wuuid]))
     # ls
     check_equals('', run_command([cl, 'ls', '-u']))
@@ -203,14 +288,13 @@ def test():
     run_command([cl, 'wedit', wuuid, '--file', '/dev/null'])  # wipe out worksheet
     # cleanup
     run_command([cl, 'rm', uuid])
-    run_command([cl, 'wrm', wuuid])
-    run_command([cl, 'work', orig_wuuid])
-add_test('worksheet', test)
 
-def test():
+@TestModule.register('freeze')
+def test(ctx):
     orig_wuuid = run_command([cl, 'work', '-u'])
     wname = random_name()
     wuuid = run_command([cl, 'new', wname])
+    ctx.collect_worksheet(wuuid)
     check_contains(['Switched', wname, wuuid], run_command([cl, 'work', wuuid]))
     # Before freezing: can modify everything
     uuid1 = run_command([cl, 'upload', 'dataset', '-c', 'hello'])
@@ -224,13 +308,9 @@ def test():
     run_command([cl, 'add', '-m', 'message'], 1)  # would add an item
     run_command([cl, 'wedit', '-t', 'new_title']) # can edit
     run_command([cl, 'wperm', wuuid, 'public', 'a']) # can edit
-    # cleanup
-    run_command([cl, 'wrm', '--force', wuuid])
-    run_command([cl, 'rm', uuid1])
-    run_command([cl, 'work', orig_wuuid])
-add_test('freeze', test)
 
-def test():
+@TestModule.register('copy')
+def test(ctx):
     uuid = run_command([cl, 'upload', 'dataset', '/etc/hosts', '/etc/group'])
     # download
     run_command([cl, 'download', uuid, '-o', uuid])
@@ -238,13 +318,15 @@ def test():
     shutil.rmtree(uuid)
     # cleanup
     run_command([cl, 'rm', uuid])
-add_test('copy', test)
 
-def test():
+@TestModule.register('detach')
+def test(ctx):
     uuid1 = run_command([cl, 'upload', 'dataset', '/etc/hosts'])
     uuid2 = run_command([cl, 'upload', 'dataset', '/etc/group'])
     run_command([cl, 'add', uuid1])
+    ctx.collect_bundle(uuid1)
     run_command([cl, 'add', uuid2])
+    ctx.collect_bundle(uuid2)
     # State after the above: 1 2 1 2
     run_command([cl, 'detach', uuid1], 1) # multiple indices
     run_command([cl, 'detach', uuid1, '-n', '3'], 1) # indes out of range
@@ -252,20 +334,18 @@ def test():
     check_equals(get_info('^', 'uuid'), uuid2)
     run_command([cl, 'detach', uuid2]) # State: 1 1
     check_equals(get_info('^', 'uuid'), uuid1)
-    # Cleanup
-    run_command([cl, 'rm', uuid1, uuid2])
-add_test('detach', test)
 
-def test():
+@TestModule.register('perm')
+def test(ctx):
     uuid = run_command([cl, 'upload', 'dataset', '/etc/hosts'])
     check_equals('all', run_command([cl, 'info', '-v', '-f', 'permission', uuid]))
     check_contains('none', run_command([cl, 'perm', uuid, 'public', 'n']))
     check_contains('read', run_command([cl, 'perm', uuid, 'public', 'r']))
     check_contains('all', run_command([cl, 'perm', uuid, 'public', 'a']))
     run_command([cl, 'rm', uuid])
-add_test('perm', test)
 
-def test():
+@TestModule.register('search')
+def test(ctx):
     name = random_name()
     uuid1 = run_command([cl, 'upload', 'dataset', '/etc/hosts', '-n', name])
     uuid2 = run_command([cl, 'upload', 'dataset', '/etc/group', '-n', name])
@@ -282,22 +362,17 @@ def test():
     size2 = float(run_command([cl, 'info', '-f', 'data_size', uuid2]))
     check_equals(size1 + size2, float(run_command([cl, 'search', 'name='+name, 'data_size=.sum'])))
     run_command([cl, 'rm', uuid1, uuid2])
-add_test('search', test)
 
-def test():
+@TestModule.register('kill')
+def test(ctx):
     uuid = run_command([cl, 'run', 'sleep 1000'])
     time.sleep(2)
     check_equals(uuid, run_command([cl, 'kill', uuid]))
     run_command([cl, 'wait', uuid], 1)
     run_command([cl, 'rm', uuid])
-add_test('kill', test)
 
-def test():
-    # Do everything on a new worksheet
-    wname = random_name()
-    old = run_command([cl, 'work', '-u'])
-    new = run_command([cl, 'new', wname])
-
+@TestModule.register('mimic')
+def test(ctx):
     name = random_name()
     def data_hash(uuid):
         run_command([cl, 'wait', uuid])
@@ -314,20 +389,14 @@ def test():
     check_equals(data_hash(uuid2), data_hash(uuid6))
     run_command([cl, 'rm', uuid1, uuid2, uuid3, uuid4, uuid5, uuid6])
 
-    # Cleanup
-    run_command([cl, 'wedit', new, '-f', '/dev/null'])
-    run_command([cl, 'wrm', new])
-    run_command([cl, 'work', old])
-
-add_test('mimic', test)
-
-def test():
+@TestModule.register('status')
+def test(ctx):
     run_command([cl, 'status'])
     run_command([cl, 'alias'])
     run_command([cl, 'help'])
-add_test('status', test)
 
-def test():
+@TestModule.register('events')
+def test(ctx):
     run_command([cl, 'events'])
     run_command([cl, 'events', '-n'])
     run_command([cl, 'events', '-g', 'user'])
@@ -335,19 +404,22 @@ def test():
     run_command([cl, 'events', '-g', 'command'])
     run_command([cl, 'events', '-o', '1', '-l', '2'])
     run_command([cl, 'events', '-a', '%true%', '-n'])
-add_test('events', test)
 
-def test():
+@TestModule.register('batch')
+def test(ctx):
+    '''Test batch resolution of bundle uuids'''
     wother = random_name()
     bnames = [random_name() for _ in range(2)]
-    buuids = []
 
-    # Create worksheets and bundles
-    run_command([cl, 'new', wother])
-    buuids.append(run_command([cl, 'upload', 'dataset', '/etc/hosts', '-n', bnames[0]]))
-    buuids.append(run_command([cl, 'upload', 'dataset', '/etc/hosts', '-n', bnames[1]]))
-    buuids.append(run_command([cl, 'upload', 'dataset', '/etc/hosts', '-n', bnames[0], '-w', wother]))
-    buuids.append(run_command([cl, 'upload', 'dataset', '/etc/hosts', '-n', bnames[1], '-w', wother]))
+    # Create worksheet and bundles
+    wuuid = run_command([cl, 'new', wother])
+    ctx.collect_worksheet(wuuid)
+    buuids = [
+        run_command([cl, 'upload', 'dataset', '/etc/hosts', '-n', bnames[0]]),
+        run_command([cl, 'upload', 'dataset', '/etc/hosts', '-n', bnames[1]]),
+        run_command([cl, 'upload', 'dataset', '/etc/hosts', '-n', bnames[0], '-w', wother]),
+        run_command([cl, 'upload', 'dataset', '/etc/hosts', '-n', bnames[1], '-w', wother])
+    ]
 
     # Test batch info call
     output = run_command([cl, 'info', '-f', 'uuid', bnames[0], bnames[1],
@@ -358,15 +430,10 @@ def test():
     output = run_command([cl, 'info', '-f', 'uuid', buuids[0], bnames[0], bnames[0], buuids[0]])
     check_equals('\n'.join([buuids[0]] * 4), output)
 
-    # Cleanup
-    run_command([cl, 'rm'] + buuids)
-    run_command([cl, 'wrm', '--force', wother])
-add_test('batch', test)
-
-if len(sys.argv) == 1:
-    print 'Usage: python %s <module> ... <module>' % sys.argv[0]
-    print 'Note that this will modify your current worksheet, but should restore it.'
-    print 'Modules: all ' + ' '.join(name for name, func in tests)
-else:
-    for name in sys.argv[1:]:
-        run_test(name)
+if __name__ == '__main__':
+    if len(sys.argv) == 1:
+        print 'Usage: python %s <module> ... <module>' % sys.argv[0]
+        print 'Note that this will modify your current worksheet, but should restore it.'
+        print 'Modules: all ' + ' '.join(TestModule.modules.keys())
+    else:
+        TestModule.run(sys.argv[1:])


### PR DESCRIPTION
In general trying to make writing new tests in test-cli.py cleaner and more robust. Figured this is a good investment as we put more work into the cli.
- Decorator for test functions
- All actions now done on temporary worksheets that are cleaned up
  automatically at the end of test modules
- If an exception is raised or an assertion fails during a test, all created resources are
  cleaned up before moving on to the next test, to avoid leaving workspace in an
  incomplete state
- Context manager for test modules to manage isolated test environments
  and handle exceptions
- Improved feedback for module selection

example output:
https://gist.github.com/kashizui/04d277c8afd8de2c5498

documentation to come
