### PR TITLE
Dependency manager.

### DIFF
--- a/tests/worker/dependency_manager_test.py
+++ b/tests/worker/dependency_manager_test.py
@@ -1,0 +1,116 @@
+import json
+import os
+import tempfile
+import threading
+import time
+import unittest
+
+from worker.dependency_manager import DependencyManager
+from worker.file_util import remove_path
+
+class DependencyManagerTest(unittest.TestCase):
+    def setUp(self):
+        self.work_dir = tempfile.mkdtemp()
+        self.manager = DependencyManager(self.work_dir, None)
+
+    def tearDown(self):
+        remove_path(self.work_dir)
+
+    def test_load_state(self):
+        self.manager.finish_run('uuid1')
+        self.manager.finish_run('uuid2')
+        with open(os.path.join(self.work_dir, 'random_file'), 'w'):
+            pass
+        self.assertIn('random_file', os.listdir(self.work_dir))
+        new_manager = DependencyManager(self.work_dir, 1)
+        self.check_state([('uuid1', ''), ('uuid2', '')], new_manager)
+        self.assertIn('state.json', os.listdir(self.work_dir))
+        self.assertNotIn('random_file', os.listdir(self.work_dir))
+
+    def test_downloading(self):
+        self.manager.add_dependee('uuid1', '', 'uuid2')
+
+        # Check cases that should not block.
+        self.check_add_dependee_blocks('uuid1', 'a', 'uuid5', False, True)  # Different path
+        self.check_add_dependee_blocks('uuid6', '', 'uuid7', False, True)  # Different UUID
+        
+        # This call will block until the failed download. Then, it will be asked
+        # to retry the download.
+        self.check_add_dependee_blocks('uuid1', '', 'uuid3', True, True)
+        
+        self.manager.finish_download('uuid1', '', False)
+        self.check_state([])
+        time.sleep(0.01)
+
+        # This call will block until both attempts to download are done. Then, 
+        # it will not be asked to retry the download.
+        self.check_add_dependee_blocks('uuid1', '', 'uuid4', True, False)
+
+        self.manager.finish_download('uuid1', '', True)
+        self.check_state([('uuid1', '')])
+
+    def test_download_path_conflict(self):
+        self.assertEqual(self.manager.add_dependee('uuid1', 'a/b_c', 'uuid2')[0],
+                         os.path.join(self.work_dir, 'uuid1_a_b_c'))
+        self.assertEqual(self.manager.add_dependee('uuid1', 'a_b/c', 'uuid2')[0],
+                         os.path.join(self.work_dir, 'uuid1_a_b_c_'))
+
+    def test_cleanup(self):
+        self.manager = DependencyManager(self.work_dir, 2)
+
+        self.manager.finish_run('uuid1') # Has dependee, so will not be removed.
+        self.manager.add_dependee('uuid1', '', 'uuid100')
+
+        self.manager.add_dependee('uuid2', '', 'uuid100') # Downloading, so will not be removed.
+    
+        self.manager.finish_run('uuid3')  # Used after uuid4, so will be left.
+        self.manager.finish_run('uuid4')  # Will be removed.
+        self.manager.add_dependee('uuid4', '', 'uuid100')
+        self.manager.remove_dependee('uuid4', '', 'uuid100')
+        self.manager.add_dependee('uuid3', '', 'uuid100')
+        self.manager.remove_dependee('uuid3', '', 'uuid100')
+
+        for uuid in ['uuid1', 'uuid2', 'uuid3', 'uuid4']:
+            with open(self.manager.get_run_path(uuid), 'wb') as f:
+                f.write(' ' * 1024 * 1024)
+
+        self.manager._cleanup_sleep_secs = 0
+        self.manager.start_cleanup_thread()
+        time.sleep(0.1)
+        self.manager.stop_cleanup_thread()
+
+        self.check_state([('uuid1', ''), ('uuid3', '')])
+        self.assertIn(('uuid2', ''), self.manager._dependencies)
+        self.assertItemsEqual(['uuid1', 'uuid2', 'uuid3', 'state.json'],
+                              os.listdir(self.work_dir))
+
+    def check_state(self, expected_targets, manager=None):
+        if manager is None:
+            manager = self.manager
+        targets = []
+        expected_paths = []
+        with manager._lock:
+            for target, dependency in manager._dependencies.iteritems():
+                if not dependency.downloading:
+                    targets.append(target)
+                expected_paths.append(dependency.path)
+            self.assertItemsEqual(expected_targets, targets)
+            self.assertItemsEqual(expected_paths, manager._paths)
+
+        state_file_targets = []
+        with open(manager._state_file, 'r') as f:
+            for dep in json.loads(f.read()):
+                state_file_targets.append(tuple(dep['target']))
+            self.assertItemsEqual(expected_targets, state_file_targets)
+
+    def check_add_dependee_blocks(self, parent_uuid, parent_path, uuid,
+                                  expected_blocks, expected_should_download):
+        blocked = [True]
+        def blocking_code():
+            _, should_download = self.manager.add_dependee(parent_uuid, parent_path, uuid)
+            self.assertEqual(should_download, expected_should_download, msg='%s/%s from %s' % (parent_uuid, parent_path, uuid))
+            blocked[0] = False
+
+        threading.Thread(target=blocking_code).start()
+        time.sleep(0.01)
+        self.assertEqual(blocked[0], expected_blocks)

