### PR TITLE
Fix error in displaying invalid bundle references with custom tables.

### DIFF
--- a/codalab/lib/download_manager.py
+++ b/codalab/lib/download_manager.py
@@ -43,12 +43,20 @@ class DownloadManager(object):
     def get_target_info(self, uuid, path, depth):
         """
         Returns information about an individual target inside the bundle, or
-        None if the target doesn't exist.
+        None if the target or bundle doesn't exist.
 
         For information about the format of the return value, see
         worker.download_util.get_target_info.
         """
-        if self._bundle_model.get_bundle_state(uuid) != State.RUNNING:
+        try:
+            bundle_state = self._bundle_model.get_bundle_state(uuid)
+        except UsageError:
+            bundle_state = None
+
+        # Return None if invalid bundle reference
+        if bundle_state is None:
+            return None
+        elif bundle_state != State.RUNNING:
             bundle_path = self._bundle_store.get_bundle_location(uuid)
             try:
                 return download_util.get_target_info(bundle_path, uuid, path, depth)

--- a/codalab/lib/download_manager.py
+++ b/codalab/lib/download_manager.py
@@ -1,6 +1,6 @@
 from contextlib import closing
 
-from codalab.common import http_error_to_exception, precondition, State, UsageError
+from codalab.common import http_error_to_exception, precondition, State, UsageError, NotFoundError
 from worker import download_util
 from worker import file_util
 
@@ -50,7 +50,7 @@ class DownloadManager(object):
         """
         try:
             bundle_state = self._bundle_model.get_bundle_state(uuid)
-        except UsageError:
+        except NotFoundError:
             bundle_state = None
 
         # Return None if invalid bundle reference

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -774,7 +774,7 @@ class BundleModel(object):
     def get_bundle_state(self, uuid):
         result_dict = self.get_bundle_states([uuid])
         if uuid not in result_dict:
-            raise UsageError('Could not find bundle with uuid %s' % uuid)
+            raise NotFoundError('Could not find bundle with uuid %s' % uuid)
         return result_dict[uuid]
 
     def get_bundle_states(self, uuids):


### PR DESCRIPTION
This PR makes suitable changes to fix codalab/codalab-worksheets#191
