### PR TITLE
Cleanup CLI dependencies on LocalBundleClient

### DIFF
--- a/codalab/lib/codalab_manager.py
+++ b/codalab/lib/codalab_manager.py
@@ -438,10 +438,6 @@ class CodaLabManager(object):
         return address
 
     # TODO(sckoo): clean up backward compatibility hacks when REST API complete
-    def local_client(self, use_rest=False):
-        return self.client('local', use_rest=use_rest)
-
-    # TODO(sckoo): clean up backward compatibility hacks when REST API complete
     def current_client(self, use_rest=False):
         return self.client(self.session()['address'], use_rest=use_rest)
 


### PR DESCRIPTION
In prep for worksheet API changes
- Move user commands into its own section
- Remove dependencies from the administrative CLI commands on
  LocalBundleClient
- Close loophole that allowed BundleStore commands to be run from the
  web terminal
- Remove 'local' requirement on administrative commands, only require
     that the CLI is not headless (i.e. not the web terminal)

@percyliang Please review
