### PR TITLE
Calling 'cl' inside python/ruby will now use the correct session

### DIFF
--- a/codalab/lib/codalab_manager.py
+++ b/codalab/lib/codalab_manager.py
@@ -274,7 +274,7 @@ class CodaLabManager(object):
             return session
 
         # Otherwise, go up process hierarchy to the *highest up shell* out of
-        # the consecutive shells.  Include Python so we can script from inside it.
+        # the consecutive shells.  Include Python and Ruby so we can script from inside them.
         #   cl bash python bash screen bash gnome-terminal init
         #                  ^
         #                  | return this
@@ -284,7 +284,8 @@ class CodaLabManager(object):
         session = 'top'
         max_depth = 10
         while process and max_depth:
-            if process.name() not in ('sh', 'bash', 'csh', 'tcsh', 'zsh', 'python'):
+            name = os.path.basename(process.cmdline()[0])
+            if name not in ('sh', 'bash', 'csh', 'tcsh', 'zsh', 'python', 'ruby'):
                 break
             session = str(process.pid)
             process = process.parent()


### PR DESCRIPTION
This patch modifies the method that identifies the CodaLab session based on the PID.

The process name when running a script (Python, Ruby, Bash, ...) is the filename and not `python`, `ruby`, etc., which confuses the method. Using the first argument of the command line instead of the process name solves the problem.
