### PR TITLE
Point Javascript app at the new REST APIs.

### DIFF
--- a/codalab/apps/web/static/js/bundle/bundle_interface.jsx
+++ b/codalab/apps/web/static/js/bundle/bundle_interface.jsx
@@ -51,7 +51,7 @@ var Bundle = React.createClass({
             type: "POST",
             cache: false,
             //  /api/bundles/0x706<...>d5b66e
-            url: "/api" + document.location.pathname,
+            url: "/rest/api" + document.location.pathname,
             contentType:"application/json; charset=utf-8",
             dataType:"json",
             data: JSON.stringify(postdata),
@@ -80,12 +80,13 @@ var Bundle = React.createClass({
         $.ajax({
             type: "GET",
             //  /api/bundles/0x706<...>d5b66e
-            url: "/api" + document.location.pathname,
+            url: "/rest/api" + document.location.pathname,
             dataType: 'json',
             cache: false,
             success: function(data) {
                 if(this.isMounted()){
                     this.setState(data);
+                    this.updateTitle(data);
                 }
                 $("#bundle-message").hide().removeClass('alert-danger alert');
             }.bind(this),
@@ -101,6 +102,16 @@ var Bundle = React.createClass({
         });
 
         this.updateFileBrowser();
+    },
+
+    updateTitle: function(data) {
+      // Doing this dynamically is not ideal, since not all crawlers run
+      // JavaScript. It's better than nothing, though.
+      if (data.metadata.name) {
+        document.title = document.title + ': ' + data.metadata.name;
+        title_meta = $('meta[property="og:title"]')
+        title_meta.attr('content', title_meta.attr('content') + ': ' + data.metadata.name);
+      }
     },
 
     // File browser is updated based on location.hash!
@@ -135,7 +146,7 @@ var Bundle = React.createClass({
         $.ajax({
             type: "GET",
             //  /api/bundles/0x706<...>d5b66e
-            url: document.location.pathname.replace('/bundles/', '/api/bundles/content/') + folder_path + '/', //extra slash at end means root dir
+            url: document.location.pathname.replace('/bundles/', '/rest/api/bundles/content/') + folder_path + '/', //extra slash at end means root dir
             dataType: 'json',
             cache: false,
             success: function(data) {
@@ -155,7 +166,7 @@ var Bundle = React.createClass({
     render: function() {
         var saveButton;
         var metadata = this.state.metadata;
-        var bundle_download_url = "/bundles/" + this.state.uuid + "/download";
+        var bundle_download_url = "/rest/bundle/" + this.state.uuid + "/contents/blob/";
         var bundleAttrs = [];
         var editing = this.state.editing;
         var tableClassName = 'table' + (editing ? ' editing' : '');
@@ -517,7 +528,7 @@ var FileBrowserItem = React.createClass({
             file_location = this.props.index;
         }
 
-        var file_link = document.location.pathname.replace('/bundles/', '/api/bundles/filecontent/') + file_location;
+        var file_link = document.location.pathname.replace('/bundles/', '/rest/bundle/') + 'contents/blob/' + file_location;
         var size = '';
         if(this.props.hasOwnProperty('size')){
             if(this.props.size == 0 || this.props.size === undefined)

--- a/codalab/apps/web/static/js/bundle/bundle_interface.jsx
+++ b/codalab/apps/web/static/js/bundle/bundle_interface.jsx
@@ -86,7 +86,6 @@ var Bundle = React.createClass({
             success: function(data) {
                 if(this.isMounted()){
                     this.setState(data);
-                    this.updateTitle(data);
                 }
                 $("#bundle-message").hide().removeClass('alert-danger alert');
             }.bind(this),
@@ -102,16 +101,6 @@ var Bundle = React.createClass({
         });
 
         this.updateFileBrowser();
-    },
-
-    updateTitle: function(data) {
-      // Doing this dynamically is not ideal, since not all crawlers run
-      // JavaScript. It's better than nothing, though.
-      if (data.metadata.name) {
-        document.title = document.title + ': ' + data.metadata.name;
-        title_meta = $('meta[property="og:title"]')
-        title_meta.attr('content', title_meta.attr('content') + ': ' + data.metadata.name);
-      }
     },
 
     // File browser is updated based on location.hash!

--- a/codalab/apps/web/static/js/worksheet/bundle_uploader.jsx
+++ b/codalab/apps/web/static/js/worksheet/bundle_uploader.jsx
@@ -39,7 +39,7 @@ var BundleUploader = React.createClass({
     fd.append('bundle_type', 'dataset');
     fd.append('worksheet_uuid', this.props.ws.info.uuid);
     $.ajax({
-      url: '/api/bundles/upload/',
+      url: '/rest/api/bundles/upload/',
       data: fd,
       processData: false,
       contentType: false,

--- a/codalab/apps/web/static/js/worksheet/editable_field.jsx
+++ b/codalab/apps/web/static/js/worksheet/editable_field.jsx
@@ -60,7 +60,7 @@ var WorksheetEditableField = React.createClass({
   },
   render: function () {
     return (
-      <EditableField {...this.props} url="/api/worksheets/command/" buildParams={this.buildParams} />
+      <EditableField {...this.props} url="/rest/api/worksheets/command/" buildParams={this.buildParams} />
     );
   }
 });
@@ -80,7 +80,7 @@ var BundleEditableField = React.createClass({
   },
   render: function () {
     return (
-      <EditableField {...this.props} url={"/api/bundles/" + this.props.uuid + "/"} buildParams={this.buildParams} />
+      <EditableField {...this.props} url={"/rest/api/bundles/" + this.props.uuid + "/"} buildParams={this.buildParams} />
     );
   }
 });

--- a/codalab/apps/web/static/js/worksheet/faq.jsx
+++ b/codalab/apps/web/static/js/worksheet/faq.jsx
@@ -8,7 +8,7 @@ var FAQ = React.createClass({
 
   componentDidMount: function () {
     $.ajax({
-      url: '/api/faq/',
+      url: '/rest/api/faq/',
       dataType: 'json',
       cache: false,
       type: 'GET',

--- a/codalab/apps/web/static/js/worksheet/sample_worksheets_interface.jsx
+++ b/codalab/apps/web/static/js/worksheet/sample_worksheets_interface.jsx
@@ -1,0 +1,43 @@
+var SampleWorksheetsBox = React.createClass({
+  getInitialState: function() {
+    return {'data': []};
+  },
+   componentDidMount: function() {
+     $.ajax({
+       url: '/rest/worksheets/sample/',
+       dataType: 'json',
+       cache: false,
+       success: function(data) {
+         this.setState({'data': data});
+       }.bind(this),
+       error: function(xhr, status, err) {
+         console.log(xhr, status, err);
+       }.bind(this)
+     });
+   },
+  render: function() {
+    var worksheetNodes = this.state.data.map(function(worksheet) {
+      var url = "/worksheets/" + worksheet.uuid + "/";
+      return (
+        <tr><td>
+          <div className="frontpage-worksheets-list-item">
+            <a target="_blank" href={url}>{worksheet.display_name}</a> by {worksheet.owner_name}
+          </div>
+        </td></tr>
+      );
+    });
+    return (
+      <table className="frontpage-worksheets-list">
+        <tr><td>
+          <div className="frontpage-worksheets-list-header">
+            Example Worksheets
+          </div> 
+        </td></tr>
+        {worksheetNodes}
+      </table>
+    );
+  }
+});
+
+// Create and render it.
+React.render(<SampleWorksheetsBox />, document.getElementById('sample_worksheets'));

--- a/codalab/apps/web/static/js/worksheet/sample_worksheets_interface.jsx
+++ b/codalab/apps/web/static/js/worksheet/sample_worksheets_interface.jsx
@@ -1,3 +1,5 @@
+// Box that displays a few sample worksheets on the home page.
+
 var SampleWorksheetsBox = React.createClass({
   getInitialState: function() {
     return {'data': []};

--- a/codalab/apps/web/static/js/worksheet/table_item_interface.jsx
+++ b/codalab/apps/web/static/js/worksheet/table_item_interface.jsx
@@ -140,7 +140,7 @@ var TableRow = React.createClass({
             if (col == 0) {
               url = base_url;
             } else if (column_with_hyperlinks.indexOf(header_key) != -1) {
-              url = '/api/bundles/filecontent/' + uuid + row_content['path'];
+              url = '/rest/bundle/' + uuid + '/contents/blob' + row_content['path'];
               if ('text' in row_content) {
                 row_content = row_content['text'];
               } else {

--- a/codalab/apps/web/static/js/worksheet/worksheet_action_bar.jsx
+++ b/codalab/apps/web/static/js/worksheet/worksheet_action_bar.jsx
@@ -123,7 +123,7 @@ var WorksheetActionBar = React.createClass({
     return $.ajax({
       type: 'POST',
       cache: false,
-      url: '/api/worksheets/command/',
+      url: '/rest/api/worksheets/command/',
       contentType: "application/json; charset=utf-8",
       dataType: 'json',
       data: JSON.stringify({
@@ -159,7 +159,7 @@ var WorksheetActionBar = React.createClass({
     $.ajax({
       type: 'POST',
       cache: false,
-      url: '/api/worksheets/command/',
+      url: '/rest/api/worksheets/command/',
       contentType: "application/json; charset=utf-8",
       dataType: 'json',
       data: JSON.stringify({

--- a/codalab/apps/web/static/js/worksheet/worksheet_chat_box.jsx
+++ b/codalab/apps/web/static/js/worksheet/worksheet_chat_box.jsx
@@ -48,7 +48,7 @@ var WorksheetChatBox = React.createClass({
     var userInfo = this.props.userInfo;
     if (userInfo === null) return;
     $.ajax({
-      url: '/api/chatbox/',
+      url: '/rest/api/chatbox/',
       dataType: 'json',
       cache: false,
       type: 'GET',
@@ -84,7 +84,7 @@ var WorksheetChatBox = React.createClass({
     chatbox.boxManager.addMsg(user, msg);
     this.setState({numOfChatHistory: this.state.numOfChatHistory + 1});
     $.ajax({
-      url: '/api/chatbox/',
+      url: '/rest/api/chatbox/',
       data: {
         senderUserId: this.props.userId,
         recipientUserId: this.props.userInfo.system_user_id,

--- a/codalab/apps/web/static/js/worksheet/worksheet_chat_portal.jsx
+++ b/codalab/apps/web/static/js/worksheet/worksheet_chat_portal.jsx
@@ -41,7 +41,7 @@ var WorksheetChatPortalInterface = React.createClass({
 
   componentDidMount: function() {
     $.ajax({
-      url: '/api/chatbox/',
+      url: '/rest/api/chatbox/',
       dataType: 'json',
       cache: false,
       type: 'GET',
@@ -83,7 +83,7 @@ var WorksheetChatPortalInterface = React.createClass({
 
   handleAnswerChat: function(recipientUserId, msg) {
     $.ajax({
-      url: '/api/chatbox/',
+      url: '/rest/api/chatbox/',
       dataType: 'json',
       type: 'POST',
       data: {

--- a/codalab/apps/web/static/js/worksheet/worksheet_content.jsx
+++ b/codalab/apps/web/static/js/worksheet/worksheet_content.jsx
@@ -6,7 +6,7 @@ var WorksheetContent = function() {
     function WorksheetContent(uuid) {
         this.uuid = uuid;
         this.info = null;  // Worksheet info
-        this.url = '/api/worksheets/' + this.uuid + '/';
+        this.url = '/rest/api/worksheets/' + this.uuid + '/';
     }
 
     WorksheetContent.prototype.fetch = function(props) {

--- a/codalab/apps/web/static/js/worksheet/worksheet_interface.jsx
+++ b/codalab/apps/web/static/js/worksheet/worksheet_interface.jsx
@@ -92,7 +92,7 @@ var Worksheet = React.createClass({
         window.history.replaceState({uuid: this.state.ws.uuid}, '', window.location.pathname);
         $('body').addClass('ws-interface');
         $.ajax({
-        url: '/api/users/',
+        url: '/rest/api/users/',
             dataType: 'json',
             cache: false,
             type: 'GET',

--- a/codalab/apps/web/static/js/worksheet/worksheet_interface.jsx
+++ b/codalab/apps/web/static/js/worksheet/worksheet_interface.jsx
@@ -306,6 +306,7 @@ var Worksheet = React.createClass({
         this.state.ws.fetch({
             success: function(data) {
                 $('#update_progress, #worksheet-message').hide();
+                this.updateTitle();
                 $('#worksheet_content').show();
                 this.setState({updating: false, version: this.state.version + 1});
                 // Fix out of bounds.
@@ -328,6 +329,22 @@ var Worksheet = React.createClass({
                 $('#worksheet_container').hide();
             }.bind(this)
         });
+    },
+
+    updateTitle: function() {
+      if (!this.state.titleUpdated) {
+        this.state.titleUpdated = true;
+        // Doing this dynamically is not ideal, since not all crawlers run
+        // JavaScript. It's better than nothing, though.
+        if (this.state.ws.info.title) {
+          title = this.state.ws.info.title;
+        } else {
+          title = this.state.ws.info.name;
+        }
+        document.title = document.title + ': ' + title;
+        title_meta = $('meta[property="og:title"]')
+        title_meta.attr('content', title_meta.attr('content') + ': ' + title);
+      }
     },
 
     openWorksheet: function(uuid) {

--- a/codalab/apps/web/static/js/worksheet/worksheet_interface.jsx
+++ b/codalab/apps/web/static/js/worksheet/worksheet_interface.jsx
@@ -306,7 +306,6 @@ var Worksheet = React.createClass({
         this.state.ws.fetch({
             success: function(data) {
                 $('#update_progress, #worksheet-message').hide();
-                this.updateTitle();
                 $('#worksheet_content').show();
                 this.setState({updating: false, version: this.state.version + 1});
                 // Fix out of bounds.
@@ -329,22 +328,6 @@ var Worksheet = React.createClass({
                 $('#worksheet_container').hide();
             }.bind(this)
         });
-    },
-
-    updateTitle: function() {
-      if (!this.state.titleUpdated) {
-        this.state.titleUpdated = true;
-        // Doing this dynamically is not ideal, since not all crawlers run
-        // JavaScript. It's better than nothing, though.
-        if (this.state.ws.info.title) {
-          title = this.state.ws.info.title;
-        } else {
-          title = this.state.ws.info.name;
-        }
-        document.title = document.title + ': ' + title;
-        title_meta = $('meta[property="og:title"]')
-        title_meta.attr('content', title_meta.attr('content') + ': ' + title);
-      }
     },
 
     openWorksheet: function(uuid) {

--- a/codalab/apps/web/static/js/worksheet/worksheet_side_panel.jsx
+++ b/codalab/apps/web/static/js/worksheet/worksheet_side_panel.jsx
@@ -249,7 +249,7 @@ var BundleDetailSidePanel = React.createClass({
       //console.log('BundleDetailSidePanel.fetchExtra', bundle_info.uuid);
       $.ajax({
           type: "GET",
-          url: "/api/bundles/" + bundle_info.uuid,
+          url: "/rest/api/bundles/" + bundle_info.uuid + "/",
           dataType: 'json',
           cache: false,
           success: function(data) {
@@ -279,7 +279,7 @@ var BundleDetailSidePanel = React.createClass({
         }
         this.setState({"currentWorkingDirectory": folder_path});
 
-        var url = '/api/bundles/content/' + this.state.uuid + '/' + folder_path;
+        var url = '/rest/api/bundles/content/' + this.state.uuid + '/' + folder_path + '/';
         $.ajax({
             type: 'GET',
             url: url,
@@ -396,7 +396,7 @@ function renderMetadata(bundle_info, bundleMetadataChanged) {
 
 function renderHeader(bundle_info, bundleMetadataChanged) {
   var bundle_url = '/bundles/' + bundle_info.uuid;
-  var bundle_download_url = "/bundles/" + bundle_info.uuid + "/download";
+  var bundle_download_url = "/rest/bundle/" + bundle_info.uuid + "/contents/blob/";
   var bundle_name;
   var bundle_description;
   if (bundle_info.metadata.name) {
@@ -445,7 +445,7 @@ function renderHeader(bundle_info, bundleMetadataChanged) {
 function renderContents(bundle_info) {
   var stdout_html = '';
   if (bundle_info.stdout) {
-    var stdout_url = '/api/bundles/filecontent/' + bundle_info.uuid + '/stdout';
+    var stdout_url = '/rest/bundle/' + bundle_info.uuid + '/contents/blob/stdout';
     stdout_html = (<div>
       <span><a href={stdout_url} target="_blank">stdout</a></span>
       &nbsp;
@@ -458,7 +458,7 @@ function renderContents(bundle_info) {
 
   var stderr_html = '';
   if (bundle_info.stderr) {
-    var stderr_url = '/api/bundles/filecontent/' + bundle_info.uuid + '/stderr';
+    var stderr_url = '/rest/bundle/' + bundle_info.uuid + '/contents/blob/stderr';
     stderr_html = (<div>
       <span><a href={stderr_url} target="_blank">stderr</a></span>
       &nbsp;
@@ -614,7 +614,7 @@ var FileBrowserItem = React.createClass({
           file_location = this.props.index;
         }
 
-        var file_link = '/api/bundles/filecontent/' + this.props.bundle_uuid + '/' + file_location;
+        var file_link = '/rest/bundle/' + this.props.bundle_uuid + '/contents/blob/' + file_location;
         var size = '';
         if (this.props.hasOwnProperty('size_str'))
           size = this.props['size_str'];

--- a/codalab/apps/web/templates/base.html
+++ b/codalab/apps/web/templates/base.html
@@ -1,5 +1,4 @@
 {% load url from future %}
-{% load account %}
 {% load analytical %}
 {% load codalab_tags %}
 {% load compress %}
@@ -20,6 +19,8 @@
     <title>CodaLab - {% block head_title %}{% endblock %}</title>
 
     {% block css %}
+        <!-- Add a timestamp to the account CSS name to prevent caching. -->
+        <link rel="stylesheet" href="/rest/account/css?={% now "U" %}">
         <!-- Included CSS Files (Compressed) -->
         <link rel="stylesheet" href="{{ STATIC_URL }}css/jquery.dataTables.css">
         <link rel="stylesheet" href="{{ STATIC_URL }}css/jquery-editable.css">
@@ -78,35 +79,30 @@
                         </form>
                     {% endif %}
                     <ul class="nav navbar-nav navbar-right">
-                        <li><a href="/worksheets/?name=home" tabIndex=2 target="_self">Public Home</a></li>
-                        {% if user.is_authenticated %}
-                          <li><a href="/worksheets/?name=/" tabIndex=2 target="_self">My Home</a></li>
-                          <li><a href="/worksheets/?name=dashboard" tabIndex=2 target="_self">My Dashboard</a></li>
-                        {% endif %}
+                        <li><a href="/rest/worksheets/?name=home" tabIndex=2 target="_self">Public Home</a></li>
+                        <li class="user-authenticated">
+                          <a href="/rest/worksheets/?name=%2F" tabIndex=2 target="_self">My Home</a>
+                        </li>
+                        <li class="user-authenticated">
+                          <a href="/rest/worksheets/?name=dashboard" tabIndex=2 target="_self">My Dashboard</a>
+                        </li>
                         <li>
                           <a href="https://github.com/codalab/codalab-worksheets/wiki" target="_blank">Help</a>
                         </li>
-                        {% if user.is_authenticated %}
-                            <li class="dropdown {% active request '/accounts/' %}">
-                                <a href="{% url 'user_settings' %}">
-                                    <img src="{{ STATIC_URL }}img/icon_mini_avatar.png" class="mini-avatar" alt="{{user.username}}"> {{user.username}} <span class="caret"></span>
-                                </a>
-                                <ul class="dropdown-menu" role="menu">
-                                    <li><a href="{% url 'user_settings' %}">Settings</a></li>
-                                    <li class="divider"></li>
-                                    <li><a href="/accounts/password/reset/" target="_self">Change Password</a></li>
-                                    <li class="divider"></li>
-                                    <li><a href="{% url 'account_logout' %}" target="_self">Sign Out</a></li>
-                                </ul>
-                            </li>
-                        {% else %}
-                            <li>
-                                <a href="{% url 'account_signup' %}?next={{request.path}}" target="_self">Sign Up</a>
-                            </li>
-                            <li>
-                                <a href="{% url 'account_login' %}?next={{request.path}}" target="_self">Sign In</a>
-                            </li>
-                        {% endif %}
+                        <li class="user-authenticated dropdown {% active request '/accounts/' %}">
+                            <a>
+                                <img src="{{ STATIC_URL }}img/icon_mini_avatar.png" class="mini-avatar"> <span class="user-name"></span> <span class="caret"></span>
+                            </a>
+                            <ul class="dropdown-menu" role="menu">
+                                <li><a href="/rest/account/logout?redirect_uri={{request.path|urlencode:""}}" target="_self">Sign Out</a></li>
+                            </ul>
+                        </li>
+                        <li class="user-not-authenticated">
+                            <a href="/rest/account/signup" target="_self">Sign Up</a>
+                        </li>
+                        <li class="user-not-authenticated">
+                            <a href="/rest/account/login?redirect_uri={{request.path|urlencode:""}}" target="_self">Sign In</a>
+                        </li>
                     </ul>
                 </div>
             {% endblock top_bar_right_menus %}

--- a/codalab/apps/web/templates/base.html
+++ b/codalab/apps/web/templates/base.html
@@ -19,7 +19,11 @@
     <title>CodaLab - {% block head_title %}{% endblock %}</title>
 
     {% block css %}
-        <!-- Add a timestamp to the account CSS name to prevent caching. -->
+        <!--
+        Read CSS that hides / shows buttons depending on whether the user is
+        logged in or not, and fills in the user name. Add a timestamp to prevent
+        caching.
+        -->
         <link rel="stylesheet" href="/rest/account/css?={% now "U" %}">
         <!-- Included CSS Files (Compressed) -->
         <link rel="stylesheet" href="{{ STATIC_URL }}css/jquery.dataTables.css">

--- a/codalab/apps/web/templates/web/bundles/detail.html
+++ b/codalab/apps/web/templates/web/bundles/detail.html
@@ -1,9 +1,9 @@
 {% extends "base.html" %}
 
-{% block head_title %}Bundle: {{bundle_title}}{% endblock head_title %}
-{% block page_title %}Bundle: {{bundle_title}}{% endblock page_title %}
+{% block head_title %}Bundle{% endblock head_title %}
+{% block page_title %}Bundle Details{% endblock page_title %}
 {% block meta %}
-    <meta property="og:title" content="Bundle: {{bundle_title}}">
+    <meta property="og:title" content="Bundle">
     <meta property="og:site_name" content="CodaLab">
     <meta property="og:type" content="article">
     <meta property="og:image" content="{{ request.META.HTTP_HOST }}{{STATIC_URL}}img/codalab-logo.png">

--- a/codalab/apps/web/templates/web/bundles/detail.html
+++ b/codalab/apps/web/templates/web/bundles/detail.html
@@ -8,6 +8,10 @@
     <meta property="og:type" content="article">
     <meta property="og:image" content="{{ request.META.HTTP_HOST }}{{STATIC_URL}}img/codalab-logo.png">
 {% endblock %}
+{% block extra_scripts %}
+<!-- Read a script that fills in the bundle title. Add a timestamp to prevent caching. -->
+<script src="/rest/titlejs/bundle/{{ uuid }}/?={% now "U" %}"></script>
+{% endblock extra_scripts %}
 
 {% block content %}
 <div id="bundle-message" class="bundle-detail">

--- a/codalab/apps/web/templates/web/index.html
+++ b/codalab/apps/web/templates/web/index.html
@@ -11,21 +11,18 @@
                     <img src="{{STATIC_URL}}img/codalab-logo-white.png" alt="CodaLab" class="img-responsive">
                     <h4><b><i>A collaborative platform for reproducible research.</i></b></h4>
                     <div class="frontpage-buttons">
-                      {% if user.is_authenticated %}
-                        <span class="frontpage-button">
-                          <a href="/worksheets/?name=/">My Home</a>
+                        <span class="user-authenticated frontpage-button">
+                          <a href="/rest/worksheets/?name=%2F">My Home</a>
                         </span>
-                        <span class="frontpage-button">
-                          <a href="/worksheets/?name=dashboard">My Dashboard</a>
+                        <span class="user-authenticated frontpage-button">
+                          <a href="/rest/worksheets/?name=dashboard">My Dashboard</a>
                         </span>
-                      {% else %}
-                        <span class="frontpage-button">
-                          <a href="/accounts/signup">Sign Up</a>
+                        <span class="user-not-authenticated frontpage-button">
+                          <a href="/rest/account/signup">Sign Up</a>
                         </span>
-                        <span class="frontpage-button">
-                          <a href="/accounts/login">Sign In</a>
+                        <span class="user-not-authenticated frontpage-button">
+                          <a href="/rest/account/login?redirect_uri={{request.path|urlencode:""}}">Sign In</a>
                         </span>
-                      {% endif %}
                     </div>
                 </div>
             </div>
@@ -45,7 +42,7 @@
             so you can be a more efficient researcher.
             <p>
             To get started, read more about the <a target="_blank" href="https://github.com/codalab/codalab-worksheets/wiki">mission</a>,
-            <a href="/accounts/signup">sign up</a> for an account,
+            <a href="/rest/account/signup">sign up</a> for an account,
             and go through the <a target="_blank" href="https://github.com/codalab/codalab-worksheets/wiki/User_CodaLab-Worksheets-Tutorial">tutorial</a> to try it out!
             </p>
           </div>
@@ -99,22 +96,15 @@
 
         <div class="row">
           <div class="col-sm-10 col-sm-offset-1">
-            <table class="frontpage-worksheets-list">
-              <tr><td>
-                <div class="frontpage-worksheets-list-header">
-                  Example Worksheets
-                </div> 
-              </td></tr>
-              {% for worksheet in worksheets %}
-                <tr><td>
-                  <div class="frontpage-worksheets-list-item">
-                    <a target="_blank" href="{% url 'ws_view' worksheet.0 %}">{{worksheet.1}}</a> by {{ worksheet.3 }}
-                  </div>
-                </td></tr>
-              {% endfor %}
-            </table>
+            <div id="sample_worksheets"></div>
           </div>
         </div>
 
     </div>
 {% endblock content %}
+
+{% block jsincludes %}
+    <script src="{{ STATIC_URL }}bower_components/react/react.min.js"></script>
+    <script src="{{ STATIC_URL }}dist/sample_worksheets_interface.js"></script>
+{% endblock jsincludes %}
+

--- a/codalab/apps/web/templates/web/worksheets/detail.html
+++ b/codalab/apps/web/templates/web/worksheets/detail.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
 {% block custom_body_attributes %}{% endblock %}
-{% block head_title %}Worksheet: {{worksheet_title}}{% endblock head_title %}
+{% block head_title %}Worksheet{% endblock head_title %}
 {% block meta %}
-    <meta property="og:title" content="Worksheet: {{worksheet_title}}">
+    <meta property="og:title" content="Worksheet">
     <meta property="og:site_name" content="CodaLab">
     <meta property="og:type" content="article">
     <meta property="og:image" content="{{ request.META.HTTP_HOST }}{{STATIC_URL}}img/codalab-logo.png">

--- a/codalab/apps/web/templates/web/worksheets/detail.html
+++ b/codalab/apps/web/templates/web/worksheets/detail.html
@@ -7,6 +7,10 @@
     <meta property="og:type" content="article">
     <meta property="og:image" content="{{ request.META.HTTP_HOST }}{{STATIC_URL}}img/codalab-logo.png">
 {% endblock %}
+{% block extra_scripts %}
+<!-- Read a script that fills in the worksheet title. Add a timestamp to prevent caching. -->
+<script src="/rest/titlejs/worksheet/{{ uuid }}/?={% now "U" %}"></script>
+{% endblock extra_scripts %}
 {% block subheader %}{% endblock subheader %}
 
 {% block content_wrapper %}


### PR DESCRIPTION
Update the Javascript app to use the migrated REST APIs. Now, Django doesn't talk to the Bundle Server at all, only the Javascript app does.

Note the css hack to get the correct things to display, depending on whether the user is logged in or not.

@kashizui @percyliang 