### PR TITLE
Allow commas to be used in API parameters

### DIFF
--- a/codalab/client/json_api_client.py
+++ b/codalab/client/json_api_client.py
@@ -108,16 +108,21 @@ class JsonApiClient(RestClient):
         if params is None:
             return None
 
+        def _escape_param(param):
+            if isinstance(param, bool):
+                return int(param)
+            if isinstance(param, (int, long, float)):
+                return param
+            if isinstance(param, (str, unicode)):
+                return unicode(param).replace('\\', '\\B').replace(',', '\\C')
+            raise NotImplementedError("Data type {} is not supported.".format(type(param)))
+
         result = {}
         for k, v in (params.iteritems() if isinstance(params, dict) else params):
             if isinstance(v, list):
-                result[k] = ','.join(
-                        unicode(x).replace('\\', '\\B').replace(',', '\\C')
-                        for x in v)
-            elif isinstance(v, bool):
-                result[k] = int(v)
+                result[k] = ','.join(unicode(_escape_param(x)) for x in v)
             else:
-                result[k] = v
+                result[k] = _escape_param(v)
         return result
 
     @staticmethod

--- a/codalab/client/json_api_client.py
+++ b/codalab/client/json_api_client.py
@@ -103,7 +103,7 @@ class JsonApiClient(RestClient):
     def _pack_params(params):
         """
         Process lists into comma-separated strings, and booleans into 1/0.
-        Does not currently support lists with strings that contain commas.
+        Escape comma as backslash-C and backslash as backslash-B.
         """
         if params is None:
             return None
@@ -111,11 +111,9 @@ class JsonApiClient(RestClient):
         result = {}
         for k, v in (params.iteritems() if isinstance(params, dict) else params):
             if isinstance(v, list):
-                v = map(unicode, v)
-                if any(',' in e for e in v):
-                    raise NotImplementedError(
-                        "Commas in list elements not currently supported.")
-                result[k] = ','.join(v)
+                result[k] = ','.join(
+                        unicode(x).replace('\\', '\\B').replace(',', '\\C')
+                        for x in v)
             elif isinstance(v, bool):
                 result[k] = int(v)
             else:

--- a/codalab/lib/server_util.py
+++ b/codalab/lib/server_util.py
@@ -16,7 +16,8 @@ from codalab.common import precondition
 def query_get_list(key):
     """
     Get comma-separated query parameter as a list of strings.
-    Assumes that the strings themselves do not contain commas.
+    In the input, each comma is escaped as backslash-C and each backslash
+    is escaped as backslash-B.
     See JsonApiClient._pack_params for how such a parameter value is assumed
     to be a constructed.
     """
@@ -24,7 +25,8 @@ def query_get_list(key):
     if not value:
         return []
     else:
-        return value.split(',')
+        return [x.replace('\\C', ',').replace('\\B', '\\')
+                for x in value.split(',')]
 
 
 def query_get_type(type_, key, default=None):

--- a/tests/client/json_api_client_test.py
+++ b/tests/client/json_api_client_test.py
@@ -25,17 +25,26 @@ class JsonApiClientTest(unittest.TestCase):
             'str': 'stringy',
             'true': 1,
             'false': 0,
-            'list': '1,2,3.3,True'
+            'list': '1,2,3.3,1'
+        })
+
+        self.assertDictEqual(JsonApiClient._pack_params({
+            'trickystring': r'this has , commas ,,\\\,\, and backslashes',
+            'trickylist': [1, 3, False, ',', r',\C\B', r'\\,\,']
+        }), {
+            'trickystring': r'this has \C commas \C\C\B\B\B\C\B\C and backslashes',
+            'trickylist': r'1,3,0,\C,\C\BC\BB,\B\B\C\B\C'
         })
 
         with self.assertRaises(NotImplementedError):
             JsonApiClient._pack_params({
-                'listwithcomma': ['this is fine', 'this, is, not']
+                'listinlist': [['nested', 'lists', 'is'], 'bad']
             })
 
         with self.assertRaises(NotImplementedError):
             JsonApiClient._pack_params({
-                'listinlist': [['nested', 'lists', 'also', 'bad']]
+                # Should raise an exception even when a comma is not present
+                'listinlist': [['bad']]
             })
 
 


### PR DESCRIPTION
Commas are used in some cl commands (e.g., `cl search owner=tom,jerry`). Currently commas are disallowed since they are used to join parameters in the API request. The following escape scheme is introduced to solve the problem:
- Escape `,` as `\C` and `\` as `\B`
- Join the strings as usual with `,`

There is no ambiguity: in the resulting string, `,` is only used to separate items, and `\` can only be followed by `B` or `C`. The conversion can also be done using simple string replacement.
