### PR TITLE
RESTify bundle actions

### DIFF
--- a/codalab/client/local_bundle_client.py
+++ b/codalab/client/local_bundle_client.py
@@ -274,54 +274,11 @@ class LocalBundleClient(BundleClient):
 
     @authentication_required
     def kill_bundles(self, bundle_uuids):
-        """
-        Send a kill command to all the given bundles.
-        """
-        check_bundles_have_all_permission(self.model, self._current_user(), bundle_uuids)
-        for bundle_uuid in bundle_uuids:
-            worker_message = {
-                'type': 'kill',
-                'uuid': bundle_uuid,
-            }
-            action_string = BundleAction.kill()
-            self._do_bundle_action(bundle_uuid, worker_message, action_string)
+        raise UsageError("API Updated: Please upgrade to the latest version of the CLI.")
 
     @authentication_required
     def write_targets(self, targets, string):
-        """
-        Write targets by sending a command to all the given bundles in the targets.
-        """
-        bundle_uuids = [bundle_uuid for (bundle_uuid, subpath) in targets]
-        check_bundles_have_all_permission(self.model, self._current_user(), bundle_uuids)
-        for bundle_uuid, subpath in targets:
-            if not re.match('^\w+$', subpath):
-                raise UsageError('Can\'t write to subpath with funny characters: %s' % subpath)
-            worker_message = {
-                'type': 'write',
-                'uuid': bundle_uuid,
-                'subpath': subpath,
-                'string': string,
-            }
-            action_string = BundleAction.write(subpath, string)
-            self._do_bundle_action(bundle_uuid, worker_message, action_string)
-
-    def _do_bundle_action(self, bundle_uuid, worker_message, action_string):
-        """
-        Sends the message to the worker to do the bundle action, and adds the
-        action string to the bundle metadata.
-        """
-        bundle = self.model.get_bundle(bundle_uuid)
-        if bundle.state != State.RUNNING:
-            raise UsageError('Cannot execute this action on a bundle that is not running.')
-
-        worker = self.worker_model.get_bundle_worker(bundle_uuid)
-        precondition(
-            self.worker_model.send_json_message(worker['socket_id'],  worker_message, 60),
-            'Unable to reach worker.')
-
-        new_actions = getattr(bundle.metadata, 'actions', []) + [action_string]
-        db_update = {'metadata': {'actions': new_actions}}
-        self.model.update_bundle(bundle, db_update)
+        raise UsageError("API Updated: Please upgrade to the latest version of the CLI.")
 
     @authentication_required
     def chown_bundles(self, bundle_uuids, user_spec):

--- a/codalab/client/local_bundle_client.py
+++ b/codalab/client/local_bundle_client.py
@@ -274,11 +274,54 @@ class LocalBundleClient(BundleClient):
 
     @authentication_required
     def kill_bundles(self, bundle_uuids):
-        raise UsageError("API Updated: Please upgrade to the latest version of the CLI.")
+        """
+        Send a kill command to all the given bundles.
+        """
+        check_bundles_have_all_permission(self.model, self._current_user(), bundle_uuids)
+        for bundle_uuid in bundle_uuids:
+            worker_message = {
+                'type': 'kill',
+                'uuid': bundle_uuid,
+            }
+            action_string = BundleAction.kill()
+            self._do_bundle_action(bundle_uuid, worker_message, action_string)
 
     @authentication_required
     def write_targets(self, targets, string):
-        raise UsageError("API Updated: Please upgrade to the latest version of the CLI.")
+        """
+        Write targets by sending a command to all the given bundles in the targets.
+        """
+        bundle_uuids = [bundle_uuid for (bundle_uuid, subpath) in targets]
+        check_bundles_have_all_permission(self.model, self._current_user(), bundle_uuids)
+        for bundle_uuid, subpath in targets:
+            if not re.match('^\w+$', subpath):
+                raise UsageError('Can\'t write to subpath with funny characters: %s' % subpath)
+            worker_message = {
+                'type': 'write',
+                'uuid': bundle_uuid,
+                'subpath': subpath,
+                'string': string,
+            }
+            action_string = BundleAction.write(subpath, string)
+            self._do_bundle_action(bundle_uuid, worker_message, action_string)
+
+    def _do_bundle_action(self, bundle_uuid, worker_message, action_string):
+        """
+        Sends the message to the worker to do the bundle action, and adds the
+        action string to the bundle metadata.
+        """
+        bundle = self.model.get_bundle(bundle_uuid)
+        if bundle.state != State.RUNNING:
+            raise UsageError('Cannot execute this action on a bundle that is not running.')
+
+        worker = self.worker_model.get_bundle_worker(bundle_uuid)
+        precondition(
+            self.worker_model.send_json_message(worker['socket_id'],  worker_message, 60),
+            'Unable to reach worker.')
+
+        new_actions = getattr(bundle.metadata, 'actions', []) + [action_string]
+        db_update = {'metadata': {'actions': new_actions}}
+        self.model.update_bundle(bundle, db_update)
 
     @authentication_required
     def chown_bundles(self, bundle_uuids, user_spec):

