### PR TITLE
renaming run bundles and home worksheets

### DIFF
--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -1421,13 +1421,12 @@ class BundleCLI(object):
         help='Create a new worksheet and add it to the current worksheet.',
         arguments=(
             Commands.Argument('name', help='name: ' + spec_util.NAME_REGEX.pattern),
-            Commands.Argument('-u', '--uuid', help='specify the uuid of worksheet (if really want this)'),
             Commands.Argument('-w', '--worksheet_spec', help='operate on this worksheet (%s)' % WORKSHEET_SPEC_FORMAT, completer=WorksheetsCompleter),
         ),
     )
     def do_new_command(self, args):
         client, worksheet_uuid = self.parse_client_worksheet_uuid(args.worksheet_spec)
-        uuid = client.new_worksheet(args.name, args.uuid)
+        uuid = client.new_worksheet(args.name)
         print uuid
 
     @Commands.command(

--- a/codalab/lib/spec_util.py
+++ b/codalab/lib/spec_util.py
@@ -62,6 +62,11 @@ def shorten_name(name, n=32):
     return name[0:n/2-1] + '..' + name[len(name)-n/2+1:]
 
 def create_default_name(bundle_type, raw_material):
+    '''
+    Takes a complicated raw_material like the run command and return something simple.
+    Example: 'java HelloWorld -n 3' => 'java'
+    '''
+    raw_material = raw_material.split(' ')[0]
     name = bundle_type + '-' + NOT_NAME_CHAR_REGEX.sub('-', raw_material)
     name = re.compile('\-+').sub('-', name)
     name = shorten_name(name)  # Shorten
@@ -69,3 +74,8 @@ def create_default_name(bundle_type, raw_material):
 
 def client_is_explicit(spec):
     return '::' in spec
+
+def home_worksheet(username):
+    return 'home-' + username
+def is_home_worksheet(name):
+    return name.startswith('home-')


### PR DESCRIPTION
- set default run bundle names to be more succinct (e.g., run-java)
- change home worksheet to home-<username>, enforce always reserved for the user

@kashizui please review
