### PR TITLE
Normalize some error handling

### DIFF
--- a/codalab/rest/legacy.py
+++ b/codalab/rest/legacy.py
@@ -314,7 +314,11 @@ class BundleService(object):
         """
         # Tokenize
         if isinstance(command, basestring):
-            args = shlex.split(command)
+            # shlex throws ValueError on incorrectly formatted commands
+            try:
+                args = shlex.split(command)
+            except ValueError as e:
+                raise UsageError(e.message)
         else:
             args = list(command)
 
@@ -328,12 +332,8 @@ class BundleService(object):
         try:
             structured_result = cli.do_command(args)
         except SystemExit:  # as exitcode:
-            # this should not happen under normal circumstances
+            # argparse sometimes throws SystemExit, we don't want to exit
             pass
-        except UsageError as e:
-            # All expected CodaLab errors are instances of UsageError
-            # Nothing bad happened, just show user the error message
-            exception = str(e)
 
         output_str = output_buffer.getvalue()
         output_buffer.close()

--- a/codalab/server/rest_server.py
+++ b/codalab/server/rest_server.py
@@ -139,36 +139,39 @@ class ErrorAdapter(object):
                     raise
                 code, message = exception_to_http_error(e)
                 if code == INTERNAL_SERVER_ERROR:
-                    query = formatting.key_value_list(request.query.allitems())
-                    forms = formatting.key_value_list(request.forms.allitems() if request.json is None else [])
-                    body = formatting.verbose_pretty_json(request.json)
-                    aux_info = textwrap.dedent("""\
-                        Query params:
-                        {0}
-
-                        Form params:
-                        {1}
-
-                        JSON body:
-                        {2}""").format(query, forms, body)
-
-                    if len(aux_info) > self.MAX_AUX_INFO_LENGTH:
-                        aux_info = aux_info[:(self.MAX_AUX_INFO_LENGTH / 2)] + \
-                                   "(...truncated...)" + \
-                                   aux_info[-(self.MAX_AUX_INFO_LENGTH / 2):]
-
-                    notify_admin(textwrap.dedent("""\
-                        Error on request by {0.user}:
-
-                        {0.method} {0.path}
-
-                        {1}
-
-                        {2}""").format(request, aux_info, traceback.format_exc()))
+                    self.report_exception()
                     message = "Unexpected Internal Error (%s). The administrators have been notified." % message
                 raise HTTPError(code, message)
 
         return wrapper
+
+    def report_exception(self):
+        query = formatting.key_value_list(request.query.allitems())
+        forms = formatting.key_value_list(request.forms.allitems() if request.json is None else [])
+        body = formatting.verbose_pretty_json(request.json)
+        aux_info = textwrap.dedent("""\
+                    Query params:
+                    {0}
+
+                    Form params:
+                    {1}
+
+                    JSON body:
+                    {2}""").format(query, forms, body)
+
+        if len(aux_info) > self.MAX_AUX_INFO_LENGTH:
+            aux_info = aux_info[:(self.MAX_AUX_INFO_LENGTH / 2)] + \
+                       "(...truncated...)" + \
+                       aux_info[-(self.MAX_AUX_INFO_LENGTH / 2):]
+
+        notify_admin(textwrap.dedent("""\
+                    Error on request by {0.user}:
+
+                    {0.method} {0.path}
+
+                    {1}
+
+                    {2}""").format(request, aux_info, traceback.format_exc()))
 
 
 def error_handler(response):


### PR DESCRIPTION
- Catch ValueError thrown by shlex.split
- Reduce handling of UsageError to one place
- Clean up admin exception notification code

Fixes #569 

Merging into master since this is a bugfix.
