### PR TITLE
Initialize root logger

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ machine:
 
 dependencies:
   override:
-    - ./setup.sh client
+    - ./setup.sh server
     - ./venv/bin/pip install --upgrade pip
     - ./venv/bin/pip install -r requirements-tests.txt
 

--- a/codalab/lib/codalab_manager.py
+++ b/codalab/lib/codalab_manager.py
@@ -126,7 +126,9 @@ class CodaLabManager(object):
         codalab_cli = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
         def replace(x):
             if isinstance(x, basestring):
-                return x.replace('$CODALAB_CLI', codalab_cli)
+                x = x.replace('$CODALAB_CLI', codalab_cli)
+                x = x.replace('$CODALAB_HOME', self.codalab_home)
+                return x
             if isinstance(x, dict):
                 return dict((k, replace(v)) for k, v in x.items())
             return x
@@ -190,7 +192,7 @@ class CodaLabManager(object):
                 }
             },
             'logging': {
-                'file_path': "{0.codalab_home}/codalab.log",
+                'file_path': "$CODALAB_HOME/codalab.log",
                 'console_level': "INFO",
                 'file_level': "DEBUG",
             }


### PR DESCRIPTION
Set up logging.

After this, instead of print statements, we should add

```
import logging
log = logging.getLogger(__name__)
```

at the top of each module, and use the standard log calls thereafter:

```
log.info("just info")
log.debug("verbose info")
log.warning("probably ok")
log.error("uh oh")
```

Logs will also be collected at the default location `$CODALAB_HOME/codalab.log`; this path, as well as log levels for both these recorded logs and the console logs can be configured.

@percyliang @klopyrev @andreweduffy @ChengshuLi Does anyone have any feedback on best practices here?

Starts to fix #180 
