### PR TITLE
Set up Nginx for the REST api

### DIFF
--- a/codalab/codalab/settings/__init__.py
+++ b/codalab/codalab/settings/__init__.py
@@ -41,6 +41,8 @@ class Base(Settings):
     PORT = os.environ.get('CONFIG_HTTP_PORT', 8000)
     MAINTENANCE_MODE = os.environ.get('MAINTENANCE_MODE', 0)
 
+    DJANGO_USE_UWSGI = config.get('DJANGO_USE_UWSGI')
+
     STARTUP_ENV = {
         'DJANGO_CONFIGURATION': os.environ['DJANGO_CONFIGURATION'],
         'DJANGO_SETTINGS_MODULE': os.environ['DJANGO_SETTINGS_MODULE'],

--- a/codalab/config/templates/nginx.conf
+++ b/codalab/config/templates/nginx.conf
@@ -1,12 +1,20 @@
 upstream django {
+    {% if DJANGO_USE_UWSGI %}
     server unix:{{LOGS_PATH}}/{{SERVER_NAME}}-{{PORT}}.sock;
+    {% else %}
+    server 127.0.0.1:2700;
+    {% endif %}
 }
 
 upstream bundleservice {
     server 127.0.0.1:2800;
 }
 
-{% if SSL_CERTIFICATE|length > 0 %}
+upstream rest {
+    server 127.0.0.1:2900;
+}
+
+{% if SSL_CERTIFICATE and SSL_CERTIFICATE|length > 0 %}
 server {
     listen {{PORT}};
     server_name {{ SSL_ALLOWED_HOSTS|join:" " }};
@@ -17,10 +25,9 @@ server {
 {% endif %}
 
 server {
-
     set $maintenance {{MAINTENANCE_MODE}};
 
-    {% if SSL_CERTIFICATE|length > 0 %}
+    {% if SSL_CERTIFICATE and SSL_CERTIFICATE|length > 0 %}
       listen {{SSL_PORT}} ssl;
       ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
       ssl_ciphers RC4:HIGH:!aNULL:!MD5;
@@ -54,8 +61,20 @@ server {
         if ($maintenance = 1) {
             return 503;
         }
-        proxy_set_header Host $host;
+        proxy_set_header Host $http_host;
         proxy_pass http://bundleservice/;
+        proxy_connect_timeout       1200;
+        proxy_send_timeout          1200;
+        proxy_read_timeout          1200;
+        send_timeout                1200;
+    }
+
+    location /rest {
+        if ($maintenance = 1) {
+            return 503;
+        }
+        proxy_set_header Host $http_host;
+        proxy_pass http://rest;
         proxy_connect_timeout       1200;
         proxy_send_timeout          1200;
         proxy_read_timeout          1200;
@@ -74,6 +93,7 @@ server {
         if ($maintenance = 1) {
             return 503;
         }
+        {% if DJANGO_USE_UWSGI %}
         uwsgi_pass  django;
         # Up timeout from default 60 to 1200 seconds (20 minutes?) to see if it helps avoid 504's
         uwsgi_read_timeout 1200;
@@ -95,6 +115,14 @@ server {
         uwsgi_param   X-Real-IP            $remote_addr;
         uwsgi_param   X-Forwarded-For      $proxy_add_x_forwarded_for;
         uwsgi_param   X-Forwarded-Proto    $http_x_forwarded_proto;
+        {% else %}
+        proxy_set_header Host $http_host;
+        proxy_pass http://django/;
+        proxy_connect_timeout       1200;
+        proxy_send_timeout          1200;
+        proxy_read_timeout          1200;
+        send_timeout                1200;
+        {% endif %}
     }
 
     error_page 503 /error/503.html;

--- a/codalab/config/templates/nginx.conf
+++ b/codalab/config/templates/nginx.conf
@@ -61,8 +61,9 @@ server {
         if ($maintenance = 1) {
             return 503;
         }
-        proxy_set_header Host $http_host;
         proxy_pass http://bundleservice/;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $http_host;
         proxy_connect_timeout       1200;
         proxy_send_timeout          1200;
         proxy_read_timeout          1200;
@@ -73,8 +74,9 @@ server {
         if ($maintenance = 1) {
             return 503;
         }
-        proxy_set_header Host $http_host;
         proxy_pass http://rest;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $http_host;
         proxy_connect_timeout       1200;
         proxy_send_timeout          1200;
         proxy_read_timeout          1200;
@@ -116,8 +118,9 @@ server {
         uwsgi_param   X-Forwarded-For      $proxy_add_x_forwarded_for;
         uwsgi_param   X-Forwarded-Proto    $http_x_forwarded_proto;
         {% else %}
-        proxy_set_header Host $http_host;
         proxy_pass http://django/;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $http_host;
         proxy_connect_timeout       1200;
         proxy_send_timeout          1200;
         proxy_read_timeout          1200;

--- a/codalab/manage
+++ b/codalab/manage
@@ -4,4 +4,5 @@
 #   runserver 0.0.0.0:8000
 #   syncdb --migrate
 # Add --traceback to print out more.
+source ../venv/bin/activate
 exec ../venv/bin/python manage.py "$@"

--- a/deployment/fabfile.py
+++ b/deployment/fabfile.py
@@ -248,6 +248,7 @@ def getWebsiteConfig(config):
         'SSL_ALLOWED_HOSTS': ssl_allowed_hosts,
         'email': config.getEmailInfo(),
         'django': config.getDjangoInfo(),
+        'DJANGO_USE_UWSGI': True,
         'database': {
             'ENGINE': config.getDatabaseEngine(),
             'NAME': config.getDatabaseName(),


### PR DESCRIPTION
3 changes, specifically:
1) Get config_gen to run again locally (It was failing on SSL_CERTIFICATE|length).
2) Add the REST server reverse proxy rule.
3) Set up Nginx for local development. I'll add instructions to the Wiki once the code is checked in, but basically:


cl server
cl rest-server
cd codalab-worksheets/codalab
./manage runserver 127.0.0.1:2700

sudo apt-get install nginx
./manage config_gen
sudo cp config/generated/nginx.conf /etc/nginx/sites-enabled
sudo service nginx restart


@percyliang @kashizui @andreweduffy 