### PR TITLE
Changes to auth setup

### DIFF
--- a/codalab/lib/server_util.py
+++ b/codalab/lib/server_util.py
@@ -42,11 +42,14 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 # BEGIN ADAPTED FROM flask_oauthlib.utils #
 
 
-def extract_params():
+def extract_params(extract_body):
     """Extract request params."""
     uri = request.url
     http_method = request.method
-    body = dict(request.forms)
+    if extract_body:
+        body = dict(request.forms)
+    else:
+        body = None
     headers = dict(request.headers)
     if 'wsgi.input' in headers:
         del headers['wsgi.input']

--- a/codalab/rest/account.py
+++ b/codalab/rest/account.py
@@ -2,97 +2,15 @@
 Login and signup views.
 Handles create new user accounts and authenticating users.
 """
-from datetime import datetime, timedelta
+
 
 from bottle import request, response, template, local, redirect, default_app, get, post
 
 from codalab.lib import spec_util
 from codalab.objects.user import User
 from codalab.common import UsageError
-
-
-class LoginSession(object):
-    """
-    Represents the user's session after logging in, usually stored as a cookie.
-    """
-    KEY = "codalab_session"
-    PATH = "/"
-
-    def __init__(self, user_id, max_age):
-        self.user_id = user_id
-        self.max_age = max_age
-        self.expires = datetime.utcnow() + timedelta(seconds=max_age)
-
-    def save(self, response=response):
-        """
-        Save session as cookie on the Bottle response object.
-        :param response: Optional. A specific Bottle response object to save cookie on.
-        :return: None
-        """
-        self.clear(response)
-        response.set_cookie(
-            self.KEY, self, secret=local.config['server']['secret_key'],
-            max_age=self.max_age, path=self.PATH)
-
-    @classmethod
-    def get(cls, request=request):
-        """
-        Get session from cookie on the Bottle request object.
-        Will only return session if exists and not expired yet.
-
-        :param request: Optional. A specific Bottle request object to get cookie from.
-        :return: LoginSession or None
-        """
-        session = request.get_cookie(
-            cls.KEY, secret=local.config['server']['secret_key'], default=None)
-        if session and session.expires > datetime.utcnow():
-            return session
-        else:
-            return None
-
-    @classmethod
-    def clear(cls, response=response):
-        """
-        Delete session cookie on the Bottle response object.
-
-        :param response: Optional. A specific Bottle response object to delete cookie from.
-        :return: None
-        """
-        response.delete_cookie(cls.KEY, path=cls.PATH)
-
-
-class AuthenticationPlugin(object):
-    """Bottle plugin that ensures that the client is authenticated.
-    local.user is set to the authenticated User if authenticated,
-    otherwise the client is redirected to the sign-in page.
-    """
-    api = 2
-
-    def __init__(self, require_login=True, require_verify=True):
-        self.require_login = require_login
-        self.require_verify = require_verify
-
-    def apply(self, callback, route):
-        def wrapper(*args, **kwargs):
-            # Redirect unauthenticated users to login page
-            session = LoginSession.get()
-            if self.require_login and not session:
-                # Make sure X-Forwarded-Host is set properly if behind reverse-proxy to use request.url
-                return redirect(default_app().get_url('login', redirect_uri=request.url))
-
-            # Set thread-local user object
-            if session:
-                local.user = local.model.get_user(user_id=session.user_id)
-            else:
-                local.user = None
-
-            # Redirect unverified users to resend verification page
-            if (self.require_verify and local.user and
-                    not local.user.is_verified):
-                return redirect(default_app().get_url('resend_key'))
-
-            return callback(*args, **kwargs)
-        return wrapper
+from codalab.server.authenticated_plugin import AuthenticatedPlugin, UserVerifiedPlugin
+from codalab.server.cookie import LoginCookie
 
 
 def send_verification_key(username, email, key):
@@ -106,15 +24,15 @@ def send_verification_key(username, email, key):
 
     # Redirect to success page
     return redirect(default_app().get_url(
-        'success',
+        'success_no_verify',
         message="Thank you for signing up for a CodaLab account! "
                 "A link to verify your account has been sent to %s." % email)
     )
 
 
-@get('/account/logout', name='logout')
+@get('/account/logout', name='logout', skip=UserVerifiedPlugin)
 def do_logout():
-    LoginSession.clear()
+    LoginCookie.clear()
     redirect_uri = request.query.get('redirect_uri')
     if redirect_uri:
         return redirect(redirect_uri)
@@ -122,9 +40,9 @@ def do_logout():
         return redirect(default_app().get_url('login'))
 
 
-@get('/account/login', name='login', apply=AuthenticationPlugin(require_login=False))
+@get('/account/login', name='login')
 def show_login():
-    if local.user:
+    if request.user:
         return redirect(default_app().get_url('success', message="You are already signed into CodaLab."))
     return template("login")
 
@@ -139,9 +57,9 @@ def do_login():
     if not (user and user.check_password(password)):
         return template("login", errors=["Login/password did not match."])
 
-    # Save session in client
-    session = LoginSession(user.user_id, max_age=3600)
-    session.save()
+    # Save cookie in client
+    cookie = LoginCookie(user.user_id, max_age=3600)
+    cookie.save()
 
     # Redirect client to next page
     if redirect_uri:
@@ -151,23 +69,24 @@ def do_login():
 
 
 @get('/account/success', name='success')
+@get('/account/success_no_verify', name='success_no_verify', skip=UserVerifiedPlugin)
 def show_success():
     title = request.query.get('title', '') or request.params.get('title', '') or 'Success!'
     message = request.query.get('message', '') or request.params.get('message', '')
     return template('success', message=message, title=title)
 
 
-@get('/account/signup', name='signup', apply=AuthenticationPlugin(require_login=False, require_verify=False))
+@get('/account/signup', name='signup')
 def show_signup():
-    if local.user:
+    if request.user:
         return redirect(default_app().get_url('success', message="You are already logged into your account."))
 
     return template('signup')
 
 
-@post('/account/signup', apply=AuthenticationPlugin(require_login=False, require_verify=False))
+@post('/account/signup')
 def do_signup():
-    if local.user:
+    if request.user:
         return redirect(default_app().get_url('success', message="You are already logged into your account."))
 
     username = request.forms.get('username')
@@ -203,25 +122,25 @@ def do_signup():
     return send_verification_key(username, email, verification_key)
 
 
-@get('/account/verify/<key>')
+@get('/account/verify/<key>', skip=UserVerifiedPlugin)
 def do_verify(key):
     if local.model.verify_user(key):
-        return redirect(default_app().get_url('login', message="Account verified!"))
+        return redirect(default_app().get_url('success', message="Account verified!"))
     else:
         return "Invalid or expired verification key."
 
 
-@get('/account/resend', name='resend_key', apply=AuthenticationPlugin(require_verify=False))
+@get('/account/resend', name='resend_key', skip=UserVerifiedPlugin)
 def resend_key():
-    if local.user.is_verified:
+    if request.user.is_verified:
         return redirect(default_app().get_url('success', message="Your account has already been verified."))
-    key = local.model.get_verification_key(local.user.user_id)
-    return send_verification_key(local.user.user_name, local.user.email, key)
+    key = local.model.get_verification_key(request.user.user_id)
+    return send_verification_key(request.user.user_name, request.user.email, key)
 
 
-@get('/account/whoami', apply=AuthenticationPlugin(require_verify=False))
+@get('/account/whoami', apply=AuthenticatedPlugin(), skip=UserVerifiedPlugin)
 def whoami():
-    info = local.user.to_dict()
+    info = request.user.to_dict()
     del info['password']
     return info
 

--- a/codalab/rest/example.py
+++ b/codalab/rest/example.py
@@ -1,11 +1,10 @@
 from bottle import get, post, request
 
 from codalab.lib import spec_util
-from codalab.rest.account import AuthenticationPlugin
-from codalab.rest.oauth2 import oauth2_provider
+from codalab.server.authenticated_plugin import AuthenticatedPlugin
 
 
-@get('/example/stream_file', apply=AuthenticationPlugin())
+@get('/example/stream_file', apply=AuthenticatedPlugin())
 def stream_file():
     # Stream a file back.
     return open(__file__, 'rb')
@@ -25,6 +24,6 @@ def post_file():
     return ''
 
 
-@get('/example/oauth_protected', apply=oauth2_provider.require_oauth())
+@get('/example/oauth_protected', apply=AuthenticatedPlugin())
 def oauth_protected():
-    return "You have access!"
+    return "Hi %s." % request.user.user_name

--- a/codalab/rest/oauth2.py
+++ b/codalab/rest/oauth2.py
@@ -15,7 +15,7 @@ the decorator handles all of the logic completely. In the case of the 'authorize
 endpoint, we have to implement some additional logic to generate our personalized
 view and process our own form fields.
 
-Note that the 'authorize' endpoint also uses our AuthenticationPlugin, which
+Note that the 'authorize' endpoint also uses our AuthenticatedPlugin, which
 ensures that the user is signed in before allowing them to authorize a request.
 
 The 'errors' endpoint is simply the default redirect destination when the
@@ -24,13 +24,11 @@ contents of the default query parameters 'error' and 'error_description'.
 """
 from datetime import datetime, timedelta
 
