### PR TITLE
Bundle Health / Sanity Check

### DIFF
--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -2341,12 +2341,14 @@ class BundleCLI(object):
         'bs-health-check',
         help='Perform a health check on the bundle store, garbage collecting bad files in the store. Performs a dry run by default, use -f to force removal.',
         arguments=(
-            Commands.Argument('-f', '--force', help='Force removal of junk', action='store_true'),
+            Commands.Argument('-f', '--force', help='Perform all garbage collection and database updates instead of just printing what would happen', action='store_true'),
+            Commands.Argument('-d', '--data-hash', help='Compute the digest for every bundle and compare against data_hash for consistency', action='store_true'),
+            Commands.Argument('-r', '--repair', help='When used with --force and --data-hash, repairs incorrect data_hash in existing bundles', action='store_true'),
         ),
     )
     def do_bs_health_check(self, args):
         print >> sys.stderr, 'Performing Health Check...'
-        self.manager.bundle_store().health_check(self.manager.current_client().model, args.force)
+        self.manager.bundle_store().health_check(self.manager.current_client().model, args.force, args.data_hash, args.repair)
 
     def _fail_if_headless(self, message):
         if self.headless:

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -142,6 +142,7 @@ OTHER_COMMANDS = (
     'bs-add-partition',
     'bs-rm-partition',
     'bs-ls-partitions',
+    'bs-health-check',
 )
 
 
@@ -2335,6 +2336,15 @@ class BundleCLI(object):
             print >> sys.stderr, "This command can only be run when MultiDiskBundleStore is in use."
             sys.exit(1)
         self.manager.bundle_store().ls_partitions()
+
+    @Commands.command(
+        'bs-health-check',
+        help='Perform a health check on the bundle store, garbage collecting bad files in the store',
+        arguments=(),
+    )
+    def do_bs_health_check(self, args):
+        print >> sys.stderr, 'Performing Health Check...'
+        self.manager.bundle_store().health_check(self.manager.current_client().model)
 
     def _fail_if_headless(self, message):
         if self.headless:

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -2339,12 +2339,14 @@ class BundleCLI(object):
 
     @Commands.command(
         'bs-health-check',
-        help='Perform a health check on the bundle store, garbage collecting bad files in the store',
-        arguments=(),
+        help='Perform a health check on the bundle store, garbage collecting bad files in the store. Performs a dry run by default, use -f to force removal.',
+        arguments=(
+            Commands.Argument('-f', '--force', help='Force removal of junk', action='store_true'),
+        ),
     )
     def do_bs_health_check(self, args):
         print >> sys.stderr, 'Performing Health Check...'
-        self.manager.bundle_store().health_check(self.manager.current_client().model)
+        self.manager.bundle_store().health_check(self.manager.current_client().model, args.force)
 
     def _fail_if_headless(self, message):
         if self.headless:

