### PR TITLE
#299 Store bundles by UUID instead of Digest

### DIFF
--- a/codalab/client/local_bundle_client.py
+++ b/codalab/client/local_bundle_client.py
@@ -429,7 +429,10 @@ class LocalBundleClient(BundleClient):
 
         # Delete the data_hash
         for uuid in relevant_uuids_set:
-            self.bundle_store.cleanup(self.model, uuid, relevant_uuids, dry_run)
+            # check first is needs to be deleted
+            bundle_location = self.bundle_store.get_location(uuid)
+            if os.path.lexists(bundle_location):
+                self.bundle_store.cleanup(self.model, uuid, relevant_uuids, dry_run)
 
         return relevant_uuids
 

--- a/codalab/client/local_bundle_client.py
+++ b/codalab/client/local_bundle_client.py
@@ -246,6 +246,10 @@ class LocalBundleClient(BundleClient):
         if not existing:
             self.validate_user_metadata(bundle_subclass, metadata)
 
+        """Generate a UUID so that BundleStore knows where to store the bundle on disk"""
+        uuid = spec_util.generate_uuid()
+        construct_args['uuid'] = uuid
+
         # Upload the source and record additional metadata from the upload.
         if sources is not None:
             (data_hash, bundle_store_metadata) = self.bundle_store.upload(sources=sources,
@@ -253,7 +257,8 @@ class LocalBundleClient(BundleClient):
                                                                           exclude_patterns=exclude_patterns,
                                                                           git=git,
                                                                           unpack=unpack,
-                                                                          remove_sources=remove_sources)
+                                                                          remove_sources=remove_sources,
+                                                                          uuid=uuid)
             metadata.update(bundle_store_metadata)
         else:
             data_hash = None
@@ -423,8 +428,8 @@ class LocalBundleClient(BundleClient):
             self.model.update_user_disk_used(self._current_user_id())
 
         # Delete the data_hash
-        for data_hash in relevant_data_hashes:
-            self.bundle_store.cleanup(self.model, data_hash, relevant_uuids, dry_run)
+        for uuid in relevant_uuids_set:
+            self.bundle_store.cleanup(self.model, uuid, relevant_uuids, dry_run)
 
         return relevant_uuids
 

--- a/codalab/lib/bundle_store.py
+++ b/codalab/lib/bundle_store.py
@@ -15,7 +15,7 @@ from codalab.lib import path_util, file_util, print_util, zip_util
 from codalab.common import UsageError
 
 class BundleStore(object):
-    DATA_SUBDIRECTORY = 'data'
+    DATA_SUBDIRECTORY = 'bundles'
     TEMP_SUBDIRECTORY = 'temp'
 
     # The amount of time a folder can live in the data and temp

--- a/codalab/lib/bundle_store.py
+++ b/codalab/lib/bundle_store.py
@@ -82,13 +82,13 @@ class BundleStore(object):
         to_delete = []
 
         # If just a single file, set the final path to be equal to that file
-        single_file = len(sources) == 1
+        single_path = len(sources) == 1
 
         final_path = os.path.join(self.data, uuid)
         if os.path.exists(final_path):
-            raise UsageError('Error, path %s already present in bundle store' % final_path)
+            raise UsageError('Path %s already present in bundle store' % final_path)
         # Only make if not there
-        elif not single_file:
+        elif not single_path:
             path_util.make_directory(final_path)
 
         # Paths to resources
@@ -96,7 +96,7 @@ class BundleStore(object):
 
         for source in sources:
             # Where to save |source| to (might change this value if we unpack).
-            if not single_file:
+            if not single_path:
                 subpath = os.path.join(final_path, os.path.basename(source))
             else:
                 subpath = final_path

--- a/codalab/lib/bundle_store.py
+++ b/codalab/lib/bundle_store.py
@@ -50,13 +50,13 @@ class BundleStore(object):
         for path in (self.data, self.temp):
             path_util.make_directory(path)
 
-    def get_location(self, data_hash, relative=False):
+    def get_location(self, uuid, relative=False):
         '''
         Returns the on-disk location of the bundle with the given data hash.
         '''
         if relative:
