### PR TITLE
Ensure more than 10 jobs can run at the same time.

### DIFF
--- a/codalab/objects/work_manager.py
+++ b/codalab/objects/work_manager.py
@@ -204,7 +204,7 @@ class Worker(object):
         new_statuses = []
         # Lookup all the uuids and bundles of the relevant job handles
         handles = [status['job_handle'] for status in statuses]
-        uuids = self.model.search_bundle_uuids(worksheet_uuid=None, user_id=self.model.root_user_id, keywords=['job_handle='+','.join(handles)])
+        uuids = self.model.search_bundle_uuids(worksheet_uuid=None, user_id=self.model.root_user_id, keywords=['job_handle='+','.join(handles), '.limit=10000'])
         bundles = self.model.batch_get_bundles(uuid=uuids)
         handle_to_bundles = {}
         for bundle in bundles:


### PR DESCRIPTION
Fix bug that causes many of the jobs running on codalab.stanford.edu to get stuck in QUEUED state. Not sure who's bright idea it was to use this search_bundle_uuids method.

@percyliang 
