### PR TITLE
 #362: Fix issue with work_manager not appending '0x' to data_hash

### DIFF
--- a/codalab/objects/work_manager.py
+++ b/codalab/objects/work_manager.py
@@ -293,7 +293,7 @@ class Worker(object):
                     print >>sys.stderr, 'Worker.finalize_bundle: installing (copying) dependencies to %s (MakeBundle)' % temp_dir
                     bundle.install_dependencies(self.bundle_store, self.get_parent_dict(bundle), temp_dir, copy=True)
 
-                db_update['data_hash'] = path_util.hash_path(temp_dir)
+                db_update['data_hash'] = '0x%s' % path_util.hash_path(temp_dir)
                 metadata.update(data_size=path_util.get_size(temp_dir))
             except Exception as e:
                 print '=== INTERNAL ERROR: %s' % e

--- a/test-cli.py
+++ b/test-cli.py
@@ -282,6 +282,11 @@ def test(ctx):
     check_equals('None', get_info(uuid, 'data_hash'))
     run_command([cl, 'rm', uuid])
 
+    # run and check the data_hash
+    uuid = run_command([cl, 'run', 'echo hello'])
+    run_command([cl, 'wait', uuid])
+    check_contains('0x', get_info(uuid, 'data_hash'))
+
 @TestModule.register('upload1')
 def test(ctx):
     # Upload contents


### PR DESCRIPTION
@percyliang This will have affected any bundles created since the UUID-based storage upgrade occurred over a week ago. Do you want me to check-in a fix-it script as well or should I just go in and do the fix on the two instances?
