### PR TITLE
Even better handling of symlinks.

### DIFF
--- a/codalab/client/local_bundle_client.py
+++ b/codalab/client/local_bundle_client.py
@@ -1067,19 +1067,19 @@ class LocalBundleClient(BundleClient):
                     target_info = self.get_target_info(data, 0)
                     if target_info is not None and target_info['type'] == 'directory':
                         data = [base64.b64encode('<directory>')]
-                    elif target_info is not None and target_info['type'] == 'file':
+                    elif target_info is not None and target_info['type'] in ['file', 'link']:
                         data = self.head_target(data, max_lines, replace_non_unicode=True)
                     else:
                         data = None
                 elif mode == 'html':
                     target_info = self.get_target_info(data, 0)
-                    if target_info is not None and target_info['type'] == 'file':
+                    if target_info is not None and target_info['type'] in ['file', 'link']:
                         data = self.head_target(data, None)
                     else:
                         data = None
                 elif mode == 'image':
                     target_info = self.get_target_info(data, 0)
-                    if target_info is not None and target_info['type'] == 'file':
+                    if target_info is not None and target_info['type'] in ['file', 'link']:
                         result = StringIO()
                         self.cat_target(data, result)
                         data = base64.b64encode(result.getvalue())
@@ -1096,7 +1096,7 @@ class LocalBundleClient(BundleClient):
                     for info in data:
                         target = info['target']
                         target_info = self.get_target_info(target, 0)
-                        if target_info is not None and target_info['type'] == 'file':
+                        if target_info is not None and target_info['type'] in ['file', 'link']:
                             contents = self.head_target(target, max_lines, replace_non_unicode=True, base64_encode=False)
                             # Assume TSV file without header for now, just return each line as a row
                             info['points'] = points = []

--- a/codalab/client/remote_bundle_client.py
+++ b/codalab/client/remote_bundle_client.py
@@ -209,7 +209,13 @@ class RemoteBundleClient(BundleClient):
                     temp_file_name = os.path.basename(source) + '.tar.gz'
                     unpack = True  # We packed it, so we have to unpack it
                 else:
-                    source_handle = gzip_file(source, follow_symlinks)
+                    resolved_source = source
+                    if os.path.islink(source):
+                        if follow_symlinks:
+                            resolved_source = os.path.realpath(source)
+                        else:
+                            raise UsageError('Can\'t upload a single symbolic link')
+                    source_handle = gzip_file(resolved_source)
                     temp_file_name = os.path.basename(source) + '.gz'
                     unpack = True  # We packed it, so we have to unpack it
 

--- a/codalab/lib/worksheet_util.py
+++ b/codalab/lib/worksheet_util.py
@@ -445,7 +445,7 @@ def interpret_file_genpath(client, target_cache, bundle_uuid, genpath, post):
     if target not in target_cache:
         target_info = client.get_target_info(target, 0)
         # Try to interpret the structure of the file by looking inside it.
-        if target_info is not None and target_info['type'] == 'file':
+        if target_info is not None and target_info['type'] in ['file', 'link']:
             contents = client.head_target(target, MAX_LINES)
             import base64
             contents = map(base64.b64decode, contents)

--- a/codalab/rest/bundle.py
+++ b/codalab/rest/bundle.py
@@ -35,7 +35,7 @@ def get_blob(uuid, path=''):
         # Always tar and gzip directories.
         filename = filename + '.tar.gz'
         fileobj = local.download_manager.stream_tarred_gzipped_directory(uuid, path)
-    elif target_info['type'] == 'file':
+    elif target_info['type'] in ['file', 'link']:
         if not zip_util.path_is_archive(filename) and request_accepts_gzip_encoding():
             # Let's gzip to save bandwidth. The browser will transparently decode
             # the file.
@@ -43,9 +43,6 @@ def get_blob(uuid, path=''):
             fileobj = local.download_manager.stream_file(uuid, path, gzipped=True)
         else:
             fileobj = local.download_manager.stream_file(uuid, path, gzipped=False)
-    else:
-        # Symlinks.
-        abort(httplib.FORBIDDEN, 'Cannot download files of this type.')
     
     # Set headers.
     mimetype, _ = mimetypes.guess_type(filename, strict=False)

--- a/tests/files/dir1/g3
+++ b/tests/files/dir1/g3
@@ -1,0 +1,1 @@
+Some stuff here.

--- a/worker/file_util.py
+++ b/worker/file_util.py
@@ -56,14 +56,10 @@ def un_tar_gzip_directory(fileobj, directory_path):
             tar.extract(member, directory_path)
 
 
-def gzip_file(file_path, follow_symlinks=False):
+def gzip_file(file_path):
     """
     Returns a file-like object containing the gzipped version of the given file.
     """
-    if follow_symlinks:
-        file_path = os.path.realpath(file_path)
-    elif os.path.islink(file_path):
-        raise IOError('Not following symbolic links.')
     args = ['gzip', '-c', '-n', file_path]
     try:
         proc = subprocess.Popen(args, stdout=subprocess.PIPE)


### PR DESCRIPTION
We really should allow the user to cat a symlink and see the contents of where it points to. However, if it points to outside the bundle, that should be prevented.

This change makes the handling of symlinks are follows:
- If the symlink points to outside the bundle, return a permission error.
- If the symlink is broken, return a not found error.
- Otherwise, return the contents of the symlink.

@percyliang 
