### PR TITLE
Render placeholders for invalid bundle references

### DIFF
--- a/codalab/lib/worksheet_util.py
+++ b/codalab/lib/worksheet_util.py
@@ -637,15 +637,17 @@ def interpret_items(schemas, items):
             schema = get_schema(args)
             header = tuple(name for (name, genpath, post) in schema)
             rows = []
+            valid_bundle_infos = []
             for bundle_info in bundle_infos:
                 if 'metadata' not in bundle_info:
                     continue
                 rows.append({name: apply_func(post, interpret_genpath(bundle_info, genpath)) for (name, genpath, post) in schema})
+                valid_bundle_infos.append(copy.deepcopy(bundle_info))
             new_items.append({
                     'mode': mode,
                     'interpreted': (header, rows),
                     'properties': properties,
-                    'bundle_info': copy.deepcopy(bundle_infos)
+                    'bundle_info': valid_bundle_infos
                 })
         else:
             raise UsageError('Unknown display mode: %s' % mode)

--- a/codalab/lib/worksheet_util.py
+++ b/codalab/lib/worksheet_util.py
@@ -637,17 +637,30 @@ def interpret_items(schemas, items):
             schema = get_schema(args)
             header = tuple(name for (name, genpath, post) in schema)
             rows = []
-            valid_bundle_infos = []
+            processed_bundle_infos = []
             for bundle_info in bundle_infos:
-                if 'metadata' not in bundle_info:
-                    continue
-                rows.append({name: apply_func(post, interpret_genpath(bundle_info, genpath)) for (name, genpath, post) in schema})
-                valid_bundle_infos.append(copy.deepcopy(bundle_info))
+                if 'metadata' in bundle_info:
+                    rows.append({
+                        name: apply_func(post, interpret_genpath(bundle_info, genpath))
+                        for (name, genpath, post) in schema
+                    })
+                    processed_bundle_infos.append(copy.deepcopy(bundle_info))
+                else:
+                    rows.append({
+                        name: '?'
+                        for (name, genpath, post) in schema
+                    })
+                    # The front-end relies on the name metadata field existing
+                    processed_bundle_info = copy.deepcopy(bundle_info)
+                    processed_bundle_info['metadata'] = {
+                        'name': '?'
+                    }
+                    processed_bundle_infos.append(processed_bundle_info)
             new_items.append({
                     'mode': mode,
                     'interpreted': (header, rows),
                     'properties': properties,
-                    'bundle_info': valid_bundle_infos
+                    'bundle_info': processed_bundle_infos
                 })
         else:
             raise UsageError('Unknown display mode: %s' % mode)


### PR DESCRIPTION
Fixes #214 

Invalid bundle references no longer crash the site, and are not rendered on the page, matching the current behavior of `cl print`.

@percyliang @pbhatnagar3 
