### PR TITLE
Some changes to REST setup.

### DIFF
--- a/codalab/bin/cl.py
+++ b/codalab/bin/cl.py
@@ -94,6 +94,10 @@ def do_rest_server_command(bundle_cli, args):
     if args.watch:
         run_server_with_watch()
     else:
+        if not args.debug:
+            # gevent.monkey.patch_all() needs to be called before importing
+            # bottle.
+            import gevent.monkey; gevent.monkey.patch_all()
         from codalab.server.rest_server import run_rest_server
         run_rest_server(bundle_cli.manager, args.debug, args.processes)
 

--- a/views/email_verification_body.tpl
+++ b/views/email_verification_body.tpl
@@ -4,7 +4,7 @@ You have signed up for an CodaLab account on {{ current_site }} using this
 email address.  To confirm and activate your account, please follow the link
 below:
 
-http://{{ current_site }}/account/verify/{{ key }}
+http://{{ current_site }}/rest/account/verify/{{ key }}
 
 Enjoy!
 

--- a/views/login.tpl
+++ b/views/login.tpl
@@ -12,7 +12,7 @@
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">
 
     <!-- Custom CSS -->
-    <link rel="stylesheet" href="/static/common.css" />
+    <link rel="stylesheet" href="/rest/static/common.css" />
 
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>

--- a/views/oauth2_authorize.tpl
+++ b/views/oauth2_authorize.tpl
@@ -12,7 +12,7 @@
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">
 
     <!-- Custom CSS -->
-    <link rel="stylesheet" href="/static/common.css" />
+    <link rel="stylesheet" href="/rest/static/common.css" />
 
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>

--- a/views/oauth2_errors.tpl
+++ b/views/oauth2_errors.tpl
@@ -12,7 +12,7 @@
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">
 
     <!-- Custom CSS -->
-    <link rel="stylesheet" href="/static/common.css" />
+    <link rel="stylesheet" href="/rest/static/common.css" />
 
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>

--- a/views/signup.tpl
+++ b/views/signup.tpl
@@ -12,7 +12,7 @@
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">
 
     <!-- Custom CSS -->
-    <link rel="stylesheet" href="/static/common.css" />
+    <link rel="stylesheet" href="/rest/static/common.css" />
 
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>

--- a/views/success.tpl
+++ b/views/success.tpl
@@ -12,7 +12,7 @@
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">
 
     <!-- Custom CSS -->
-    <link rel="stylesheet" href="/static/common.css" />
+    <link rel="stylesheet" href="/rest/static/common.css" />
 
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>


### PR DESCRIPTION
1. Place all REST endpoints behind /rest/. The idea is that we'll see up reverse proxying so that it forwards requests, such as https://worksheets.codalab.org/rest/xxx to localhost:2900/rest/xxxx. The Bottle side change is needed so that redirection works properly (e.g. when during account sign-up, the redirect goes to https://worksheets.codalab.org/rest/account/success, instead of https://worksheets.codalab.org/account/success.
2. Don't monkey patch when debugging rest-server, since we're not using gevent. This change is needed so that you can connect the Python remote debugger to the Gunicorn process.
3. Return a non-HTML error response for Ajax calls.
4. Minor style clean-up.
5. Increase Gunicorn timeout.
6. Remove unnecessary /status API.

@percyliang @kashizui 