-from bottle import request, template, local, route, post, get, default_app
+from bottle import request, template, local, route, post, get
 
 from codalab.objects.oauth2 import OAuth2AuthCode, OAuth2Token
-from codalab.rest.account import AuthenticationPlugin
-from codalab.server.oauth2_provider import OAuth2Provider
-
-oauth2_provider = OAuth2Provider(default_app())
+from codalab.server.authenticated_plugin import AuthenticatedPlugin
+from codalab.server.oauth2_provider import oauth2_provider
 
 
 @oauth2_provider.clientgetter
@@ -53,7 +51,7 @@ def set_grant(client_id, code, _request, *args, **kwargs):
         code=code['code'],
         redirect_uri=_request.redirect_uri,
         scopes=','.join(_request.scopes),
-        user_id=local.user.user_id,
+        user_id=request.user.user_id,
         expires=expires
     )
     return local.model.save_oauth2_auth_code(grant)
@@ -67,9 +65,9 @@ def get_token(access_token=None, refresh_token=None):
 @oauth2_provider.tokensetter
 def set_token(token, _request, *args, **kwargs):
     # _request.user only available for "password" grant types,
-    # while local.user is available on views with @require_login,
+    # while request.user is available on views with @require_login,
     # i.e. the authorize view
-    user = _request.user or local.user
+    user = _request.user or request.user
 
     # Make sure that every client has only one token connected to a user
     local.model.clear_oauth2_tokens(_request.client.client_id, user.user_id)
