### PR TITLE
Notify admins of unexpected errors

### DIFF
--- a/codalab/client/json_api_client.py
+++ b/codalab/client/json_api_client.py
@@ -21,7 +21,8 @@ def wrap_exception(message):
                 return f(*args, **kwargs)
             except urllib2.HTTPError as e:
                 # Translate known errors to the standard CodaLab errors
-                exc = http_error_to_exception(e.code, e.read())
+                error_body = e.read()
+                exc = http_error_to_exception(e.code, error_body)
                 # All standard CodaLab errors are subclasses of UsageError
                 if isinstance(exc, UsageError):
                     raise exc.__class__, exc, sys.exc_info()[2]
@@ -30,7 +31,7 @@ def wrap_exception(message):
                     raise JsonApiException, \
                         JsonApiException(message.format(*args, **kwargs) +
                                          ': ' + httplib.responses[e.code] +
-                                         ' - ' + e.read(),
+                                         ' - ' + error_body,
                                          400 <= e.code < 500), \
                         sys.exc_info()[2]
             except RestClientException as e:

--- a/codalab/lib/codalab_manager.py
+++ b/codalab/lib/codalab_manager.py
@@ -305,7 +305,6 @@ class CodaLabManager(object):
             sessions[name] = {'address': address, 'worksheet_uuid': worksheet_uuid}
         return sessions[name]
 
-
     @cached
     def default_user_info(self):
         info = self.config['server'].get('default_user_info', {'time_quota': '1y', 'disk_quota': '1t'})
@@ -379,6 +378,7 @@ class CodaLabManager(object):
                                     self.config['server']['rest_port'])
         return RestOAuthHandler(address, self.model())
 
+    @property
     @cached
     def emailer(self):
         if 'email' in self.config:

