### PR TITLE
Send user to right place after verifying account

### DIFF
--- a/codalab/apps/web/templates/web/account/verify_success.html
+++ b/codalab/apps/web/templates/web/account/verify_success.html
@@ -10,7 +10,8 @@
 <div class="row">
     <div class="col-md-6">
         <h4>Your account has been verified!</h4>
-        <p>Check out your <a href="/rest/worksheets/?name=dashboard" tabIndex=2 target="_self">dashboard</a> to get started.</p>
+        <p class="user-authenticated">Check out your <a href="/rest/worksheets/?name=dashboard" tabIndex=2 target="_self">dashboard</a> to get started.</p>
+        <p class="user-not-authenticated"><a href="{% url 'account_login' %}?next={{'/rest/worksheets/?name=dashboard'|urlencode:''}}" target="_self">Sign In</a> to get started.</p>
     </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
New behavior on verification success page:

- If user is already already signed in, show link to dashboard.
- If user is not yet signed in, show link to sign in page (with `next=` set to the dashboard).

Fixes #136 

@klopyrev 