### PR TITLE
Include missing bundles in relative bundle references

### DIFF
--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -848,13 +848,12 @@ class BundleCLI(object):
         Return dict of dicts containing name, uuid and type for each bundle/worksheet
         in the info_list. This information is needed to recover URL on the cient side.
         '''
-        if len(info_list) == 0:
-            return {}
         return {
             worksheet_util.apply_func(self.UUID_POST_FUNC, info['uuid']) : {
                 'type': info_type,
                 'uuid': info['uuid'],
-                'name': info['metadata']['name'] if 'metadata' in info else info['name']
+                # 'name': info['metadata']['name'] or info['name'] or None
+                'name': info.get('metadata', info).get('name', None)
             } for info in info_list
         }
 

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -852,7 +852,6 @@ class BundleCLI(object):
             worksheet_util.apply_func(self.UUID_POST_FUNC, info['uuid']) : {
                 'type': info_type,
                 'uuid': info['uuid'],
-                # 'name': info['metadata']['name'] or info['name'] or None
                 'name': info.get('metadata', info).get('name', None)
             } for info in info_list
         }

--- a/codalab/lib/canonicalize.py
+++ b/codalab/lib/canonicalize.py
@@ -64,7 +64,7 @@ def get_bundle_uuid(model, user_id, worksheet_uuid, bundle_spec):
         if bundle_spec:
             bundle_spec = bundle_spec.replace('.*', '%')  # Convert regular expression syntax to SQL syntax
             if '%' in bundle_spec:
-                bundle_spec_query = LikeQuery(bundle_spec) 
+                bundle_spec_query = LikeQuery(bundle_spec)
             else:
                 bundle_spec_query = bundle_spec
         else:

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -456,6 +456,7 @@ class BundleModel(object):
                 clause = true()
             if conditions['worksheet_uuid']:
                 # Select things on the given worksheet
+                # WARNING: Will also include invalid bundle ids that are listed on the worksheet
                 clause = and_(clause, self.make_clause(cl_worksheet_item.c.worksheet_uuid, conditions['worksheet_uuid']))
                 clause = and_(clause, cl_worksheet_item.c.bundle_uuid != None)
                 join = cl_worksheet_item.outerjoin(cl_bundle_metadata, cl_worksheet_item.c.bundle_uuid == cl_bundle_metadata.c.bundle_uuid)

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -457,8 +457,9 @@ class BundleModel(object):
             if conditions['worksheet_uuid']:
                 # Select things on the given worksheet
                 clause = and_(clause, self.make_clause(cl_worksheet_item.c.worksheet_uuid, conditions['worksheet_uuid']))
-                clause = and_(clause, cl_worksheet_item.c.bundle_uuid == cl_bundle_metadata.c.bundle_uuid)  # Join
-                query = select([cl_bundle_metadata.c.bundle_uuid, cl_worksheet_item.c.id]).distinct().where(clause)
+                clause = and_(clause, cl_worksheet_item.c.bundle_uuid != None)
+                join = cl_worksheet_item.outerjoin(cl_bundle_metadata, cl_worksheet_item.c.bundle_uuid == cl_bundle_metadata.c.bundle_uuid)
+                query = select([cl_worksheet_item.c.bundle_uuid, cl_worksheet_item.c.id]).select_from(join).distinct().where(clause)
                 query = query.order_by(cl_worksheet_item.c.id.desc()).limit(max_results)
             else:
                 if not conditions['name']:


### PR DESCRIPTION
Fixes #157 

New behavior:

```
$ cl ls
### Worksheet: local::codalab(0xeb8e04e347d249a2ab1ebeb13e886f7b)
### Title: None
### Owner: codalab(0)
### Permissions: public(0xf07253):read
ref  uuid      name            bundle_type  owner       created              data_size  state  
-----------------------------------------------------------------------------------------------
^11  0x559d52  hosts           dataset      codalab(0)  2015-09-30 12:04:44        214  ready  
^10  0x253272  test2           dataset      codalab(0)  2015-09-30 12:04:50        214  ready  
 ^9  0xcaa1be  group           dataset      codalab(0)  2015-09-30 12:04:56       2.3K  ready  
 ^8  0xe70bce  monitor.py      program      codalab(0)  2015-09-30 12:05:12       6.9K  ready  
 ^7  0xffd3c3  alembic.ini     dataset      codalab(0)  2015-09-30 12:06:03       1.1K  ready  
 ^6  0x128eb4  asl.conf        dataset      codalab(0)  2015-09-30 12:06:23        975  ready  
 ^5  0x55ef60  nanorc          dataset      codalab(0)  2015-09-30 12:07:04         11  ready  
 ^4  0x912fd4  rmtab           dataset      codalab(0)  2015-09-30 12:07:11          0  ready  
 ^3  0x8b3af1  run-echo-hello  run          codalab(0)  2015-10-10 08:49:21        142  ready  
 ^2  0x4561ca  Amazon.pdf      dataset      codalab(0)  2015-10-10 10:46:26       176K  ready  
 ^1  0x4561ca  MISSING         MISSING      MISSING                                     MISSING
```

```
$ cl info ^1
UsageError: Unable to retrieve information about bundle with uuid 0x4561ca0633b64e264ee7f47a07e84c04
```
