### PR TITLE
Bundle upload method.

### DIFF
--- a/codalab/rest/bundle.py
+++ b/codalab/rest/bundle.py
@@ -1,13 +1,25 @@
 import httplib
 import mimetypes
 import os.path
+import re
+import shutil
 import subprocess
+import tarfile
+import zlib
 
-from bottle import abort, get, local, request, response
+from bottle import abort, get, local, put, request, response
 
 from codalab.common import PermissionError, UsageError
 from codalab.lib import path_util, spec_util
-from codalab.objects.permission import check_bundles_have_read_permission
+from codalab.objects.permission import check_bundles_have_all_permission, check_bundles_have_read_permission
+from codalab.server.authenticated_plugin import AuthenticatedPlugin
+
+
+def safe_get_bundle(uuid):
+    try:
+        return local.model.get_bundle(uuid)
+    except UsageError as e:
+        abort(httplib.NOT_FOUND, e.message)
 
 
 @get('/bundle/<uuid:re:%s>/contents/blob/' % spec_util.UUID_STR)
@@ -26,10 +38,7 @@ def get_blob(uuid, path=''):
     except PermissionError as e:
         abort(httplib.FORBIDDEN, e.message)
 
-    try:
-        bundle = local.model.get_bundle(uuid)
-    except UsageError as e:
-        abort(httplib.NOT_FOUND, e.message)
+    bundle = safe_get_bundle(uuid)
 
     # Find the data.
     bundle_root = os.path.realpath(local.bundle_store.get_bundle_location(uuid))
@@ -77,3 +86,81 @@ def get_blob(uuid, path=''):
     response.set_header('Content-Encoding', encoding or 'identity')
 
     return fileobj
+
+
+@put('/bundle/<uuid:re:%s>/contents/blob/' % spec_util.UUID_STR,
+     apply=AuthenticatedPlugin())
+def put_blob(uuid):
+    try:
+        check_bundles_have_all_permission(local.model, request.user, [uuid])
+    except PermissionError as e:
+        abort(httplib.FORBIDDEN, e.message)
+
+    bundle = safe_get_bundle(uuid)
+
+    # If this bundle already has data, remove it.
+    bundle_path = os.path.realpath(local.bundle_store.get_bundle_location(uuid))
+    if os.path.exists(bundle_path):
+        local.bundle_store.cleanup(uuid, dry_run=False)
+        bundle_update = {
+            'data_hash': None,
+        }
+        local.model.update_bundle(bundle, bundle_update)
+
+    # Figure out what kind of upload it is.
+    tar_archive = False
+    single_file_archive = False
+    if 'Content-Disposition' in request.headers:
+        match = re.search('filename="([^"]*)"',
+                          request.headers['Content-Disposition'])
+        if match:
+            filename = match.group(1)
+            if filename.endswith('.tar.gz'):
+                tar_archive = True
+            elif filename.endswith('.gz'):
+                single_file_archive = True
+
+    def do_abort(code, message):
+        local.bundle_store.cleanup(uuid, dry_run=False)
+        abort(code, message)
+
+    # Store the data.
+    input_stream = request['wsgi.input']
+    if tar_archive:
+        os.mkdir(bundle_path)
+        try:
+            with tarfile.open(fileobj=input_stream, mode='r|gz') as tar:
+                for member in tar:
+                    # Make sure that there is no trickery going on (see note in
+                    # TarFile.extractall() documentation.
+                    member_path = os.path.realpath(os.path.join(bundle_path, member.name))
+                    if not member_path.startswith(bundle_path):
+                        do_abort(httplib.BAD_REQUEST, 'Invalid archive')
+
+                    tar.extract(member, bundle_path)
+        except tarfile.TarError as e:
+            do_abort(httplib.BAD_REQUEST, 'Invalid archive')
+    elif single_file_archive:
+        try:
+            d = zlib.decompressobj(16 + zlib.MAX_WBITS)
+            with open(bundle_path, 'wb') as f:
+                while True:
+                    chunk = input_stream.read(16 * 1024)
+                    if not chunk:
+                        break
+                    f.write(d.decompress(chunk))
+                f.write(d.flush())
+        except zlib.error as e:
+            do_abort(httplib.BAD_REQUEST, 'Invalid archive')
+    else:
+        with open(bundle_path, 'wb') as f:
+            shutil.copyfileobj(input_stream, f)
+
+    bundle_update = {
+       'data_hash': '0x%s' % path_util.hash_path(bundle_path),
+       'metadata': {
+            'data_size': path_util.get_size(bundle_path),             
+        },
+    }
+    local.model.update_bundle(bundle, bundle_update)
+    local.model.update_user_disk_used(bundle.owner_id)


### PR DESCRIPTION
Add a method for uploading a bundle. Currently, this version is used by the workers to upload data to a bundle that already exists. For uploading new bundles from the website, I recommend adding in query parameters specifying how to create the bundle (e.g. worksheet_uuid, etc)

@percyliang @andreweduffy 
