### PR TITLE
Get dependencies working properly for the NLP cluster.

### DIFF
--- a/worker/docker_client.py
+++ b/worker/docker_client.py
@@ -154,6 +154,7 @@ No ldconfig found. Not loading libcuda libraries.
                         request_network, dependencies):
         # Set up the command.
         docker_bundle_path = '/' + uuid
+        docker_dependencies_path = '/' + uuid + '_dependencies'
         docker_commands = [
             'ldconfig',
             'BASHRC=$(pwd)/.bashrc',
@@ -182,9 +183,12 @@ No ldconfig found. Not loading libcuda libraries.
                 libcuda_file, os.path.basename(libcuda_file)))
         volume_bindings.append('%s:%s' % (bundle_path, docker_bundle_path))
         for dependency_path, child_path in dependencies:
+            bundle_dependency_path = os.path.join(bundle_path, child_path)
+            docker_dependency_path = os.path.join(docker_dependencies_path, child_path)
             volume_bindings.append('%s:%s:ro' % (
                 os.path.abspath(dependency_path),
-                os.path.join(docker_bundle_path, child_path)))
+                docker_dependency_path))
+            os.symlink(docker_dependency_path, bundle_dependency_path)
 
         # Set up the devices.
         devices = []

--- a/worker/file_util.py
+++ b/worker/file_util.py
@@ -217,8 +217,10 @@ def remove_path(path):
     """
     Removes a path if it exists.
     """
-    if os.path.exists(path):
-        if os.path.isdir(path):
+    if os.path.islink(path) or os.path.exists(path):
+        if os.path.islink(path):
+            os.remove(path)
+        elif os.path.isdir(path):
             shutil.rmtree(path)
         else:
             os.remove(path)

--- a/worker/run.py
+++ b/worker/run.py
@@ -126,6 +126,12 @@ class Run(object):
                         dep['parent_uuid'], dep['parent_path'], self._uuid,
                         check_killed)
 
+                child_path = os.path.normpath(
+                    os.path.join(self._bundle_path, dep['child_path']))
+                if not child_path.startswith(self._bundle_path):
+                    raise Exception('Invalid key for dependency: %s' % (
+                        dep['child_path']))
+
                 dependencies.append((dependency_path, dep['child_path']))
 
             def do_start():
@@ -351,11 +357,10 @@ class Run(object):
                 if not self._worker.shared_file_system:
                     self._worker.remove_dependency(
                         dep['parent_uuid'], dep['parent_path'], self._uuid)
-                # Docker creates files for each mounted volume. Delete them.
-                child_path = os.path.realpath(
-                    os.path.join(self._bundle_path, dep['child_path']))
-                if child_path.startswith(self._bundle_path):
-                    remove_path(child_path)
+                # The DockerClient creates symlinks for dependencies. Delete
+                # them.
+                child_path = os.path.join(self._bundle_path, dep['child_path'])
+                remove_path(child_path)
 
             if not self._worker.shared_file_system:
                 logger.debug('Uploading results for run with UUID %s', self._uuid)


### PR DESCRIPTION
It seems that Docker can't modify the bundle path to add the special dependency files on the NLP cluster. Work around this by mounting dependencies in a different location inside the container and adding symlinks to point to that container. Also, fix remove_path to work with symlinks.

@percyliang 
