### PR TITLE
stdout-error-sidebar

### DIFF
--- a/codalab/client/local_bundle_client.py
+++ b/codalab/client/local_bundle_client.py
@@ -895,24 +895,6 @@ class LocalBundleClient(BundleClient):
             # Assign the interpreted from the processed data
             item['interpreted'] = data
 
-            # We need to get check if this is a run and we can get the stdout and stderr
-            if 'bundle_info' in item:  # making sure this is a bundle, not markdown or something else
-                for info in item['bundle_info']:
-                    if isinstance(info, dict) and info.get('bundle_type', None) == 'run':
-                        target = (info['uuid'], '')
-                        target_info = self.get_target_info(target, 2)
-                        target_info['stdout'] = None
-                        target_info['stderr'] = None
-                        # If we have stdout or stderr, update it.
-                        contents = target_info.get('contents')
-                        if contents:
-                            for item in contents:
-                                if item['name'] in ['stdout', 'stderr']:
-                                    lines = self.head_target((info['uuid'], item['name']), 100)
-                                    if lines:
-                                        lines = ' '.join(lines)
-                                        info[item['name']] = lines
-
             is_last_newline = is_newline
 
         return interpreted_items

--- a/codalab/lib/worksheet_util.py
+++ b/codalab/lib/worksheet_util.py
@@ -397,6 +397,16 @@ def interpret_file_genpath(client, target_cache, bundle_uuid, genpath, post):
             if info == None: break
     return apply_func(post, info)
 
+def format_metadata(metadata):
+    '''
+    Format worksheet item metadata based on field type specified in the schema.
+    '''
+    if metadata:
+        unformatted_fields = [(name, func) for (_, name, func) in get_default_schemas()['default'] if func]
+        for (name, func) in unformatted_fields:
+            if metadata.get(name):
+                metadata[name] = apply_func(func, metadata[name])
+
 def canonicalize_schema_item(args):
     '''
     Users who type in schema items can specify a partial argument list.


### PR DESCRIPTION
Changes made for #1324 https://github.com/codalab/codalab/pull/1331 

Now, stdout and stderror info is not returned when retrieving the worksheet. Also the metadata that is returned is correctly formatted which enables the side-panel to correctly show the info in the first place. 
#### Testing

All unit tests pass