-            return data_hash
-        return os.path.join(self.data, data_hash)
+            return uuid
+        return os.path.join(self.data, uuid)
 
     def get_temp_location(self, identifier):
         '''
@@ -71,7 +71,7 @@ class BundleStore(object):
         path_util.make_directory(self.get_temp_location(identifier));
 
 
-    def upload(self, sources, follow_symlinks, exclude_patterns, git, unpack, remove_sources):
+    def upload(self, sources, follow_symlinks, exclude_patterns, git, unpack, remove_sources, uuid):
         '''
         |sources|: specifies the locations of the contents to upload.  Each element is either a URL or a local path.
         |follow_symlinks|: for local path(s), whether to follow (resolve) symlinks
@@ -155,7 +155,7 @@ class BundleStore(object):
         print_util.open_line('BundleStore.upload: computing size of %s' % temp_path)
         data_size = path_util.get_size(temp_path, dirs_and_files)
         print_util.clear_line()
-        final_path = os.path.join(self.data, data_hash)
+        final_path = os.path.join(self.data, uuid)
         if os.path.exists(final_path):
             # Already exists, just delete it
             path_util.remove(temp_path)

--- a/codalab/lib/bundle_store.py
+++ b/codalab/lib/bundle_store.py
@@ -164,17 +164,15 @@ class BundleStore(object):
         assert(os.path.lexists(final_path)), 'Uploaded to %s failed!' % (final_path,)
         return (data_hash, {'data_size': data_size})
 
-    def cleanup(self, model, data_hash, except_bundle_uuids, dry_run):
+    def cleanup(self, model, uuid, except_bundle_uuids, dry_run):
         '''
         If the given data hash is not needed by any bundle (not in
         except_bundle_uuids), delete the data.
         '''
-        bundles = model.batch_get_bundles(data_hash=data_hash)
-        if all(bundle.uuid in except_bundle_uuids for bundle in bundles):
-            absolute_path = self.get_location(data_hash)
-            print >>sys.stderr, "cleanup: data %s" % absolute_path
-            if not dry_run:
-                path_util.remove(absolute_path)
+        absolute_path = self.get_location(uuid)
+        print >>sys.stderr, "cleanup: data %s" % absolute_path
+        if not dry_run:
+            path_util.remove(absolute_path)
 
     def full_cleanup(self, model, dry_run):
         '''

--- a/codalab/lib/bundle_store.py
+++ b/codalab/lib/bundle_store.py
@@ -58,19 +58,6 @@ class BundleStore(object):
             return uuid
         return os.path.join(self.data, uuid)
 
-    def get_temp_location(self, identifier):
-        '''
-        Returns the on-disk location of the temporary bundle directory.
-        '''
-        return os.path.join(self.temp, identifier)
-
-    def make_temp_location(self, identifier):
-        '''
-        Creates directory with given name under TEMP_SUBDIRECTORY
-        '''
-        path_util.make_directory(self.get_temp_location(identifier));
-
-
     def upload(self, sources, follow_symlinks, exclude_patterns, git, unpack, remove_sources, uuid):
         '''
         |sources|: specifies the locations of the contents to upload.  Each element is either a URL or a local path.

--- a/codalab/lib/bundle_store.py
+++ b/codalab/lib/bundle_store.py
@@ -99,9 +99,7 @@ class BundleStore(object):
 
         final_path = os.path.join(self.data, uuid)
         if os.path.exists(final_path):
-            # Already exists, just delete it
-            print >> sys.stderr, 'Error, path %s already present in bundle store' % final_path
-            return (None, None)
+            raise UsageError('Error, path %s already present in bundle store' % final_path)
         # Only make if not there
         elif not single_file:
             path_util.make_directory(final_path)

--- a/codalab/lib/canonicalize.py
+++ b/codalab/lib/canonicalize.py
@@ -107,7 +107,7 @@ def get_current_location(bundle_store, uuid):
     """
     Return the on-disk location of currently running target.
     """
-    return bundle_store.get_temp_location(uuid)
+    return bundle_store.get_location(uuid)
 
 
 def get_target_path(bundle_store, model, target):

