### PR TITLE
Make directive de/serialization proper inverses

### DIFF
--- a/codalab/lib/formatting.py
+++ b/codalab/lib/formatting.py
@@ -5,6 +5,7 @@ Provides basic formatting utilities.
 import datetime
 import json
 import shlex
+import pipes
 
 from worker import formatting as worker_formatting
 
@@ -116,7 +117,7 @@ def tokens_to_string(tokens):
     :param tokens: list of string tokens
     :return: space-separated string of tokens
     """
-    return ' '.join(quote(token) for token in tokens)
+    return ' '.join(map(pipes.quote, tokens))
 
 
 def string_to_tokens(s):


### PR DESCRIPTION
Fixes #326 by using `pipes.quotes` in the `tokens_to_string` function of `formatting.py` so that quotes are maintained in the representation. 