@@ -93,12 +91,12 @@ def set_token(token, _request, *args, **kwargs):
 @oauth2_provider.usergetter
 def get_user(username, password, *args, **kwargs):
     user = local.model.get_user(username=username)
-    if user.check_password(password):
+    if user is not None and user.check_password(password):
         return user
     return None
 
 
-@route('/oauth2/authorize', ['GET', 'POST'], apply=AuthenticationPlugin())
+@route('/oauth2/authorize', ['GET', 'POST'], apply=AuthenticatedPlugin())
 @oauth2_provider.authorize_handler
 def authorize(*args, **kwargs):
     if request.method == 'GET':

--- a/codalab/server/authenticated_plugin.py
+++ b/codalab/server/authenticated_plugin.py
@@ -1,0 +1,54 @@
+from bottle import (
+  abort,
+  httplib,
+  redirect,
+  request,
+  url,
+)
+
+
+class AuthenticatedPlugin(object):
+    """
+    Fails the request if the user is not authenticated (i.e. request.user hasn't
+    been set).
+
+    This method redirects the user to login unless the request is an AJAX request
+    (i.e. has X-Requested-With header set to XMLHttpRequest). The worker system
+    sets this header as well and so should any other code that doesn't want
+    redirection to happen.
+    """
+    api = 2
+
+    def apply(self, callback, route):
+        def wrapper(*args, **kwargs):
+            if not hasattr(request, 'user') or request.user is None:
+                if request.is_ajax:
+                    abort(httplib.UNAUTHORIZED, 'Not authorized')
+                else:
+                    redirect(url('login', redirect_uri=request.url))
+
+            return callback(*args, **kwargs)
+
+        return wrapper
+
+
+class UserVerifiedPlugin(object):
+    """
+    Fails the request if the user is authenticated but not verified.
+
+    The handling of AJAX requests is the same as above for AuthenticatedPlugin.
+    """
+    api = 2
+
+    def apply(self, callback, route):
+        def wrapper(*args, **kwargs):
+            if (hasattr(request, 'user') and request.user is not None and
+                not request.user.is_verified):
+                if request.is_ajax:
+                    abort(httplib.UNAUTHORIZED, 'User is not verified')
+                else:
+                    redirect(url('resend_key'))
+
+            return callback(*args, **kwargs)
+
+        return wrapper