--- a/codalab/lib/canonicalize.py
+++ b/codalab/lib/canonicalize.py
@@ -115,12 +115,7 @@ def get_target_path(bundle_store, model, target):
     Return the on-disk location of the target (bundle_uuid, subpath) pair.
     """
     (uuid, path) = target
-    bundle = model.get_bundle(uuid)
-    if not bundle.data_hash:
-        # Note that the bundle might not be ready, but return the location anyway to the temporary directory.
-        bundle_root = get_current_location(bundle_store, uuid)
-    else:
-        bundle_root = bundle_store.get_location(bundle.data_hash)
+    bundle_root = bundle_store.get_location(uuid)
     final_path = path_util.safe_join(bundle_root, path)
 
     result = path_util.TargetPath(final_path, target)

--- a/codalab/lib/path_util.py
+++ b/codalab/lib/path_util.py
@@ -295,6 +295,13 @@ def get_info(path, depth):
         result['perm'] = os.stat(path).st_mode & 0777
     return result
 
+def hash_path(path, dirs_and_files=None):
+    if os.path.isfile(path):
+        return hash_file_contents(path)
+    elif os.path.isdir(path):
+        return hash_directory(path, dirs_and_files)
+    else:
+        print >> sys.stderr, 'Path %s not valid' % path
 
 def hash_directory(path, dirs_and_files=None):
     """

--- a/codalab/lib/zip_util.py
+++ b/codalab/lib/zip_util.py
@@ -42,6 +42,13 @@ def path_is_archive(path):
                 return True
     return False
 
+def get_archive_ext(fname):
+    """Returns the extension for fname if it's an archive, empty string otherwise."""
+    for ext in ARCHIVE_EXTS:
+        if fname.endswith(ext):
+            return ext
+    return ''
+
 
 def strip_archive_ext(path):
     for ext in ARCHIVE_EXTS:

--- a/codalab/objects/bundle.py
+++ b/codalab/objects/bundle.py
@@ -96,10 +96,10 @@ class Bundle(ORMObject):
         def process_dep(dep):
             parent = parent_dict[dep.parent_uuid]
             # Compute an absolute target and check that the dependency exists.
-            if not parent.data_hash:
-                raise UsageError('Parent %s does not have data hash' % parent)
+            if not parent.uuid:
+                raise UsageError('Parent %s does not have uuid' % parent)
             target = path_util.safe_join(
-              bundle_store.get_location(parent.data_hash),
+              bundle_store.get_location(parent.uuid),
               dep.parent_path,
             )
             if not os.path.exists(target):
@@ -110,7 +110,7 @@ class Bundle(ORMObject):
                 # Create a symlink that points to the dependency's relative target.
                 target = path_util.safe_join(
                   (os.pardir if dep.child_path else ''),
-                  bundle_store.get_location(parent.data_hash, relative=True),
+                  bundle_store.get_location(parent.uuid, relative=True),
                   dep.parent_path,
                 )
             link_path = path_util.safe_join(dest_path, dep.child_path)

--- a/codalab/objects/work_manager.py
+++ b/codalab/objects/work_manager.py
@@ -298,7 +298,8 @@ class Worker(object):
                                                                               exclude_patterns=None,
                                                                               git=False,
                                                                               unpack=False,
-                                                                              remove_sources=True)
+                                                                              remove_sources=True,
+                                                                              uuid=bundle.uuid)
                 db_update['data_hash'] = data_hash
                 metadata.update(bundle_store_metadata)
             except Exception as e:

--- a/codalab/objects/work_manager.py
+++ b/codalab/objects/work_manager.py
@@ -115,9 +115,9 @@ class Worker(object):
                 except Exception as e:
                     # If there's an exception, we just make the bundle fail
                     # (even if it's not the bundle's fault).
-                    temp_dir = canonicalize.get_current_location(self.bundle_store, bundle.uuid)
-                    path_util.make_directory(temp_dir)
-                    status = {'bundle': bundle, 'success': False, 'failure_message': 'Internal error: ' + str(e), 'temp_dir': temp_dir}
+                    real_path = canonicalize.get_current_location(self.bundle_store, bundle.uuid)
+                    path_util.make_directory(real_path)
+                    status = {'bundle': bundle, 'success': False, 'failure_message': 'Internal error: ' + str(e), 'temp_dir': real_path}
                     print '=== INTERNAL ERROR: %s' % e
                     started = True  # Force failing
                     traceback.print_exc()
@@ -129,9 +129,9 @@ class Worker(object):
 
             # If we have a MakeBundle, then just process it immediately.
             if isinstance(bundle, MakeBundle):
