### PR TITLE
Accept user name and affiliation while sign up.

### DIFF
--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -1694,12 +1694,16 @@ class BundleModel(object):
 
         return row is not None and row.is_active
 
-    def add_user(self, username, email, password, user_id=None, is_verified=False):
+    def add_user(self, username, email, first_name, last_name, password,
+                 affiliation, user_id=None, is_verified=False):
         """
         Create a brand new unverified user.
         :param username:
         :param email:
+        :param first_name:
+        :param last_name:
         :param password:
+        :param affiliation:
         :return: (new integer user ID, verification key to send)
         """
         with self.engine.begin() as connection:
@@ -1712,8 +1716,8 @@ class BundleModel(object):
                 "email": email,
                 "last_login": None,
                 "is_active": True,
-                "first_name": None,
-                "last_name": None,
+                "first_name": first_name,
+                "last_name": last_name,
                 "date_joined": now,
                 "is_verified": is_verified,
                 "is_superuser": False,
@@ -1722,7 +1726,7 @@ class BundleModel(object):
                 "time_used": 0,
                 "disk_quota": self.default_user_info['disk_quota'],
                 "disk_used": 0,
-                "affiliation": None,
+                "affiliation": affiliation,
                 "url": None,
             }))
 

--- a/codalab/rest/account.py
+++ b/codalab/rest/account.py
@@ -66,8 +66,11 @@ def do_signup():
     success_uri = request.forms.get('success_uri')
     error_uri = request.forms.get('error_uri')
     username = request.forms.get('username')
-    password = request.forms.get('password')
     email = request.forms.get('email')
+    first_name = request.forms.get('first_name')
+    last_name = request.forms.get('last_name')
+    password = request.forms.get('password')
+    affiliation = request.forms.get('affiliation')
 
     errors = []
     if request.forms.get('confirm_password') != password:
@@ -98,10 +101,19 @@ def do_signup():
             'next': success_uri,
             'email': email,
             'username': username,
+            'first_name': first_name,
+            'last_name': last_name,
+            'affiliation': affiliation
         })
 
+    # If user leaves it blank, empty string is obtained - make it of NoneType.
+    if not affiliation:
+        affiliation = None
+
     # Create unverified user
-    _, verification_key = local.model.add_user(username, email, password)
+    _, verification_key = local.model.add_user(
+        username, email, first_name, last_name, password, affiliation
+    )
 
     # Send key
     send_verification_key(username, email, verification_key)

--- a/scripts/create-root-user.py
+++ b/scripts/create-root-user.py
@@ -38,4 +38,4 @@ if model.get_user(user_id=user_id, check_active=False):
     }
     model.update_user_info(update)
 else:
-    model.add_user(username, '', password, user_id, is_verified=True)
+    model.add_user(username, '', '', '', password, '', user_id, is_verified=True)

--- a/tests/client/local_bundle_client_test.py
+++ b/tests/client/local_bundle_client_test.py
@@ -27,8 +27,8 @@ class GroupsAndPermsTest(unittest.TestCase):
         users = [User('root', '0'), User('user1', '1'), User('user2', '2'), User('user4', '4')]
         cls.auth_handler = MockAuthHandler(users)
         for user in users:
-            cls.model.add_user(user.name, user.name + '@codalab.org', '',
-                               user_id=user.unique_id, is_verified=True)
+            cls.model.add_user(user.name, user.name + '@codalab.org', '', '',
+                               '', '', user_id=user.unique_id, is_verified=True)
         cls.client = LocalBundleClient('local', cls.bundle_store, cls.model, None, None, None, cls.auth_handler, verbose=1)
 
     @classmethod


### PR DESCRIPTION
This PR is in conjunction to codalab/codalab-worksheets#201 and aims to fix codalab/codalab-worksheets#200 . Changes here reflect acceptance of first and last names, affiliation while sign up and populate the database accordingly.