--- a/codalab/server/authenticated_plugin.py
+++ b/codalab/server/authenticated_plugin.py
@@ -13,9 +13,11 @@ class AuthenticatedPlugin(object):
     been set).
 
     This method redirects the user to login unless the request is an AJAX request
-    (i.e. has X-Requested-With header set to XMLHttpRequest). The worker system
-    sets this header as well and so should any other code that doesn't want
-    redirection to happen.
+    (i.e. has X-Requested-With header set to XMLHttpRequest). This header should
+    be set by:
+      - AJAX requests in the Javascript app.
+      - Requests from the workers.
+      - Requests from the CLI.
     """
     api = 2
 

--- a/codalab/server/cookie.py
+++ b/codalab/server/cookie.py
@@ -1,0 +1,75 @@
+"""
+Handles reading the session cookie.
+"""
+import datetime
+
+from bottle import (
+  local,
+  request,
+  response
+)
+
+
+class LoginCookie(object):
+    """
+    Represents the user's session cookie after logging in.
+    """
+    KEY = "codalab_session"
+    PATH = "/"
+
+    def __init__(self, user_id, max_age):
+        self.user_id = user_id
+        self.max_age = max_age
+        self.expires = datetime.datetime.utcnow() + datetime.timedelta(seconds=max_age)
+
+    def save(self):
+        """
+        Save cookie on the Bottle response object.
+        """
+        self.clear()
+        response.set_cookie(
+            self.KEY, self, secret=local.config['server']['secret_key'],
+            max_age=self.max_age, path=self.PATH)
+
+    @classmethod
+    def get(cls):
+        """
+        Get cookie on the Bottle request object.
+        Will only return cookie if exists and not expired yet.
+
+        :return: LoginCookie or None
+        """
+        cookie = request.get_cookie(
+            cls.KEY, secret=local.config['server']['secret_key'], default=None)
+        if cookie and cookie.expires > datetime.datetime.utcnow():
+            return cookie
+        else:
+            return None
+
+    @classmethod
+    def clear(cls):
+        """
+        Delete cookie on the Bottle response object.
+        """
+        response.delete_cookie(cls.KEY, path=cls.PATH)
+
+
+class CookieAuthenticationPlugin(object):
+    """
+    Bottle plugin that checks the cookie and populates request.user if it is
+    found and valid.
+    """
+    api = 2
+
+    def apply(self, callback, route):
+        def wrapper(*args, **kwargs):
+            if not hasattr(request, 'user') or request.user is None:
+                cookie = LoginCookie.get()
+                if cookie:
+                    request.user = local.model.get_user(user_id=cookie.user_id)
+                else:
+                    request.user = None
+
+            return callback(*args, **kwargs)
+
+        return wrapper

--- a/codalab/server/rest_server.py
+++ b/codalab/server/rest_server.py
@@ -21,6 +21,9 @@ import codalab.rest.account
 import codalab.rest.example
 import codalab.rest.oauth2
 import codalab.rest.users
+from codalab.server.authenticated_plugin import UserVerifiedPlugin
+from codalab.server.cookie import CookieAuthenticationPlugin
+from codalab.server.oauth2_provider import oauth2_provider
 
 
 class SaveEnvironmentPlugin(object):
@@ -111,6 +114,9 @@ def run_rest_server(manager, debug, num_processes):
     install(SaveEnvironmentPlugin(manager))
     install(CheckJsonPlugin())
     install(LoggingPlugin())
+    install(oauth2_provider.check_oauth())
+    install(CookieAuthenticationPlugin())
+    install(UserVerifiedPlugin())
 
     root_app = Bottle()
     root_app.mount('/rest', default_app())


### PR DESCRIPTION
Specifically,

1) When verifying the access token in the request, don't check request.forms since that screws up the input stream and breaks file uploading.
2) For all requests check either the cookie or access token by default. Populate request.user, instead of local.user.
3) Force account verification for most APIs via a plugin.

@kashizui @percyliang 
