### PR TITLE
Improve documentation and upload

### DIFF
--- a/codalab/bundles/named_bundle.py
+++ b/codalab/bundles/named_bundle.py
@@ -15,12 +15,12 @@ class NamedBundle(Bundle):
     NAME_LENGTH = 32
 
     METADATA_SPECS = (
-      MetadataSpec('name', basestring, 'short variable name (not necessarily unique); must conform to ' + spec_util.NAME_REGEX.pattern, short_key='n'),
-      MetadataSpec('description', basestring, 'full description of the bundle', short_key='d'),
-      MetadataSpec('tags', list, 'space-separated list of tags used for search (e.g., machine-learning)', metavar='TAG'),
-      MetadataSpec('created', int, 'time when this bundle was created', generated=True, formatting='date'),
-      MetadataSpec('data_size', int, 'size of this bundle (in bytes)', generated=True, formatting='size'),
-      MetadataSpec('failure_message', basestring, 'error message if bundle failed', generated=True),
+      MetadataSpec('name', basestring, 'Short variable name (not necessarily unique); must conform to %s.' % spec_util.NAME_REGEX.pattern, short_key='n'),
+      MetadataSpec('description', basestring, 'Full description of the bundle.', short_key='d'),
+      MetadataSpec('tags', list, 'Space-separated list of tags used for search (e.g., machine-learning).', metavar='TAG'),
+      MetadataSpec('created', int, 'Time when this bundle was created.', generated=True, formatting='date'),
+      MetadataSpec('data_size', int, 'Size of this bundle (in bytes).', generated=True, formatting='size'),
+      MetadataSpec('failure_message', basestring, 'Error message if this run bundle failed.', generated=True),
     )
 
     @classmethod

--- a/codalab/bundles/program_bundle.py
+++ b/codalab/bundles/program_bundle.py
@@ -7,9 +7,7 @@ When a RunBundle is constructed, its program_target must be in a ProgramBundle.
 from codalab.bundles.uploaded_bundle import UploadedBundle
 from codalab.objects.metadata_spec import MetadataSpec
 
-
+# This class will eventually be deprecated.
 class ProgramBundle(UploadedBundle):
     BUNDLE_TYPE = 'program'
     METADATA_SPECS = list(UploadedBundle.METADATA_SPECS)
-    METADATA_SPECS.append(MetadataSpec('architectures', list, 'viable architectures'))
-    METADATA_SPECS.append(MetadataSpec('language', list, 'which programming language was used'))

--- a/codalab/bundles/run_bundle.py
+++ b/codalab/bundles/run_bundle.py
@@ -29,30 +29,30 @@ class RunBundle(NamedBundle):
     METADATA_SPECS = list(NamedBundle.METADATA_SPECS)
     # Note that these are strings, which need to be parsed
     # Request a machine with this much resources and don't let run exceed these resources
-    METADATA_SPECS.append(MetadataSpec('request_docker_image', basestring, 'which docker container we wish to use'))
-    METADATA_SPECS.append(MetadataSpec('request_time', basestring, 'amount of time (e.g. 3, 3m, 3h, 3d) allowed for this run'))
-    METADATA_SPECS.append(MetadataSpec('request_memory', basestring, 'amount of memory (e.g., 3, 3k, 3m, 3g, 3t) allowed for this run'))
-    METADATA_SPECS.append(MetadataSpec('request_disk', basestring, 'amount of disk space (e.g. 3, 3k, 3m, 3g, 3t) allowed for this run'))
-    METADATA_SPECS.append(MetadataSpec('request_cpus', int, 'number of CPUs allowed for this run'))
-    METADATA_SPECS.append(MetadataSpec('request_gpus', int, 'number of GPUs allowed for this run'))
-    METADATA_SPECS.append(MetadataSpec('request_queue', basestring, 'submit job to this queue'))
-    METADATA_SPECS.append(MetadataSpec('request_priority', int, 'job priority (higher is more important)'))
+    METADATA_SPECS.append(MetadataSpec('request_docker_image', basestring, 'Which docker image (e.g., codalab/ubuntu:1.9) we wish to use.'))
+    METADATA_SPECS.append(MetadataSpec('request_time', basestring, 'Amount of time (e.g. 3, 3m, 3h, 3d) allowed for this run.'))
+    METADATA_SPECS.append(MetadataSpec('request_memory', basestring, 'Amount of memory (e.g., 3, 3k, 3m, 3g, 3t) allowed for this run.'))
+    METADATA_SPECS.append(MetadataSpec('request_disk', basestring, 'Amount of disk space (e.g. 3, 3k, 3m, 3g, 3t) allowed for this run.'))
+    METADATA_SPECS.append(MetadataSpec('request_cpus', int, 'Number of CPUs allowed for this run.'))
+    METADATA_SPECS.append(MetadataSpec('request_gpus', int, 'Number of GPUs allowed for this run.'))
+    METADATA_SPECS.append(MetadataSpec('request_queue', basestring, 'Submit run to this job queue.'))
+    METADATA_SPECS.append(MetadataSpec('request_priority', int, 'Job priority (higher is more important).'))
 
