### PR TITLE
Rate limit error admin notifications

### DIFF
--- a/codalab/rest/util.py
+++ b/codalab/rest/util.py
@@ -4,17 +4,17 @@ Most of these are adapted from the LocalBundleClient methods,
 Placed in this central location to prevent circular imports.
 """
 import httplib
+import sys
 import threading
 from functools import wraps
 
 from bottle import abort, HTTPError, local, request
 
 from codalab.common import http_error_to_exception, precondition
-from codalab.lib.emailer import ConsoleEmailer
+from codalab.lib.server_util import rate_limited
 from codalab.objects.permission import (
     unique_group,
 )
-
 
 
 def get_resource_ids(document, type_):
@@ -104,24 +104,21 @@ def local_bundle_client_compatible(f):
 
 
 # For non-REST services, should call with client=CodaLabManager
+@rate_limited(6, per_seconds=(60 * 60))
 @local_bundle_client_compatible
 def notify_admin(local, request, message):
-    if 'admin_email' in local.config['server']:
-        admin_email = local.config['server']['admin_email']
-        emailer = local.emailer
-    else:
-        import sys
-        # Print intended email in console if no recipient available
-        admin_email = "ADMIN"
-        emailer = ConsoleEmailer(sys.stderr)
+    # Caller is responsible for logging message anyway if desired
+    if 'admin_email' not in local.config['server']:
+        print >>sys.stderr, 'Warning: No admin_email configured, so no email sent.'
+        return
 
     subject = "CodaLab Admin Notification"
     if 'instance_name' in local.config['server']:
         subject += " (%s)" % local.config['server']['instance_name']
 
-    emailer.send_email(subject=subject,
-                       body=message,
-                       recipient=admin_email)
+    local.emailer.send_email(subject=subject,
+                             body=message,
+                             recipient=local.config['server']['admin_email'])
 
 #############################################################
 # GROUPS

--- a/codalab/rest/util.py
+++ b/codalab/rest/util.py
@@ -104,7 +104,7 @@ def local_bundle_client_compatible(f):
 
 
 # For non-REST services, should call with client=CodaLabManager
-@rate_limited(6, per_seconds=(60 * 60))
+@rate_limited(max_calls_per_hour=6)
 @local_bundle_client_compatible
 def notify_admin(local, request, message):
     # Caller is responsible for logging message anyway if desired

--- a/codalab/server/bundle_rpc_server.py
+++ b/codalab/server/bundle_rpc_server.py
@@ -20,6 +20,7 @@ have a matching call to finalize_file.
 '''
 from SimpleXMLRPCServer import  SimpleXMLRPCServer, SimpleXMLRPCRequestHandler
 import SocketServer
+import sys
 import time
 import traceback
 import xmlrpclib
@@ -135,11 +136,12 @@ class BundleRPCServer(SocketServer.ThreadingMixIn, SimpleXMLRPCServer):
                         # All expected CodaLab errors are instances of UsageError
                         # This is really bad and shouldn't happen.
                         from codalab.rest.util import notify_admin
-                        notify_admin("Error on RPC request by %s(%s):\n\n%s %s\n\n%s" %
-                                     (self.client._current_user_name(),
-                                      self.client._current_user_id(),
-                                      command, log_args, traceback.format_exc()),
-                                     client=manager)
+                        message = ("Error on RPC request by %s(%s):\n\n%s %s\n\n%s" %
+                                   (self.client._current_user_name(),
+                                    self.client._current_user_id(),
+                                    command, log_args, traceback.format_exc()))
+                        print >>sys.stderr, message
+                        notify_admin(message, client=manager)
                     raise e
 
             return function_to_register

--- a/codalab/server/rest_server.py
+++ b/codalab/server/rest_server.py
@@ -21,8 +21,8 @@ from bottle import (
     static_file,
 )
 
-from codalab.common import exception_to_http_error
-from codalab.lib import formatting
+from codalab.common import exception_to_http_error, PreconditionViolation
+from codalab.lib import formatting, server_util
 import codalab.rest.account
 import codalab.rest.bundles
 import codalab.rest.groups
@@ -164,14 +164,17 @@ class ErrorAdapter(object):
                        "(...truncated...)" + \
                        aux_info[-(self.MAX_AUX_INFO_LENGTH / 2):]
 
-        notify_admin(textwrap.dedent("""\
-                    Error on request by {0.user}:
+        message = textwrap.dedent("""\
+             Error on request by {0.user}:
 
-                    {0.method} {0.path}
+             {0.method} {0.path}
 
-                    {1}
+             {1}
 
-                    {2}""").format(request, aux_info, traceback.format_exc()))
+             {2}""").format(request, aux_info, traceback.format_exc())
+
+        print >>sys.stderr, message
+        notify_admin(message)
 
 
 def error_handler(response):

--- a/tests/lib/server_util_test.py
+++ b/tests/lib/server_util_test.py
@@ -1,0 +1,31 @@
+import unittest
+
+from codalab.lib.server_util import *
+
+import time
+
+
+class ServerUtilTest(unittest.TestCase):
+    def test_rate_limit_not_exceeded(self):
+        @rate_limited(10, 1)
+        def limited_function(arg):
+            return arg
+
+        for _ in xrange(10):
+            self.assertEqual(limited_function("same"), "same")
+
+        time.sleep(1)
+
+        for _ in xrange(10):
+            self.assertEqual(limited_function("same"), "same")
+
+    def test_rate_limit_exceeded(self):
+        @rate_limited(10, 3600)
+        def limited_function():
+            pass
+
+        def make_n_calls(n):
+            for _ in xrange(n):
+                limited_function()
+
+        self.assertRaises(RateLimitExceededError, lambda: make_n_calls(11))

--- a/tests/lib/server_util_test.py
+++ b/tests/lib/server_util_test.py
@@ -7,25 +7,23 @@ import time
 
 class ServerUtilTest(unittest.TestCase):
     def test_rate_limit_not_exceeded(self):
-        @rate_limited(10, 1)
+        sentinel = 23948
+
+        @rate_limited(3600)
         def limited_function(arg):
             return arg
 
-        for _ in xrange(10):
-            self.assertEqual(limited_function("same"), "same")
+        for _ in xrange(3600):
+            self.assertEqual(limited_function(sentinel), sentinel)
 
+        # After one second, should recover credit for at least another call
         time.sleep(1)
-
-        for _ in xrange(10):
-            self.assertEqual(limited_function("same"), "same")
+        self.assertEqual(limited_function(sentinel), sentinel)
 
     def test_rate_limit_exceeded(self):
-        @rate_limited(10, 3600)
+        @rate_limited(10)
         def limited_function():
             pass
 
-        def make_n_calls(n):
-            for _ in xrange(n):
-                limited_function()
-
-        self.assertRaises(RateLimitExceededError, lambda: make_n_calls(11))
+        self.assertRaises(RateLimitExceededError,
+                          lambda: [limited_function() for _ in xrange(11)])


### PR DESCRIPTION
Adds rate limit on admin notifications.

Limit is hard-coded at 6 per hour for now (one message every 10 minutes), but can add ability to configure this in the future.

Merging into master for quick deployment.

Resolves #567 

@percyliang 
