### PR TITLE
Clean-up of download and some upload code.

### DIFF
--- a/codalab/client/local_bundle_client.py
+++ b/codalab/client/local_bundle_client.py
@@ -512,7 +512,7 @@ class LocalBundleClient(BundleClient):
 
         return bundle_dict
 
-    def check_download_permission(self, target):
+    def check_target_has_read_permission(self, target):
         check_bundles_have_read_permission(self.model, self._current_user(), [target[0]])
 
     def get_target_info(self, target, depth):
@@ -520,7 +520,7 @@ class LocalBundleClient(BundleClient):
         Returns information about an individual target inside the bundle, or
         None if the target doesn't exist.
         """
-        self.check_download_permission(target)
+        self.check_target_has_read_permission(target)
         return self.download_manager.get_target_info(target[0], target[1], depth)
 
     def open_tarred_gzipped_directory(self, target):
@@ -528,7 +528,7 @@ class LocalBundleClient(BundleClient):
         Opens a tarred and gzipped archive of the target directory for
         streaming. The caller should ensure that the target is a directory.
         """
-        self.check_download_permission(target)
+        self.check_target_has_read_permission(target)
         return self.download_manager.stream_tarred_gzipped_directory(target[0], target[1])
 
     def open_gzipped_file(self, target):
@@ -536,7 +536,7 @@ class LocalBundleClient(BundleClient):
         Opens a gzipped archive of the target file. The caller should ensure
         that the target is a file.
         """
-        self.check_download_permission(target)
+        self.check_target_has_read_permission(target)
         return self.download_manager.stream_file(target[0], target[1], gzipped=True)
 
     def download_directory(self, target, download_path):
@@ -544,7 +544,7 @@ class LocalBundleClient(BundleClient):
         Downloads the target directory to the given path. The caller should
         ensure that the target is a directory.
         """
-        self.check_download_permission(target)
+        self.check_target_has_read_permission(target)
         with closing(self.download_manager.stream_tarred_gzipped_directory(target[0], target[1])) as fileobj:
             os.mkdir(download_path)
             un_tar_gzip_directory(fileobj, download_path)
@@ -564,12 +564,12 @@ class LocalBundleClient(BundleClient):
         self._do_download_file(target, out_fileobj=out)
 
     def _do_download_file(self, target, out_path=None, out_fileobj=None):
-        self.check_download_permission(target)
+        self.check_target_has_read_permission(target)
         with closing(self.download_manager.stream_file(target[0], target[1], gzipped=False)) as fileobj:
             if out_path is not None:
                 with open(out_path, 'wb') as out:
                     shutil.copyfileobj(fileobj, out)
-            else:
+            elif out_fileobj is not None:
                 shutil.copyfileobj(fileobj, out_fileobj)
 
     def read_file_section(self, target, offset, length, gzipped=False):
@@ -578,7 +578,7 @@ class LocalBundleClient(BundleClient):
         starting at offset and of the given length. The caller should ensure
         that the target is a file.
         """
-        self.check_download_permission(target)
+        self.check_target_has_read_permission(target)
         return self.download_manager.read_file_section(
             target[0], target[1], offset, length, gzipped)
 
@@ -591,7 +591,7 @@ class LocalBundleClient(BundleClient):
 
         The caller should ensure that the target is a file.
         '''
-        self.check_download_permission(target)
+        self.check_target_has_read_permission(target)
         lines = self.download_manager.summarize_file(
             target[0], target[1],
             max_num_lines, 0, self.MAX_BYTES_PER_LINE, None,

--- a/codalab/client/remote_bundle_client.py
+++ b/codalab/client/remote_bundle_client.py
@@ -3,12 +3,13 @@ RemoteBundleClient is a BundleClient implementation that shells out to a
 BundleRPCServer for each command. Filesystem operations are implemented using
 the FileServer operations exposed by the RPC server.
 '''
+from contextlib import closing
 import os
-import contextlib
 import sys
 import urllib
 import tempfile
 import xmlrpclib
+import shutil
 import socket
 
 from codalab.client import get_address_host
@@ -24,6 +25,7 @@ from codalab.lib import (
   zip_util,
 )
 from codalab.server.rpc_file_handle import RPCFileHandle
+from worker.file_util import gzip_file, tar_gzip_directory, un_tar_gzip_directory, un_gzip_stream, un_gzip_string
 
 # Hack to allow 64-bit integers
 xmlrpclib.Marshaller.dispatch[int] = lambda _, v, w : w("<value><i8>%d</i8></value>" % v)
@@ -120,16 +122,21 @@ class RemoteBundleClient(BundleClient):
     # Implemented by the BundleRPCServer.
     SERVER_COMMANDS = (
       'finish_upload_bundle',
-      'open_target',  # Limited access to files (read)
-      'open_target_archive',  # Limited access to files (read)
-    )
-    # Implemented by the FileServer (superclass of BundleRPCServer).
-    FILE_COMMANDS = (
-      'open_temp_file',  # Limited access to files (write)
-      'read_file',
+      'open_tarred_gzipped_directory',
+      'open_gzipped_file',
+      'read_gzipped_file_section',
+
+      # Deprecated methods below.
+      'open_target',
+      'open_target_archive',
       'readline_file',
       'tell_file',
       'seek_file',
+    )
+    # Implemented by the FileServer.
+    FILE_COMMANDS = (
+      'open_temp_file',  # Limited access to files (write)
+      'read_file',
       'write_file',
       'close_file',
       'finalize_file',
@@ -190,46 +197,73 @@ class RemoteBundleClient(BundleClient):
         if all(path_util.path_is_url(source) for source in sources):
             return self.upload_bundle_url(sources, follow_symlinks, exclude_patterns, git, unpack, remove_sources, info, worksheet_uuid, add_to_worksheet)
 
-        # 1) Copy sources up to the server (temporary remote zip file)
         remote_file_uuids = []
-        for source in sources:
-            remote_file_uuid = self.open_temp_file(zip_util.add_packed_suffix(os.path.basename(source)))
-            remote_file_uuids.append(remote_file_uuid)
-            dest_handle = RPCFileHandle(remote_file_uuid, self.proxy)
-            if zip_util.path_is_archive(source):
-                source_handle = open(source)
-            else:
-                source_handle = zip_util.open_packed_path(source, follow_symlinks, exclude_patterns)
-                unpack = True  # We packed it, so we have to unpack it
-            status = 'Uploading %s%s to %s' % (source, ' ('+info['uuid']+')' if 'uuid' in info else '', self.address)
-            # FileServer does not expose an API for forcibly flushing writes, so
-            # we rely on closing the file to flush it.
-            file_util.copy(source_handle, dest_handle, autoflush=False, print_status=status)
-            dest_handle.close()
+        try:
+            # 1) Copy sources up to the server (temporary remote zip file)
+            for source in sources:
+                if zip_util.path_is_archive(source):
+                    source_handle = open(source)
+                    temp_file_name = os.path.basename(source)
+                elif os.path.isdir(source):
+                    source_handle = tar_gzip_directory(source, follow_symlinks, exclude_patterns)
+                    temp_file_name = os.path.basename(source) + '.tar.gz'
+                    unpack = True  # We packed it, so we have to unpack it
+                else:
+                    source_handle = gzip_file(source, follow_symlinks)
+                    temp_file_name = os.path.basename(source) + '.gz'
+                    unpack = True  # We packed it, so we have to unpack it
 
-        # 2) Install upload (this call will be in charge of deleting the temporary file).
-        result = self.finish_upload_bundle(remote_file_uuids, unpack, info, worksheet_uuid, add_to_worksheet)
+                remote_file_uuid = self.open_temp_file(temp_file_name)
+                remote_file_uuids.append(remote_file_uuid)
+                with closing(RPCFileHandle(remote_file_uuid, self.proxy)) as dest_handle:
+                    status = 'Uploading %s%s to %s' % (source, ' ('+info['uuid']+')' if 'uuid' in info else '', self.address)
+                    file_util.copy(source_handle, dest_handle, autoflush=False, print_status=status)
 
-        return result
+            # 2) Install upload (this call will be in charge of deleting the temporary file).
+            return self.finish_upload_bundle(remote_file_uuids, unpack, info, worksheet_uuid, add_to_worksheet)
+        except:
+            for remote_file_uuid in remote_file_uuids:
+                self.finalize_file(remote_file_uuid)
+            raise
 
-    def open_target_handle(self, target):
-        remote_file_uuid = self.open_target(target)
-        if remote_file_uuid is not None:
-            return RPCFileHandle(remote_file_uuid, self.proxy)
-        return None
+    def download_directory(self, target, download_path):
+        """
+        Downloads the target directory to the given path. The caller should
+        ensure that the target is a directory.
+        """
+        remote_file_uuid = self.open_tarred_gzipped_directory(target)
+        with closing(RPCFileHandle(remote_file_uuid, self.proxy, finalize_on_close=True)) as fileobj:
+            os.mkdir(download_path)
+            un_tar_gzip_directory(fileobj, download_path)
 
-    def close_target_handle(self, handle):
-        handle.close()
-        self.finalize_file(handle.file_uuid)
+    def download_file(self, target, download_path):
+        """
+        Downloads the target file to the given path. The caller should
+        ensure that the target is a file.
+        """
+        self._do_download_file(target, out_path=download_path)
 
     def cat_target(self, target, out):
-        source = self.open_target_handle(target)
-        if not source: return
-        file_util.copy(source, out)
-        self.close_target_handle(source)
+        """
+        Prints the contents of the target file into the file-like object out.
+        The caller should ensure that the target is a file.
+        """
+        self._do_download_file(target, out_fileobj=out)
 
-    def download_target(self, target, final_path):
-        source_uuid = self.open_target_archive(target)
-        source = RPCFileHandle(source_uuid, self.proxy)
-        zip_util.unpack(source, final_path)
-        self.finalize_file(source_uuid)
+    def _do_download_file(self, target, out_path=None, out_fileobj=None):
+        remote_file_uuid = self.open_gzipped_file(target)
+        with closing(un_gzip_stream(RPCFileHandle(remote_file_uuid, self.proxy, finalize_on_close=True))) as fileobj:
+            if out_path is not None:
+                with open(out_path, 'wb') as out:
+                    shutil.copyfileobj(fileobj, out)
+            else:
+                shutil.copyfileobj(fileobj, out_fileobj)
+
+    def read_file_section(self, target, offset, length):
+        """
+        Returns the string representing the section of the given target file
+        starting at offset and of the given length. The caller should ensure
+        that the target is a file.
+        """
+        return un_gzip_string(
+            self.read_gzipped_file_section(target, offset, length).data)

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -15,6 +15,7 @@ results in the following:
   BundleCLI.do_upload_command(['foo'])
 """
 import argparse
