### PR TITLE
Improve the display of various states.

### DIFF
--- a/codalab/apps/web/static/js/bundle/bundle_interface.jsx
+++ b/codalab/apps/web/static/js/bundle/bundle_interface.jsx
@@ -141,16 +141,38 @@ var Bundle = React.createClass({
         var saveButton;
         var metadata = this.state.metadata;
         var bundle_download_url = "/rest/bundles/" + this.state.uuid + "/contents/blob/";
+        var headerRows = [];
         var bundleAttrs = [];
         var editing = this.state.editing;
         var tableClassName = 'table' + (editing ? ' editing' : '');
         var editButtonText = editing ? 'cancel' : 'edit';
+
+        function createRow(key, value) {
+          return (<tr>
+            <th width="33%">{key}</th>
+            <td>{value}</td>
+          </tr>);
+        }
+        if (this.state.bundle_type == 'run') {
+            headerRows.push(createRow('Command', this.state.command));
+        }
+        headerRows.push(createRow('State', this.state.state));
+        if (metadata.failure_message) {
+            headerRows.push(createRow('Failure Message', metadata.failure_message));
+        }
+        if (this.state.bundle_type == 'run' && this.state.state == "running" && metadata.run_status != "Running") {
+            headerRows.push(createRow('Run Status', metadata.run_status));
+        }
 
         if (editing)
             saveButton = <button className="btn btn-success btn-sm" onClick={this.saveMetadata}>save</button>;
 
         var keys = [];
         for (var property in metadata) {
+            if (["run_status", "failure_message"].indexOf(property) != -1) {
+                // These are displayed in the header.
+                continue;
+            }
             if (metadata.hasOwnProperty(property))
                 keys.push(property);
         }
@@ -305,30 +327,9 @@ var Bundle = React.createClass({
                 </p>
                     <div className="metadata-table">
                         <table>
-                            <tr>
-                                <th width="33%">
-                                    State
-                                </th>
-                                <td>
-                                    {this.state.state}
-                                </td>
-                            </tr>
-                            <tr>
-                                <th width="33%">
-                                    Command
-                                </th>
-                                <td>
-                                    {this.state.command || "<none>"}
-                                </td>
-                            </tr>
-                             <tr>
-                                <th width="33%">
-                                    Data Hash
-                                </th>
-                                <td>
-                                    {this.state.data_hash || "<none>"}
-                                </td>
-                            </tr>
+                            <tbody>
+                                {headerRows}
+                            </tbody>
                         </table>
                     </div>
 

--- a/codalab/apps/web/static/js/worksheet/worksheet_side_panel.jsx
+++ b/codalab/apps/web/static/js/worksheet/worksheet_side_panel.jsx
@@ -344,6 +344,10 @@ function renderMetadata(bundle_info, bundleMetadataChanged) {
   keys.sort();
   for (var i = 0; i < keys.length; i++) {
     var property = keys[i];
+    if (["run_status", "failure_message"].indexOf(property) != -1) {
+    	// These are displayed in the header.
+      continue;
+    }
     if (bundle_info.edit_permission && editableMetadataFields && editableMetadataFields.indexOf(property) >= 0){
       metadata_list_html.push(<tr>
         <th>{property}</th>
@@ -397,7 +401,13 @@ function renderHeader(bundle_info, bundleMetadataChanged) {
   rows.push(createRow('permissions', render_permissions(bundle_info)));
   if (bundle_info.bundle_type == 'run') {
     rows.push(createRow('command', bundle_info.command));
-    rows.push(createRow('state', <span className={bundle_state_class}>{bundle_info.state}</span>));
+  }
+  rows.push(createRow('state', <span className={bundle_state_class}>{bundle_info.state}</span>));
+  if (bundle_info.metadata.failure_message) {
+    rows.push(createRow('failure_message', bundle_info.metadata.failure_message));
+  }
+  if (bundle_info.bundle_type == 'run' && bundle_info.state == "running" && bundle_info.metadata.run_status != "Running") {
+    rows.push(createRow('run_status', bundle_info.metadata.run_status));
   }
 
   return (<div>

--- a/codalab/apps/web/static/less/worksheets.less
+++ b/codalab/apps/web/static/less/worksheets.less
@@ -17,11 +17,9 @@
 }
 .bundle-state {
    .label;
+   .label-warning;
    &.state-ready {
       .label-success;
-   }
-   &.state-running {
-      .label-warning;
    }
    &.state-failed {
       .label-danger;


### PR DESCRIPTION
Improve how states are displayed. Specifically:

1) Move run_status and failure_message up to the header. run_status will only be shown if is something like "Downloading Docker Image".
2) Use the same orange color for created, staged, waiting_for_worker_startup, starting, running. Otherwise, it's hard to see since it is white on grey.


@percyliang 