### PR TITLE
Fix#126 displaying hyperlinks of bundles

### DIFF
--- a/codalab/client/local_bundle_client.py
+++ b/codalab/client/local_bundle_client.py
@@ -859,7 +859,7 @@ class LocalBundleClient(BundleClient):
             if mode == 'markup':
                 # no need to do anything
                 pass
-            elif mode== 'Parameters' or mode == 'record' or mode == 'table':
+            elif mode == 'record' or mode == 'table':
                 # header_name_posts is a list of (name, post-processing) pairs.
                 header, contents = data
                 # Request information
@@ -906,6 +906,7 @@ class LocalBundleClient(BundleClient):
                                         info[item['name']] = lines
 
             is_last_newline = is_newline
+
         return interpreted_items
 
     #############################################################################

--- a/codalab/client/local_bundle_client.py
+++ b/codalab/client/local_bundle_client.py
@@ -859,7 +859,7 @@ class LocalBundleClient(BundleClient):
             if mode == 'markup':
                 # no need to do anything
                 pass
-            elif mode == 'record' or mode == 'table':
+            elif mode== 'Parameters' or mode == 'record' or mode == 'table':
                 # header_name_posts is a list of (name, post-processing) pairs.
                 header, contents = data
                 # Request information
@@ -906,7 +906,6 @@ class LocalBundleClient(BundleClient):
                                         info[item['name']] = lines
 
             is_last_newline = is_newline
-
         return interpreted_items
 
     #############################################################################

--- a/codalab/client/local_bundle_client.py
+++ b/codalab/client/local_bundle_client.py
@@ -865,10 +865,6 @@ class LocalBundleClient(BundleClient):
                 # Request information
                 contents = worksheet_util.interpret_genpath_table_contents(self, contents)
                 data = (header, contents)
-            elif mode == 'inline':
-                if not (is_newline and is_last_newline):
-                    if isinstance(data, tuple) or isinstance(data, type):
-                        data = self.interpret_file_genpaths([data])[0]
             elif mode == 'contents':
                 info = self.get_target_info(data, 1)
                 if 'type' not in info:

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -1357,13 +1357,9 @@ class BundleCLI(object):
             data = item['interpreted']
             properties = item['properties']
             is_newline = (data == '')
-            if mode == 'link' or mode == 'inline' or mode == 'markup' or mode == 'contents':
+            if mode == 'markup' or mode == 'contents':
                 if not (is_newline and is_last_newline):
-                    if mode == 'inline':
-                        if isinstance(data, tuple):
-                            data = client.interpret_file_genpaths([data])[0]
-                        print '[' + str(data) + ']'
-                    elif mode == 'contents':
+                    if mode == 'contents':
                         maxlines = properties.get('maxlines')
                         if maxlines:
                             maxlines = int(maxlines)
@@ -1373,12 +1369,12 @@ class BundleCLI(object):
                             print 'ERROR:', e
                     else:
                         print data
-            elif mode == 'record' or mode == 'table':
+            elif mode == 'Parameters' or mode == 'record' or mode == 'table':
                 # header_name_posts is a list of (name, post-processing) pairs.
                 header, contents = data
                 contents = worksheet_util.interpret_genpath_table_contents(client, contents)
                 # Print the table
-                self.print_table(header, contents, show_header=(mode == 'table'), indent='  ')
+                self.print_table(header, contents, show_header=(mode == 'table' or mode == 'Parameters'), indent='  ')
             elif mode == 'html' or mode == 'image':
                 # Placeholder
                 print '[' + mode + ' ' + str(data) + ']'

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -815,16 +815,23 @@ class BundleCLI(object):
         return self.create_structured_info_map([('refs', reference_map),])
 
     def create_structured_info_map(self, structured_info_list):
+        '''
+        Return dict of info dicts (eg. bundle/worksheet reference_map) containing
+        information associated to bundles/worksheets. cl wls, ls, etc. show uuids
+        which are too short. This dict contains additional information that is
+        needed to recover URL on the client side.
+        '''
         return { k: v for k, v in structured_info_list}
 
-    def shorten_uuid(self, uuid):
-        return uuid[0:8]
-
     def create_reference_map(self, info_type, info_list):
