### PR TITLE
Change argument order for tar archiving

### DIFF
--- a/codalab/lib/zip_util.py
+++ b/codalab/lib/zip_util.py
@@ -56,12 +56,13 @@ def open_packed_path(source, follow_symlinks, exclude_patterns):
     """
     if path_is_archive(source):
         return open(source)
-    args = ['tar', 'cfz', '-', '-C', os.path.dirname(source) or '.', os.path.basename(source)]
+    args = ['tar', 'cfz', '-', '-C', os.path.dirname(source) or '.']
     if follow_symlinks:
         args.append('-h')
     if exclude_patterns is not None:
         for pattern in exclude_patterns:
             args.append('--exclude=' + pattern)
+    args.append(os.path.basename(source))
     proc = subprocess.Popen(args, stdout=subprocess.PIPE)
     return proc.stdout
 

--- a/codalab/lib/zip_util.py
+++ b/codalab/lib/zip_util.py
@@ -9,6 +9,7 @@ file/directory.  In other words, zip files represent unnamed file/directories.
 To zip/unzip, we use the standard temp files.
 """
 import os
+import re
 import shutil
 import sys
 import subprocess
@@ -20,9 +21,19 @@ from codalab.lib import path_util, print_util, file_util
 # Files with these extensions are considered archive.
 ARCHIVE_EXTS = ['.tar.gz', '.tgz', '.tar.bz2', '.zip']
 
-# When deciding whether an archive contains a single file/directory, ignore
-# these contents.
-IGNORE_FILES = ['.DS_Store', '__MACOSX']
+# When deciding whether an archive contains a single file/directory...
+
+# ... ignore files that match any of these exactly
+IGNORE_FILE_EXACT = ['.DS_Store', '__MACOSX']
+# ... ignore files that match any of these patterns
+IGNORE_FILE_PATTERNS = [re.compile(s) for s in ['^\._.*']]
+
+
+def ignore_file(filename):
+    if filename in IGNORE_FILE_EXACT:
+        return True
+    return any([pattern.match(filename) for pattern in IGNORE_FILE_PATTERNS])
+
 
 def path_is_archive(path):
     if isinstance(path, basestring):
@@ -98,7 +109,7 @@ def unpack(source, dest_path):
 
     # Move files into the right place.
     # If archive only contains one path, then use that.
-    files = [f for f in os.listdir(tmp_path) if f not in IGNORE_FILES]
+    files = [f for f in os.listdir(tmp_path) if not ignore_file(f)]
     if len(files) == 1:
         path_util.rename(os.path.join(tmp_path, files[0]), dest_path)
         path_util.remove(tmp_path)


### PR DESCRIPTION
For some versions of tar, options must be specified before the source file. This should allow the --exclude options to be processed correctly.

I verified that this works on Mac OS X Yosemite, and on CentOS 6.7.