--- a/codalab/lib/bundle_action.py
+++ b/codalab/lib/bundle_action.py
@@ -1,3 +1,6 @@
+from codalab.common import PreconditionViolation
+
+
 class BundleAction(object):
     """
     A bundle action is something that a client sends to a bundle, which gets
@@ -10,10 +13,11 @@ class BundleAction(object):
     SEPARATOR = '\t'
 
     @staticmethod
-    def kill():
-        return BundleAction.KILL
-
-    @staticmethod
-    def write(subpath, string):
-        # Note: assume subpath must not have the separator in it.
-        return BundleAction.SEPARATOR.join([BundleAction.WRITE, subpath, string])
+    def as_string(action):
+        if action['type'] == BundleAction.KILL:
+            return BundleAction.KILL
+        elif action['type'] == BundleAction.WRITE:
+            # Note: assume subpath must not have the separator in it.
+            return BundleAction.SEPARATOR.join([BundleAction.WRITE, action['subpath'], action['string']])
+        else:
+            raise PreconditionViolation("Unsupported bundle action %r" % action['type'])

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -2056,11 +2056,14 @@ class BundleCLI(object):
     def do_kill_command(self, args):
         args.bundle_spec = spec_util.expand_specs(args.bundle_spec)
 
-        client, worksheet_uuid = self.parse_client_worksheet_uuid(args.worksheet_spec)
+        client, worksheet_uuid = self.parse_client_worksheet_uuid(args.worksheet_spec, use_rest=True)
         bundle_uuids = worksheet_util.get_bundle_uuids(client, worksheet_uuid, args.bundle_spec)
         for bundle_uuid in bundle_uuids:
             print >>self.stdout, bundle_uuid
-        client.kill_bundles(bundle_uuids)
+        client.create('bundle-actions', [{
+            'type': 'kill',
+            'uuid': uuid
+        } for uuid in bundle_uuids])
 
     @Commands.command(
         'write',
@@ -2072,9 +2075,14 @@ class BundleCLI(object):
         ),
     )
     def do_write_command(self, args):
-        client, worksheet_uuid = self.parse_client_worksheet_uuid(args.worksheet_spec)
+        client, worksheet_uuid = self.parse_client_worksheet_uuid(args.worksheet_spec, use_rest=True)
         target = self.parse_target(client, worksheet_uuid, args.target_spec)
-        client.write_targets([target], args.string)
+        client.create('bundle-actions', {
+            'type': 'write',
+            'uuid': target[0],
+            'subpath': target[1],
+            'string': args.string,
+        })
         print >>self.stdout, target[0]
 
     #############################################################################

--- a/codalab/model/worker_model.py
+++ b/codalab/model/worker_model.py
@@ -286,7 +286,7 @@ class WorkerModel(object):
         If the message is not sent successfully after timeout_secs, return
         False. Otherwise, returns True.
 
-        Note, only the worker should call this method with autoretry sent to
+        Note, only the worker should call this method with autoretry set to
         False. See comments below.
         """
         start_time = time.time()

--- a/codalab/rest/bundle_actions.py
+++ b/codalab/rest/bundle_actions.py
@@ -1,0 +1,49 @@
+from bottle import local, post, request
+from marshmallow import validate
+from marshmallow_jsonapi import Schema, fields
+
+from codalab.common import State, UsageError, precondition
+from codalab.lib.bundle_action import BundleAction
+from codalab.lib.spec_util import validate_child_path, validate_uuid
+from codalab.objects.permission import check_bundles_have_all_permission
+from codalab.server.authenticated_plugin import AuthenticatedPlugin
+
+
+class BundleActionSchema(Schema):
+    id = fields.Integer(dump_only=True, default=None)
+    uuid = fields.String(validate=validate_uuid)
+    type = fields.String(validate=validate.OneOf({BundleAction.KILL, BundleAction.WRITE}))
+    subpath = fields.String(validate=validate_child_path)
+    string = fields.String()
+
+    class Meta:
+        type_ = 'bundle-actions'
+
+
+@post('/bundle-actions', apply=AuthenticatedPlugin())
+def create_bundle_actions():
+    """
+    Sends the message to the worker to do the bundle action, and adds the
+    action string to the bundle metadata.
+    """
+    actions = BundleActionSchema(
+        strict=True, many=True,
+    ).load(request.json).data
+
+    check_bundles_have_all_permission(local.model, request.user, [a['uuid'] for a in actions])
+
+    for action in actions:
+        bundle = local.model.get_bundle(action['uuid'])
+        if bundle.state != State.RUNNING:
+            raise UsageError('Cannot execute this action on a bundle that is not running.')
+
+        worker = local.worker_model.get_bundle_worker(action['uuid'])
+        precondition(
+            local.worker_model.send_json_message(worker['socket_id'], action, 60),
+            'Unable to reach worker.')
+
+        new_actions = getattr(bundle.metadata, 'actions', []) + [BundleAction.as_string(action)]
+        db_update = {'metadata': {'actions': new_actions}}
+        local.model.update_bundle(bundle, db_update)
+
+    return BundleActionSchema(many=True).dump(actions).data

--- a/codalab/server/rest_server.py
+++ b/codalab/server/rest_server.py
@@ -24,6 +24,7 @@ from bottle import (
 from codalab.common import exception_to_http_error, PreconditionViolation
 from codalab.lib import formatting, server_util
 import codalab.rest.account
+import codalab.rest.bundle_actions
 import codalab.rest.bundles
 import codalab.rest.groups
 import codalab.rest.legacy


### PR DESCRIPTION
Decided to implement this first before the worksheets API (which is already underway) so that I could be free to clean up deprecated code while working on the worksheets API.

Fixes #507 
