### PR TITLE
Prepend '0x' to user ids while sign up.

### DIFF
--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -1708,7 +1708,7 @@ class BundleModel(object):
         """
         with self.engine.begin() as connection:
             now = datetime.datetime.utcnow()
-            user_id = user_id or uuid.uuid4().hex
+            user_id = user_id or '0x%s' % uuid.uuid4().hex
 
             connection.execute(cl_user.insert().values({
                 "user_id": user_id,


### PR DESCRIPTION
This PR introduces a partial fix to #515. New users from now on will have a 32 character long hexadecimal UUID4 string ( `0x<uuid4>` ) as user id. Prepending `0x` to user id of already existing users is kept out of scope of this PR.
