### PR TITLE
Change argument order for tar archiving

### DIFF
--- a/codalab/lib/zip_util.py
+++ b/codalab/lib/zip_util.py
@@ -56,12 +56,13 @@ def open_packed_path(source, follow_symlinks, exclude_patterns):
     """
     if path_is_archive(source):
         return open(source)
-    args = ['tar', 'cfz', '-', '-C', os.path.dirname(source) or '.', os.path.basename(source)]
+    args = ['tar', 'cfz', '-', '-C', os.path.dirname(source) or '.']
     if follow_symlinks:
         args.append('-h')
     if exclude_patterns is not None:
         for pattern in exclude_patterns:
             args.append('--exclude=' + pattern)
+    args.append(os.path.basename(source))
     proc = subprocess.Popen(args, stdout=subprocess.PIPE)
     return proc.stdout
 


### PR DESCRIPTION
Options must be specified before the source file. This should allow the --exclude options to be processed correctly.
