### PR TITLE
fix #145 cl edit opens a editor when no additional args are supplied

### DIFF
--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -694,13 +694,16 @@ class BundleCLI(object):
 
         metadata = info['metadata']
         new_metadata = copy.deepcopy(metadata)
+        is_new_metadata_updated = False
         if args.name:
             new_metadata['name'] = args.name
+            is_new_metadata_updated = True
         if args.description:
             new_metadata['description'] = args.description
+            is_new_metadata_updated = True
 
         # Prompt user for all information
-        if not self.headless and metadata == new_metadata:
+        if not is_new_metadata_updated and not self.headless and metadata == new_metadata:
             new_metadata = metadata_util.request_missing_metadata(bundle_subclass, args, new_metadata)
 
         if metadata != new_metadata:

--- a/codalab/lib/metadata_util.py
+++ b/codalab/lib/metadata_util.py
@@ -82,7 +82,7 @@ def request_missing_metadata(bundle_subclass, args, initial_metadata=None):
 
     # If args.edit exists (when doing 'cl edit'), then we want to show
     # the editor.
-    if not getattr(args, 'edit', False):
+    if not getattr(args, 'edit', True):
         return initial_metadata
 
     # Construct a form template with the required keys, prefilled with the


### PR DESCRIPTION
#145

cl edit opens an editor when no additional args are supplied. Also added logic for handling the use case where the new and the old values are the same, the editor does not open

```
cl edit a.txt -n a.txt
```

now does not open the editor. 
![image](https://cloud.githubusercontent.com/assets/5567951/10273551/fc28e620-6ae6-11e5-9a8b-4db76204ce6c.png)

and when their are no arguments supplied:
![image](https://cloud.githubusercontent.com/assets/5567951/10273565/0f75dbde-6ae7-11e5-9086-812fad17a130.png)

@percyliang @kashizui please review.