-    METADATA_SPECS.append(MetadataSpec('actions', list, 'actions performed on this run', generated=True))
+    METADATA_SPECS.append(MetadataSpec('actions', list, 'Actions (e.g., kill) that were performed on this run.', generated=True))
 
-    METADATA_SPECS.append(MetadataSpec('time', float, 'amount of time (seconds) used by this run (total)', generated=True, formatting='duration'))
-    METADATA_SPECS.append(MetadataSpec('time_user', float, 'amount of time (seconds) by user', generated=True, formatting='duration'))
-    METADATA_SPECS.append(MetadataSpec('time_system', float, 'amount of time (seconds) by the system', generated=True, formatting='duration'))
-    METADATA_SPECS.append(MetadataSpec('memory', float, 'amount of memory (bytes) used by this run', generated=True, formatting='size'))
-    METADATA_SPECS.append(MetadataSpec('disk_read', float, 'number of bytes read', generated=True, formatting='size'))
-    METADATA_SPECS.append(MetadataSpec('disk_write', float, 'number of bytes written', generated=True, formatting='size'))
+    METADATA_SPECS.append(MetadataSpec('time', float, 'Amount of time (seconds) used by this run (total).', generated=True, formatting='duration'))
+    METADATA_SPECS.append(MetadataSpec('time_user', float, 'Amount of time (seconds) by user.', generated=True, formatting='duration'))
+    METADATA_SPECS.append(MetadataSpec('time_system', float, 'Amount of time (seconds) by the system.', generated=True, formatting='duration'))
+    METADATA_SPECS.append(MetadataSpec('memory', float, 'Amount of memory (bytes) used by this run.', generated=True, formatting='size'))
+    METADATA_SPECS.append(MetadataSpec('disk_read', float, 'Number of bytes read.', generated=True, formatting='size'))
+    METADATA_SPECS.append(MetadataSpec('disk_write', float, 'Number of bytes written.', generated=True, formatting='size'))
 
     # Information about running
-    METADATA_SPECS.append(MetadataSpec('docker_image', basestring, 'which docker container was used to run the process', generated=True))
-    METADATA_SPECS.append(MetadataSpec('exitcode', int, 'exitcode of the process', generated=True))
-    METADATA_SPECS.append(MetadataSpec('job_handle', basestring, 'identifies the job handle (internal)', generated=True))
-    METADATA_SPECS.append(MetadataSpec('remote', basestring, 'where this job was run', generated=True))
-    METADATA_SPECS.append(MetadataSpec('temp_dir', basestring, 'temporary directory where job is running (internal)', generated=True))
+    METADATA_SPECS.append(MetadataSpec('docker_image', basestring, 'Which docker image was used to run the process.', generated=True))
+    METADATA_SPECS.append(MetadataSpec('exitcode', int, 'Exitcode of the process.', generated=True))
+    METADATA_SPECS.append(MetadataSpec('job_handle', basestring, 'Identifies the job handle (internal).', generated=True))
+    METADATA_SPECS.append(MetadataSpec('remote', basestring, 'Where this job is/was run (internal).', generated=True))
+    METADATA_SPECS.append(MetadataSpec('temp_dir', basestring, 'Temporary directory where job is/was running (internal)', generated=True))
 
     @classmethod
     def construct(cls, targets, command, metadata, owner_id, uuid=None, data_hash=None, state=State.CREATED):

