### PR TITLE
Fix config error found during local development setup.

### DIFF
--- a/codalab/lib/codalab_manager.py
+++ b/codalab/lib/codalab_manager.py
@@ -178,7 +178,7 @@ class CodaLabManager(object):
                 'rest_host': 'localhost',
                 'rest_port': 2900,
                 'auth': {
-                    'class': 'RestAuthHandler'
+                    'class': 'RestOAuthHandler'
                 },
                 'verbose': 1,
             },

--- a/codalab/lib/codalab_manager.py
+++ b/codalab/lib/codalab_manager.py
@@ -178,7 +178,7 @@ class CodaLabManager(object):
                 'rest_host': 'localhost',
                 'rest_port': 2900,
                 'auth': {
-                    'class': 'MockAuthHandler'
+                    'class': 'RestAuthHandler'
                 },
                 'verbose': 1,
             },


### PR DESCRIPTION
During local development we always want credential verification to go through the REST server.

@kashizui 
