### PR TITLE
Send less load from workers to REST server.

### DIFF
--- a/codalab/rest/worker.py
+++ b/codalab/rest/worker.py
@@ -22,7 +22,7 @@ def checkin(worker_id):
     Waits for a message for the worker for WAIT_TIME_SECS seconds. Returns the
     message or None if there isn't one.
     """
-    WAIT_TIME_SECS = 2.0
+    WAIT_TIME_SECS = 5.0
 
     torque_worker = ('torque' in local.config['workers'] and
                      request.user.user_id == local.model.root_user_id)

--- a/worker/docker_client.py
+++ b/worker/docker_client.py
@@ -195,7 +195,6 @@ No ldconfig found. Not loading libcuda libraries.
                 'CgroupPermissions': 'mrw'})
 
         # Create the container.
-        logger.debug('Creating Docker container with command %s', command)
         create_request = {
             'Cmd': ['bash', '-c', '; '.join(docker_commands)],
             'Image': docker_image,
@@ -216,8 +215,8 @@ No ldconfig found. Not loading libcuda libraries.
             container_id = json.loads(create_response.read())['Id']
 
         # Start the container.
-        logger.debug('Starting Docker container with command %s, container ID %s',
-            command, container_id)
+        logger.debug('Starting Docker container for UUID %s with command %s, container ID %s',
+            uuid, command, container_id)
         with closing(self._create_connection()) as start_conn:
             start_conn.request('POST', '/containers/%s/start' % container_id)
             start_response = start_conn.getresponse()
@@ -227,7 +226,6 @@ No ldconfig found. Not loading libcuda libraries.
         return container_id
 
     def get_container_stats(self, container_id):
-        logger.debug('Getting statistics for container ID %s', container_id)
         # We don't use the stats API since it doesn't seem to be reliable, and
         # is definitely slow. This doesn't work on Mac.
         cgroup = None


### PR DESCRIPTION
1) Check-in blocks on worker socket for 5 seconds, instead of 2. That makes shutting down the worker longer, since it needs to wait for the check-in call to return. Yet, it sends less traffic to the REST server. Responsiveness should be the same or better.
2) Report resource utilization every 5 seconds, instead of every half a second.
3) Minor changes to debug log messages.

@percyliang 