--- a/worker/dependency_manager.py
+++ b/worker/dependency_manager.py
@@ -1,0 +1,276 @@
+import json
+import os
+import threading
+import time
+
+from file_util import get_path_size, remove_path
+
+
+class DependencyManager(object):
+    """
+    Manages the dependencies available on the worker, and ensures that no two
+    runs download the same dependency at the same time. Ensures that the total
+    size of all the dependencies doesn't exceed the given limit.
+    """
+    def __init__(self, work_dir, max_work_dir_size_mb):
+        self._work_dir = work_dir
+        self._max_work_dir_size_mb = max_work_dir_size_mb
+        self._state_file = os.path.join(work_dir, 'state.json')
+        self._lock = threading.Lock()
+        self._stop_cleanup = False
+        self._cleanup_thread = None
+        self._cleanup_sleep_secs = 10
+        self._dependencies = {}
+        self._paths = set()
+
+        if os.path.exists(self._state_file):
+            self._load_state()
+        else:
+            remove_path(work_dir)
+            os.makedirs(work_dir, 0770)
+            self._save_state()
+
+    def _load_state(self):
+        with open(self._state_file, 'r') as f:
+            loaded_state = json.loads(f.read())
+
+        # Initialize self._dependencies.
+        for dependency in loaded_state:
+            dep = self._dependencies[tuple(dependency['target'])] = (
+                Dependency.load(dependency, self._lock))
+            self._paths.add(dep.path)
+
+        # Remove paths that aren't complete (e.g. interrupted downloads and runs).
+        for path in set(os.listdir(self._work_dir)) - self._paths - set(['state.json']):
+            remove_path(os.path.join(self._work_dir, path))
+
+    def _save_state(self):
+        """
+        Should be called with the lock held.
+        """
+        state = []
+        for target, dependency in self._dependencies.iteritems():
+            if not dependency.downloading:
+                dumped_dependency = dependency.dump()
+                dumped_dependency['target'] = target
+                state.append(dumped_dependency)
+
+        with open(self._state_file, 'w') as f:
+            f.write(json.dumps(state))
+
+    def start_cleanup_thread(self):
+        self._cleanup_thread = threading.Thread(target=DependencyManager._do_cleanup, args=[self])
+        self._cleanup_thread.start()
+
+    def _do_cleanup(self):
+        while not self._should_stop_cleanup():
+            while True:
+                # If the total size of all dependencies exceeds
+                # self._max_work_dir_size_mb, remove the oldest unused
+                # dependency. Otherwise, break out of the loop.
+                total_size_bytes = 0
+                first_used_time = float('inf')
+                first_used_target = None
+                self._lock.acquire()
+                for target, dependency in self._dependencies.items():
+                    if dependency.downloading:
+                        continue
+
+                    # We compute the size of dependencies here to keep the code
+                    # that adds new bundles to the dependency manager simpler.
+                    if dependency.size_bytes is None:
+                        self._lock.release()
+                        size_bytes = get_path_size(os.path.join(self._work_dir,
+                                                                dependency.path))
+                        self._lock.acquire()
+                        dependency.size_bytes = size_bytes
+                        self._save_state()
+
+                    total_size_bytes += dependency.size_bytes
+                    if (not dependency.has_dependees() and
+                        dependency.last_used < first_used_time):
+                        first_used_time = dependency.last_used
+                        first_used_target = target
+                self._lock.release()
+
+                if (total_size_bytes > self._max_work_dir_size_mb * 1024 * 1024 and
+                    first_used_target is not None):
+                    with self._lock:
+                        dependency = self._dependencies[first_used_target]
+                        if dependency.has_dependees():
+                            # Since we released the lock there could be new
+                            # dependees.
+                            continue
+                        del self._dependencies[first_used_target]
+                        self._paths.remove(dependency.path)
+                        self._save_state()
+                        remove_path(os.path.join(self._work_dir, dependency.path))
+                else:
+                    break
+
+            # Sleep for 10 seconds, allowing interruptions every second.
+            for _ in xrange(0, self._cleanup_sleep_secs):
+                time.sleep(1)
+                if self._should_stop_cleanup():
+                    break
+
+    def stop_cleanup_thread(self):
+        with self._lock:
+            self._stop_cleanup = True
+        self._cleanup_thread.join()
+
+    def _should_stop_cleanup(self):
+        with self._lock:
+            return self._stop_cleanup
+
+    def dependencies(self):
+        """
+        Returns tuple of UUID, path of all the dependencies stored on the worker.
+        """
+        with self._lock:
+            return self._dependencies.keys()
+
+    def add_dependee(self, parent_uuid, parent_path, uuid):
+        """
+        Reports that the bundle with UUID uuid is starting to run and
+        has the path parent_path of bundle with UUID parent_uuid as a
+        dependency.
+
+        Returns a tuple containing the path to the dependency and whether
+        the dependency needs to be downloaded. finish_download should be called
+        once the download is finished, whether successful or not.
+
+        Note that if multiple runs need to download the same dependency at the
+        same time, add_dependee will return True for only one of them, and will
+        block the others until the download has finished.
+        """
+        target = (parent_uuid, parent_path)
+        with self._lock:
+            while True:
+                if target in self._dependencies:
+                    dependency = self._dependencies[target]
+                    if dependency.downloading:
+                        # Wait for download to finish. Then, check again (i.e.
+                        # go through the loop again) just in case the download
+                        # failed.
+                        #
+                        # Note, wait releases self._lock. However, since the
+                        # condition uses self._lock when wait returns the thread
+                        # will again hold self._lock.
+                        dependency.wait_on_download()
+                    else:
+                        # Already downloaded.
+                        dependency.add_dependee(uuid)
+                        return os.path.join(self._work_dir, dependency.path), False
+                else:
+                    if parent_path:
+                        path = os.path.join(parent_uuid, parent_path)
+                    else:
+                        path = parent_uuid
+                    path = path.replace(os.path.sep, '_')
+
+                    # You could have a conflict between, for example a/b_c and
+                    # a_b/c. We have to avoid those.
+                    while path in self._paths:
+                        path = path + '_'
+
+                    dependency = self._dependencies[target] = (
+                        Dependency(path, True, self._lock))
+                    self._paths.add(path)
+                    dependency.add_dependee(uuid)
+                    return os.path.join(self._work_dir, path), True
+
+    def finish_download(self, uuid, path, success):
+        """
+        Reports that the download of dependency with UUID uuid and path path
+        has finished.
+        """
+        target = (uuid, path)
+        with self._lock:
+            dependency = self._dependencies[target]
+            if success:
+                dependency.finish_download()
+                self._save_state()
+            else:
+                del self._dependencies[target]
+                self._paths.remove(dependency.path)
+
+            # All threads currently waiting for the download would receive the
+            # notification. However, they would unblock only as soon as they are
+            # able to grab self._lock.
+            dependency.notify_download_finished()
+
+    def remove_dependee(self, parent_uuid, parent_path, uuid):
+        """
+        Reports that the bundle with UUID uuid has finished running and
+        no longer needs the path parent_path of bundle with UUID parent_uuid as
+        a dependency.
+        """
+        target = (parent_uuid, parent_path)
+        with self._lock:
+            if target in self._dependencies:
+                self._dependencies[target].remove_dependee(uuid)
+                self._save_state()
+
+    def get_run_path(self, uuid):
+        return os.path.join(self._work_dir, uuid)
+
+    def finish_run(self, uuid):
+        """
+        Reports that the bundle with UUID can now be used by other running
+        bundles as a dependency.
+        """
+        target = (uuid, '')
+        with self._lock:
+            self._dependencies[target] = Dependency(uuid, False, self._lock)
+            self._paths.add(uuid)
+            self._save_state()
+
+
+class Dependency(object):
+    """
+    Keeps track of the state of a single dependency.
+    """
+    def __init__(self, path, downloading, lock):
+        self.path = path
+        self.downloading = downloading
+        self._download_condition = threading.Condition(lock)
+        self.size_bytes = None
+        self._dependees = set()
+        self.last_used = time.time()
+
+    @staticmethod
+    def load(dumped_dependency, lock):
+        dependency = Dependency(dumped_dependency['path'], False, lock)
+        dependency.size_bytes = dumped_dependency['size_bytes']
+        dependency.last_used = dumped_dependency['last_used']
+        return dependency
+
+    def dump(self):
+        return {
+            'path': self.path,
+            'size_bytes': self.size_bytes,
+            'last_used': self.last_used,
+        }
+
+    def add_dependee(self, uuid):
+        self._dependees.add(uuid)
+
+    def remove_dependee(self, uuid):
+        if uuid in self._dependees:
+            self._dependees.remove(uuid)
+
+        self.last_used = time.time()
+
+    def has_dependees(self):
+        return bool(self._dependees)
+
+    def wait_on_download(self):
+        self._download_condition.wait()
+
+    def notify_download_finished(self):
+        self._download_condition.notify_all()
+
+    def finish_download(self):
+        self.downloading = False
+        self.last_used = time.time()

--- a/worker/file_util.py
+++ b/worker/file_util.py
@@ -272,6 +272,20 @@ def summarize_file(file_path, num_head_lines, num_tail_lines, max_line_length, t
     
     return ''.join(lines)
 
+def get_path_size(path, ignore_paths=[]):
+    """
+    Returns the size of the contents of the given path, in bytes.
+
+    If path is a directory, any directory entries in ignore_paths will be
+    ignored.
+    """
+    result = os.lstat(path).st_size
+    if not os.path.islink(path) and os.path.isdir(path):
+        for child in os.listdir(path):
+            if child not in ignore_paths:
+                result += get_path_size(os.path.join(path, child))
+    return result
+
 def remove_path(path):
     """
     Removes a path if it exists.


### PR DESCRIPTION
Just want to send out another piece of the worker that's fully ready. You've already seen most of this.

Note that the dependency manager doesn't actually download dependencies. That is done by the worker.py library.

@percyliang 
