### PR TITLE
Clean-up FileServer.

### DIFF
--- a/codalab/server/file_server.py
+++ b/codalab/server/file_server.py
@@ -1,94 +1,32 @@
 '''
-FileServer is an RPC server that exposes a file-like interface for reading and
-writing files on the server's local filesystem.
+FileServer is a library with a file-like interface for reading and writing,
+most of which is exposed by the BundleRPCServer for calling remotely.
 
 The core method that opens files handles, open_file, is NOT exposed as an RPC
 method for security reasons. Instead, alternate methods for opening files (such
-as open_temp_file) are exposed by this class and its subclasses. These methods
-all return a file uuid, which is like a Unix file descriptor.
+as open_temp_file) are exposed by this class. These methods all return a file
+uuid, which is like a Unix file descriptor.
 
-The other RPC methods on this server are read_file, write_file, and close_file.
-These methods take a file uuid in addition to their regular arguments, and they
-perform the requested operation on the file handle corresponding to that uuid.
+The other methods, such as read_file, write_file, and close_file, are exposed
+as RPC methods. These methods take a file uuid in addition to their regular
+arguments, and they perform the requested operation on the file handle
+corresponding to that uuid.
 '''
 import os
-from SimpleXMLRPCServer import (
-    SimpleXMLRPCServer,
-    SimpleXMLRPCRequestHandler,
-)
-import SocketServer
 import tempfile
-import threading
 import uuid
 import xmlrpclib
 
-from codalab.client.remote_bundle_client import RemoteBundleClient
 from codalab.lib import path_util, zip_util
 
-# Hack to allow 64-bit integers
-xmlrpclib.Marshaller.dispatch[int] = lambda _, v, w : w("<value><i8>%d</i8></value>" % v)
 
-
-class AuthenticatedXMLRPCRequestHandler(SimpleXMLRPCRequestHandler):
-    """
-    Simple XML-RPC request handler class which also reads authentication
-    information included in HTTP headers.
-    """
-
-    def decode_request_content(self, data):
-        '''
-        Overrides in order to capture Authorization header.
-        '''
-        token = None
-        if 'Authorization' in self.headers:
-            value = self.headers.get("Authorization", "")
-            token = value[8:] if value.startswith("Bearer: ") else ""
-
-        if self.server.auth_handler.validate_token(token):
-            return SimpleXMLRPCRequestHandler.decode_request_content(self, data)
-        else:
-            self.send_response(401, "Could not authenticate with OAuth")
-            self.send_header("WWW-Authenticate", "realm=\"https://www.codalab.org\"")
-            self.send_header("Content-length", "0")
-            self.end_headers()
-
-    def send_response(self, code, message=None):
-        '''
-        Overrides to capture end of request.
-        '''
-        # Clear current user
-        self.server.auth_handler.validate_token(None)
-        SimpleXMLRPCRequestHandler.send_response(self, code, message)
-
-
-class AsyncXMLRPCServer(SocketServer.ThreadingMixIn, SimpleXMLRPCServer):
-    pass
-
-
-class FileServer(AsyncXMLRPCServer):
-    FILE_SUBDIRECTORY = 'file'
-
-    def __init__(self, address, temp, auth_handler):
+class FileServer(object):
+    def __init__(self):
         # Keep a dictionary mapping file uuids to open file handles and a
         # dictionary mapping temporary file's file uuids to their absolute paths.
         self.file_paths = {}
         self.file_handles = {}
         self.delete_file_paths = {}
-        self.temp = temp
-        self.auth_handler = auth_handler
-
-        # Register file-like RPC methods to allow for file transfer.
-        SimpleXMLRPCServer.__init__(self, address, allow_none=True,
-                                    requestHandler=AuthenticatedXMLRPCRequestHandler,
-                                    logRequests=(self.verbose >= 1))
-        def wrap(command, func):
-            def inner(*args, **kwargs):
-                if self.verbose >= 1:
-                    print "file_server: %s %s" % (command, args)
-                return func(*args, **kwargs)
-            return inner
-        for command in RemoteBundleClient.FILE_COMMANDS:
-            self.register_function(wrap(command, getattr(self, command)), command)
 
     def open_file(self, path):
         '''


### PR DESCRIPTION
Clean-up some weirdness with the BundleRPCServer. No idea why the XML RPC logic is split up among 2 different files. Here, I move it all into a single file: BundleRPCServer. The FileServer just does its file stuff.

@percyliang 
