### PR TITLE
Fix unicode support for user fields

### DIFF
--- a/codalab/model/tables.py
+++ b/codalab/model/tables.py
@@ -236,16 +236,16 @@ user = Table(
   Column('email', String(254), nullable=False, unique=True),  # Length of 254 to be compliant with RFC3696/5321
   Column('last_login', DateTime),  # Null if user has never logged in
   Column('is_active', Boolean, nullable=False, default=True),  # Set to False instead of deleting users to maintain foreign key integrity
-  Column('first_name', String(30)),
-  Column('last_name', String(30)),
+  Column('first_name', String(30, convert_unicode=True)),
+  Column('last_name', String(30, convert_unicode=True)),
   Column('date_joined', DateTime, nullable=False),
   Column('is_verified', Boolean, nullable=False, default=False),
   Column('is_superuser', Boolean, nullable=False, default=False),
   Column('password', String(128), nullable=False),
 
   # Additional information
-  Column('affiliation', String(255), nullable=True),
-  Column('url', String(255), nullable=True),
+  Column('affiliation', String(255, convert_unicode=True), nullable=True),
+  Column('url', String(255, convert_unicode=True), nullable=True),
 
   # Quotas
   Column('time_quota', Float, nullable=False),  # Number of seconds allowed

--- a/codalab/objects/user.py
+++ b/codalab/objects/user.py
@@ -2,8 +2,6 @@
 User objects representing rows from the user table
 """
 import base64
-import hashlib
-import hmac
 
 from codalab.common import UsageError
 from codalab.model.orm_object import ORMObject
@@ -24,9 +22,6 @@ class User(ORMObject):
     @property
     def name(self):
         return self.user_name
-
-    def validate(self):
-        pass
 
     @staticmethod
     def encode_password(password, salt, iterations=30000):

--- a/codalab/rest/account.py
+++ b/codalab/rest/account.py
@@ -6,6 +6,7 @@ from bottle import request, response, template, local, redirect, default_app, ge
 
 from codalab.lib import crypt_util, spec_util
 from codalab.lib.server_util import redirect_with_query
+from codalab.lib.spec_util import NAME_REGEX
 from codalab.objects.user import User
 from codalab.common import UsageError
 from codalab.server.authenticated_plugin import AuthenticatedPlugin, UserVerifiedPlugin
@@ -87,6 +88,9 @@ def do_signup():
 
     if local.model.user_exists(username, email):
         errors.append("User with this username or email already exists.")
+
+    if not NAME_REGEX.match(username):
+        errors.append("Username characters must be alphanumeric, underscores, periods, or dashes.")
 
     if errors:
         return redirect_with_query(error_uri, {

--- a/codalab/rest/users.py
+++ b/codalab/rest/users.py
@@ -8,6 +8,7 @@ from marshmallow import ValidationError
 from marshmallow_jsonapi import Schema, fields
 
 from codalab.lib import formatting
+from codalab.lib.spec_util import NAME_REGEX
 from codalab.server.authenticated_plugin import (
     AuthenticatedPlugin,
     UserVerifiedPlugin,
@@ -76,6 +77,10 @@ def update_authenticated_user():
     if (user_info.get('user_name', request.user.user_name) != request.user.user_name and
         local.model.user_exists(user_info['user_name'], None)):
         abort(httplib.BAD_REQUEST, "User name %s is already taken." % user_info['user_name'])
+
+    # Validate user name
+    if not NAME_REGEX.match(user_info.get('user_name', request.user.user_name)):
+        abort(httplib.BAD_REQUEST, "User name characters must be alphanumeric, underscores, periods, or dashes.")
 
     # Update user
     local.model.update_user_info(user_info)


### PR DESCRIPTION
Make SQLAlchemy correctly convert between Python unicode objects and utf-8 encoded strings in the database for most user text fields, and validate other fields (i.e. user_name) to constrict its character set.

@percyliang @klopyrev 
