### PR TITLE
"Fixed" CirclCI config

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -8,4 +8,4 @@ dependencies:
 
 test:
   override:
-    - (cd codalab && python manage.py get_users)
+    - (cd codalab && ./manage get_users)


### PR DESCRIPTION
In reference to #48 
Truth is this won't be completely fixed until nosetests start working
again, and with the separation of Worksheets and Competitions it looks
like the Selenium tests are broken.

@percyliang 