### PR TITLE
Move bundle contents update endpoint to /bundles

### DIFF
--- a/codalab/rest/bundle.py
+++ b/codalab/rest/bundle.py
@@ -1,10 +1,14 @@
 import httplib
 import mimetypes
 
-from bottle import abort, get, local, request, response
+from bottle import abort, get, local, put, request, response
 
 from codalab.lib import spec_util, zip_util
-from codalab.objects.permission import check_bundles_have_read_permission
+from codalab.objects.permission import (
+    check_bundles_have_all_permission,
+    check_bundles_have_read_permission,
+)
+from codalab.server.authenticated_plugin import AuthenticatedPlugin
 
 
 @get('/bundle/<uuid:re:%s>/contents/blob/' % spec_util.UUID_STR)
@@ -59,6 +63,36 @@ def get_blob(uuid, path=''):
     response.set_header('Content-Disposition', 'filename="%s"' % filename)
 
     return fileobj
+
+
+@put('/bundles/<uuid:re:%s>/contents/blob/' % spec_util.UUID_STR,
+     apply=AuthenticatedPlugin())
+def update_blob(uuid):
+    """
+    Update the contents of the given running or uploading bundle.
+
+    Accepts the filename as a query parameter, used to determine whether the
+    upload contains an archive.
+    """
+    check_bundles_have_all_permission(local.model, request.user, [uuid])
+    bundle = local.model.get_bundle(uuid)
+
+    # If this bundle already has data, remove it.
+    if local.upload_manager.has_contents(bundle):
+        local.upload_manager.cleanup_existing_contents(bundle)
+
+    # Store the data.
+    try:
+        local.upload_manager.upload_to_bundle_store(
+            bundle, sources=[(request.query.filename, request['wsgi.input'])],
+            follow_symlinks=False, exclude_patterns=False, remove_sources=False,
+            git=False, unpack=True, simplify_archives=False)
+        local.upload_manager.update_metadata_and_save(bundle, new_bundle=False)
+
+    except Exception:
+        if local.upload_manager.has_contents(bundle):
+            local.upload_manager.cleanup_existing_contents(bundle)
+        raise
 
 
 def request_accepts_gzip_encoding():

--- a/codalab/rest/worker.py
+++ b/codalab/rest/worker.py
@@ -136,35 +136,6 @@ def update_bundle_metadata(worker_id, uuid):
     local.model.update_bundle(bundle, {'metadata': metadata_update})
 
 
-@put('/worker/<worker_id>/update_bundle_contents/<uuid:re:%s>' % spec_util.UUID_STR,
-     apply=AuthenticatedPlugin())
-def update_bundle_contents(worker_id, uuid):
-    """
-    Update the contents of the given running bundle.
-
-    Accepts the filename as a query parameter, used to determine whether the
-    upload contains an archive.
-    """
-    bundle = local.model.get_bundle(uuid)
-    check_run_permission(bundle)
-
-    # If this bundle already has data, remove it.
-    if local.upload_manager.has_contents(bundle):
-        local.upload_manager.cleanup_existing_contents(bundle)
-
-    # Store the data.
-    try:
-        local.upload_manager.upload_to_bundle_store(
-            bundle, sources=[(request.query.filename, request['wsgi.input'])],
-            follow_symlinks=False, exclude_patterns=False, remove_sources=False,
-            git=False, unpack=True, simplify_archives=False)
-        local.upload_manager.update_metadata_and_save(bundle, new_bundle=False)
-    except Exception:
-        if local.upload_manager.has_contents(bundle):
-            local.upload_manager.cleanup_existing_contents(bundle)
-        raise
-
-
 @post('/worker/<worker_id>/finalize_bundle/<uuid:re:%s>' % spec_util.UUID_STR,
       apply=AuthenticatedPlugin())
 def finalize_bundle(worker_id, uuid):

--- a/worker/bundle_service_client.py
+++ b/worker/bundle_service_client.py
@@ -159,7 +159,7 @@ class BundleServiceClient(object):
     def update_bundle_contents(self, worker_id, uuid, path):
         with closing(tar_gzip_directory(path)) as fileobj:
             self._upload_with_chunked_encoding(
-                'PUT', self._worker_url_prefix(worker_id) + '/update_bundle_contents/' + uuid,
+                'PUT', '/bundles/' + uuid + '/contents/blob/',
                 query_params={'filename': 'bundle.tar.gz'}, fileobj=fileobj)
 
     @authorized


### PR DESCRIPTION
Leaving further modifications to the upload method for future pull requests, but this should clear the worker system for deployment before the rest of the REST API.

@klopyrev 
