### PR TITLE
Fix child path validation

### DIFF
--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -65,7 +65,7 @@ class BundleDependencySchema(PlainSchema):
     create a set of dependencies once at bundle creation.
     """
     child_uuid = fields.String(validate=validate_uuid, dump_only=True)
-    child_path = fields.String(validate=validate_child_path)
+    child_path = fields.String()  # Validated in Bundle ORMObject
     parent_uuid = fields.String(validate=validate_uuid)
     parent_path = fields.String()
     parent_name = fields.Method('get_parent_name', dump_only=True)  # for convenience

--- a/test-cli.py
+++ b/test-cli.py
@@ -670,6 +670,8 @@ def test(ctx):
     check_equals('hello', run_command([cl, 'cat', uuid+'/stdout']))
     # block
     check_contains('hello', run_command([cl, 'run', 'echo hello', '--tail']))
+    # invalid child path
+    run_command([cl, 'run', 'not/allowed:' + uuid, 'date'], expected_exit_code=1)
 
 
 @TestModule.register('read')


### PR DESCRIPTION
Fixes #575 

There seems to be an issue with reporting validation errors within nested schemas either in Marshmallow or Marshmallow-JSONAPI. (BundleDependencySchema is nested inside BundleSchema.) Circumventing the problem for now by relying on the child path validation in `Bundle.validate()`.

@percyliang @yashsavani 
