### PR TITLE
delete temporary bundles all at once and dedup

### DIFF
--- a/test-cli.py
+++ b/test-cli.py
@@ -116,8 +116,9 @@ class ModuleContext(object):
             self.bundles.extend(run_command([cl, 'ls', worksheet, '-u']).split())
             run_command([cl, 'wrm', '--force', worksheet])
 
-        for bundle in self.bundles:
-            run_command([cl, 'rm', '--force', bundle])
+        # Delete all bundles (dedup first)
+        if len(self.bundles) > 0:
+            run_command([cl, 'rm', '--force'] + list(set(self.bundles)))
 
         # Do not reraise exception
         return True


### PR DESCRIPTION
test-cli.py was failing on 'detach' because it was trying to delete a bundle more than once.  So this change dedups.  And just to streamline things, might as well delete all bundles at once.
@kashizui 
