### PR TITLE
Clear only expired tokens

### DIFF
--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -1819,7 +1819,9 @@ class BundleModel(object):
     def clear_oauth2_tokens(self, client_id, user_id):
         with self.engine.begin() as connection:
             connection.execute(oauth2_token.delete().where(
-                and_(oauth2_token.c.client_id == client_id, oauth2_token.c.user_id == user_id)
+                and_(oauth2_token.c.client_id == client_id,
+                     oauth2_token.c.user_id == user_id,
+                     oauth2_token.c.expires <= datetime.datetime.utcnow())
             ))
 
     def delete_oauth2_token(self, token_id):


### PR DESCRIPTION
Only clear out expired tokens for a given user_id and client_id. This allows a user to have multiple workers with the same client_id authenticate through the password grant.

access_token and refresh_token already have unique indices on them, thanks to the `unique=True` kwarg:

```
oauth2_token = Table(
  'oauth2_token',
  db_metadata,
  Column('id', Integer, primary_key=True, nullable=False),
  Column('client_id', String(63), ForeignKey(oauth2_client.c.client_id), nullable=False),
  Column('user_id', String(63), ForeignKey(user.c.user_id), nullable=False),
  Column('scopes', Text, nullable=False),
  Column('access_token', String(255), unique=True),
  Column('refresh_token', String(255), unique=True),
  Column('expires', DateTime, nullable=False),
  sqlite_autoincrement=True,
)
```

http://docs.sqlalchemy.org/en/latest/core/constraints.html#unique-constraint

@klopyrev @percyliang 