--- a/codalab/lib/codalab_manager.py
+++ b/codalab/lib/codalab_manager.py
@@ -48,7 +48,7 @@ from codalab.lib.bundle_store import (
 from codalab.lib.crypt_util import get_random_string
 from codalab.lib.download_manager import DownloadManager
 from codalab.lib.emailer import SMTPEmailer, ConsoleEmailer
-from codalab.lib.print_util import pretty_print
+from codalab.lib.print_util import pretty_print_json
 from codalab.lib.upload_manager import UploadManager
 from codalab.lib import formatting
 from codalab.model.worker_model import WorkerModel
@@ -63,7 +63,7 @@ def cached(fn):
 
 def write_pretty_json(data, path):
     with open(path, 'w') as f:
-        pretty_print(data, f)
+        pretty_print_json(data, f)
 
 def read_json_or_die(path):
     try:

--- a/codalab/lib/codalab_manager.py
+++ b/codalab/lib/codalab_manager.py
@@ -48,6 +48,7 @@ from codalab.lib.bundle_store import (
 from codalab.lib.crypt_util import get_random_string
 from codalab.lib.download_manager import DownloadManager
 from codalab.lib.emailer import SMTPEmailer, ConsoleEmailer
+from codalab.lib.print_util import pretty_print
 from codalab.lib.upload_manager import UploadManager
 from codalab.lib import formatting
 from codalab.model.worker_model import WorkerModel
@@ -62,8 +63,7 @@ def cached(fn):
 
 def write_pretty_json(data, path):
     with open(path, 'w') as f:
-        json.dump(data, f, sort_keys=True, indent=4, separators=(',', ': '))
-        f.write('\n')
+        pretty_print(data, f)
 
 def read_json_or_die(path):
     try:

--- a/codalab/lib/emailer.py
+++ b/codalab/lib/emailer.py
@@ -78,9 +78,10 @@ class ConsoleEmailer(Emailer):
         self.out = out
 
     def send_email(self, subject, body, recipient, sender=None):
+        print >>self.out, ("=" * 40)
         print >>self.out, "From: %s" % (sender or 'console')
         print >>self.out, "To: %s" % recipient
         print >>self.out, "Subject: %s" % subject
         print >>self.out
         print >>self.out, body
-
+        print >>self.out, ("=" * 40)

--- a/codalab/lib/formatting.py
+++ b/codalab/lib/formatting.py
@@ -9,6 +9,10 @@ import shlex
 from worker import formatting as worker_formatting
 
 
+NONE_PLACEHOLDER = '<none>'
+BINARY_PLACEHOLDER = '<binary>'
+
+
 def contents_str(input_string):
     """
     input_string: raw string (may be None)
@@ -31,12 +35,12 @@ def verbose_contents_str(input_string):
     Return a friendly string (which is more verbose than contents_str).
     """
     if input_string is None:
-        return '<none>'
+        return NONE_PLACEHOLDER
 
     try:
         input_string.decode('utf-8')
     except UnicodeDecodeError:
-        return '<binary>'
+        return BINARY_PLACEHOLDER
 
     return input_string
 
@@ -123,3 +127,9 @@ def string_to_tokens(s):
 
 def pretty_json(obj):
     return json.dumps(obj, sort_keys=True, indent=4, separators=(',', ': '))
+
+
+def verbose_pretty_json(obj):
+    if obj is None:
+        return NONE_PLACEHOLDER
+    return pretty_json(obj)

--- a/codalab/lib/formatting.py
+++ b/codalab/lib/formatting.py
@@ -3,7 +3,7 @@ Provides basic formatting utilities.
 """
 
 import datetime
-import sys
+import json
 import shlex
 
 from worker import formatting as worker_formatting
@@ -119,3 +119,7 @@ def string_to_tokens(s):
     :return: list ["a", "b", "c d", "e"]
     """
     return shlex.split(s, comments=False, posix=True)
+
+
+def pretty_json(obj):
+    return json.dumps(obj, sort_keys=True, indent=4, separators=(',', ': '))

--- a/codalab/lib/print_util.py
+++ b/codalab/lib/print_util.py
@@ -1,8 +1,7 @@
-import json
 import sys
 import time
 
-from codalab.lib.formatting import ratio_str
+from codalab.lib.formatting import pretty_json, ratio_str
 
 
 def open_line(s, f=sys.stderr):
@@ -14,7 +13,9 @@ def clear_line(f=sys.stderr):
 
 
 def pretty_print(obj, f=sys.stdout):
-    json.dump(obj, f, sort_keys=True, indent=4, separators=(',', ': '))
+    f.write(pretty_json(obj))
+    f.write('\n')
+    f.flush()
 
 
 class FileTransferProgress(object):

--- a/codalab/lib/print_util.py
+++ b/codalab/lib/print_util.py
@@ -12,7 +12,7 @@ def clear_line(f=sys.stderr):
     print >>f, '\r\033[K',
 
 
-def pretty_print(obj, f=sys.stdout):
+def pretty_print_json(obj, f=sys.stdout):
     f.write(pretty_json(obj))
     f.write('\n')
     f.flush()

--- a/codalab/objects/user.py
+++ b/codalab/objects/user.py
@@ -95,6 +95,9 @@ class User(ORMObject):
                 raise UsageError('Out of disk quota: %s' %
                                  formatting.ratio_str(formatting.size_str, self.disk_used, self.disk_quota))
 
+    def __str__(self):
+        return "%s(%s)" % (self.user_name, self.user_id)
+
 
 PUBLIC_USER = User({
     "user_id": None,  # sentinel for BundleModel methods indicating public user

--- a/codalab/rest/legacy.py
+++ b/codalab/rest/legacy.py
@@ -10,6 +10,7 @@ from oauthlib.common import generate_token
 import random
 import shlex
 import threading
+import traceback
 
 from bottle import (
   abort,
@@ -41,6 +42,7 @@ from codalab.lib.codalab_manager import CodaLabManager
 from codalab.model.tables import GROUP_OBJECT_PERMISSION_ALL
 from codalab.objects.oauth2 import OAuth2Token
 from codalab.objects.permission import permission_str
+from codalab.rest.util import notify_admin
 from codalab.server.auth import LocalUserAuthHandler, RestOAuthHandler
 from codalab.server.authenticated_plugin import AuthenticatedPlugin
 from codalab.server.rpc_file_handle import RPCFileHandle
@@ -330,13 +332,8 @@ class BundleService(object):
             pass
         except UsageError as e:
             # All expected CodaLab errors are instances of UsageError
-            # No need to print stacktrace, just show user the error message
+            # Nothing bad happened, just show user the error message
             exception = str(e)
-        except BaseException:
-            import sys
-            import traceback
-            traceback.print_exc(file=sys.stderr)
-            exception = "Internal Error. If the problem persists, please contact the administrators."
 
         output_str = output_buffer.getvalue()
         output_buffer.close()

--- a/codalab/server/bundle_rpc_server.py
+++ b/codalab/server/bundle_rpc_server.py
@@ -134,9 +134,12 @@ class BundleRPCServer(SocketServer.ThreadingMixIn, SimpleXMLRPCServer):
                     if not isinstance(e, UsageError):
                         # All expected CodaLab errors are instances of UsageError
                         # This is really bad and shouldn't happen.
-                        # If it does, someone should get paged.
-                        print '=== INTERNAL ERROR:', e
-                        traceback.print_exc()
+                        from codalab.rest.util import notify_admin
+                        notify_admin("Error on RPC request by %s(%s):\n\n%s %s\n\n%s" %
+                                     (self.client._current_user_name(),
+                                      self.client._current_user_id(),
+                                      command, log_args, traceback.format_exc()),
+                                     client=manager)
                     raise e
 
             return function_to_register

--- a/codalab/server/rest_server.py
+++ b/codalab/server/rest_server.py
@@ -21,6 +21,7 @@ from bottle import (
 )
 
 from codalab.common import exception_to_http_error
+from codalab.lib import formatting
 import codalab.rest.account
 import codalab.rest.bundles
 import codalab.rest.groups
@@ -29,6 +30,7 @@ import codalab.rest.oauth2
 import codalab.rest.titlejs
 import codalab.rest.users
 import codalab.rest.workers
+from codalab.rest.util import notify_admin
 from codalab.server.authenticated_plugin import UserVerifiedPlugin
 from codalab.server.cookie import CookieAuthenticationPlugin
 from codalab.server.json_api_plugin import JsonApiPlugin
@@ -60,7 +62,7 @@ class SaveEnvironmentPlugin(object):
             local.download_manager = self.manager.download_manager()
             local.bundle_store = self.manager.bundle_store()
             local.config = self.manager.config
-            local.emailer = self.manager.emailer()
+            local.emailer = self.manager.emailer
             return callback(*args, **kwargs)
 
         return wrapper
@@ -134,7 +136,10 @@ class ErrorAdapter(object):
                     raise
                 code, message = exception_to_http_error(e)
                 if code == INTERNAL_SERVER_ERROR:
-                    traceback.print_exc()
+                    pretty_json = formatting.pretty_json(request.json) if request.json is not None else "<EMPTY>"
+                    notify_admin("Error on request by {0.user}:\n\n{0.method} {0.path}\n\n{1}\n\n{2}"
+                                 .format(request, pretty_json, traceback.format_exc()))
+                    message = "Unexpected Internal Error [%s]. The administrators have been notified." % message
                 raise HTTPError(code, message)
 
         return wrapper

--- a/codalab/server/rest_server.py
+++ b/codalab/server/rest_server.py
@@ -136,10 +136,10 @@ class ErrorAdapter(object):
                     raise
                 code, message = exception_to_http_error(e)
                 if code == INTERNAL_SERVER_ERROR:
-                    pretty_json = formatting.pretty_json(request.json) if request.json is not None else "<EMPTY>"
+                    pretty_json = formatting.verbose_pretty_json(request.json)
                     notify_admin("Error on request by {0.user}:\n\n{0.method} {0.path}\n\n{1}\n\n{2}"
                                  .format(request, pretty_json, traceback.format_exc()))
-                    message = "Unexpected Internal Error [%s]. The administrators have been notified." % message
+                    message = "Unexpected Internal Error (%s). The administrators have been notified." % message
                 raise HTTPError(code, message)
 
         return wrapper

--- a/monitor.py
+++ b/monitor.py
@@ -54,7 +54,7 @@ bundles_password = m.group(2)
 print 'bundles DB: %s; user: %s' % (bundles_db, bundles_user)
 
 # Email
-recipient = config.get('admin-email')
+recipient = config['server'].get('admin_email')
 sender_info = config.get('email')
 
 # Create backup directory


### PR DESCRIPTION
Sends email to admin when unexpected errors occur.

New configs to add:

```
$ cl config server/admin_email oncall@codalab.org
$ cl config server/instance_name worksheets.codalab.org
```

Uses sane defaults when configurations (e.g. prints message to console instead) not available.

Potential risk is too many emails, but email explosions should always be temporary since we really shouldn't be getting any of these errors. Email explosions will naturally be contained to some degree by the fact that all emails will have the same subject line. (Plus the amount of effort to code up an email aggregation queue would take too much time for now.)

Fixes #563 
@percyliang 
