### PR TITLE
allow connecting to any URL that looks like http://.../bundleservice

### DIFF
--- a/codalab/lib/codalab_manager.py
+++ b/codalab/lib/codalab_manager.py
@@ -432,8 +432,7 @@ class CodaLabManager(object):
         elif o.hostname == 'localhost' and o.port == 3800:
             # Hard-coded for test-cli, which uses these ports for aux servers
             address = address.replace('3800', '3900')
-        elif (o.netloc == 'worksheets.codalab.org' or
-                      o.netloc == 'worksheets-test.codalab.org'):
+        else:
             # http://worksheets.codalab.org/bundleservice => http://worksheets.codalab.org
             address = address.replace('/bundleservice', '')
         return address


### PR DESCRIPTION
allow connecting to any URL that looks like http://.../bundleservice, not just worksheets.codalab.org/bundleservice

@kashizui merging to master to take immediate effect
