### PR TITLE
Set user on oauth protected views

### DIFF
--- a/codalab/rest/account.py
+++ b/codalab/rest/account.py
@@ -97,9 +97,12 @@ class AuthenticationPlugin(object):
             # Set thread-local user object
             if session:
                 local.user = local.model.get_user(user_id=session.user_id)
+            else:
+                local.user = None
 
             # Redirect unverified users to resend verification page
-            if self.require_verify and hasattr(local, 'user') and not local.user.is_verified:
+            if (self.require_verify and local.user and
+                    not local.user.is_verified):
                 return redirect(default_app().get_url('resend_key'))
 
             return callback(*args, **kwargs)
@@ -135,7 +138,7 @@ def do_logout():
 
 @get('/account/login', name='login', apply=AuthenticationPlugin(require_login=False))
 def show_login():
-    if hasattr(local, 'user'):
+    if local.user:
         return redirect(default_app().get_url('success', message="You are already signed into CodaLab."))
     return template("login")
 
@@ -170,7 +173,7 @@ def show_success():
 
 @get('/account/signup', name='signup', apply=AuthenticationPlugin(require_login=False, require_verify=False))
 def show_signup():
-    if hasattr(local, 'user'):
+    if local.user:
         return redirect(default_app().get_url('success', message="You are already logged into your account."))
 
     return template('signup')
@@ -178,7 +181,7 @@ def show_signup():
 
 @post('/account/signup', apply=AuthenticationPlugin(require_login=False, require_verify=False))
 def do_signup():
-    if hasattr(local, 'user'):
+    if local.user:
         return redirect(default_app().get_url('success', message="You are already logged into your account."))
 
     username = request.forms.get('username')

--- a/codalab/rest/example.py
+++ b/codalab/rest/example.py
@@ -1,4 +1,4 @@
-from bottle import get, post, request
+from bottle import get, post, request, local
 
 from codalab.lib import spec_util
 from codalab.rest.account import AuthenticationPlugin
@@ -27,4 +27,4 @@ def post_file():
 
 @get('/example/oauth_protected', apply=oauth2_provider.require_oauth())
 def oauth_protected():
-    return "You have access!"
+    return "Hi %s." % local.user.user_name

--- a/codalab/rest/example.py
+++ b/codalab/rest/example.py
@@ -25,6 +25,9 @@ def post_file():
     return ''
 
 
-@get('/example/oauth_protected', apply=oauth2_provider.require_oauth())
+@get('/example/oauth_protected', apply=oauth2_provider.use_oauth())
 def oauth_protected():
-    return "Hi %s." % local.user.user_name
+    if local.user:
+        return "Hi %s." % local.user.user_name
+    else:
+        return "Hi stranger."

--- a/codalab/rest/oauth2.py
+++ b/codalab/rest/oauth2.py
@@ -104,9 +104,7 @@ def set_request_user(valid, oauth_request):
     Called after an oauth-protected request is validated.
     If the request is valid, sets local.user to the User that owns the access token.
     """
-    if valid:
-        local.user = oauth_request.user
-
+    local.user = oauth_request.user if valid else None
     return valid, oauth_request
 
 

--- a/codalab/rest/oauth2.py
+++ b/codalab/rest/oauth2.py
@@ -98,6 +98,18 @@ def get_user(username, password, *args, **kwargs):
     return None
 
 
+@oauth2_provider.after_request
+def set_request_user(valid, oauth_request):
+    """
+    Called after an oauth-protected request is validated.
+    If the request is valid, sets local.user to the User that owns the access token.
+    """
+    if valid:
+        local.user = oauth_request.user
+
+    return valid, oauth_request
+
+
 @route('/oauth2/authorize', ['GET', 'POST'], apply=AuthenticationPlugin())
 @oauth2_provider.authorize_handler
 def authorize(*args, **kwargs):


### PR DESCRIPTION
Sets `local.user` for views protected by the `require_oauth` decorator.

Also create new `use_oauth` decorator for views where an oauth token is optional. `local.user` will be `None` if no valid token is provided.

@klopyrev 
