### PR TITLE
Downgrade line mapping assertion to warning

### DIFF
--- a/codalab/lib/worksheet_util.py
+++ b/codalab/lib/worksheet_util.py
@@ -29,6 +29,7 @@ See get_worksheet_lines for documentation on the specification of the directives
 import copy
 import os
 import re
+import sys
 import types
 import yaml
 import json
@@ -938,8 +939,10 @@ def interpret_items(schemas, raw_items):
         finally:
             last_was_empty_line = new_last_was_empty_line
 
+    if len(raw_to_interpreted) != len(raw_items):
+        print >>sys.stderr, "WARNING: Length of raw_to_interpreted does not match length of raw_items"
+
     # Package the result
-    assert len(raw_to_interpreted) == len(raw_items)
     interpreted_to_raw = {}
     next_interpreted_index = None
     # Go in reverse order so we can assign raw items that map to None to the next interpreted item

--- a/codalab/lib/worksheet_util.py
+++ b/codalab/lib/worksheet_util.py
@@ -939,6 +939,7 @@ def interpret_items(schemas, raw_items):
         finally:
             last_was_empty_line = new_last_was_empty_line
 
+    # TODO: fix inconsistencies resulting from UsageErrors thrown in flush_bundles()
     if len(raw_to_interpreted) != len(raw_items):
         print >>sys.stderr, "WARNING: Length of raw_to_interpreted does not match length of raw_items"
 


### PR DESCRIPTION
This fixes the unrecoverable error when worksheet has something like `% display bad`.

In this case, the line mapping still works regardless, but it may cause some inconsistent mappings in the frontend editor in the future if the worksheet contains a lot of errors. I'm claiming that this isn't too bad a problem to have until we can have more time to clean up the worksheet interpretation, since jumping to the wrong line with a bad worksheet isn't life or death.

@percyliang @pbhatnagar3 please review