+from contextlib import closing
 import copy
 import inspect
 import itertools
@@ -858,7 +859,7 @@ class BundleCLI(object):
         target = self.parse_target(client, worksheet_uuid, args.target_spec)
         bundle_uuid, subpath = target
 
-        # Copy into desired path.
+        # Figure out where to download.
         info = client.get_bundle_info(bundle_uuid)
         if args.output_path:
             local_path = args.output_path
@@ -869,9 +870,17 @@ class BundleCLI(object):
             print >>self.stdout, 'Local file/directory \'%s\' already exists.' % local_path
             return
 
-        # Download first to a local location path.
-        client.download_target(target, final_path)
-        print >>self.stdout, 'Downloaded %s/%s => %s' % (self.simple_bundle_str(info), target[1], final_path)
+        # Do the download.
+        target_info = client.get_target_info(target, 0)
+        if target_info is not None and target_info['type'] == 'directory':
+            client.download_directory(target, final_path)
+        elif target_info is not None and target_info['type'] == 'file':
+            client.download_file(target, final_path)
+        else:
+            print >>self.stdout, 'Invalid download target.'
+            return
+
+        print >>self.stdout, 'Downloaded %s/%s => %s' % (self.simple_bundle_str(info), subpath, final_path)
 
     def copy_bundle(self, source_client, source_bundle_uuid, dest_client, dest_worksheet_uuid, copy_dependencies, add_to_worksheet):
         """
@@ -916,65 +925,81 @@ class BundleCLI(object):
 
         print >>self.stdout, "Copying %s..." % source_desc
         target = (source_bundle_uuid, '')
-
-        if source_info['data_hash']:
+        target_info = source_client.get_target_info(target, 0)
+        
+        source = None
+        dest_file_uuid = None
+        try:
             # Open source (as archive)
-            if isinstance(source_client, LocalBundleClient):
-                source = zip_util.open_packed_path(source_client.get_target_path(target), follow_symlinks=False, exclude_patterns=None)
-            else:
-                source_file_uuid = source_client.open_target_archive((source_bundle_uuid, ''))
-                source = RPCFileHandle(source_file_uuid, source_client.proxy)
+            if target_info is not None and target_info['type'] == 'directory':
+                filename_suffix = '.tar.gz'
+                if isinstance(source_client, LocalBundleClient):
+                    source = source_client.open_tarred_gzipped_directory(target)
+                else:
+                    source = RPCFileHandle(
+                        source_client.open_tarred_gzipped_directory(target),
+                        source_client.proxy, finalize_on_close=True)
+            elif target_info is not None and target_info['type'] == 'file':
+                filename_suffix = '.gz'
+                if isinstance(source_client, LocalBundleClient):
+                    source = source_client.open_gzipped_file(target)
+                else:
+                    source = RPCFileHandle(
+                        source_client.open_gzipped_file(target),
+                        source_client.proxy, finalize_on_close=True)
 
-            # Open target (temporary file)
-            if isinstance(dest_client, LocalBundleClient):
-                dest_path = tempfile.mkstemp('.tar.gz')[1]
-                dest = open(dest_path, 'w')
-            else:
-                dest_file_uuid = dest_client.open_temp_file('bundle.tar.gz')
-                dest = RPCFileHandle(dest_file_uuid, dest_client.proxy)
-
-            # Copy contents over from source to target.
-            file_util.copy(
-                source,
-                dest,
-                autoflush=False,
-                print_status='Copying %s from %s to %s' % (source_bundle_uuid, source_client.address, dest_client.address))
-            dest.close()
+            if source is not None:
+                # Open target (temporary file)
+                if isinstance(dest_client, LocalBundleClient):
+                    dest_path = tempfile.mkstemp(filename_suffix)[1]
+                    dest = open(dest_path, 'wb')
+                else:
+                    dest_file_uuid = dest_client.open_temp_file('bundle' + filename_suffix)
+                    dest = RPCFileHandle(dest_file_uuid, dest_client.proxy)
+                with closing(dest):
+                    # Copy contents over from source to target.
+                    file_util.copy(
+                        source,
+                        dest,
+                        autoflush=False,
+                        print_status='Copying %s from %s to %s' % (source_bundle_uuid, source_client.address, dest_client.address))
 
             # Set sources
-            if isinstance(dest_client, LocalBundleClient):
+            if source is None:
+                sources = [None]
+            elif isinstance(dest_client, LocalBundleClient):
                 sources = [dest_path]
             else:
                 sources = [dest_file_uuid]
-        else:
-            sources = None
 
-        # Finally, install the archive (this function will delete it).
-        if isinstance(dest_client, LocalBundleClient):
-            result = dest_client.upload_bundle(
-                sources=sources,
-                follow_symlinks=False,
-                exclude_patterns=None,
-                git=False,
-                unpack=True,
-                remove_sources=True,
-                info=source_info,
-                worksheet_uuid=dest_worksheet_uuid,
-                add_to_worksheet=add_to_worksheet,
-            )
-        else:
-            result = dest_client.finish_upload_bundle(
-                sources,
-                True,
-                source_info,
-                dest_worksheet_uuid,
-                add_to_worksheet)
-
-        if source_info['data_hash']:
-            if not isinstance(source_client, LocalBundleClient):
-                source_client.finalize_file(source_file_uuid)
-        return result
-
+            # Finally, install the archive (this function will delete it).
+            if isinstance(dest_client, LocalBundleClient):
+                result = dest_client.upload_bundle(
+                    sources=sources,
+                    follow_symlinks=False,
+                    exclude_patterns=None,
+                    git=False,
+                    unpack=True,
+                    remove_sources=True,
+                    info=source_info,
+                    worksheet_uuid=dest_worksheet_uuid,
+                    add_to_worksheet=add_to_worksheet,
+                )
+            else:
+                result = dest_client.finish_upload_bundle(
+                    sources,
+                    True,
+                    source_info,
+                    dest_worksheet_uuid,
+                    add_to_worksheet)
+            
+            return result
+        except:
+            if source is not None:
+                source.close()
+            if dest_file_uuid is not None:
+                dest_client.finalize_file(dest_file_uuid)
+            raise
 
     @Commands.command(
         'make',
@@ -1389,9 +1414,8 @@ class BundleCLI(object):
         print >>self.stdout, wrap('contents')
         bundle_uuid = info['uuid']
         info = self.print_target_info(client, (bundle_uuid, ''), decorate=True)
-        contents = info.get('contents')
-        if contents:
-            for item in contents:
+        if info is not None and info['type'] == 'directory':
+            for item in info['contents']:
                 if item['name'] not in ['stdout', 'stderr']:
                     continue
                 print >>self.stdout, wrap(item['name'])
@@ -1491,53 +1515,73 @@ class BundleCLI(object):
         subpaths: list of files to print >>self.stdout, out output as we go along.
         Return READY or FAILED based on whether it was computed successfully.
         """
