### PR TITLE
Tell user to click Upload button

### DIFF
--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -858,11 +858,9 @@ class BundleCLI(object):
         + EDIT_ARGUMENTS,
     )
     def do_upload_command(self, args):
-        # If headless and no args provided, request an Upload dialog on the front end.
-        if self.headless and not args.path and args.contents is None:
-            # Can't actually open file dialog from code on the frontend, so just tell the user
-            # to click the Upload button.
-            raise UsageError("Click the Upload button in the sidebar to select files for upload.")
+        # Uploading from local filesystem not allowed for headless CLI (i.e. web terminal)
+        if self.headless and args.path:
+            raise UsageError("Upload from local filesystem not supported in headless CLI.")
 
         if args.contents is None and not args.path:
             raise UsageError("Nothing to upload.")

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -860,7 +860,9 @@ class BundleCLI(object):
     def do_upload_command(self, args):
         # If headless and no args provided, request an Upload dialog on the front end.
         if self.headless and not args.path and args.contents is None:
-            return ui_actions.serialize([ui_actions.Upload()])
+            # Can't actually open file dialog from code on the frontend, so just tell the user
+            # to click the Upload button.
+            raise UsageError("Click the Upload button in the sidebar to select files for upload.")
 
         if args.contents is None and not args.path:
             raise UsageError("Nothing to upload.")

--- a/codalab/lib/ui_actions.py
+++ b/codalab/lib/ui_actions.py
@@ -1,6 +1,6 @@
-'''
+"""
 Mappings for UI action representation on the frontend side.
-'''
+"""
 
 class UIAction(object):
     def __init__(self, parameter=None):
@@ -8,17 +8,23 @@ class UIAction(object):
             raise NotImplementedError
         self.parameter = parameter
 
+
 class OpenWorksheet(UIAction):
     KEY = 'openWorksheet'
+
 
 class SetEditMode(UIAction):
     KEY = 'setEditMode'
 
+
 class OpenBundle(UIAction):
     KEY = 'openBundle'
 
+
+# Note: currently unsupported by the frontend
 class Upload(UIAction):
     KEY = 'upload'
+
 
 def serialize(actions):
     return {

--- a/codalab/lib/ui_actions.py
+++ b/codalab/lib/ui_actions.py
@@ -21,11 +21,6 @@ class OpenBundle(UIAction):
     KEY = 'openBundle'
 
 
-# Note: currently unsupported by the frontend
-class Upload(UIAction):
-    KEY = 'upload'
-
-
 def serialize(actions):
     return {
         'ui_actions': [[a.KEY, a.parameter] for a in actions]


### PR DESCRIPTION
...when we receive a bare `cl upload` command on the web terminal.

We do this browsers do not allow JavaScript code to directly
open a file dialog outside of a user-initiated event. Because
there is a network call in the chain of events from typing in
`cl upload` in the web terminal to receiving an Upload "UI action"
from the server, the browser considers the final callback to be
script-initiated, not directly user-initiated.

Resolves codalab/codalab-worksheets#205

@percyliang @yashsavani 
