### PR TITLE
Fix help in the web UI.

### DIFF
--- a/codalab/bin/cl.py
+++ b/codalab/bin/cl.py
@@ -71,7 +71,7 @@ def do_server_command(bundle_cli, args):
 
 
 @Commands.command(
-    'rest_server',
+    'rest-server',
     help='Start an instance of a CodaLab bundle service with a REST API.',
     arguments=(
         Commands.Argument(

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -134,6 +134,7 @@ OTHER_COMMANDS = (
     'alias',
     'work-manager',
     'server',
+    'rest-server',
     'logout',
 )
 
@@ -257,13 +258,16 @@ class Commands(object):
                 name += ' (%s)' % ', '.join(list(aliases))
             return name
 
+        available_other_commands = filter(
+            lambda command: command in cls.commands, OTHER_COMMANDS)
+
         indent = 2
         max_length = max(
           len(command_name(command)) for command in itertools.chain(
               BUNDLE_COMMANDS,
               WORKSHEET_COMMANDS,
               GROUP_AND_PERMISSION_COMMANDS,
-              OTHER_COMMANDS)
+              available_other_commands)
         )
 
         def command_help_text(command):
@@ -319,7 +323,7 @@ class Commands(object):
             bundle_commands=command_group_help_text(BUNDLE_COMMANDS),
             worksheet_commands=command_group_help_text(WORKSHEET_COMMANDS),
             group_and_permission_commands=command_group_help_text(GROUP_AND_PERMISSION_COMMANDS),
-            other_commands=command_group_help_text(OTHER_COMMANDS),
+            other_commands=command_group_help_text(available_other_commands),
         ).strip()
 
     @classmethod


### PR DESCRIPTION
This fix doesn't show help for the server and rest-server commands in the web UI, which is the correct behavior since you can't run a server from the web UI.

Fixes https://github.com/codalab/codalab-worksheets/issues/103

@percyliang 