-        handles = [None] * len(subpaths)
+        subpath_is_file = [None] * len(subpaths)
+        subpath_offset = [None] * len(subpaths)
+    
 
         # Constants for a simple exponential backoff routine that will decrease the
         # frequency at which we check this bundle's state from 1s to 1m.
         period = 1.0
         backoff = 1.1
         max_period = 60.0
-        info = None
+
+        # Wait for the run to start.
         while True:
-            # Call update functions
+            info = client.get_bundle_info(bundle_uuid)
+            if info['state'] in (State.RUNNING, State.READY, State.FAILED):
+                break
+            time.sleep(period)
+
+        info = None
+        run_finished = False
+        while True:
+            if not run_finished:
+                info = client.get_bundle_info(bundle_uuid)
+                run_finished = info['state'] in (State.READY, State.FAILED)
+
+            # Read data.
             change = False
-            for i, handle in enumerate(handles):
-                if not handle:
-                    handle = handles[i] = client.open_target_handle((bundle_uuid, subpaths[i]))
-                    if not handle: continue
-                    # Go to near the end of the file (TODO: make this match up with lines)
-                    pos = max(handle.tell() - 64, 0)
-                    handle.seek(pos, 0)
-                # Read from that file
+            for i in xrange(0, len(subpaths)):
+                # If the subpath we're interested in appears, check if it's a
+                # file and if so, initialize the offset.
+                if subpath_is_file[i] is None:
+                    target_info = client.get_target_info((bundle_uuid, subpaths[i]), 0)
+                    if target_info is not None:
+                        if target_info['type'] == 'file':
+                            subpath_is_file[i] = True
+                            # Go to near the end of the file (TODO: make this match up with lines)
+                            subpath_offset[i] = max(target_info['size'] - 64, 0)
+                        else:
+                            subpath_is_file[i] = False
+
+                if not subpath_is_file[i]:
+                    continue
+
+                # Read from that file.
                 while True:
-                    result = handle.read(16384)
-                    if result == '': break
+                    READ_LENGTH = 16384
+                    result = client.read_file_section((bundle_uuid, subpaths[i]), subpath_offset[i], READ_LENGTH)
+                    if not result:
+                        break
                     change = True
+                    subpath_offset[i] += len(result)
                     self.stdout.write(result)
+                    if len(result) < READ_LENGTH:
+                        # No more to read.
+                        break
+
             self.stdout.flush()
 
-            # Update bundle info
-            info = client.get_bundle_info(bundle_uuid)
-            if info['state'] in (State.READY, State.FAILED): break
+            # The run finished and we read all the data.
+            if run_finished:
+                break
 
-            # Sleep if nothing happened
+            # If we got no data this time around, check less often.
             if not change:
-                time.sleep(period)
                 period = min(backoff*period, max_period)
 
-        for handle in handles:
-            if not handle:
-                continue
-
-            # Read the remainder of the file
-            while True:
-                result = handle.read(16384)
-                if result == '':
-                    break
-                self.stdout.write(result)
-
-            client.close_target_handle(handle)
+            # Sleep, since we've finished reading all the data available.
+            time.sleep(period)
 
         return info['state']
 

--- a/codalab/lib/canonicalize.py
+++ b/codalab/lib/canonicalize.py
@@ -2,7 +2,6 @@
 canonicalize provides helpers that convert ambiguous inputs to canonical forms:
   get_bundle_uuid: bundle_spec (which is <uuid>|<name>) -> uuid
   get_worksheet_uuid: worksheet_spec -> uuid
-  get_target_path: target (bundle_spec, subpath) -> filesystem path
 
 These methods are only available if we have direct access to the bundle system.
 Converting a bundle spec to a uuid requires access to the bundle databases,