+        '''
+        Return dict of dicts containing name, uuid and type for each bundle/worksheet
+        in the info_list. This information is needed to recover URL on the cient side.
+        '''
         if len(info_list) == 0:
             return None
         return {
-            self.shorten_uuid(info['uuid']) : {
+            worksheet_util.apply_func(self.UUID_POST_FUNC, info['uuid']) : {
                 'type': info_type,
                 'uuid': info['uuid'],
                 'name': info['metadata']['name'] if 'metadata' in info else info['name']

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -793,7 +793,7 @@ class BundleCLI(object):
         bundle_uuids = client.search_bundle_uuids(worksheet_uuid, args.keywords)
         if not isinstance(bundle_uuids, list):  # Direct result
             print bundle_uuids
-            return create_structured_info([('refs', None),])
+            return self.create_structured_info_map([('refs', None)])
 
         # Print out bundles
         bundle_infos = client.get_bundle_infos(bundle_uuids)
@@ -812,7 +812,7 @@ class BundleCLI(object):
                 client.add_worksheet_item(worksheet_uuid, worksheet_util.bundle_item(bundle_uuid))
             worksheet_info = client.get_worksheet_info(worksheet_uuid, False)
             print 'Added %d bundles to %s' % (len(bundle_uuids), self.worksheet_str(worksheet_info))
-        return self.create_structured_info_map([('refs', reference_map),])
+        return self.create_structured_info_map([('refs', reference_map)])
 
     def create_structured_info_map(self, structured_info_list):
         '''
@@ -821,7 +821,7 @@ class BundleCLI(object):
         which are too short. This dict contains additional information that is
         needed to recover URL on the client side.
         '''
-        return { k: v for k, v in structured_info_list}
+        return dict(structured_info_list)
 
     def create_reference_map(self, info_type, info_list):
         '''
@@ -829,7 +829,7 @@ class BundleCLI(object):
         in the info_list. This information is needed to recover URL on the cient side.
         '''
         if len(info_list) == 0:
-            return None
+            return {}
         return {
             worksheet_util.apply_func(self.UUID_POST_FUNC, info['uuid']) : {
                 'type': info_type,
@@ -851,7 +851,7 @@ class BundleCLI(object):
         if len(bundle_info_list) > 0:
             self.print_bundle_info_list(bundle_info_list, args.uuid_only, print_ref=True)
         reference_map = self.create_reference_map('bundle', bundle_info_list)
-        return self.create_structured_info_map([('refs', reference_map),])
+        return self.create_structured_info_map([('refs', reference_map)])
 
     def _worksheet_description(self, worksheet_info):
         return '### Worksheet: %s\n### Title: %s\n### Owner: %s(%s)\n### Permissions: %s%s' % \
@@ -1369,12 +1369,12 @@ class BundleCLI(object):
                             print 'ERROR:', e
                     else:
                         print data
-            elif mode == 'Parameters' or mode == 'record' or mode == 'table':
+            elif mode == 'record' or mode == 'table':
                 # header_name_posts is a list of (name, post-processing) pairs.
                 header, contents = data
                 contents = worksheet_util.interpret_genpath_table_contents(client, contents)
                 # Print the table
-                self.print_table(header, contents, show_header=(mode == 'table' or mode == 'Parameters'), indent='  ')
+                self.print_table(header, contents, show_header=(mode == 'table'), indent='  ')
             elif mode == 'html' or mode == 'image':
                 # Placeholder
                 print '[' + mode + ' ' + str(data) + ']'

--- a/codalab/lib/worksheet_util.py
+++ b/codalab/lib/worksheet_util.py
@@ -580,13 +580,13 @@ def interpret_items(schemas, items):
         elif mode == 'Parameters':
             rows = []
             schema = [(args[0], args[0], args[1] )]
-            header = tuple(name for (name, genpath, post) in schema)
+            header = ('text',)
             for bundle_info in bundle_infos:
                 if is_missing(bundle_info):
                     continue
 
                 # Result: either a string (rendered) or (bundle_uuid, genpath, properties) triple
-                rows.append({name: apply_func(post, interpret_genpath(bundle_info, genpath)) for (name, genpath, post) in schema})
+                rows.extend(apply_func(post, interpret_genpath(bundle_info, genpath)) for (_, genpath, post) in schema)
             new_items.append({
                     'mode': mode,
                     'interpreted': (header, rows),

--- a/codalab/lib/worksheet_util.py
+++ b/codalab/lib/worksheet_util.py
@@ -447,6 +447,11 @@ def apply_func(func, arg):
                     arg = arg[start:end]
                 else:
                     return '<invalid function: %s>' % f
+            elif f.startswith('add'):
+                k, v = f.split(' ')[1:]
+                arg[k] = v
+            elif f.startswith('key'):
+                arg = {f.split(' ')[1]: arg}
             else:
                 return '<invalid function: %s>' % f
         return arg
@@ -476,7 +481,7 @@ def interpret_items(schemas, items):
     schemas: initial mapping from name to list of schema items (columns of a table)
     items: list of worksheet items (triples) to interpret
     Return a list of interpreted items, where each item is either:
-    - ('markup'|'inline'|'contents'|'image'|'html', rendered string | (bundle_uuid, genpath, properties))
+    - ('markup'|'contents'|'image'|'html', rendered string | (bundle_uuid, genpath, properties))
     - ('record'|'table', (col1, ..., coln), [{col1:value1, ... coln:value2}, ...]),
       where value is either a rendered string or a (bundle_uuid, genpath, post) tuple
     - ('search', [keyword, ...])
@@ -509,17 +514,7 @@ def interpret_items(schemas, items):
         properties = {}
         if mode == 'hidden':
             pass
-        elif mode == 'link':
-            for bundle_info in bundle_infos:
-                if len(args) == 0:
-                    args = [bundle_info['metadata']['name']]
-                new_items.append({
-                    'mode': mode,
-                    'interpreted': '[%s](%s)' % (args[0], bundle_info['uuid']),
-                    'properties': properties,
-                    'bundle_info': copy.deepcopy(bundle_info)
-                })
-        elif mode == 'inline' or mode == 'contents' or mode == 'image' or mode == 'html':
+        elif mode == 'contents' or mode == 'image' or mode == 'html':
             for bundle_info in bundle_infos:
                 if is_missing(bundle_info):
                     continue
@@ -535,8 +530,6 @@ def interpret_items(schemas, items):
                     bundle_uuid, genpath = interpreted
                     if not is_file_genpath(genpath):
                         raise UsageError('Expected a file genpath, but got %s' % genpath)
-                    if mode == 'inline':
-                        interpreted = (bundle_uuid, genpath, None)
                     else:
                         # interpreted is a target: strip off the leading /
                         interpreted = (bundle_uuid, genpath[1:])
@@ -577,6 +570,22 @@ def interpret_items(schemas, items):
             for bundle_info in bundle_infos:
                 if 'metadata' not in bundle_info:
                     continue
+                rows.append({name: apply_func(post, interpret_genpath(bundle_info, genpath)) for (name, genpath, post) in schema})
+            new_items.append({
+                    'mode': mode,
+                    'interpreted': (header, rows),
+                    'properties': properties,
+                    'bundle_info': copy.deepcopy(bundle_infos)
+                })
+        elif mode == 'Parameters':
+            rows = []
+            schema = [(args[0], args[0], args[1] )]
+            header = tuple(name for (name, genpath, post) in schema)
+            for bundle_info in bundle_infos:
+                if is_missing(bundle_info):
+                    continue
+
+                # Result: either a string (rendered) or (bundle_uuid, genpath, properties) triple
                 rows.append({name: apply_func(post, interpret_genpath(bundle_info, genpath)) for (name, genpath, post) in schema})
             new_items.append({
                     'mode': mode,

--- a/codalab/lib/worksheet_util.py
+++ b/codalab/lib/worksheet_util.py
@@ -577,22 +577,6 @@ def interpret_items(schemas, items):
                     'properties': properties,
                     'bundle_info': copy.deepcopy(bundle_infos)
                 })
-        elif mode == 'Parameters':
-            rows = []
-            schema = [(args[0], args[0], args[1] )]
-            header = ('text',)
-            for bundle_info in bundle_infos:
-                if is_missing(bundle_info):
-                    continue
-
-                # Result: either a string (rendered) or (bundle_uuid, genpath, properties) triple
-                rows.extend(apply_func(post, interpret_genpath(bundle_info, genpath)) for (_, genpath, post) in schema)
-            new_items.append({
-                    'mode': mode,
-                    'interpreted': (header, rows),
-                    'properties': properties,
-                    'bundle_info': copy.deepcopy(bundle_infos)
-                })
         else:
             raise UsageError('Unknown display mode: %s' % mode)
         bundle_infos[:] = []  # Clear


### PR DESCRIPTION
This change enables showing hyperlinks:
for instance, using Parameters directive

```
% display Parameters uuid "key uuid | add text params | add path /output"
...bundles....
```

we can create a link to `/output` file in the bundle
### Testing

For testing, the following worksheet was used 

```
[dataset graph-1.txt]{0x618463edcbfc4d77b228d15a28b9cac1}
[dataset graph-2.txt]{0xea56ce648ef14b579e0c31fd20dce1c9}
[program topological-sort.py]{0x48dee814856648d8ab1498462e7d6127}
[run topological-sort-graph-1 -- sort.py:topological-sort.py,input:graph-1.txt : python sort.py < input > output]{0xdafcc128243d46fb8a7f76926148ed7a}
[run topological-sort-graph-2 -- sort.py:topological-sort.py,input:graph-2.txt : python sort.py < input > output]{0xf557919567db4b7494226faed6176935}

% display Parameters uuid "key uuid | add text params | add path /output"
[run topological-sort-graph-1 -- sort.py:topological-sort.py,input:graph-1.txt : python sort.py < input > output]{0xdafcc128243d46fb8a7f76926148ed7a}
[run topological-sort-graph-2 -- sort.py:topological-sort.py,input:graph-2.txt : python sort.py < input > output]{0xf557919567db4b7494226faed6176935}
```
#### Manual Testing

![image](https://cloud.githubusercontent.com/assets/5567951/10261036/431b364a-693a-11e5-91ca-474e97e57d20.png)
#### web-interface

 it looks like the following:
![image](https://cloud.githubusercontent.com/assets/5567951/10261045/7a103218-693a-11e5-9912-881d9391b6b1.png)
#### unit tests

All tests pass
#126

@percyliang  @kashizui please take a look
