### PR TITLE
Re-disable event logging for worker calls and shorten command name

### DIFF
--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -268,8 +268,8 @@ def _set_bundle_permissions():
     return BundlePermissionSchema(many=True).dump(new_permissions).data
 
 
-@get('/bundles/<uuid:re:%s>/contents/info/' % spec_util.UUID_STR)
-@get('/bundles/<uuid:re:%s>/contents/info/<path:path>' % spec_util.UUID_STR)
+@get('/bundles/<uuid:re:%s>/contents/info/' % spec_util.UUID_STR, name='fetch_bundle_contents_info')
+@get('/bundles/<uuid:re:%s>/contents/info/<path:path>' % spec_util.UUID_STR, name='fetch_bundle_contents_info')
 def _fetch_bundle_contents_info(uuid, path=''):
     depth = query_get_type(int, 'depth', default=0)
     if depth < 0:
@@ -281,8 +281,8 @@ def _fetch_bundle_contents_info(uuid, path=''):
     }
 
 
-@get('/bundles/<uuid:re:%s>/contents/blob/' % spec_util.UUID_STR)
-@get('/bundles/<uuid:re:%s>/contents/blob/<path:path>' % spec_util.UUID_STR)
+@get('/bundles/<uuid:re:%s>/contents/blob/' % spec_util.UUID_STR, name='fetch_bundle_contents_blob')
+@get('/bundles/<uuid:re:%s>/contents/blob/<path:path>' % spec_util.UUID_STR, name='fetch_bundle_contents_blob')
 def _fetch_bundle_contents_blob(uuid, path=''):
     """
     API to download the contents of a bundle or a subpath within a bundle.
@@ -352,7 +352,8 @@ def _fetch_bundle_contents_blob(uuid, path=''):
     return fileobj
 
 
-@put('/bundles/<uuid:re:%s>/contents/blob/' % spec_util.UUID_STR, apply=AuthenticatedPlugin())
+@put('/bundles/<uuid:re:%s>/contents/blob/' % spec_util.UUID_STR,
+     name='update_bundle_contents_blob', apply=AuthenticatedPlugin())
 def _update_bundle_contents_blob(uuid):
     """
     Update the contents of the given running or uploading bundle.

--- a/codalab/rest/workers.py
+++ b/codalab/rest/workers.py
@@ -15,7 +15,7 @@ from worker.worker import VERSION
 
 
 @post('/workers/<worker_id>/checkin',
-      apply=AuthenticatedPlugin())
+      name='worker_checkin', apply=AuthenticatedPlugin())
 def checkin(worker_id):
     """
     Checks in with the bundle service, storing information about the worker.
@@ -40,7 +40,7 @@ def checkin(worker_id):
 
 
 @post('/workers/<worker_id>/checkout',
-      apply=AuthenticatedPlugin())
+      name='worker_checkout', apply=AuthenticatedPlugin())
 def checkout(worker_id):
     """
     Checks out from the bundle service, cleaning up any state related to the
@@ -59,7 +59,7 @@ def check_reply_permission(worker_id, socket_id):
 
 
 @post('/workers/<worker_id>/reply/<socket_id:int>',
-      apply=AuthenticatedPlugin())
+      name='worker_reply_json', apply=AuthenticatedPlugin())
 def reply(worker_id, socket_id):
     """
     Replies with a single JSON message to the given socket ID.
@@ -69,7 +69,7 @@ def reply(worker_id, socket_id):
 
 
 @post('/workers/<worker_id>/reply_data/<socket_id:int>',
-      apply=AuthenticatedPlugin())
+      name='worker_reply_blob', apply=AuthenticatedPlugin())
 def reply_data(worker_id, socket_id):
     """
     Replies with a stream of data to the given socket ID. This reply mechanism
@@ -103,7 +103,7 @@ def check_run_permission(bundle):
 
 
 @post('/workers/<worker_id>/start_bundle/<uuid:re:%s>' % spec_util.UUID_STR,
-      apply=AuthenticatedPlugin())
+      name='worker_start_bundle', apply=AuthenticatedPlugin())
 def start_bundle(worker_id, uuid):
     """
     Checks whether the bundle is still assigned to run on the worker with the
@@ -122,7 +122,7 @@ def start_bundle(worker_id, uuid):
 
 
 @put('/workers/<worker_id>/update_bundle_metadata/<uuid:re:%s>' % spec_util.UUID_STR,
-      apply=AuthenticatedPlugin())
+     name='worker_update_bundle_metadata', apply=AuthenticatedPlugin())
 def update_bundle_metadata(worker_id, uuid):
     """
     Updates metadata related to a running bundle.
@@ -138,7 +138,7 @@ def update_bundle_metadata(worker_id, uuid):
 
 
 @post('/workers/<worker_id>/finalize_bundle/<uuid:re:%s>' % spec_util.UUID_STR,
-      apply=AuthenticatedPlugin())
+      name='worker_finalize_bundle', apply=AuthenticatedPlugin())
 def finalize_bundle(worker_id, uuid):
     """
     Reports that the bundle has finished running.
@@ -175,7 +175,7 @@ def finalize_bundle(worker_id, uuid):
                                 request.json['failure_message'])
 
 
-@get('/workers/code.tar.gz')
+@get('/workers/code.tar.gz', name='worker_download_code')
 def code():
     """
     Returns .tar.gz archive containing the code of the worker.

--- a/codalab/server/rest_server.py
+++ b/codalab/server/rest_server.py
@@ -45,7 +45,7 @@ from codalab.server.oauth2_provider import oauth2_provider
 # Don't log requests to routes matching these regexes.
 ROUTES_NOT_LOGGED_REGEXES = [
     re.compile(r'/oauth2/.*'),
-    re.compile(r'/worker/.*'),
+    re.compile(r'/workers/.*'),
 ]
 
 
@@ -92,7 +92,7 @@ class CheckJsonPlugin(object):
 class LoggingPlugin(object):
     """Logs successful requests to the events log."""
     api = 2
-    
+
     def apply(self, callback, route):
         def wrapper(*args, **kwargs):
             if not self._should_log(route.rule):
@@ -101,7 +101,7 @@ class LoggingPlugin(object):
             start_time = time.time()
 
             res = callback(*args, **kwargs)
-            
+
             command = route.method + ' ' + route.rule
             query_dict = (
                 dict(map(lambda k: (k, request.query[k]), request.query)))

--- a/codalab/server/rest_server.py
+++ b/codalab/server/rest_server.py
@@ -45,7 +45,7 @@ from codalab.server.oauth2_provider import oauth2_provider
 # Don't log requests to routes matching these regexes.
 ROUTES_NOT_LOGGED_REGEXES = [
     re.compile(r'/oauth2/.*'),
-    re.compile(r'/workers/.*'),
+    # re.compile(r'/workers/.*'),
 ]
 
 
@@ -102,7 +102,8 @@ class LoggingPlugin(object):
 
             res = callback(*args, **kwargs)
 
-            command = route.method + ' ' + route.rule
+            # Use explicitly defined route name or 'METHOD /rule'
+            command = route.name or (route.method + ' ' + route.rule)
             query_dict = (
                 dict(map(lambda k: (k, request.query[k]), request.query)))
             args = [request.path, query_dict]


### PR DESCRIPTION
Fix a typo that accidentally activated logging on all worker calls.
In the future, we should reenable logging for most worker calls, but
with certain additional policies such as random sampling and/or
truncating the args.

Use route name in event log for the `command` column, and define route names for some of the longer routes.

Contributes to #573 
Fixes #552

@percyliang 