@@ -109,18 +108,6 @@ def get_current_location(bundle_store, uuid):
     Return the on-disk location of currently running target.
     """
     return bundle_store.get_bundle_location(uuid)
-
-
-def get_target_path(bundle_store, model, target):
-    """
-    Return the on-disk location of the target (bundle_uuid, subpath) pair.
-    """
-    (uuid, path) = target
-    bundle_root = get_current_location(bundle_store, uuid)
-    final_path = path_util.safe_join(bundle_root, path)
-
-    result = path_util.TargetPath(final_path, target)
-    return result
 
 
 def get_worksheet_uuid(model, base_worksheet_uuid, worksheet_spec):

--- a/codalab/lib/completers.py
+++ b/codalab/lib/completers.py
@@ -163,12 +163,16 @@ class TargetsCompleter(CodaLabCompleter):
             return (suggestion_format.format(b) for b in BundlesCompleter(self.cli)(bundle_spec, action, parsed_args))
         else:
             # then suggest completions for subpath
-            target = self.cli.parse_target(client, worksheet_uuid, bundle_spec)
-            info = client.get_target_info(target, 0)
-            if 'type' in info and info['type'] == 'directory':
-                base_path = client.get_target_path(target)
-                completions = FilesCompleter()(os.path.join(base_path, subpath))
-                return (suggestion_format.format(p[len(base_path) + 1:]) for p in completions)
+            target = self.cli.parse_target(client, worksheet_uuid, bundle_spec + '/' + subpath)
+            dir_target = (target[0], os.path.dirname(subpath))
+            info = client.get_target_info(dir_target, 1)
+            if info is not None and info['type'] == 'directory':
+                matching_child_names = []
+                basename = os.path.basename(subpath)
+                for child in info['contents']:
+                    if child['name'].startswith(basename):
+                        matching_child_names.append(child['name'])
+                return (suggestion_format.format(os.path.join(dir_target[1], child_name)) for child_name in matching_child_names)
             else:
                 return ()
 

--- a/codalab/lib/download_manager.py
+++ b/codalab/lib/download_manager.py
@@ -1,0 +1,83 @@
+import os
+
+from codalab.common import PermissionError
+from codalab.lib import path_util
+from worker.download_util import get_invalid_bundle_path_error_string, get_target_path, is_valid_bundle_path
+from worker import file_util
+
+
+class DownloadManager(object):
+    """
+    Used for downloading the contents of bundles. The main purpose of this class
+    is to fetch bundle data, whether it is available locally or needs to be
+    downloaded from the worker.
+
+    Note, this class does not check permissions in any way. The caller is
+    responsible for doing all required permissions checks.
+
+    TODO(klopyrev): Worker code in a future pull request.
+    """
+
+    def __init__(self, bundle_store):
+        self._bundle_store = bundle_store
+
+    def get_target_info(self, uuid, path, depth):
+        """
+        Returns information about an individual target inside the bundle, or
+        None if the target doesn't exist.
+        """
+        bundle_path = self._bundle_store.get_bundle_location(uuid)
+        final_path = get_target_path(bundle_path, path)
+        if not os.path.exists(final_path):
+            return None
+        return path_util.get_info(final_path, depth)
+
+    def stream_tarred_gzipped_directory(self, uuid, path):
+        """
+        Returns a file-like object containing a tarred and gzipped archive
+        of the given directory.
+        """
+        directory_path = self._get_and_check_target_path(uuid, path)
+        return file_util.tar_gzip_directory(directory_path)
+
+    def stream_file(self, uuid, path, gzipped):
+        """
+        Returns a file-like object reading the given file. This file is gzipped
+        if gzipped is True.
+        """
+        file_path = self._get_and_check_target_path(uuid, path)
+        if gzipped:
+            return file_util.gzip_file(file_path)
+        else:
+            return open(file_path)
+
+    def read_file_section(self, uuid, path, offset, length, gzipped):
+        """
+        Reads length bytes of the file at the given path in the bundle.
+        The result is gzipped if gzipped is True.
+        """
+        file_path = self._get_and_check_target_path(uuid, path)
+        string = file_util.read_file_section(file_path, offset, length)
+        if gzipped:
+            string = file_util.gzip_string(string)
+        return string
+
+    def summarize_file(self, uuid, path, num_head_lines, num_tail_lines, max_line_length, truncation_text, gzipped):
+        """
+        Summarizes the file at the given path in the bundle, returning a string
+        containing the given numbers of lines from beginning and end of the file.
+        If the file needs to be truncated, places truncation_text at the
+        truncation point.
+        This string is gzipped if gzipped is True.
+        """
+        file_path = self._get_and_check_target_path(uuid, path)
+        string = file_util.summarize_file(file_path, num_head_lines, num_tail_lines, max_line_length, truncation_text)
+        if gzipped:
+            string = file_util.gzip_string(string)
+        return string
+
+    def _get_and_check_target_path(self, uuid, path):
+        bundle_path = self._bundle_store.get_bundle_location(uuid)
+        if not is_valid_bundle_path(bundle_path, path):
+            raise PermissionError(get_invalid_bundle_path_error_string(path))
+        return get_target_path(bundle_path, path)

--- a/codalab/lib/path_util.py
+++ b/codalab/lib/path_util.py
@@ -284,6 +284,10 @@ def copy(source_path, dest_path, follow_symlinks=False, exclude_patterns=None):
         with open(dest_path, 'wb') as dest:
             file_util.copy(sys.stdin, dest, autoflush=False, print_status='Copying %s to %s' % (source_path, dest_path))
     else:
+        if not follow_symlinks and os.path.islink(source_path):
+            raise path_error('not following symlinks', source_path)
+        if not os.path.exists(source_path):
+            raise path_error('does not exist', source_path)
         command = [
             'rsync',
             '-pr%s' % ('L' if follow_symlinks else 'l'),

--- a/codalab/lib/path_util.py
+++ b/codalab/lib/path_util.py
@@ -9,12 +9,11 @@ There are a few classes of methods provided here:
     safe_join, get_relative_path, ls, recursive_ls
 
   Functions to read files to compute hashes, write results to stdout, etc:
-    cat, getmtime, get_size, hash_directory, hash_file_contents
+    getmtime, get_size, hash_directory, hash_file_contents
 
   Functions that modify that filesystem in controlled ways:
     copy, make_directory, set_write_permissions, rename, remove
 """
-import contextlib
 import errno
 import hashlib
 import itertools
@@ -22,13 +21,12 @@ import os
 import shutil
 import subprocess
 import sys
-import tempfile
 
 from codalab.common import (
   precondition,
   UsageError,
 )
-from codalab.lib import file_util, formatting
+from codalab.lib import file_util
 
 
 # Block sizes and canonical strings used when hashing files.
@@ -37,54 +35,11 @@ FILE_PREFIX = 'file'
 LINK_PREFIX = 'link'
 
 
-class TargetPath(unicode):
-    """
-    Wrapper around unicode objects that allows us to add extra attributes to them.
-    In particular, canonicalize.get_target_path will return a TargetPath with the
-    'target' attribute set to the un-canonicalized target.
-    """
-    def __new__(cls, value, target):
-        self = super(TargetPath, cls).__new__(cls, value)
-        self.target = target
-        return self
-
-
 def path_error(message, path):
     """
-    Raised when a user-supplied path causes an exception. If the path passed to
-    this error's constructor came from a call to get_target_path, the target will
-    be appended to the message instead of the computed path.
+    Raised when a user-supplied path causes an exception.
     """
-    if isinstance(path, TargetPath):
-        path = safe_join(*path.target)
-
     return UsageError(message + ': ' + path)
