### PR TITLE
Disable request buffering in nginx

### DIFF
--- a/codalab/config/templates/nginx.conf
+++ b/codalab/config/templates/nginx.conf
@@ -40,6 +40,8 @@ server {
     listen {{PORT}};
     {% endif %}
 
+    proxy_http_version 1.1;
+
     gzip on;
     gzip_min_length  4096;
     gzip_buffers  4 32k;
@@ -50,6 +52,12 @@ server {
     charset     utf-8;
     client_max_body_size 4096m;
     client_body_buffer_size 64m;
+
+    # Turn off request body buffering to allow direct streaming uploads.
+    # Note that the request body will be buffered regardless of this directive
+    # value unless HTTP/1.1 is enabled for proxying (configured above).
+    proxy_request_buffering off;
+
     #keepalive_timeout 10;
     #proxy_buffering off;
     #proxy_connect_timeout       1200;


### PR DESCRIPTION
Allows streaming uploads directly into our unzipping functions.

Fixes codalab/codalab-cli#599

References:
http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_request_buffering
http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_http_version

@percyliang 