### PR TITLE
Handle unicode properly

### DIFF
--- a/codalab/lib/formatting.py
+++ b/codalab/lib/formatting.py
@@ -27,10 +27,13 @@ def verbose_contents_str(input_string):
     """
     if input_string is None:
         return '<none>'
+
     try:
-        return input_string.encode('utf-8')
+        input_string.decode('utf-8')
     except UnicodeDecodeError:
         return '<binary>'
+
+    return input_string
 
 
 def size_str(size):

--- a/codalab/lib/path_util.py
+++ b/codalab/lib/path_util.py
@@ -254,7 +254,7 @@ def read_lines(path, max_num_lines=None, max_total_bytes=None):
 
     with open(path, 'rb') as file_handle:
         if max_total_bytes is None:
-            lines = (line for line in file_handle)
+            lines = file_handle.__iter__()
         else:
             lines = truncated_read_lines(file_handle, max_total_bytes)
 


### PR DESCRIPTION
I can now print Chinese characters, while hiding binary content (as in a PDF or executable).

I misunderstood slightly how Unicode worked the first time around, sorry about that!

@percyliang please review