-                temp_dir = canonicalize.get_current_location(self.bundle_store, bundle.uuid)
-                path_util.make_directory(temp_dir)
-                status = {'bundle': bundle, 'success': True, 'temp_dir': temp_dir}
+                real_path = canonicalize.get_current_location(self.bundle_store, bundle.uuid)
+                path_util.make_directory(real_path)
+                status = {'bundle': bundle, 'success': True, 'temp_dir': real_path}
 
             # Update database
             if started:
@@ -292,7 +292,7 @@ class Worker(object):
                     print >>sys.stderr, 'Worker.finalize_bundle: installing (copying) dependencies to %s (MakeBundle)' % temp_dir
                     bundle.install_dependencies(self.bundle_store, self.get_parent_dict(bundle), temp_dir, copy=True)
 
-                db_update['data_hash'] = path_util.hash_directory(temp_dir)
+                db_update['data_hash'] = path_util.hash_path(temp_dir)
                 metadata.update(data_size=path_util.get_size(temp_dir))
             except Exception as e:
                 print '=== INTERNAL ERROR: %s' % e

--- a/codalab/objects/work_manager.py
+++ b/codalab/objects/work_manager.py
@@ -292,16 +292,8 @@ class Worker(object):
                     print >>sys.stderr, 'Worker.finalize_bundle: installing (copying) dependencies to %s (MakeBundle)' % temp_dir
                     bundle.install_dependencies(self.bundle_store, self.get_parent_dict(bundle), temp_dir, copy=True)
 
-                # Note: uploading will move temp_dir to the bundle store.
-                (data_hash, bundle_store_metadata) = self.bundle_store.upload(sources=[temp_dir],
-                                                                              follow_symlinks=False,
-                                                                              exclude_patterns=None,
-                                                                              git=False,
-                                                                              unpack=False,
-                                                                              remove_sources=True,
-                                                                              uuid=bundle.uuid)
-                db_update['data_hash'] = data_hash
-                metadata.update(bundle_store_metadata)
+                db_update['data_hash'] = path_util.hash_directory(temp_dir)
+                metadata.update(data_size=path_util.get_size(temp_dir))
             except Exception as e:
                 print '=== INTERNAL ERROR: %s' % e
                 traceback.print_exc()

--- a/scripts/migrate-hash-uuid.py
+++ b/scripts/migrate-hash-uuid.py
@@ -1,0 +1,55 @@
+#!./venv/bin/python
+"""
+Script that goes through and reindexes all bundles on disk to be located by their UUID instead of by their data_hash.
+
+For every bundle, finds its associated data_hash, and copies the data underneath data_hash/
+"""
+
+import os
+import sys
+sys.path.append('.')
+
+from codalab.lib.codalab_manager import CodaLabManager
+from codalab.lib import path_util
+
+manager = CodaLabManager()
+model = manager.model()
+
+CODALAB_HOME = manager.codalab_home
+
+"""Move data/ directory over to a temp area, and create a staging tree for uuid-based storage"""
+DATA_DIR = os.path.join(CODALAB_HOME, 'data')
+TEMP_DIR = os.path.join(CODALAB_HOME, 'migration-temp')
+STAGING_AREA = os.path.join(CODALAB_HOME, 'migration-staging')
+
+path_util.rename(DATA_DIR, TEMP_DIR)
+path_util.make_directory(STAGING_AREA)
+
+"""For each data hash, get a list of all bundles that have that hash, and make a copy of the bundle in the staging
+area under the UUID for the bundle."""
+
+data_hashes = reduce(lambda x,y: x+y, path_util.ls(TEMP_DIR))
+for data_hash in data_hashes:
+    orig_location = os.path.join(TEMP_DIR, data_hash)
+
+    bundles_with_hash = model.batch_get_bundles(data_hash=data_hash)
+    for bundle in bundles_with_hash:
+        uuid = bundle.uuid
+        copy_location = os.path.join(STAGING_AREA, uuid)
+        print >> sys.stderr, 'Copying Bundle 0x%s with data_hash 0x%s to %s' % (uuid, data_hash, copy_location)
+        path_util.copy(orig_location, copy_location)
+
+"""Move the staging location to DATA_DIR, and tell the user to delete the TEMP_DIR"""
+path_util.rename(STAGING_AREA, DATA_DIR)
+
+explain_str = """
+Migration complete! The directory %s has been left with your old data, if you believe something is out of place run the
+following command to restore your old bundle state:
+
+    mv %s %s
+
+To delete the old data off of disk:
+
+    rm -rf %s
+""".lstrip() % (TEMP_DIR, TEMP_DIR, DATA_DIR, TEMP_DIR)
+print >> sys.stderr, explain_str

