### PR TITLE
(Yet another) attempt to get GPUs working. Doesn't work on jagupard3, which was down when I tested the last time.

### DIFF
--- a/worker/worker.py
+++ b/worker/worker.py
@@ -14,7 +14,7 @@ from file_util import remove_path, un_gzip_stream, un_tar_directory
 from run import Run
 
 
-VERSION = 3
+VERSION = 4
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
This set up is more consistent with how libcuda is set up natively. It helps a bit on jagupard3 given that libcuda.so is now correctly loaded (https://codalab.stanford.edu/bundles/0x7828b37fb2ff4b3aa803bec2eaf0baf0/), but it has other problems with GPUs. Hopefully, with this more correct set up libraries that I haven't tested with are more likely to work correctly.

@percyliang 