--- a/codalab/bundles/uploaded_bundle.py
+++ b/codalab/bundles/uploaded_bundle.py
@@ -9,8 +9,8 @@ from codalab.objects.metadata_spec import MetadataSpec
 
 class UploadedBundle(NamedBundle):
     METADATA_SPECS = list(NamedBundle.METADATA_SPECS)
-    METADATA_SPECS.append(MetadataSpec('license', basestring, 'which license this program/data is released under'))
-    METADATA_SPECS.append(MetadataSpec('source_url', basestring, 'where this data came from'))
+    METADATA_SPECS.append(MetadataSpec('license', basestring, 'The license under which this program/dataset is released.'))
+    METADATA_SPECS.append(MetadataSpec('source_url', basestring, 'URL corresponding to the original source of this bundle.'))
 
     @classmethod
     def construct(cls, data_hash, metadata, owner_id, uuid=None):

--- a/codalab/lib/metadata_defaults.py
+++ b/codalab/lib/metadata_defaults.py
@@ -38,7 +38,7 @@ class MetadataDefaults(object):
             for path in args.path:
                 absolute_path = path_util.normalize(path)
                 items.append(os.path.basename(absolute_path))
-            return '-'.join(items)
+            return spec_util.create_default_name(None, '-'.join(items))
         elif bundle_subclass is MakeBundle:
             if len(args.target_spec) == 1 and ':' not in args.target_spec[0]:  # direct link
                 return os.path.basename(args.target_spec[0])

--- a/codalab/lib/spec_util.py
+++ b/codalab/lib/spec_util.py
@@ -12,6 +12,7 @@ from codalab.common import (
 UUID_REGEX = re.compile('^0x[0-9a-f]{32}$')
 UUID_PREFIX_REGEX = re.compile('^0x[0-9a-f]{1,31}$')
 
+BEGIN_NAME_STR = '[a-zA-Z_]'
 NAME_STR = '[a-zA-Z_][a-zA-Z0-9_\.\-]*'
 NAME_PATTERN_STR = '[%\*a-zA-Z0-9_\.\-]+'  # Allow % for matching wildcard (SQL syntax), and * (regular expressions)
 
@@ -66,9 +67,12 @@ def create_default_name(bundle_type, raw_material):
     Takes a complicated raw_material like the run command and return something simple.
     Example: 'java HelloWorld -n 3' => 'java'
     '''
-    raw_material = raw_material.split(' ')[0]
-    name = bundle_type + '-' + NOT_NAME_CHAR_REGEX.sub('-', raw_material)
-    name = re.compile('\-+').sub('-', name)
+    if bundle_type == 'run':
+        raw_material = raw_material.split(' ')[0]
+    name = (bundle_type + '-' if bundle_type else '') + NOT_NAME_CHAR_REGEX.sub('-', raw_material)
+    name = re.compile('\-+').sub('-', name)  # Collapse '---' => '-'
+    if not re.match(BEGIN_NAME_STR, name):
+        name = '_' + name
     name = shorten_name(name)  # Shorten
     return name
 

--- a/codalab/lib/worksheet_util.py
+++ b/codalab/lib/worksheet_util.py
@@ -124,13 +124,7 @@ def get_worksheet_lines(worksheet_info):
     '''
     Generator that returns pretty-printed lines of text for the given worksheet.
     '''
-    header = '''
-// Editing worksheet %s(%s).
-// https://github.com/codalab/codalab/wiki/User_Worksheet-Markdown
-//
-    '''.strip() % (worksheet_info['name'], worksheet_info['uuid'],)
-    lines = header.split('\n')
-
+    lines = []
     for (bundle_info, subworksheet_info, value_obj, item_type) in worksheet_info['items']:
         if item_type == TYPE_MARKUP:
             lines.append(value_obj)


### PR DESCRIPTION
- Change 'cl upload dataset/program file' to 'cl upload file'
- Change 'cl ls worksheet' to 'cl ls -w worksheet'
- Add 'cl help -v' to show all help
- Added documentation for commands and made it more consistent
- When uploading bundle with weird name, gets sanitized to default name instead of throwing an error
- Fix quoting bug in copying files
  @kashizui please review
