### PR TITLE
Issue #104: automatically refresh worksheet if some bundle is not ready

### DIFF
--- a/codalab/apps/web/static/js/worksheet/worksheet_interface.jsx
+++ b/codalab/apps/web/static/js/worksheet/worksheet_interface.jsx
@@ -320,8 +320,9 @@ var Worksheet = React.createClass({
                 if (!this.allBundlesReady(items) && !this.state.updateIntervalId) {
                     // if some bundle is not ready, refresh the worksheet once every second
                     var self = this;
-                    this.setState({updateIntervalId: setInterval(function() {self.refreshWorksheet(false)}, 3000)});
+                    this.setState({updateIntervalId: setInterval(function() {self.refreshWorksheet(false)}, 1000)});
                 } else if (this.allBundlesReady(items) && this.state.updateIntervalId) {
+                    // otherwise, clear that interval if it exists
                     clearInterval(this.state.updateIntervalId);
                     this.setState({updateIntervalId: null});
                 }


### PR DESCRIPTION
@percyliang 

Fixed issue#104. If some bundle is not ready, refresh the worksheet once every second. 

I think it still makes sense to refresh the whole worksheet instead of each bundle because it will ensure one-way data flow from the worksheet to each bundle, as what we have done before. This will make things easier to debug in the future and for the sake of style I would love to keep it that way. Plus, I have tried and I think refresh a worksheet won't take too long. 

Let me know :)
