### PR TITLE
Log last login

### DIFF
--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -1820,6 +1820,15 @@ class BundleModel(object):
         user_info['time_used'] += amount
         self.update_user_info(user_info)
 
+    def update_user_last_login(self, user_id):
+        """
+        Update user's last login date to now.
+        """
+        self.update_user_info({
+            'user_id': user_id,
+            'last_login': datetime.datetime.utcnow(),
+        })
+
     def _get_disk_used(self, user_id):
         return self.search_bundle_uuids(user_id, None, ['size=.sum', 'owner_id=' + user_id, 'data_hash=%']) or 0
 

--- a/codalab/rest/account.py
+++ b/codalab/rest/account.py
@@ -43,6 +43,9 @@ def do_login():
             "next": success_uri,
         })
 
+    # Update last login
+    local.model.update_user_last_login(user.user_id)
+
     # Save cookie in client
     cookie = LoginCookie(user.user_id, max_age=30 * 24 * 60 * 60)
     cookie.save()


### PR DESCRIPTION
Update user last_login field on login.

(For now using UTC like date_joined, but need to address time zones in the future. Also updated codalab/codalab-worksheets#134 to indicate that dates are UTC as a stopgap.)

Fixes #410 

@klopyrev 
