### PR TITLE
Don't copy uuids in mimic

### DIFF
--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -1856,8 +1856,13 @@ class BundleCLI(object):
                                        for dep in old_info['dependencies'])
             if lone_output or downstream_of_inputs:
                 # Now create a new bundle that mimics the old bundle.
-                # Only change the name if the output name is supplied.
                 new_info = copy.deepcopy(old_info)
+
+                # Make sure that new uuids are generated
+                new_info.pop('uuid', None)
+                new_info.pop('id', None)
+
+                # Only change the name if the output name is supplied.
                 new_metadata = new_info['metadata']
                 if new_output_name:
                     if old_bundle_uuid == old_output:


### PR DESCRIPTION
Original problem:

> The only thing I found is that I think cl mimic is broken:
> 
> ```
> cl up a.txt
> cl up b.txt
> cl run input:a.txt 'wc -l input'
> cl mimic a.txt b.txt
> This creates a bundle that still uses a.txt instead of b.txt...
> ```

The source of the problem was newly allowing users to specify their own UUIDs for new bundles, for the use cases of `cl add` and `cl wadd`. Before this, `cl mimic` relied on the assumption that the server would ignore any specified UUIDs in new bundles. But once the restriction was eased, the mimic operation accidentally used the old UUIDs when creating the new mimicked bundles, causing the server to do nothing. Thus `cl mimic a.txt b.txt` above actually just duplicated the _item_ without creating a new bundle.

@percyliang 
