### PR TITLE
remove MISSING inconsistencies

### DIFF
--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -190,11 +190,11 @@ class BundleCLI(object):
             parser.formatter_class = mock_formatter_class
 
     def simple_bundle_str(self, info):
-        return '%s(%s)' % (info.get('metadata', {}).get('name', 'MISSING'), info['uuid'])
+        return '%s(%s)' % (contents_str(info.get('metadata', {}).get('name')), info['uuid'])
     def simple_worksheet_str(self, info):
-        return '%s(%s)' % (info.get('name', 'MISSING'), info['uuid'])
+        return '%s(%s)' % (contents_str(info.get('name')), info['uuid'])
     def simple_user_str(self, info):
-        return '%s(%s)' % (info.get('name', 'MISSING'), info['id'])
+        return '%s(%s)' % (contents_str(info.get('name')), info['id'])
 
     def get_worksheet_bundles(self, worksheet_info):
         '''
@@ -251,7 +251,7 @@ class BundleCLI(object):
                 cell = row_dict.get(col)
                 func = post_funcs.get(col)
                 if func: cell = worksheet_util.apply_func(func, cell)
-                if cell == None: cell = 'MISSING'
+                if cell == None: cell = contents_str(cell)
                 row.append(cell)
             rows.append(row)
 
@@ -972,7 +972,7 @@ class BundleCLI(object):
             lines.append(label + ':')
             for dep in deps:
                 child = dep['child_path']
-                parent = path_util.safe_join((dep['parent_name'] or 'MISSING') + '(' + dep['parent_uuid'] + ')', dep['parent_path'])
+                parent = path_util.safe_join(contents_str(dep['parent_name']) + '(' + dep['parent_uuid'] + ')', dep['parent_path'])
                 lines.append('  %s: %s' % (child, parent))
         if info['dependencies']:
             deps = info['dependencies']

--- a/codalab/lib/formatting.py
+++ b/codalab/lib/formatting.py
@@ -8,9 +8,9 @@ import sys
 def contents_str(input_string):
     '''
     input_string: raw string (may be None)
-    Return 'MISSING' if input_string is None.
+    Return '' if input_string is None.
     '''
-    return input_string if input_string is not None else 'MISSING'
+    return input_string if input_string is not None else ''
 
 def size_str(size):
     '''

--- a/codalab/lib/worksheet_util.py
+++ b/codalab/lib/worksheet_util.py
@@ -132,7 +132,7 @@ def get_worksheet_lines(worksheet_info):
             if 'metadata' not in bundle_info:
                 # This happens when we add bundles by uuid and don't actually make sure they exist
                 #lines.append('ERROR: non-existent bundle %s' % bundle_info['uuid'])
-                description = 'MISSING'
+                description = formatting.contents_str(None)
             else:
                 metadata = bundle_info['metadata']
                 description = bundle_info['bundle_type']
@@ -143,7 +143,7 @@ def get_worksheet_lines(worksheet_info):
                 if command: description += ' : ' + command
             lines.append(bundle_line(description, bundle_info['uuid']))
         elif item_type == TYPE_WORKSHEET:
-            lines.append(worksheet_line('worksheet ' + subworksheet_info.get('name', 'MISSING'), subworksheet_info['uuid']))
+            lines.append(worksheet_line('worksheet ' + formatting.contents_str(subworksheet_info.get('name')), subworksheet_info['uuid']))
         else:
             raise InternalError('Invalid worksheet item type: %s' % type)
     return lines
@@ -478,13 +478,13 @@ def apply_func(func, arg):
         # String encoding of a function: size s/a/b
         for f in func.split(FUNC_DELIM):
             if f == 'date':
-                arg = formatting.date_str(float(arg)) if arg != None else ''
+                arg = formatting.date_str(float(arg)) if arg != None else None
             elif f == 'duration':
-                arg = formatting.duration_str(float(arg)) if arg != None else ''
+                arg = formatting.duration_str(float(arg)) if arg != None else None
             elif f == 'size':
-                arg = formatting.size_str(float(arg)) if arg != None else ''
+                arg = formatting.size_str(float(arg)) if arg != None else None
             elif f.startswith('%'):
-                arg = (f % float(arg)) if arg != None else ''
+                arg = (f % float(arg)) if arg != None else None
             elif f.startswith('s/'):  # regular expression: s/<old string>/<new string>
                 esc_slash = '_ESC_SLASH_'  # Assume this doesn't occur in s
                 # Preserve escaped characters: \/


### PR DESCRIPTION
https://github.com/codalab/codalab/issues/1336: resolves MISSING inconsistencies

The following worksheet was used for testing:

```
// Editing worksheet testground(0x6ba83eb905bb41aa8ee172da96038d70).
// https://github.com/codalab/codalab/wiki/User_Worksheet-Markdown
//
% schema s2
% add mem1 memory
% add mem2 memory size
% add mem3 memory %d
% add mem4 memory s/0/z
% add mem5 memory "%s | s/0/z"
% add |
% display table s2
[run sort-run -- sort.py:topological-sort.py,input:graph-1.txt : python sort.py < input > output]{0x8a5a3466bc0a4e64b6495f15c235b66b}

```
#### Unit tests

all tests pass
###### all the columns now show MISSING (there are no inconsistencies)

![23](https://cloud.githubusercontent.com/assets/5567951/10799949/bdfe0fd6-7d6c-11e5-96f2-a2b7d7588875.png)
###### since now the MISSING word has been removed, all of these columns show empty

![24](https://cloud.githubusercontent.com/assets/5567951/10799948/bdfdbbb2-7d6c-11e5-89f8-f652e8f8a1ae.png)
###### The codebase no longer contains MISSING in various parts. If developer wants to change '' to something else, just go to formatting.contents_str() method and change the return value when the input_string is None. This ensures that the output is the same for all use-cases.

![25](https://cloud.githubusercontent.com/assets/5567951/10799946/bdf35b7c-7d6c-11e5-8caf-7f135c5b1223.png)
###### Also takes care of the cli side

![27](https://cloud.githubusercontent.com/assets/5567951/10800375/c39c1b98-7d6e-11e5-9b52-1886a5dcf453.png)

@percyliang @kashizui please review.