-
-@contextlib.contextmanager
-def mkdtemp(suffix="", dir=None):
-    """
-    Create a directory as a context manager. Python3.x supports this OOTB with
-    tempfile.TemporaryFile, but it doesn't exist in Python 2.7 so this is a
-    simple wrapper.
-    """
-    directory = tempfile.mkdtemp(suffix, dir=dir)
-    try:
-        yield directory
-    finally:
-        remove(directory)
-
-@contextlib.contextmanager
-def chdir(new_dir):
-    """
-    Context manager that changes the current working directory of this process
-    for the duration of the context.
-    """
-    cur_dir = os.getcwd()
-    try:
-        os.chdir(new_dir)
-        yield
-    finally:
-        os.chdir(cur_dir)
 
 
 ################################################################################
@@ -132,14 +87,6 @@ def check_isfile(path, fn_name):
     check_isvalid(path, fn_name)
     if os.path.isdir(path):
         raise path_error('%s got directory:' % (fn_name,), path)
-
-
-def check_under_path(path, parent_path):
-    """
-    Check that the path is under its parent path.
-    """
-    if not os.path.realpath(path).startswith(os.path.realpath(parent_path)):
-        raise path_error('Path not under %s' % (parent_path,), path)
 
 
 def path_is_url(path):
@@ -217,56 +164,6 @@ def recursive_ls(path):
 # Functions to read files to compute hashes, write results to stdout, etc.
 ################################################################################
 
-def cat(path, out):
-    """
-    Copy data from the file at the given path to the file descriptor |out|.
-    """
-    if not os.path.isfile(path):
-        return None
-
-    with open(path, 'rb') as file_handle:
-        file_util.copy(file_handle, out)
-
-
-def read_lines(path, max_num_lines=None, max_total_bytes=None):
-    """
-    Return list of lines (up to num_lines).
-
-    :param path: string path to file to read
-    :param max_num_lines: maximum number of lines to read from path
-    :param max_total_bytes: maximum total number of bytes to read from path
-    :return: list of strings read from path
-    """
-    if path is None or not os.path.isfile(path):
-        return None
-
-    lines = []
-    with open(path, 'rb') as file_handle:
-        num_bytes_read = 0
-        # While we haven't exceeded lines or bytes quota...
-        while (max_num_lines is None or num_bytes_read < max_total_bytes) and \
-              (max_total_bytes is None or len(lines) < max_num_lines):
-            # Read a line
-            line = file_handle.readline(max_total_bytes - num_bytes_read)
-            if not line:
-                break
-            # Update buffer and counts.
-            lines.append(line)
-            num_bytes_read += len(line)
-    return lines
-
-
-def base64_encode(path):
-    """
-    takes a file and returns a base64 encoded version
-    """
-    if not os.path.isfile(path):
-        return None
-
-    with open(path, 'rb') as file_handle:
-        import base64
-        return base64.b64encode(file_handle.read())
-
 
 def getmtime(path):
     """
@@ -285,7 +182,6 @@ def get_size(path, dirs_and_files=None):
     dirs_and_files = dirs_and_files or recursive_ls(path)
     return sum(os.lstat(path).st_size for path in itertools.chain(*dirs_and_files))
 
-
 def get_info(path, depth):
     """
     Return a hash containing properties of the path:
@@ -293,19 +189,23 @@ def get_info(path, depth):
         size: size of all files
         contents: list of files
     """
+    stat = os.lstat(path)
+
     result = {}
     result['name'] = os.path.basename(path)
+    result['size'] = stat.st_size
+    result['perm'] = stat.st_mode & 0777
     if os.path.islink(path):
+        result['type'] = 'link'
         result['link'] = os.readlink(path)
-    if os.path.isfile(path):
+    elif os.path.isfile(path):
         result['type'] = 'file'
-        result['size'] = get_size(path)
     elif os.path.isdir(path):
         result['type'] = 'directory'
         if depth > 0:
-            result['contents'] = [get_info(os.path.join(path, file_name), depth-1) for file_name in os.listdir(path)]
-    if os.path.exists(path):
-        result['perm'] = os.stat(path).st_mode & 0777
+            result['contents'] = [
+                get_info(os.path.join(path, file_name), depth - 1)
+                for file_name in os.listdir(path)]
     return result
 
 def hash_path(path, dirs_and_files=None):

--- a/codalab/lib/worksheet_util.py
+++ b/codalab/lib/worksheet_util.py
@@ -443,9 +443,10 @@ def interpret_file_genpath(client, target_cache, bundle_uuid, genpath, post):
 
     target = (bundle_uuid, subpath)
     if target not in target_cache:
-        contents = client.head_target(target, MAX_LINES)
+        target_info = client.get_target_info(target, 0)
         # Try to interpret the structure of the file by looking inside it.
-        if contents is not None:
+        if target_info is not None and target_info['type'] == 'file':
+            contents = client.head_target(target, MAX_LINES)
             import base64
             contents = map(base64.b64decode, contents)
             if all('\t' in x for x in contents):

--- a/codalab/rest/bundle.py
+++ b/codalab/rest/bundle.py
@@ -1,11 +1,9 @@
 import httplib
 import mimetypes
-import os.path
-import subprocess
 
 from bottle import abort, get, local, request, response
 
-from codalab.lib import path_util, spec_util
+from codalab.lib import spec_util, zip_util
 from codalab.objects.permission import check_bundles_have_read_permission
 
 @get('/bundle/<uuid:re:%s>/contents/blob/' % spec_util.UUID_STR)
@@ -14,57 +12,64 @@ def get_blob(uuid, path=''):
     """
     API to download the contents of a bundle or a subpath within a bundle.
 
-    Directories are always archived. Files are archived only if the archive
-    query parameter is set to 1.
-    """
-    archive = 'archive' in request.query and request.query['archive'] == '1'
+    For directories this method always returns a tarred and gzipped archive of
+    the directory.
 
+    For files, if the request has an Accept-Encoding header containing gzip,
+    then the returned file is gzipped.
+    """
     check_bundles_have_read_permission(local.model, request.user, [uuid])
     bundle = local.model.get_bundle(uuid)
 
-    # Find the data.
-    bundle_root = os.path.realpath(local.bundle_store.get_bundle_location(uuid))
-    final_path = os.path.realpath(path_util.safe_join(bundle_root, path))
-
-    # Check for errors.
-    if not final_path.startswith(bundle_root):
-        abort(httplib.BAD_REQUEST,
-              'Invalid target %s in bundle %s' % (path, uuid))
-    if not os.path.exists(final_path):
-        abort(httplib.NOT_FOUND,
-              'Invalid target %s in bundle %s' % (path, uuid))
+    target_info = local.download_manager.get_target_info(uuid, path, 0)
+    if target_info is None:
+        abort(httplib.NOT_FOUND, 'Not found.')
 
     # Figure out the file name.
-    if path:
-        filename = os.path.basename(path)
-    elif bundle.metadata.name:
+    if not path and bundle.metadata.name:
         filename = bundle.metadata.name
     else:
-        filename = uuid
+        filename = target_info['name']
 
-    # Archive, if needed.
-    if os.path.isdir(final_path):
+    if target_info['type'] == 'directory':
+        # Always tar and gzip directories.
         filename = filename + '.tar.gz'
-        args = ['tar', 'czf', '-', '-C', final_path]
-        files = os.listdir(final_path)
-        if files:
-            args.extend(files)
+        fileobj = local.download_manager.stream_tarred_gzipped_directory(uuid, path)
+    elif target_info['type'] == 'file':
+        if not zip_util.path_is_archive(filename) and request_accepts_gzip_encoding():
+            # Let's gzip to save bandwidth. The browser will transparently decode
+            # the file.
+            filename = filename + '.gz'
+            fileobj = local.download_manager.stream_file(uuid, path, gzipped=True)
         else:
