### PR TITLE
Few changes to server setup

### DIFF
--- a/codalab/bin/cl.py
+++ b/codalab/bin/cl.py
@@ -84,6 +84,11 @@ def do_server_command(bundle_cli, args):
                  'CPUs.',
             type=int, default=1),
         Commands.Argument(
+            '-t', '--threads',
+            help='Number of threads to use. The server will be able to handle '
+                 '(--processes) x (--threads) requests at the same time.',
+            type=int, default=50),
+        Commands.Argument(
             '-d', '--debug', help='Run the development server for debugging.',
             action='store_true')
     ),
@@ -94,12 +99,8 @@ def do_rest_server_command(bundle_cli, args):
     if args.watch:
         run_server_with_watch()
     else:
-        if not args.debug:
-            # gevent.monkey.patch_all() needs to be called before importing
-            # bottle.
-            import gevent.monkey; gevent.monkey.patch_all()
         from codalab.server.rest_server import run_rest_server
-        run_rest_server(bundle_cli.manager, args.debug, args.processes)
+        run_rest_server(bundle_cli.manager, args.debug, args.processes, args.threads)
 
 
 if __name__ == '__main__':

--- a/codalab/objects/user.py
+++ b/codalab/objects/user.py
@@ -21,6 +21,10 @@ class User(ORMObject):
     def unique_id(self):
         return self.user_id
 
+    @property
+    def name(self):
+        return self.user_name
+
     def validate(self):
         pass
 

--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -1,4 +1,4 @@
 bottle==0.12.9
-gevent==1.0.2
+futures==3.0.5
 gunicorn==19.4.5
 oauthlib==1.0.3


### PR DESCRIPTION
1. Get rid of gevent completely. gevent is a non-preemptive worker type. When a request is blocked on some I/O in order for a thread switch to happen the blocked thread must yield. Unfortunately, the MySQL-python library uses an external C library which doesn't get monkey patched. We could switch to pymysql. However, even worse it turns out that gevent doesn't work well with the standard file library. Notably, a file upload blocks other requests from being handled for some periods of time. We're now using gthread, a worker that uses a thread pool.
2. Add a name method to user.py. The reason it is needed is to support using the new user object with the old check_bundles_have_read_permission, check_bundles_have_all_permission, etc. method calls.
3. Don't log requests to some endpoints, such as /oauth2, since there are too many of them and they are not interesting. We won't be logging requests from the workers either.
4. Fix the error handler. It needs to be added to default_app(), not root_app.

@percyliang @kashizui 
