### PR TITLE
Make AuthHandler data thread-local

### DIFF
--- a/codalab/client/local_bundle_client.py
+++ b/codalab/client/local_bundle_client.py
@@ -49,12 +49,15 @@ from codalab.model.tables import (
 
 from codalab.lib.formatting import contents_str
 
+
 def authentication_required(func):
-    def decorate(self, *args, **kwargs):
+    def decorated(self, *args, **kwargs):
         if self.auth_handler.current_user() is None:
             raise AuthorizationError("Not authenticated")
         return func(self, *args, **kwargs)
-    return decorate
+
+    return decorated
+
 
 class LocalBundleClient(BundleClient):
     def __init__(self, address, bundle_store, model, auth_handler, verbose):
@@ -66,9 +69,11 @@ class LocalBundleClient(BundleClient):
 
     def _current_user(self):
         return self.auth_handler.current_user()
+
     def _current_user_id(self):
         user = self._current_user()
         return user.unique_id if user else None
+
     def _current_user_name(self):
         user = self._current_user()
         return user.name if user else None

--- a/codalab/client/remote_bundle_client.py
+++ b/codalab/client/remote_bundle_client.py
@@ -10,7 +10,6 @@ import urllib
 import tempfile
 import xmlrpclib
 import socket
-xmlrpclib.Marshaller.dispatch[int] = lambda _, v, w : w("<value><i8>%d</i8></value>" % v)  # Hack to allow 64-bit integers
 
 from codalab.client import get_address_host
 from codalab.client.bundle_client import BundleClient
@@ -24,6 +23,10 @@ from codalab.lib import (
   zip_util,
 )
 from codalab.server.rpc_file_handle import RPCFileHandle
+
+# Hack to allow 64-bit integers
+xmlrpclib.Marshaller.dispatch[int] = lambda _, v, w : w("<value><i8>%d</i8></value>" % v)
+
 
 class AuthenticatedTransport(xmlrpclib.SafeTransport):
     '''

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -372,7 +372,7 @@ class BundleCLI(object):
 
     def __init__(self, manager, headless=False):
         self.manager = manager
-        self.verbose = manager.cli_verbose()
+        self.verbose = manager.cli_verbose
         self.headless = headless
 
     def exit(self, message, error_code=1):

--- a/codalab/lib/codalab_manager.py
+++ b/codalab/lib/codalab_manager.py
@@ -373,6 +373,7 @@ class CodaLabManager(object):
 
     def root_user_name(self):
         return self.config['server'].get('root_user_name', 'codalab')
+
     def root_user_id(self):
         return self.config['server'].get('root_user_id', '0')
 
@@ -391,7 +392,7 @@ class CodaLabManager(object):
         '''
         if address in self.clients:
             return self.clients[address]
-        # if local force mockauth or if locl server use correct auth
+        # if local force mockauth or if local server use correct auth
         if is_local_address(address):
             bundle_store = self.bundle_store()
             model = self.model()
@@ -406,12 +407,14 @@ class CodaLabManager(object):
                 auth_handler.validate_token(access_token)
         else:
             from codalab.client.remote_bundle_client import RemoteBundleClient
-            client = RemoteBundleClient(address, lambda a_client: self._authenticate(a_client), self.cli_verbose())
+            client = RemoteBundleClient(address, lambda a_client: self._authenticate(a_client), self.cli_verbose)
             self.clients[address] = client
             self._authenticate(client)
         return client
 
-    def cli_verbose(self): return self.config.get('cli', {}).get('verbose')
+    @property
+    def cli_verbose(self):
+        return self.config.get('cli', {}).get('verbose')
 
     def _authenticate(self, client):
         '''

--- a/codalab/server/auth.py
+++ b/codalab/server/auth.py
@@ -2,6 +2,7 @@
 AuthHandler encapsulates the logic to authenticate users on the server-side.
 '''
 import json
+import threading
 import time
 import urllib
 import urllib2
@@ -74,7 +75,7 @@ class MockAuthHandler(object):
         return self._user
 
 
-class OAuthHandler(object):
+class OAuthHandler(threading.local):
     '''
     Handles user authentication with an OAuth authorization server.
     '''

--- a/codalab/server/auth.py
+++ b/codalab/server/auth.py
@@ -78,6 +78,11 @@ class MockAuthHandler(object):
 class OAuthHandler(threading.local):
     '''
     Handles user authentication with an OAuth authorization server.
+
+    Inherits from threading.local, which makes all instance attributes thread-local.
+    When an OAuthHandler instance is used from a new thread, __init__ will be called
+    again, and all attributes may be different between threads.
+    https://hg.python.org/cpython/file/2.7/Lib/_threading_local.py
     '''
     def __init__(self, address, app_id, app_key):
         '''

--- a/codalab/server/auth.py
+++ b/codalab/server/auth.py
@@ -81,7 +81,7 @@ class OAuthHandler(threading.local):
 
     Inherits from threading.local, which makes all instance attributes thread-local.
     When an OAuthHandler instance is used from a new thread, __init__ will be called
-    again, and all attributes may be different between threads.
+    again, and from thereon all attributes may be different between threads.
     https://hg.python.org/cpython/file/2.7/Lib/_threading_local.py
     '''
     def __init__(self, address, app_id, app_key):

--- a/codalab/server/bundle_rpc_server.py
+++ b/codalab/server/bundle_rpc_server.py
@@ -17,24 +17,25 @@ import tempfile
 import traceback
 import os
 import time
-import datetime
 
 from codalab.common import (
     precondition,
     UsageError,
     PermissionError,
 )
+from codalab.client.local_bundle_client import LocalBundleClient
 from codalab.client.remote_bundle_client import RemoteBundleClient
 from codalab.lib import zip_util, path_util
 from codalab.server.file_server import FileServer
+
 
 class BundleRPCServer(FileServer):
     def __init__(self, manager):
         self.host = manager.config['server']['host']
         self.port = manager.config['server']['port']
         self.verbose = manager.config['server']['verbose']
-        # This server is backed by a LocalBundleClient that processes client commands
-        self.client = manager.client('local', is_cli=False)
+        self.bundle_store = manager.bundle_store()
+        self.model = manager.model()
 
         # args might be a large object; summarize it (e.g., take prefixes of lists)
         def compress_args(args):
@@ -53,25 +54,43 @@ class BundleRPCServer(FileServer):
             return args
 
         tempdir = tempfile.gettempdir()  # Consider using CodaLab's temp directory
-        FileServer.__init__(self, (self.host, self.port), tempdir, manager.auth_handler())
-        def wrap(command, func):
-            def inner(*args, **kwargs):
-                if command == 'login':
+        FileServer.__init__(self, (self.host, self.port), tempdir, manager)
+
+        def wrap(target_type, method_name):
+            def function_to_register(*args, **kwargs):
+                client = self._get_local_client()
+
+                # Select the recipient object of the method call
+                if target_type == 'client':
+                    target = client
+                elif target_type == 'server':
+                    target = self
+                else:
+                    raise RuntimeError("Invalid target_type %s" % target_type)
+
+                # Process args for logging
+                if method_name == 'login':
                     log_args = args[:2]  # Don't log password
                 else:
                     log_args = compress_args(args)
+
                 if self.verbose >= 1:
-                    print "bundle_rpc_server: %s %s" % (command, log_args)
+                    print "bundle_rpc_server: %s %s" % (method_name, log_args)
+
                 try:
                     start_time = time.time()
-                    result = func(*args, **kwargs)
+
+                    # Dynamically get the bound method and call it
+                    result = getattr(target, method_name)(*args, **kwargs)
+
                     # Log this activity.
-                    self.client.model.update_events_log(
+                    client.model.update_events_log(
                         start_time=start_time,
-                        user_id=self.client._current_user_id(),
-                        user_name=self.client._current_user_name(),
-                        command=command,
+                        user_id=client._current_user_id(),
+                        user_name=client._current_user_name(),
+                        command=method_name,
                         args=log_args)
+
                     return result
                 except Exception, e:
                     if not (isinstance(e, UsageError) or isinstance(e, PermissionError)):
@@ -80,11 +99,22 @@ class BundleRPCServer(FileServer):
                         print '=== INTERNAL ERROR:', e
                         traceback.print_exc()
                     raise e
-            return inner
+
+            return function_to_register
+
         for command in RemoteBundleClient.CLIENT_COMMANDS:
-            self.register_function(wrap(command, getattr(self.client, command)), command)
+            self.register_function(wrap('client', command), command)
+
         for command in RemoteBundleClient.SERVER_COMMANDS:
-            self.register_function(wrap(command, getattr(self, command)), command)
+            self.register_function(wrap('server', command), command)
+
+    def _get_local_client(self):
+        """
+        Create and return a new instance LocalBundleClient with a thread-local AuthHandler instance.
+
+        :return: a LocalBundleClient instance
+        """
+        return LocalBundleClient('local', self.bundle_store, self.model, self.auth_handler, self.verbose)
 
     def upload_bundle_zip(self, file_uuid, construct_args, worksheet_uuid, follow_symlinks, add_to_worksheet):
         '''


### PR DESCRIPTION
and activate multithreading
- Handle each request on BundleRPCServer with new LocalBundleClient instance
- Each new LocalBundleClient instance is given a thread-local
  AuthHandler instance

Fixes codalab/codalab#1356