--- a/scripts/migrate-hash-uuid.py
+++ b/scripts/migrate-hash-uuid.py
@@ -3,6 +3,9 @@
 Script that goes through and reindexes all bundles on disk to be located by their UUID instead of by their data_hash.
 
 For every bundle, finds its associated data_hash, and copies the data underneath data_hash/
+
+By default, this script runs in dry-run mode, i.e. it prints verbose output but does not make changes to
+the file system. When you're ready to perform the migration, run with the '-f' flag.
 """
 
 import os
@@ -12,6 +15,8 @@ sys.path.append('.')
 from codalab.lib.codalab_manager import CodaLabManager
 from codalab.lib import path_util
 
+dry_run = False if len(sys.argv) > 1 and sys.argv[1] == '-f' else True
+
 manager = CodaLabManager()
 model = manager.model()
 
@@ -19,37 +24,37 @@ CODALAB_HOME = manager.codalab_home
 
 """Move data/ directory over to a temp area, and create a staging tree for uuid-based storage"""
 DATA_DIR = os.path.join(CODALAB_HOME, 'data')
-TEMP_DIR = os.path.join(CODALAB_HOME, 'migration-temp')
-STAGING_AREA = os.path.join(CODALAB_HOME, 'migration-staging')
+FINAL_LOCATION = os.path.join(CODALAB_HOME, 'bundles')
 
-path_util.rename(DATA_DIR, TEMP_DIR)
-path_util.make_directory(STAGING_AREA)
+if not dry_run:
+    path_util.make_directory(FINAL_LOCATION)
 
 """For each data hash, get a list of all bundles that have that hash, and make a copy of the bundle in the staging
 area under the UUID for the bundle."""
-
-data_hashes = reduce(lambda x,y: x+y, path_util.ls(TEMP_DIR))
+data_hashes = reduce(lambda x,y: x+y, path_util.ls(DATA_DIR))
 for data_hash in data_hashes:
-    orig_location = os.path.join(TEMP_DIR, data_hash)
+    orig_location = os.path.join(DATA_DIR, data_hash)
 
     bundles_with_hash = model.batch_get_bundles(data_hash=data_hash)
     for bundle in bundles_with_hash:
         uuid = bundle.uuid
-        copy_location = os.path.join(STAGING_AREA, uuid)
-        print >> sys.stderr, 'Copying Bundle 0x%s with data_hash 0x%s to %s' % (uuid, data_hash, copy_location)
-        path_util.copy(orig_location, copy_location)
+        copy_location = os.path.join(FINAL_LOCATION, uuid)
+        print >> sys.stderr, 'Moving Bundle 0x%s with data_hash 0x%s to %s' % (uuid, data_hash, copy_location)
+        if not dry_run:
+            path_util.copy(orig_location, copy_location)
 
-"""Move the staging location to DATA_DIR, and tell the user to delete the TEMP_DIR"""
-path_util.rename(STAGING_AREA, DATA_DIR)
+
+dry_run_str = """
+This was a dry run, no migration occurred. To perform full migration, run again with `-f':
+
+    %s -f
+""" % sys.argv[0]
 
 explain_str = """
-Migration complete! The directory %s has been left with your old data, if you believe something is out of place run the
-following command to restore your old bundle state:
-
-    mv %s %s
+Migration complete! The directory %s has been left with your old data.
 
 To delete the old data off of disk:
 
     rm -rf %s
-""".lstrip() % (TEMP_DIR, TEMP_DIR, DATA_DIR, TEMP_DIR)
+%s""".lstrip() % (DATA_DIR, DATA_DIR, dry_run_str if dry_run else '')
 print >> sys.stderr, explain_str

--- a/tests/lib/bundle_store_test.py
+++ b/tests/lib/bundle_store_test.py
@@ -83,8 +83,8 @@ class BundleStoreTest(unittest.TestCase):
         contents = 'contents'
         test_uuid1 = '0xdeadbeef'
         test_uuid2 = '0xaaaaaaaa'
-        final_path1 = 'mock_root/data/%s' % test_uuid1
-        final_path2 = 'mock_root/data/%s' % test_uuid2
+        final_path1 = 'mock_root/bundles/%s' % test_uuid1
+        final_path2 = 'mock_root/bundles/%s' % test_uuid2
         global_paths.add(contents)
 
         bundle_store.upload(sources=[contents], follow_symlinks=False, exclude_patterns=None, git=False, unpack=False, remove_sources=False, uuid=test_uuid1)

--- a/tests/lib/bundle_store_test.py
+++ b/tests/lib/bundle_store_test.py
@@ -8,10 +8,9 @@ from codalab.lib.bundle_store import BundleStore
 
 class BundleStoreTest(unittest.TestCase):
     @mock.patch('codalab.lib.bundle_store.tempfile')
-    @mock.patch('codalab.lib.bundle_store.uuid')
     @mock.patch('codalab.lib.bundle_store.path_util')
     @mock.patch('codalab.lib.bundle_store.os', new_callable=mock.Mock)
-    def test_upload(self, mock_os, mock_path_util, mock_uuid, mock_tempfile):
+    def test_upload(self, mock_os, mock_path_util, mock_tempfile):
         '''
         Tries to upload a bundle: should copy bundle into temp, hash and move
         it in to the data directory.
@@ -82,12 +81,15 @@ class BundleStoreTest(unittest.TestCase):
         ### Main: upload!
 
         contents = 'contents'
-        final_path = 'mock_root/data/0x12345'
+        test_uuid1 = '0xdeadbeef'
+        test_uuid2 = '0xaaaaaaaa'
+        final_path1 = 'mock_root/data/%s' % test_uuid1
+        final_path2 = 'mock_root/data/%s' % test_uuid2
         global_paths.add(contents)
 
-        bundle_store.upload(sources=[contents], follow_symlinks=False, exclude_patterns=None, git=False, unpack=False, remove_sources=False)
-        self.assertEquals(global_paths, set([contents, final_path]))
+        bundle_store.upload(sources=[contents], follow_symlinks=False, exclude_patterns=None, git=False, unpack=False, remove_sources=False, uuid=test_uuid1)
+        self.assertEquals(global_paths, set([contents, final_path1]))
 
-        bundle_store.upload(sources=[contents], follow_symlinks=False, exclude_patterns=None, git=False, unpack=False, remove_sources=True)
+        bundle_store.upload(sources=[contents], follow_symlinks=False, exclude_patterns=None, git=False, unpack=False, remove_sources=True, uuid=test_uuid2)
         self.assertNotIn(contents, global_paths)  # File is not there
-        self.assertEquals(global_paths, set([final_path]))
+        self.assertEquals(global_paths, set([final_path1, final_path2]))

--- a/tests/lib/canonicalize_test.py
+++ b/tests/lib/canonicalize_test.py
@@ -10,7 +10,7 @@ from codalab.lib import (
   canonicalize,
   spec_util,
 )
- 
+
 
 class CanonicalizeTest(unittest.TestCase):
   def test_get_bundle_uuid(self):
@@ -74,10 +74,8 @@ class CanonicalizeTest(unittest.TestCase):
     test_model = MockBundleModel()
 
     class MockBundleStore(object):
-      def get_temp_location(self, identifier):
-        return os.path.join('temp', identifier)
-      def get_location(self, data_hash):
-        tester.assertEqual(data_hash, test_data_hash)
+      def get_location(self, uuid):
+        tester.assertEqual(uuid, test_uuid)
         return test_location
     bundle_store = MockBundleStore()
 


### PR DESCRIPTION
@percyliang 

I've tested functionality both locally and using `cl server`, and have tested the migration script by creating a bunch of bundles from the same data, changed them to be stored de-duped by their `data_hash`, and then run `./scripts/migrate-hash-uuid.py`.

Steps:
1. Create a bunch of bundles:
   
   ```
   cl up alembic.ini
   cl up alembic.ini
   cl up README.md
   cl up alembic.ini
   ```
2. Run `cl info` to find the `data_hash`, then do `mv ~/.codalab/data/$uuid ~/.codalab/data/$data_hash`. There should only end up being 2 entries in `~/.codalab/data`.
3. Run `./scripts/migrate-hash-uuid.py`. You should see that there are 4 things in `~/.codalab/data`, and the directory `~/.codalab/migration-temp` is still intact with the old tree structure in case you want to restore (script prints a message telling you how to do so).