--- a/codalab/lib/bundle_store.py
+++ b/codalab/lib/bundle_store.py
@@ -432,7 +432,8 @@ class MultiDiskBundleStore(BaseBundleStore, BundleStoreCleanupMixin, BundleStore
 
         def _check_bundle_paths(bundle_paths, db_bundle_by_uuid):
             """
-            Takes in a list of bundle paths, and returns a list of paths and subpaths that need to be removed.
+            Takes in a list of bundle paths and a mapping of UUID to BundleModels, and returns a list of paths and
+            subpaths that need to be removed.
             """
             to_delete = []
             # Batch get information for all bundles stored on-disk

--- a/codalab/lib/bundle_store.py
+++ b/codalab/lib/bundle_store.py
@@ -528,8 +528,13 @@ class MultiDiskBundleStore(BaseBundleStore, BundleStoreCleanupMixin, BundleStore
 
 
         if force:
-            print >> sys.stderr, 'Deleted %d objects from the bundle store' % trash_count
-            print >> sys.stderr, 'Recomputed data_hash for %d bundles' % data_hash_recomputed
+            print >> sys.stderr, '\tDeleted %d objects from the bundle store' % trash_count
+            print >> sys.stderr, '\tRecomputed data_hash for %d bundles' % data_hash_recomputed
+        else:
+            print >> sys.stderr, 'Dry-Run Statistics, re-run with --force to perform updates:'
+            print >> sys.stderr, '\tObjects marked for deletion: %d' % trash_count
+            print >> sys.stderr, '\tBundles that need data_hash recompute: %d' % data_hash_recomputed
+
 
 
 

--- a/codalab/lib/bundle_store.py
+++ b/codalab/lib/bundle_store.py
@@ -46,7 +46,7 @@ class BundleStoreHealthCheckMixin(object):
     BundleStore. Note that this method IS allowed to perform operations destructive to objects stored in the bundle
     store, i.e. this is not an idempotent operation, and calling this method should be done with care.
     """
-    def health_check(self):
+    def health_check(self, model, force):
         pass
 
 class BaseBundleStore(object):
@@ -396,27 +396,27 @@ class MultiDiskBundleStore(BaseBundleStore, BundleStoreCleanupMixin, BundleStore
             path_util.remove(absolute_path)
 
 
-    def health_check(self, model):
+    def health_check(self, model, force=True):
         """
         MultiDiskBundleStore.health_check(): In the MultiDiskBundleStore, bundle contents are stored on disk, and
         occasionally the disk gets out of sync with the database, in which case we make repairs in the following ways:
 
-            1. Creates a trash directory
-            2. Moves the contents of bundles with corresponding UUID not in the database to trash
-            3. Any files that don't begin with a UUID string should be moved to trash
+            1. Deletes bundles with corresponding UUID not in the database.
+            3. Deletes any files not beginning with UUID string.
             4. For each bundle marked READY or FAILED, ensure that its dependencies are not located in the bundle
-               directory.
-            5. Bundles that are stored in <UUID>.cid or <UUID>.status/ should be marked as READY or FAILED
-            6. <UUID>.sh and <UUID>-internal.sh should be gone for bundles marked READY or FAILED
+               directory. If they are then delete the dependencies.
+            5. For bundle <UUID> marked READY or FAILED, <UUID>.cid or <UUID>.status, or the <UUID>(-internal).sh files
+               should not exist.
         """
         # Create a trash directory
         trash_dir = os.path.join(self.codalab_home, 'trash')
         path_util.make_directory(trash_dir)
 
-        def _trash_bundle(bundle_loc, trash_loc):
-            print >> sys.stderr, 'Moving %s to trash...' % bundle_loc
-            trash_path = os.path.join(trash_loc, os.path.basename(bundle_loc))
-            path_util.rename(bundle_loc, trash_path)
+        def _delete_path(loc):
+            cmd = 'rm -r %s' % loc
+            print cmd
+            if force:
+                path_util.remove(loc)
 
         # Scan files in the data directory for every partition, moving bundles that are marked as garbage to the trash
         partitions, _ = path_util.ls(self.partitions)
@@ -424,20 +424,20 @@ class MultiDiskBundleStore(BaseBundleStore, BundleStoreCleanupMixin, BundleStore
         for partition in partitions:
             partition_path = os.path.join(self.partitions, partition, MultiDiskBundleStore.DATA_SUBDIRECTORY)
             for entry in reduce(lambda d,f: d + f, path_util.ls(partition_path)):
-                bundle = os.path.join(partition_path, entry)
-                if self.__check_should_trash(bundle, model):
-                    _trash_bundle(bundle, trash_dir)
-                    trash_count += 0
+                store_entry = os.path.join(partition_path, entry)
+                if self.__check_should_trash(store_entry, model):
+                    _delete_path(store_entry)
+                    trash_count += 1
 
-        print >> sys.stderr, 'Moved %d objects to the trash at %s' % (trash_count, trash_dir)
+        print >> sys.stderr, 'Deleted %d objects from the bundle store' % trash_count
 
 
-    def __check_should_trash(self, bundle_path, model):
-        """Checks a path to a bundle to see if it needs to be trashed.
+    def __check_should_trash(self, path, model):
+        """Checks a path inside of the bundle store to see if it needs to be trashed.
         """
 
         UUID_REGEX = re.compile(r'^(0x[0-9a-z]{32})')
-        file_name = os.path.basename(bundle_path)
+        file_name = os.path.basename(path)
         uuid_match = UUID_REGEX.match(file_name)
         if not uuid_match:
             return True
@@ -451,19 +451,23 @@ class MultiDiskBundleStore(BaseBundleStore, BundleStoreCleanupMixin, BundleStore
             return True
 
         if bundle_db.state in [State.READY, State.FAILED]:
-            # This is the set of paths that should be gone if the bundle is either READY or FAILED
-            # If these paths are still around then something has gone wrong and we should move the bundle to the trash.
-            dep_paths = [
-                    os.path.join(bundle_path, dep.child_path)
-                    for dep in bundle_db.dependencies
-                  ]
-            for path in dep_paths:
-                if os.path.exists(path):
-                    return True
+            # Ensure that the directory of a bundle does not include its dependencies.
+            if file_name == uuid:
+                dep_paths = [
+                        os.path.join(path, dep.child_path)
+                        for dep in bundle_db.dependencies
+                      ]
+                for path in dep_paths:
+                    if os.path.exists(path):
+                        return True
 
-            # Bundles marked as READY or FAILED should not end with .cid, .status or .sh
-            if bundle_path.endswith('.cid') or bundle_path.endswith('.status') or bundle_path.endswith('.sh'):
+            # Bundles marked as READY or FAILED should no longer store .cid, .status, .sh or -internal.sh
+            if path.endswith('.cid') or path.endswith('.status') or path.endswith('.sh'):
                 return True
+
+            # Warn about any other paths with extensions
+            elif '.' in path:
+                print >> sys.stderr, 'WARNING: File %s is likely junk.' % path
 
         return False
 


### PR DESCRIPTION
@percyliang I also went ahead and added a rule that will delete the `.sh` files if its corresponding bundle is marked ready or failed. Everything else is as specified in #346 
