### PR TITLE
Escape filenames when gzipping directories

### DIFF
--- a/test-cli.py
+++ b/test-cli.py
@@ -454,7 +454,11 @@ def test(ctx):
 
 @TestModule.register('download')
 def test(ctx):
-    uuid = run_command([cl, 'upload', test_path('')])
+    # Upload test files directory as archive to preserve everything invariant of the upload implementation
+    archive_path = temp_path('.tar.gz')
+    contents_path = test_path('')
+    run_command(['tar', 'cfz', archive_path, '-C', os.path.dirname(contents_path), '--'] + os.listdir(contents_path))
+    uuid = run_command([cl, 'upload', archive_path])
 
     # Download whole bundle
     path = temp_path('')
@@ -470,6 +474,11 @@ def test(ctx):
     # Download a target inside (crazy name)
     run_command([cl, 'download', uuid + '/' + crazy_name, '-o', path])
     check_equals(test_path_contents(crazy_name), path_contents(path))
+    os.unlink(path)
+
+    # Download a target inside (name starting with hyphen)
+    run_command([cl, 'download', uuid + '/' + '-AmMDnVl4s8', '-o', path])
+    check_equals(test_path_contents('-AmMDnVl4s8'), path_contents(path))
     os.unlink(path)
 
     # Download a target inside (symlink)

--- a/tests/files/-AmMDnVl4s8
+++ b/tests/files/-AmMDnVl4s8
@@ -1,0 +1,2 @@
+This file starts with a hyphen, which can cause problems if filenames are passed
+directly to command line utilities without escaping (i.e. with a lone '--').

--- a/worker/file_util.py
+++ b/worker/file_util.py
@@ -28,6 +28,7 @@ def tar_gzip_directory(directory_path, follow_symlinks=False,
             args.append('--exclude=' + pattern)
     names = [name for name in os.listdir(directory_path) if name not in exclude_names]
     if names:
+        args.append('--')  # Ensure no filename gets misinterpreted as an option
         args.extend(names)
     else:
         args.extend(['--files-from', '/dev/null'])


### PR DESCRIPTION
Fixes codalab/codalab-worksheets#216

Merging into master as hotfix.

@percyliang 
