### PR TITLE
Upgrade cl uedit and add cl uinfo

### DIFF
--- a/codalab/client/json_api_client.py
+++ b/codalab/client/json_api_client.py
@@ -342,6 +342,7 @@ class JsonApiClient(RestClient):
     def update(self, resource_type, data, params=None):
         """
         Request to update a resource or resources.
+        Always uses bulk update.
 
         :param resource_type: resource type as string
         :param data: update dict or list of update dicts, update dicts
@@ -354,7 +355,8 @@ class JsonApiClient(RestClient):
                 method='PATCH',
                 path=self._get_resource_path(resource_type),
                 query_params=self._pack_params(params),
-                data=self._pack_document(data, resource_type)))
+                data=self._pack_document(
+                    data if isinstance(data, list) else [data], resource_type)))
         # Return list iff original data was list
         return result if isinstance(data, list) else result[0]
 

--- a/codalab/client/json_api_client.py
+++ b/codalab/client/json_api_client.py
@@ -424,3 +424,20 @@ class JsonApiClient(RestClient):
                     resource_type, resource_id, relationship_key),
                 query_params=self._pack_params(params),
                 data=(relationship and relationship.as_dict())))
+
+    @wrap_exception('Unable to update authenticated user')
+    def update_authenticated_user(self, data, params=None):
+        """
+        Request to update the authenticated user.
+        Uses special /user endpoint, but keeps the 'users' resource type.
+
+        :param data: dict containing user field updates
+        :param params: dict of query parameters
+        :return: updated user dict
+        """
+        return self._unpack_document(
+            self._make_request(
+                method='PATCH',
+                path=self._get_resource_path('user'),
+                query_params=self._pack_params(params),
+                data=self._pack_document(data, 'users')))

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -714,10 +714,6 @@ class BundleCLI(object):
         print >>self.stdout, "current_worksheet: %s" % self.simple_worksheet_str(worksheet_info)
         print >>self.stdout, "user: %s" % self.simple_user_str(client.user_info(None))
 
-        user_info = client.get_user_info(None)
-        print >>self.stdout, "time: %s" % formatting.ratio_str(formatting.duration_str, user_info['time_used'], user_info['time_quota'])
-        print >>self.stdout, "disk: %s" % formatting.ratio_str(formatting.size_str, user_info['disk_used'], user_info['disk_quota'])
-
     @Commands.command(
         'logout',
         help='Logout of the current session.',
@@ -2304,27 +2300,84 @@ class BundleCLI(object):
         'uedit',
         help=[
             'Edit user information.',
+            'Note that password and email can only be changed through the web interface.',
         ],
         arguments=(
-            Commands.Argument('-u', '--user-id', help='User to set quota for'),
+            Commands.Argument('user_spec', nargs='?', help='Username or id of user to update [default: the authenticated user]'),
             Commands.Argument('-t', '--time-quota', help='Total amount of time allowed (e.g., 3, 3m, 3h, 3d)'),
             Commands.Argument('-d', '--disk-quota', help='Total amount of disk allowed (e.g., 3, 3k, 3m, 3g, 3t)'),
+            Commands.Argument('--first-name', help='First name'),
+            Commands.Argument('--last-name', help='Last name'),
+            Commands.Argument('--affiliation', help='Affiliation'),
+            Commands.Argument('--url', help='Website URL'),
         ),
     )
     def do_uedit_command(self, args):
         """
         Edit properties of users.
         """
-        client = self.manager.current_client()
-        user_update = {}
-        if args.time_quota is not None:
-            user_update['time_quota'] = formatting.parse_duration(args.time_quota)
-        if args.disk_quota is not None:
-            user_update['disk_quota'] = formatting.parse_size(args.disk_quota)
-        if args.user_id is not None:
-            user_update['user_id'] = args.user_id
-        if user_update:
-            client.update_user_info(user_update)
+        client = self.manager.current_client(use_rest=True)
+
+        # Build user info
+        user_info = {}
+        for key in ('time_quota', 'disk_quota', 'first_name', 'last_name',
+                    'affiliation', 'url'):
+            if getattr(args, key) is not None:
+                user_info[key] = getattr(args, key)
+
+        if not user_info:
+            raise UsageError("No fields to update.")
+
+        # If user id is not specified, update the authenticated user
+        if args.user_spec is None:
+            user = client.update_authenticated_user(user_info)
+            self.print_user_info(user, include_private=True)
+        else:
+            user_info['id'] = client.fetch('users', args.user_spec)['id']
+            user = client.update('users', [user_info])[0]
+            self.print_user_info(user, include_private=False)
+
+    @Commands.command(
+        'uinfo',
+        help=[
+            'Show user information.',
+        ],
+        arguments=(
+            Commands.Argument('user_spec', nargs='?', help='Username or id of user to show [default: the authenticated user]'),
+        ),
+    )
+    def do_uinfo_command(self, args):
+        """
+        Edit properties of users.
+        """
+        client = self.manager.current_client(use_rest=True)
+
+        if args.user_spec is None:
+            user = client.fetch('user')
+            self.print_user_info(user, include_private=True)
+        else:
+            user = client.fetch('users', args.user_spec)
+            self.print_user_info(user, include_private=False)
+
+    def print_user_info(self, user, include_private=False):
+        for key in ('id', 'user_name', 'first_name', 'last_name',
+                    'affiliation', 'url', 'date_joined'):
+            print >>self.stdout, u'{:<15}: {}'.format(key, user.get(key, None))
+
+        if include_private:
+            for key in ('email', 'last_login'):
+                print >>self.stdout, u'{:<15}: {}'.format(key, user.get(key, None))
+
+            print >>self.stdout, u'{:<15}: {}'.format(
+                'time', formatting.ratio_str(
+                    formatting.duration_str,
+                    user['time_used'],
+                    user['time_quota']))
+
+            print >>self.stdout, u'{:<15}: {}'.format(
+                'disk', formatting.ratio_str(formatting.size_str,
+                                             user['disk_used'],
+                                             user['disk_quota']))
 
     @Commands.command(
         'reset',

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -132,6 +132,11 @@ GROUP_AND_PERMISSION_COMMANDS = (
     'chown',
 )
 
+USER_COMMANDS = (
+    'uinfo',
+    'uedit',
+)
+
 OTHER_COMMANDS = (
     'help',
     'status',
@@ -326,12 +331,16 @@ class Commands(object):
         Commands for groups and permissions:
         {group_and_permission_commands}
 
+        Commands for users:
+        {user_commands}
+
         Other commands:
         {other_commands}
         """).format(
             bundle_commands=command_group_help_text(BUNDLE_COMMANDS),
             worksheet_commands=command_group_help_text(WORKSHEET_COMMANDS),
             group_and_permission_commands=command_group_help_text(GROUP_AND_PERMISSION_COMMANDS),
+            user_commands=command_group_help_text(USER_COMMANDS),
             other_commands=command_group_help_text(available_other_commands),
         ).strip()
 