-            args.extend(['--files-from', '/dev/null'])
-        proc = subprocess.Popen(args, stdout=subprocess.PIPE)
-        fileobj = proc.stdout
-    elif archive:
-        filename = filename + '.gz'
-        args = ['gzip', '-c', '-n', final_path]
-        proc = subprocess.Popen(args, stdout=subprocess.PIPE)
-        fileobj = proc.stdout
+            fileobj = local.download_manager.stream_file(uuid, path, gzipped=False)
     else:
-        fileobj = open(final_path, 'rb')
-
+        # Symlinks.
+        abort(httplib.FORBIDDEN, 'Cannot download files of this type.')
+    
     # Set headers.
-    mimetype, encoding = mimetypes.guess_type(filename, strict=False)
-    response.set_header('Content-Disposition', 'filename="%s"' % filename)
+    mimetype, _ = mimetypes.guess_type(filename, strict=False)
     response.set_header('Content-Type', mimetype or 'text/plain')
-    response.set_header('Content-Encoding', encoding or 'identity')
+    if zip_util.get_archive_ext(filename) == '.gz' and request_accepts_gzip_encoding():
+        filename = zip_util.strip_archive_ext(filename)
+        response.set_header('Content-Encoding', 'gzip')
+    else:
+        response.set_header('Content-Encoding', 'identity')
+    response.set_header('Content-Disposition', 'filename="%s"' % filename)
 
     return fileobj
+
+
+def request_accepts_gzip_encoding():
+    # See rules for parsing here: https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html
+    # Browsers silently decode gzipped files, so we save some bandwidth.
+    if 'Accept-Encoding' not in request.headers:
+        return False
+    for encoding in request.headers['Accept-Encoding'].split(','):
+        encoding = encoding.strip().split(';')
+        if encoding[0] == 'gzip':
+            if len(encoding) > 1 and encoding[1] == 'q=0':
+                return False
+            else:
+                return True
+    return False

--- a/codalab/server/bundle_rpc_server.py
+++ b/codalab/server/bundle_rpc_server.py
@@ -188,7 +188,7 @@ class BundleRPCServer(SocketServer.ThreadingMixIn, SimpleXMLRPCServer):
         streaming, returning a file UUID that can be read from using the
         FileServer. The caller should ensure that the target is a directory.
         """
-        self.client.check_download_permission(target)
+        self.client.check_target_has_read_permission(target)
         handle = self.download_manager.stream_tarred_gzipped_directory(target[0], target[1])
         return self.file_server.manage_handle(handle)
 
@@ -198,7 +198,7 @@ class BundleRPCServer(SocketServer.ThreadingMixIn, SimpleXMLRPCServer):
         can be read from using the FileServer. The caller should ensure that the
         target is a file.
         """
-        self.client.check_download_permission(target)
+        self.client.check_target_has_read_permission(target)
         handle = self.download_manager.stream_file(target[0], target[1], gzipped=True)
         return self.file_server.manage_handle(handle)
 

--- a/codalab/server/rest_server.py
+++ b/codalab/server/rest_server.py
@@ -52,6 +52,7 @@ class SaveEnvironmentPlugin(object):
             # the server. This is intentional to ensure that any MySQL engine
             # objects are created after forking.
             local.model = self.manager.model()
+            local.download_manager = self.manager.download_manager()
             local.bundle_store = self.manager.bundle_store()
             local.config = self.manager.config
             local.emailer = self.manager.emailer()

--- a/codalab/server/rpc_file_handle.py
+++ b/codalab/server/rpc_file_handle.py
@@ -1,28 +1,20 @@
 '''
 RPCFileHandle is a wrapper class that takes a file uuid and a proxy for the
-FileServer that provided that file uuid. This wrapper provides a very simple
-file-like interface for that file handle.
+FileServer that manages that file uuid. This wrapper provides a very simple
+file-like interface for reading and writing to that file handle.
 '''
 import xmlrpclib
 
 
 class RPCFileHandle(object):
-    def __init__(self, file_uuid, proxy):
+    def __init__(self, file_uuid, proxy, finalize_on_close=False):
         self.file_uuid = file_uuid
         self.proxy = proxy
+        self.finalize_on_close = finalize_on_close
         self.closed = False
 
     def read(self, num_bytes=None):
         return self.proxy.read_file(self.file_uuid, num_bytes).data
-
-    def seek(self, offset, whence):
-        return self.proxy.seek_file(self.file_uuid, offset, whence)
-
-    def tell(self):
-        return self.proxy.tell_file(self.file_uuid)
-
-    def readline(self):
-        return self.proxy.readline_file(self.file_uuid).data
 
     def write(self, buffer):
         binary = xmlrpclib.Binary(buffer)
@@ -31,4 +23,6 @@ class RPCFileHandle(object):
     def close(self):
         if not self.closed:
             self.proxy.close_file(self.file_uuid)
+            if self.finalize_on_close:
+                self.proxy.finalize_file(self.file_uuid)
             self.closed = True

--- a/test-cli.py
+++ b/test-cli.py
@@ -300,23 +300,25 @@ def test(ctx):
     # Upload file with crazy name
     uuid = run_command([cl, 'upload', test_path(crazy_name)])
     check_equals(test_path_contents(crazy_name), run_command([cl, 'cat', uuid]))
-
-    # Upload symlink
-    uuid = run_command([cl, 'upload', test_path('passwd')])
-    run_command([cl, 'cat', uuid], 1)  # Should not resolve this - otherwise it's dangerous!
-
+ 
+    # Upload directory with a symlink
+    uuid = run_command([cl, 'upload', test_path('')])
+    check_equals(' -> /etc/passwd', run_command([cl, 'cat', uuid + '/passwd']))
+    
+    # Upload symlink without following it.
+    uuid = run_command([cl, 'upload', test_path('a-symlink.txt')], 1)
+ 
     # Upload symlink, follow link
     uuid = run_command([cl, 'upload', test_path('a-symlink.txt'), '--follow-symlinks'])
     check_equals(test_path_contents('a-symlink.txt'), run_command([cl, 'cat', uuid]))
     run_command([cl, 'cat', uuid])  # Should have the full contents
-
-    # Upload broken symlink (should be possible)
-    uuid = run_command([cl, 'upload', test_path('broken-symlink')])
-    run_command([cl, 'cat', uuid], 1)
-
+ 
+    # Upload broken symlink (should not be possible)
+    uuid = run_command([cl, 'upload', test_path('broken-symlink'), '--follow-symlinks'], 1)
+ 
     # Upload directory with excluded files
     uuid = run_command([cl, 'upload', test_path('dir1'), '--exclude-patterns', 'f*'])
-    check_num_lines(2 + 1, run_command([cl, 'cat', uuid]))  # 2 lines header,oOnly one file left after excluding
+    check_num_lines(2 + 2, run_command([cl, 'cat', uuid]))  # 2 header lines, Only two files left after excluding and extracting.
 
 @TestModule.register('upload2')
 def test(ctx):

--- a/tests/client/local_bundle_client_test.py
+++ b/tests/client/local_bundle_client_test.py
@@ -25,7 +25,7 @@ class GroupsAndPermsTest(unittest.TestCase):
         cls.model.root_user_id = '0'
         users = [User('root', '0'), User('user1', '1'), User('user2', '2'), User('user4', '4')]
         cls.auth_handler = MockAuthHandler(users)
