### PR TITLE
Remove unnecessary requirements.

### DIFF
--- a/codalab/requirements/common.txt
+++ b/codalab/requirements/common.txt
@@ -1,5 +1,4 @@
 Django==1.5.9
-alembic==0.6.7
 anyjson==0.3.3
 argparse
 azure==0.7.1
@@ -31,7 +30,6 @@ six==1.10.0
 South==1.0.2
 watchdog==0.8.1
 wsgiref==0.1.2
-django-simple-captcha==0.4.5
 django-bootstrap-form==3.2
 newrelic==2.54.0.41
 python-memcached==1.57


### PR DESCRIPTION
Remove unnecessary requirements. Both are no longer used. One causes an error during installation since it requires some other package on the system.

@kashizui 