### PR TITLE
Handle null parent name in dependency

### DIFF
--- a/codalab/lib/worksheet_util.py
+++ b/codalab/lib/worksheet_util.py
@@ -379,7 +379,8 @@ def interpret_genpath(bundle_info, genpath):
     elif genpath == 'summary':
         def friendly_render_dep(dep):
             key = dep['child_path'] or dep['parent_name']
-            value = key + '{' + (dep['parent_name'] + ':' if key != dep['parent_name'] else '') + \
+            friendly_parent_name = dep['parent_name'] or '<unnamed>'
+            value = key + '{' + (friendly_parent_name + ':' if key != dep['parent_name'] else '') + \
                 dep['parent_uuid'][0:4] + '}'
             return key, value
         # Nice easy-to-ready description of how this bundle got created.

--- a/codalab/lib/worksheet_util.py
+++ b/codalab/lib/worksheet_util.py
@@ -379,7 +379,7 @@ def interpret_genpath(bundle_info, genpath):
     elif genpath == 'summary':
         def friendly_render_dep(dep):
             key = dep['child_path'] or dep['parent_name']
-            friendly_parent_name = dep['parent_name'] or '<unnamed>'
+            friendly_parent_name = formatting.verbose_contents_str(dep['parent_name'])
             value = key + '{' + (friendly_parent_name + ':' if key != dep['parent_name'] else '') + \
                 dep['parent_uuid'][0:4] + '}'
             return key, value


### PR DESCRIPTION
Fixes #307 

@percyliang please review

Markdown:

```
Next, we extract the accuracies for each run:
[program get_speech_accuracy.sh]{0x9725527ce06d41f9877ecf49cb9c91fe}
[run accuracy -- hybrid-0:,up-0:,down-0:,:abstract-0,:abstract-5,:abstract-10,:abstract-15,:abstract-20,:decode-0,:decode-5,:decode-10,:decode-15,:decode-20,:get_speech_accuracy.sh : bash get_speech_accuracy.sh]{0x9997581ad6e142788f3f255208fc00d7}
```

now renders as:
![screen shot 2016-01-29 at 12 15 14 pm](https://cloud.githubusercontent.com/assets/614837/12686998/00b4e094-c682-11e5-8072-cfc15987a02a.png)
