### PR TITLE
Don't require MYSQL-Python when setting up Worksheets.

### DIFF
--- a/codalab/requirements/common.txt
+++ b/codalab/requirements/common.txt
@@ -55,7 +55,6 @@ Fabric==1.10.2
 selenium==2.48.0
 
 # Required by codalab-cli
-MySQL-python
 docker-py==1.6.0
 # Use sckoo@stanford.edu's patched argcomplete, until pull request has been accepted
 # https://github.com/kislyuk/argcomplete/pull/118


### PR DESCRIPTION
If mysql_config is not installed, this requirement breaks the setup script. MYSQL-Python should be installed as part of the MySQL setup.

@percyliang 

This commit fixes #59 