### PR TITLE
 #345: cl upload on multiple files adds ".tar.gz" to each uploaded file.

### DIFF
--- a/codalab/lib/bundle_store.py
+++ b/codalab/lib/bundle_store.py
@@ -105,7 +105,7 @@ class BundleStore(object):
                 to_delete.append(source)
             source_unpack = unpack and zip_util.path_is_archive(source)
 
-            if source_unpack:
+            if source_unpack and single_path:
                 # Load the file into the bundle store under the given path
                 subpath += zip_util.get_archive_ext(source)
 

--- a/test-cli.py
+++ b/test-cli.py
@@ -346,6 +346,17 @@ def test(ctx):
     uuid = run_command([cl, 'upload', 'https://github.com/codalab/codalab-cli', '--git'])
     check_contains(['README.md', 'codalab', 'scripts'], run_command([cl, 'cat', uuid]))
 
+@TestModule.register('upload4')
+def test(ctx):
+    # Uploads a pair of archives at the same time. Makes sure they're named correctly when unpacked.
+    archive_paths = [temp_path(''), temp_path('')]
+    archive_exts = map(lambda p: p + '.tar.gz', archive_paths)
+    contents_paths = [test_path('dir1'), test_path('a.txt')]
+    for (archive, content) in zip(archive_exts, contents_paths):
+        run_command(['tar', 'cfz', archive, '-C', os.path.dirname(content), os.path.basename(content)])
+    uuid = run_command([cl, 'upload'] + archive_exts)
+    # Make sure the names do not include the trailing things
+    check_contains([os.path.basename(archive_paths[0]) + r'\s', os.path.basename(archive_paths[1]) + r'\s'], run_command([cl, 'cat', uuid]))
 
 @TestModule.register('download')
 def test(ctx):


### PR DESCRIPTION
@percyliang 

Fix for #345 

The reason for the bug was because bundles that are just single files need to be named `CODALAB_HOME/bundles/UUID.extension`, so I was simply adding `.extension` to the end of `subpath`. However, I forgot subpath is the name of the sourcefile for non-single file uploads, so we were uploading `thing.zip` and it was being placed in `CODALAB_HOME/bundles/UUID/thing.zip.zip` and unpacking to `CODALAB_HOME/bundles/UUID/thing.zip`. This ensures that we only append the archive extension if we're uploading a single file.
