### PR TITLE
Stop error email notification from Django

### DIFF
--- a/codalab/codalab/settings/__init__.py
+++ b/codalab/codalab/settings/__init__.py
@@ -119,6 +119,7 @@ class Base(Settings):
         EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
     ADMINS = []
+    # The following two lines are commented out to suppress emails. 
     # if 'django' in config:
     #     ADMINS.append(('Admin', config['django']['admin-email']))
     MANAGERS = ADMINS

--- a/codalab/codalab/settings/__init__.py
+++ b/codalab/codalab/settings/__init__.py
@@ -119,8 +119,8 @@ class Base(Settings):
         EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
     ADMINS = []
-    if 'django' in config:
-        ADMINS.append(('Admin', config['django']['admin-email']))
+    # if 'django' in config:
+    #     ADMINS.append(('Admin', config['django']['admin-email']))
     MANAGERS = ADMINS
 
     ############################################################


### PR DESCRIPTION
One way around this. 
Keep ADMINS as an empty list
It won't affect monitor.py because monitor.py is sending email to config['django']['admin-email'] rather than ADMINS. 

