### PR TITLE
Fix problem with empty titles

### DIFF
--- a/codalab/lib/worksheet_util.py
+++ b/codalab/lib/worksheet_util.py
@@ -87,8 +87,10 @@ def get_worksheet_info_edit_command(raw_command_map):
     Input:
         raw_command: a map containing the info to edit, new_value and the action to perform
     """
-    if not raw_command_map.get('k') or not raw_command_map.get('v') or not raw_command_map.get(
-            'action') == 'worksheet-edit':
+    key = raw_command_map.get('k')
+    value = raw_command_map.get('v')
+    action = raw_command_map.get('action')
+    if key is None or not key or value is None or not action == 'worksheet-edit':
         return None
     return 'wedit -{k[0]} "{v}"'.format(**raw_command_map)
 


### PR DESCRIPTION
Fix part 1 of https://github.com/codalab/codalab-worksheets/issues/36. This change allows worksheet edit commands with empty values. I tested the change with both the worksheet title and name. The title can now be changed to empty, as expected. The name can't be changed, due to a slightly more appropriate error ("worksheet with name already exists"). If not for this error, though, there's another check for empty name later on in the Worksheet.validate method.

@kashizui 
