### PR TITLE
Clean-up the duplicate creation of symlinks when the Docker image needs downloading

### DIFF
--- a/worker/docker_client.py
+++ b/worker/docker_client.py
@@ -154,7 +154,6 @@ No ldconfig found. Not loading libcuda libraries.
                         request_network, dependencies):
         # Set up the command.
         docker_bundle_path = '/' + uuid
-        docker_dependencies_path = '/' + uuid + '_dependencies'
         docker_commands = [
             'ldconfig',
             'BASHRC=$(pwd)/.bashrc',
@@ -182,13 +181,10 @@ No ldconfig found. Not loading libcuda libraries.
             volume_bindings.append('%s:/usr/lib/x86_64-linux-gnu/%s:ro' % (
                 libcuda_file, os.path.basename(libcuda_file)))
         volume_bindings.append('%s:%s' % (bundle_path, docker_bundle_path))
-        for dependency_path, child_path in dependencies:
-            bundle_dependency_path = os.path.join(bundle_path, child_path)
-            docker_dependency_path = os.path.join(docker_dependencies_path, child_path)
+        for dependency_path, docker_dependency_path in dependencies:
             volume_bindings.append('%s:%s:ro' % (
                 os.path.abspath(dependency_path),
                 docker_dependency_path))
-            os.symlink(docker_dependency_path, bundle_dependency_path)
 
         # Set up the devices.
         devices = []


### PR DESCRIPTION
Since create is called twice when the image is not present, there was a call to create the symlink twice which causes a File exists error.

Note, this design makes more sense, since we create the symlinks in the same file as we delete them.
