### PR TITLE
Bundle contents index.

### DIFF
--- a/alembic/versions/2016031317_add_bundle_contents_index_40d61632fd13.py
+++ b/alembic/versions/2016031317_add_bundle_contents_index_40d61632fd13.py
@@ -1,0 +1,22 @@
+"""Add bundle contents index
+
+Revision ID: 40d61632fd13
+Revises: 58eccccb346d
+Create Date: 2016-03-13 17:00:23.055571
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '40d61632fd13'
+down_revision = '58eccccb346d'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    # bundle_contents_index automatically added
+    pass
+
+def downgrade():
+    op.drop_table('bundle_contents_index')

--- a/codalab/lib/codalab_manager.py
+++ b/codalab/lib/codalab_manager.py
@@ -341,6 +341,12 @@ class CodaLabManager(object):
         info['disk_quota'] = formatting.parse_size(info['disk_quota'])
         return info
 
+    def launch_new_worker_system(self):
+        try:
+            return self.config['workers']['launch_new_worker_system']
+        except KeyError:
+            return False
+
     @cached
     def model(self):
         """
@@ -365,7 +371,7 @@ class CodaLabManager(object):
 
     @cached
     def download_manager(self):
-        return DownloadManager(self.bundle_store())
+        return DownloadManager(self.launch_new_worker_system(), self.model(), self.bundle_store())
 
     def auth_handler(self, mock=False):
         '''

--- a/codalab/lib/codalab_manager.py
+++ b/codalab/lib/codalab_manager.py
@@ -342,10 +342,9 @@ class CodaLabManager(object):
         return info
 
     def launch_new_worker_system(self):
-        try:
-            return self.config['workers']['launch_new_worker_system']
-        except KeyError:
-            return False
+        # TODO: This flag and all code in the False code path of this flag will
+        # get deleted once the new worker system is launched.
+        return self.config['workers'].get('launch_new_worker_system', False)
 
     @cached
     def model(self):

--- a/codalab/lib/path_util.py
+++ b/codalab/lib/path_util.py
@@ -182,31 +182,6 @@ def get_size(path, dirs_and_files=None):
     dirs_and_files = dirs_and_files or recursive_ls(path)
     return sum(os.lstat(path).st_size for path in itertools.chain(*dirs_and_files))
 
-def get_info(path, depth):
-    """
-    Return a hash containing properties of the path:
-        type: one of {'file', 'directory'}
-        size: size of all files
-        contents: list of files
-    """
-    stat = os.lstat(path)
-
-    result = {}
-    result['name'] = os.path.basename(path)
-    result['size'] = stat.st_size
-    result['perm'] = stat.st_mode & 0777
-    if os.path.islink(path):
-        result['type'] = 'link'
-        result['link'] = os.readlink(path)
-    elif os.path.isfile(path):
-        result['type'] = 'file'
-    elif os.path.isdir(path):
-        result['type'] = 'directory'
-        if depth > 0:
-            result['contents'] = [
-                get_info(os.path.join(path, file_name), depth - 1)
-                for file_name in os.listdir(path)]
-    return result
 
 def hash_path(path, dirs_and_files=None):
     if os.path.isfile(path):

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -695,6 +695,13 @@ class BundleModel(object):
             connection.execute(cl_bundle.update().where(cl_bundle.c.uuid.in_(uuids)).values({'data_hash': None}))
 
     def update_bundle_contents_index(self, uuid, index):
+        """
+        Deletes the old contents of the index, and updates them with the new
+        values.
+
+        For reference on the format of index, see
+        worker.file_util.index_contents.
+        """
         rows = []
         def recurse(entry, parent_path):
             entry['bundle_uuid'] = uuid
@@ -722,6 +729,10 @@ class BundleModel(object):
             self.do_multirow_insert(connection, cl_bundle_contents_index, rows)
 
     def get_bundle_contents_index(self, uuid):
+        """
+        For reference on the format of the returned index, see
+        worker.file_util.index_contents.
+        """
         with self.engine.begin() as connection:
             # Sort so that all directories appear before the files inside them.
             rows = connection.execute(

--- a/codalab/model/tables.py
+++ b/codalab/model/tables.py
@@ -74,6 +74,20 @@ bundle_action = Table(
   sqlite_autoincrement=True,
 )
 
+# Stores information about the files, directories and links stored in the
+# bundle.
+bundle_contents_index = Table(
+  'bundle_contents_index',
+  db_metadata,
+  Column('bundle_uuid', String(63), ForeignKey(bundle.c.uuid), nullable=False),
+  Column('path', Text, nullable=False),
+  Column('type', String(63), nullable=False),
+  Column('size', Integer, nullable=False),
+  Column('perm', Integer, nullable=False),
+  Column('link', Text, nullable=True),
+  Index('bundle_uuid_index', 'bundle_uuid', mysql_length=63),
+)
+
 # The worksheet table does not have many columns now, but it will eventually
 # include columns for owner, group, permissions, etc.
 worksheet = Table(

--- a/scripts/index-bundle-store-contents.py
+++ b/scripts/index-bundle-store-contents.py
@@ -1,0 +1,38 @@
+#!./venv/bin/python
+"""
+Indexes the contents of the bundle store. Used during the launch of the new
+worker system.
+
+TODO(klopyrev): Delete once it's launched.
+"""
+import sys
+sys.path.append('.')
+
+from codalab.common import State
+from codalab.lib.codalab_manager import CodaLabManager
+from codalab.model.tables import bundle as cl_bundle, bundle_contents_index as cl_bundle_contents_index
+from sqlalchemy import distinct, select
+from worker.file_util import index_contents
+
+
+manager = CodaLabManager()
+bundle_store = manager.bundle_store()
+model = manager.model()
+engine = model.engine
+
+with engine.begin() as conn:
+    bundles = conn.execute(
+        select([cl_bundle.c.uuid])
+        .where(cl_bundle.c.state.in_([State.READY, State.FAILED]))
+    ).fetchall()
+    indexed_bundles = conn.execute(
+        select([distinct(cl_bundle_contents_index.c.bundle_uuid)])
+    ).fetchall()
+
+uuids_to_index = (set(bundle.uuid for bundle in bundles) -
+                  set(bundle.bundle_uuid for bundle in indexed_bundles))
+
+for uuid in uuids_to_index:
+    print 'Indexing', uuid
+    index = index_contents(bundle_store.get_bundle_location(uuid))
+    model.update_bundle_contents_index(uuid, index)

--- a/worker/file_util.py
+++ b/worker/file_util.py
@@ -1,4 +1,5 @@
 from contextlib import closing
+import copy
 from cStringIO import StringIO
 import gzip
 import os
@@ -42,16 +43,15 @@ def restrict_contents_index(index, path, depth=None):
     """
     Given an index generates a restricted version.
     
-    First, it finds the entry for the given path. If no entry is found, None is
-    returned.
+    First, it finds the entry in the index for the given path. If no entry is
+    found, None is returned.
 
     Then, if depth is not None, it filters out any entries more than depth levels
     deep. Depth 0, for example, means only the top-level entry is included, and
     no contents. Depth 1 means the contents of the top-level are included, but
     nothing deeper.
     """
-    if index is None:
-        return None
+    index = copy.deepcopy(index)
 
     if path:
         names = path.split(os.path.sep)


### PR DESCRIPTION
Add an index of the bundle contents. Once the worker system is launched, this index will be used, instead of calling path_util.get_info. The worker updates this index pretty often, so it should be fresh.

I'm also moving the get_info method to worker.file_util since it'll be used by the worker.

Add a script to index the current contents of the bundle store. This will be used to launch the new worker system.

@percyliang 

Note: since this change depends on the download_manager change, I've done a trick where I made the pull requests again the download_manager branch in codalab/codalab-cli that is identical to the one in klopyrev/codalab-cli. Once the download_manager change is submitted, I'll fix the pull request to be for the codalab/codalab-cli develop branch.