@@ -2366,24 +2375,27 @@ class BundleCLI(object):
             user = client.fetch('users', args.user_spec)
         self.print_user_info(user)
 
-    def print_user_info(self, user, include_private=False):
+    def print_user_info(self, user):
+        def print_attribute(key, value):
+            print >>self.stdout, u'{:<15}: {}'.format(key, value).encode('utf-8')
+
         for key in ('id', 'user_name', 'first_name', 'last_name',
                     'affiliation', 'url', 'date_joined'):
-            print >>self.stdout, u'{:<15}: {}'.format(key, user.get(key, None))
+            print_attribute(key, user.get(key, None))
 
         # These fields will not be returned by the server if the
         # authenticated user is not root, so stop early on first KeyError
         try:
             for key in ('last_login', 'email'):
-                print >>self.stdout, u'{:<15}: {}'.format(key, user[key])
+                print_attribute(key, user[key])
 
-            print >>self.stdout, u'{:<15}: {}'.format(
+            print_attribute(
                 'time', formatting.ratio_str(
                     formatting.duration_str,
                     user['time_used'],
                     user['time_quota']))
 
-            print >>self.stdout, u'{:<15}: {}'.format(
+            print_attribute(
                 'disk', formatting.ratio_str(formatting.size_str,
                                              user['disk_used'],
                                              user['disk_quota']))


### PR DESCRIPTION
Fixes #466 
Replaces #467 

Allow more fields to be edited through `cl uedit`, and allow users to edit their own fields.

```
usage: cl uedit [-h] [-t TIME_QUOTA] [-d DISK_QUOTA] [--first-name FIRST_NAME]
                [--last-name LAST_NAME] [--affiliation AFFILIATION]
                [--url URL]
                [user_spec]

Edit user information.
Note that password and email can only be changed through the web interface.

positional arguments:
  user_spec             Username or id of user to update [default: the authenticated user]

optional arguments:
  -h, --help            show this help message and exit
  -t TIME_QUOTA, --time-quota TIME_QUOTA
                        Total amount of time allowed (e.g., 3, 3m, 3h, 3d)
  -d DISK_QUOTA, --disk-quota DISK_QUOTA
                        Total amount of disk allowed (e.g., 3, 3k, 3m, 3g, 3t)
  --first-name FIRST_NAME
                        First name
  --last-name LAST_NAME
                        Last name
  --affiliation AFFILIATION
                        Affiliation
  --url URL             Website URL
```

Create the `cl uinfo` command:

```
usage: cl uinfo [-h] [user_spec]

Show user information.

positional arguments:
  user_spec   Username or id of user to show [default: the authenticated user]

optional arguments:
  -h, --help  show this help message and exit
```

Example output from `cl uinfo`:

```
id             : 6f2e70e0fed2487185fe0f21fffde98f
user_name      : sckoo
first_name     : 靖
last_name      : Stéphån
affiliation    : koop
url            : http://sckoo.net/though
date_joined    : Mon Mar 28 22:49:17 2016
email          : sckoo@cs.stanford.edu
last_login     : Tue May 10 02:45:35 2016
time           : 18m22s / 2y0d (0.0%)
disk           : 685k / 1023g (0.0%)
```

Users can now be referred to by username in addition to ID.

@klopyrev @percyliang 