-        cls.client = LocalBundleClient('local', cls.bundle_store, cls.model, cls.auth_handler, verbose=1)
+        cls.client = LocalBundleClient('local', cls.bundle_store, cls.model, None, cls.auth_handler, verbose=1)
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/lib/canonicalize_test.py
+++ b/tests/lib/canonicalize_test.py
@@ -57,38 +57,3 @@ class CanonicalizeTest(unittest.TestCase):
       UsageError,
       lambda: canonicalize.get_bundle_uuid(model, user_id, worksheet_uuid, 'names have no exclamations!'),
     )
-
-  def test_get_target_path(self):
-    tester = self
-    test_bundle_spec = 'test_bundle_spec'
-    test_uuid = 'test_uuid'
-    test_data_hash = 'test_data_hash'
-    test_location = 'test_location'
-    test_path = 'test_path'
-    target = (test_uuid, test_path)
-
-    class MockBundleModel(object):
-      def get_bundle(self, uuid):
-        tester.assertEqual(uuid, test_uuid)
-        return self._bundle
-    test_model = MockBundleModel()
-
-    class MockBundleStore(object):
-      def get_bundle_location(self, uuid):
-        tester.assertEqual(uuid, test_uuid)
-        return test_location
-    bundle_store = MockBundleStore()
-
-    def get_bundle_uuid(model, bundle_spec):
-      self.assertEqual(model, test_model)
-      self.assertEqual(bundle_spec, test_bundle_spec)
-      return test_uuid
-
-    with mock.patch('codalab.lib.canonicalize.get_bundle_uuid', get_bundle_uuid):
-      test_model._bundle = type('MockBundle', (object,), {
-        'state': State.CREATED,
-        'data_hash': None,
-      })
-      test_model._bundle.data_hash = test_data_hash
-      result = canonicalize.get_target_path(bundle_store, test_model, target)
-      self.assertEqual(result, os.path.join(test_location, test_path))

--- a/tests/worker/file_util_test.py
+++ b/tests/worker/file_util_test.py
@@ -1,0 +1,44 @@
+import os
+import tempfile
+import unittest
+
+from worker.file_util import gzip_file, gzip_string, remove_path, tar_gzip_directory, un_gzip_stream, un_gzip_string, un_tar_gzip_directory
+
+
+class FileUtilTest(unittest.TestCase):
+    def test_tar_has_files(self):
+        dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'files')
+        output_dir = tempfile.mkdtemp()
+        self.addCleanup(lambda: remove_path(output_dir))
+
+        un_tar_gzip_directory(
+            tar_gzip_directory(dir, False, ['f2'], ['f1', 'b.txt']),
+            output_dir)
+        output_dir_entries = os.listdir(output_dir)
+        self.assertIn('dir1', output_dir_entries)
+        self.assertIn('a.txt', output_dir_entries)
+        self.assertNotIn('b.txt', output_dir_entries)
+        self.assertTrue(os.path.exists(os.path.join(output_dir, 'dir1', 'f1')))
+        self.assertFalse(os.path.exists(os.path.join(output_dir, 'dir1', 'f2')))
+        self.assertTrue(os.path.islink(os.path.join(output_dir, 'a-symlink.txt')))
+
+    def test_tar_empty(self):
+        dir = tempfile.mkdtemp()
+        self.addCleanup(lambda: remove_path(dir))
+        output_dir = tempfile.mkdtemp()
+        self.addCleanup(lambda: remove_path(output_dir))
+
+        un_tar_gzip_directory(tar_gzip_directory(dir), output_dir)
+        self.assertEquals(os.listdir(output_dir), [])
+
+    def test_gzip_stream(self):
+        with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+            self.addCleanup(lambda: os.remove(temp_file.name))    
+            temp_file.write('contents')
+            name = temp_file.name
+
+        self.assertEquals(un_gzip_stream(gzip_file(name)).read(), 'contents')
+
+    def test_gzip_string(self):
+        self.assertEqual(un_gzip_string(gzip_string('contents')), 'contents')
+    

--- a/worker/download_util.py
+++ b/worker/download_util.py
@@ -1,18 +1,27 @@
 import os
 
-
-def is_valid_bundle_path(bundle_path, path):
+def get_and_check_target_path(bundle_path, uuid, path):
     """
-    Checks to ensure that the given path is inside the bundle, after resolving
-    any links.
+    Security checks to ensure that the contents at the given path in the bundle
+    can be downloaded.
+
+    Returns a tuple (target_path, error_message). If the contents are not
+    allowed to be downloaded, error_message is not None and contains the message
+    to display to the user. Otherwise, it's None.
     """
-    bundle_path = os.path.realpath(bundle_path)
-    final_path = os.path.realpath(get_target_path(bundle_path, path))
-    return final_path.startswith(bundle_path)
+    target_path = get_target_path(bundle_path, path)
+    error_path = get_target_path(uuid, path)
 
+    # This handles the case of paths such as ..
+    if not os.path.realpath(target_path).startswith(os.path.realpath(bundle_path)):
+        return None, '%s is not inside the bundle.' % error_path
 
-def get_invalid_bundle_path_error_string(path):
-    return 'Path %s is not inside the bundle.' % path
+    if os.path.islink(target_path):
+        # We shouldn't get here, unless the user is a hacker or a developer
+        # didn't use get_target_info correctly.
+        return None, '%s is a symlink and following symlinks is not allowed.' % error_path
+
+    return target_path, None
 
 
 def get_target_path(bundle_path, path):
