### PR TITLE
Changes to REST server setup.

### DIFF
--- a/codalab/bin/cl.py
+++ b/codalab/bin/cl.py
@@ -78,10 +78,10 @@ def do_server_command(bundle_cli, args):
             '--watch', help='Restart the server on code changes.',
             action='store_true'),
         Commands.Argument(
-            '-w', '--workers',
-            help='Number of worker processes to use. A production deployment '
-                 'should use more than 1 process to make the best use of '
-                 'multiple CPUs.',
+            '-p', '--processes',
+            help='Number of processes to use. A production deployment should '
+                 'use more than 1 process to make the best use of multiple '
+                 'CPUs.',
             type=int, default=1),
         Commands.Argument(
             '-d', '--debug', help='Run the development server for debugging.',
@@ -93,7 +93,7 @@ def do_rest_server_command(bundle_cli, args):
         run_server_with_watch()
     else:
         from codalab.server.rest_server import run_rest_server
-        run_rest_server(bundle_cli.manager, args.debug, args.workers)
+        run_rest_server(bundle_cli.manager, args.debug, args.processes)
 
 
 if __name__ == '__main__':

--- a/codalab/server/rest_server.py
+++ b/codalab/server/rest_server.py
@@ -1,21 +1,38 @@
-from bottle import abort, install, local, request, run
-import codalab.rest.example
+# gevent.monkey.patch_all() needs to be called before importing bottle.
+import gevent.monkey; gevent.monkey.patch_all()
+
+from bottle import (
+    abort,
+    get,
+    HTTPError,
+    HTTPResponse,
+    install,
+    local,
+    request,
+    run,
+)
 from httplib import BAD_REQUEST
+import sys
 import time
+
+import codalab.rest.example
 
 
 class SaveEnvironmentPlugin(object):
     """Saves environment objects in the local request variable."""
     api = 2
     
-    def __init__(self, model, bundle_store):
-        self.model = model
-        self.bundle_store = bundle_store
+    def __init__(self, manager):
+        self.manager = manager
 
     def apply(self, callback, route):
         def wrapper(*args, **kwargs):
-            local.model = self.model
-            local.bundle_store = self.bundle_store
+            # Note that the model is created here during the first request to
+            # the server. This is intentional to ensure that any MySQL engine
+            # objects are created after forking.
+            local.model = self.manager.model()
+            local.bundle_store = self.manager.bundle_store()
+            local.config = self.manager.config
             return callback(*args, **kwargs)
 
         return wrapper
@@ -68,22 +85,40 @@ class CheckJsonPlugin(object):
         return wrapper
 
 
-def run_rest_server(manager, debug, num_workers):
+class ErrorHandlerPlugin(object):
+    """Simple error handler that doesn't use the Bottle error template."""
+    api = 2
+    def apply(self, callback, route):
+        def wrapper(*args, **kwargs):
+            response = callback(*args, **kwargs)
+            if isinstance(response, HTTPError):
+                return HTTPResponse(body=response.body, status=response.status)
+            return response
+        return wrapper
+
+
+@get('/status')
+def status():
+    return 'OK'
+
+
+def run_rest_server(manager, debug, num_processes):
     """Runs the REST server."""
     host = manager.config['server']['rest_host']
     port = manager.config['server']['rest_port']
 
-    install(SaveEnvironmentPlugin(manager.model(), manager.bundle_store()))
+    install(SaveEnvironmentPlugin(manager))
     install(CheckJsonPlugin())
     install(LoggingPlugin())
+    install(ErrorHandlerPlugin())
 
-    if not debug:
-        # We use gunicorn to create a server with multiple processes, since in
-        # Python a single process uses at most 1 CPU due to the Global
-        # Interpreter Lock.
-        # We use gevent so that each of the processes handles each request in a
-        # greenlet (a sort of a lightweight thread).
-        run(host=host, port=port, debug=False, server='gunicorn',
-            workers=num_workers, worker_class='gevent')
-    else:
-        run(host=host, port=port, debug=True)
+    # We use gunicorn to create a server with multiple processes, since in
+    # Python a single process uses at most 1 CPU due to the Global Interpreter
+    # Lock.
+    # We use gevent so that each of the processes handles each request in a
+    # greenlet (a sort of a lightweight thread).
+    sys.argv = sys.argv[:1] # Small hack to work around a Gunicorn arg parsing
+                            # bug. None of the arguments to cl should go to
+                            # Gunicorn.
+    run(host=host, port=port, debug=debug, server='gunicorn',
+        workers=num_processes, worker_class='gevent' if not debug else 'sync')


### PR DESCRIPTION
A few changes to the REST server setup, including:

1) Monkey patching before importing Bottle. This ensures that the Bottle thread locals work correctly.
2) Calling codalab_manager.model() and thus creating the SQL engine only on the first request. This is a hack to work around the requirement that any SQL engine objects are creating after forking (here the forking happening in the Gunicorn code)
3) Working around some logic in Bottle that returns a complex HTML error page on errors. With the new solution the error page simply contains the error text. This ensures that any code calling the REST API can display errors the way it wants.
4) Rename workers to processes for clarity.
5) Work around a bug in Gunicorn that tries to read all command line arguments, even when it's called as a library.

@percyliang @kashizui 
