### PR TITLE
Split space separated words in metadata 'tag' entry to individual tags.

### DIFF
--- a/codalab/client/local_bundle_client.py
+++ b/codalab/client/local_bundle_client.py
@@ -847,7 +847,10 @@ class LocalBundleClient(BundleClient):
             elif key == 'title':
                 metadata[key] = value
             elif key == 'tags':
-                metadata[key] = value
+                if isinstance(value, str):
+                    metadata[key] = value.split()
+                else:
+                    metadata[key] = value
             elif key == 'freeze':
                 metadata['frozen'] = datetime.datetime.now()
             else:

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -1227,6 +1227,11 @@ class BundleCLI(object):
             is_new_metadata_updated = True
         if args.tags:
             new_metadata['tags'] = args.tags
+            for index, tag in enumerate(args.tags):
+                args.tags[index] = u'-'.join(
+                    word for word in tag.strip().split() if word != u''
+                )
+            new_metadata['tags'] = args.tags
             is_new_metadata_updated = True
 
         # Prompt user for all information
@@ -2242,6 +2247,10 @@ class BundleCLI(object):
             if args.title != None:
                 info['title'] = args.title
             if args.tags != None:
+                for index, tag in enumerate(args.tags):
+                    args.tags[index] = u'-'.join(
+                        word for word in tag.strip().split() if word != u''
+                    )
                 info['tags'] = args.tags
             if args.owner_spec != None:
                 info['owner_spec'] = args.owner_spec

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -742,6 +742,14 @@ class BundleModel(object):
         # Apply the column and metadata updates in memory and validate the result.
         metadata_update = update.pop('metadata', {})
         bundle.update_in_memory(update)
+
+        # Make individual tags out of space separated words
+        if 'tags' in metadata_update:
+            for index, tag in enumerate(metadata_update['tags']):
+                metadata_update['tags'][index] = u'-'.join(
+                    word for word in tag.strip().split() if word != u''
+                )
+
         for (key, value) in metadata_update.iteritems():
             bundle.metadata.set_metadata_key(key, value)
         bundle.validate()


### PR DESCRIPTION
This PR is a fix for #336. Providing space separated tags through CLI automatically considered them as individual tags. With this PR, space separated words entered through web interface would be separated into individual tags.
