### PR TITLE
Get single dependency make working again.

### DIFF
--- a/codalab/worker/bundle_manager.py
+++ b/codalab/worker/bundle_manager.py
@@ -201,9 +201,13 @@ class BundleManager(object):
                 deps.append((dependency_path, child_path))
 
             remove_path(path)
-            os.mkdir(path)
-            for dependency_path, child_path in deps:
-                path_util.copy(dependency_path, child_path, follow_symlinks=False)
+            
+            if len(deps) == 1 and deps[0][1] == path:
+                path_util.copy(deps[0][0], path, follow_symlinks=False)
+            else:
+                os.mkdir(path)
+                for dependency_path, child_path in deps:
+                    path_util.copy(dependency_path, child_path, follow_symlinks=False)
 
             self._upload_manager.update_metadata_and_save(bundle, new_bundle=False)
             logger.info('Finished making bundle %s', bundle.uuid)


### PR DESCRIPTION
The old code handled this case in a very hidden way, so I missed it.

@percyliang 