@@ -20,6 +29,8 @@ def get_target_path(bundle_path, path):
     Returns the path to the given target.
     """
     if path:
-        return os.path.join(bundle_path, path)
+        # Don't use os.path.join, since we don't want an absolute path to
+        # override the bundle path.
+        return bundle_path + os.path.sep + path
     else:
         return bundle_path

--- a/worker/download_util.py
+++ b/worker/download_util.py
@@ -1,0 +1,25 @@
+import os
+
+
+def is_valid_bundle_path(bundle_path, path):
+    """
+    Checks to ensure that the given path is inside the bundle, after resolving
+    any links.
+    """
+    bundle_path = os.path.realpath(bundle_path)
+    final_path = os.path.realpath(get_target_path(bundle_path, path))
+    return final_path.startswith(bundle_path)
+
+
+def get_invalid_bundle_path_error_string(path):
+    return 'Path %s is not inside the bundle.' % path
+
+
+def get_target_path(bundle_path, path):
+    """
+    Returns the path to the given target.
+    """
+    if path:
+        return os.path.join(bundle_path, path)
+    else:
+        return bundle_path

--- a/worker/file_util.py
+++ b/worker/file_util.py
@@ -1,0 +1,187 @@
+from contextlib import closing
+from cStringIO import StringIO
+import gzip
+import os
+import subprocess
+import tarfile
+import zlib
+
+
+def tar_gzip_directory(directory_path, follow_symlinks=False,
+                       exclude_patterns=[], exclude_names=[]):
+    """
+    Returns a file-like object containing a tarred and gzipped archive of the
+    given directory.
+
+    follow_symlinks: Whether symbolic links should be followed.
+    ignore_names: Any top-level directory entries with names in ignore_names
+                  are not included.
+    exclude_patterns: Any directory entries with the given names at any depth in
+                      the directory structure are excluded.
+    """
+    args = ['tar', 'czf', '-', '-C', directory_path]
+    if follow_symlinks:
+        args.append('-h')
+    if exclude_patterns:
+        for pattern in exclude_patterns:
+            args.append('--exclude=' + pattern)
+    names = [name for name in os.listdir(directory_path) if name not in exclude_names]
+    if names:
+        args.extend(names)
+    else:
+        args.extend(['--files-from', '/dev/null'])
+    try:
+        proc = subprocess.Popen(args, stdout=subprocess.PIPE)
+        return proc.stdout
+    except subprocess.CalledProcessError as e:
+        raise IOError(e.output)
+
+
+def un_tar_gzip_directory(fileobj, directory_path):
+    """
+    Extracts the given file-like object containing a tarred and gzipped archive
+    into the given directory. The directory should already exist.
+
+    Raises tarfile.TarError if the archive is not valid.
+    """
+    directory_path = os.path.realpath(directory_path)
+    with tarfile.open(fileobj=fileobj, mode='r|gz') as tar:
+        for member in tar:
+            # Make sure that there is no trickery going on (see note in
+            # TarFile.extractall() documentation.
+            member_path = os.path.realpath(os.path.join(directory_path, member.name))
+            if not member_path.startswith(directory_path):
+                raise tarfile.TarError('Archive member extracts outside the directory.')
+
+            tar.extract(member, directory_path)
+
+
+def gzip_file(file_path, follow_symlinks=False):
+    """
+    Returns a file-like object containing the gzipped version of the given file.
+    """
+    if follow_symlinks:
+        file_path = os.path.realpath(file_path)
+    elif os.path.islink(file_path):
+        raise IOError('Not following symbolic links.')
+    args = ['gzip', '-c', '-n', file_path]
+    try:
+        proc = subprocess.Popen(args, stdout=subprocess.PIPE)
+        return proc.stdout
+    except subprocess.CalledProcessError as e:
+        raise IOError(e.output)
+
+
+def un_gzip_stream(fileobj):
+    """
+    Returns a file-like object containing the contents of the given file-like
+    object after gunzipping.
+
+    Raises an IOError if the archive is not valid.
+    """
+    class UnGzipStream(object):
+        def __init__(self, fileobj):
+            self._fileobj = fileobj
+            self._decoder = zlib.decompressobj(16 + zlib.MAX_WBITS)
+            self._buffer = ''
+            self._finished = False
+    
+        def read(self, num_bytes=None):
+            # Read more data, if we need to.
+            while not self._finished and (num_bytes is None or len(self._buffer) < num_bytes):
+                chunk = self._fileobj.read(num_bytes) if num_bytes is not None else self._fileobj.read()
+                if chunk:
+                    self._buffer += self._decoder.decompress(chunk)
+                else:
+                    self._buffer += self._decoder.flush()
+                    self._finished = True
+            if num_bytes is None:
+                num_bytes = len(self._buffer)
+            result = self._buffer[:num_bytes]
+            self._buffer = self._buffer[num_bytes:]
+            return result
+
+        def close(self):
+            self._fileobj.close()
+    
+    # Note, that we don't use gzip.GzipFile or the gunzip shell command since
+    # they require the input file-like object to support either tell() or
+    # fileno(). Our version requires only read() and close().
+    return UnGzipStream(fileobj)
+
+
+def gzip_string(string):
+    """
+    Gzips the given string.
+    """
+    with closing(StringIO()) as output_fileobj:
+        with gzip.GzipFile(None, 'wb', 6, output_fileobj) as fileobj:
+            fileobj.write(string)
+        return output_fileobj.getvalue()
+
+
+def un_gzip_string(string):
+    """
+    Gunzips the given string.
+
+    Raises an IOError if the archive is not valid.
+    """
+    with closing(StringIO(string)) as input_fileobj:
+        with gzip.GzipFile(None, 'rb', fileobj=input_fileobj) as fileobj:
+            return fileobj.read()
+
+
+def read_file_section(file_path, offset, length):
+    """
+    Reads length bytes of the given file from the given offset.
+    """
+    file_size = os.stat(file_path).st_size
+    if offset >= file_size:
+        return ''
+    with open(file_path) as fileobj:
+        fileobj.seek(offset, os.SEEK_SET)
+        return fileobj.read(length)
+
+
+def summarize_file(file_path, num_head_lines, num_tail_lines, max_line_length, truncation_text):
+    """
+    Summarizes the file at the given path, returning a string containing the
+    given numbers of lines from beginning and end of the file. If the file needs
+    to be truncated, places truncation_text at the truncation point.
+    """
+    assert(num_head_lines > 0 or num_tail_lines > 0)
+
+    def ensure_ends_with_newline(lines):
+        if lines and not lines[-1].endswith('\n'):
+            lines[-1] += '\n'
+    
+    file_size = os.stat(file_path).st_size
+    with open(file_path) as fileobj:
+        if file_size > (num_head_lines + num_tail_lines) * max_line_length:
+            if num_head_lines > 0:
+                head_lines = fileobj.read(num_head_lines * max_line_length).splitlines(True)[:num_head_lines]
+                ensure_ends_with_newline(head_lines)
+
+            if num_tail_lines > 0:
+                fileobj.seek(file_size - num_tail_lines * max_line_length, os.SEEK_SET)
+                tail_lines = fileobj.read(num_tail_lines * max_line_length).splitlines(True)[-num_tail_lines:]
+                ensure_ends_with_newline(tail_lines)
+            
+            if num_head_lines > 0 and num_tail_lines > 0:
+                lines = head_lines + [truncation_text] + tail_lines
+            elif num_head_lines > 0:
+                lines = head_lines
+            else:
+                lines = tail_lines
+        else:
+            lines = fileobj.readlines()
+            ensure_ends_with_newline(lines)
+            if len(lines) > num_head_lines + num_tail_lines:
+                if num_head_lines > 0 and num_tail_lines > 0:
+                    lines = lines[:num_head_lines] + [truncation_text] + lines[-num_tail_lines:]
+                elif num_head_lines > 0:
+                    lines = lines[:num_head_lines]
+                else:
+                    lines = lines[-num_tail_lines:]
+    
+    return ''.join(lines)


### PR DESCRIPTION
This change introduces a download manager that all requests that access bundle content need to go through. In a future CL, this download manager will support getting the data from the worker.

Additionally, other related changes are:

1) Fix all places where files are accessed to check type. Before, there was pretty bad handling of things like symlinks, directories where files are expected, etc.
2) Fix upload code to not leave temporary files when uploads are interrepted.
3) Fix the get_info method (that indexes the contents of a path) to handle symlinks better. Note that isfile returns True for symlinks).
4) Don't follow symlinks where you shouldn't. Ensure all paths are inside the bundle (i.e. no more cl run "cat "%blah//etc/passwd%")
5) Add support for unzipping .gz archives. Switch to using them to transferring single files, as opposed to tar archives.
6) Fix the download REST API. There were some bugs there before.
7) Move a bunch of logic into the worker directory. The reason for doing that is to make the worker code self contained and not depend on other codalab code.

Note, this change is a bit invasive, especially in deprecating some XML RPC APIs. However, it should be pretty easy to migrate and is necessary since with downloading from the worker we can't support things like "tell()" and "seek()".

@percyliang 
