### PR TITLE
Fix create default clients script.

### DIFF
--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -1776,12 +1776,6 @@ class BundleModel(object):
             client.id = result.lastrowid
         return client
 
-    def delete_oauth2_client(self, client_id):
-        with self.engine.begin() as connection:
-            connection.execute(oauth2_client.delete().where(
-                oauth2_client.c.client_id == client_id
-            ))
-
     def get_oauth2_token(self, access_token=None, refresh_token=None):
         if access_token is not None:
             clause = (oauth2_token.c.access_token == access_token)

--- a/scripts/create-default-clients.py
+++ b/scripts/create-default-clients.py
@@ -5,8 +5,6 @@ Script that creates the default CodaLab OAuth2 clients.
  - codalab_cli_client for the Bundle CLI clients authenticating through the Password Grant
  - codalab_worker_client for workers authenticating through the Password Grant
 
-Also creates a dummy user for testing.
-
 TODO(skoo): Create row for the web client given a redirect url.
 """
 import sys
@@ -18,32 +16,28 @@ from codalab.objects.oauth2 import OAuth2Client
 manager = CodaLabManager()
 model = manager.model()
 
-if model.get_oauth2_client('codalab_cli_client'):
-    model.delete_oauth2_client('codalab_cli_client')
+if not model.get_oauth2_client('codalab_cli_client'):
+    model.save_oauth2_client(OAuth2Client(
+        model,
+        client_id='codalab_cli_client',
+        secret=None,
+        name='Codalab CLI',
+        user_id=None,
+        grant_type='password',
+        response_type='token',
+        scopes='default',
+        redirect_uris='',
+    ))
 
-model.save_oauth2_client(OAuth2Client(
-    model,
-    client_id='codalab_cli_client',
-    secret=None,
-    name='Codalab CLI',
-    user_id=None,
-    grant_type='password',
-    response_type='token',
-    scopes='default',
-    redirect_uris='',
-))
-
-if model.get_oauth2_client('codalab_worker_client'):
-    model.delete_oauth2_client('codalab_worker_client')
-
-model.save_oauth2_client(OAuth2Client(
-    model,
-    client_id='codalab_worker_client',
-    secret=None,
-    name='Codalab Worker',
-    user_id=None,
-    grant_type='password',
-    response_type='token',
-    scopes='default',
-    redirect_uris='',
-))
+if not model.get_oauth2_client('codalab_worker_client'):
+    model.save_oauth2_client(OAuth2Client(
+        model,
+        client_id='codalab_worker_client',
+        secret=None,
+        name='Codalab Worker',
+        user_id=None,
+        grant_type='password',
+        response_type='token',
+        scopes='default',
+        redirect_uris='',
+    ))


### PR DESCRIPTION
Don't delete default clients if they already exist. There could be oauth tokens for them and the delete will fail. No databases out there should currently have a row that's not correct, so updating is not necessary.

@percyliang @kashizui 
