### PR TITLE
Fix state logic for uploading bundles

### DIFF
--- a/codalab/client/json_api_client.py
+++ b/codalab/client/json_api_client.py
@@ -7,7 +7,6 @@ import urllib2
 from codalab.common import (
     http_error_to_exception,
     precondition,
-    State,
     UsageError,
 )
 from worker.rest_client import RestClient, RestClientException

--- a/codalab/client/json_api_client.py
+++ b/codalab/client/json_api_client.py
@@ -7,6 +7,7 @@ import urllib2
 from codalab.common import (
     http_error_to_exception,
     precondition,
+    State,
     UsageError,
 )
 from worker.rest_client import RestClient, RestClientException
@@ -569,7 +570,7 @@ class JsonApiClient(RestClient):
         """
         request_path = '/bundles/%s/contents/blob/' % bundle_id
         params = params or {}
-        params['finalize'] = True
+        params['finalize_on_failure'] = True  # no retry mechanism implemented yet
         params = self._pack_params(params)
         if fileobj is None:
             self._make_request(

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -1063,6 +1063,7 @@ class BundleCLI(object):
         dest_bundle = dest_client.create('bundles', source_info, params={
             'worksheet': dest_worksheet_uuid,
             'detached': not add_to_worksheet,
+            'wait_for_upload': True,
         })
 
         # If bundle contents don't exist, finish after just copying metadata

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -867,7 +867,6 @@ class BundleCLI(object):
             '  upload <path> ... <path> : Upload one bundle whose directory contents contain <path> ... <path>.',
             '  upload -c <text>         : Upload one bundle whose file contents is <text>.',
             '  upload <url>             : Upload one bundle whose file contents is downloaded from <url>.',
-            '  upload                   : Open file browser dialog and upload contents of the selected file as a bundle (website only).',
             'Most of the other arguments specify metadata fields.',
         ],
         arguments=(
@@ -907,14 +906,12 @@ class BundleCLI(object):
             'metadata': metadata,
         }
 
-        # Create bundle
-        new_bundle = client.create('bundles', bundle_info, params={
-            'worksheet': worksheet_uuid
-        })
-
         # Option 1: Upload contents string
         if args.contents is not None:
             contents_buffer = StringIO(args.contents)
+            new_bundle = client.create('bundles', bundle_info, params={
+                'worksheet': worksheet_uuid
+            })
             client.upload_contents_blob(
                 new_bundle['id'],
                 fileobj=contents_buffer,
@@ -927,6 +924,9 @@ class BundleCLI(object):
             if not all(map(path_util.path_is_url, args.path)):
                 raise UsageError("URLs and local files cannot be uploaded in the same bundle.")
 
+            new_bundle = client.create('bundles', bundle_info, params={
+                'worksheet': worksheet_uuid
+            })
             client.upload_contents_blob(new_bundle['id'], params={
                 'urls': args.path,
                 'git': args.git,
@@ -948,6 +948,16 @@ class BundleCLI(object):
                     exclude_patterns=args.exclude_patterns,
                     force_compression=args.force_compression)
 
+            # Create bundle.
+            # We must create the bundle right before we upload it because we
+            # perform some input validation in functions such as
+            # zip_util.pack_files_for_upload that we want to fail fast before
+            # we try to create or upload the bundle, otherwise you will be left
+            # with empty shells of failed uploading bundles on your worksheet.
+            new_bundle = client.create('bundles', bundle_info, params={
+                'worksheet': worksheet_uuid,
+                'wait_for_upload': True,
+            })
             print >>self.stderr, 'Uploading %s (%s) to %s' %\
                                  (packed['filename'], new_bundle['id'], client.address)
             progress = FileTransferProgress('Sent ', packed['filesize'], f=self.stderr)
@@ -1079,6 +1089,14 @@ class BundleCLI(object):
         else:
             unpack = False
 
+        # Bundles stuck in non-final states such as 'running' should not keep
+        # that state at the destination server, and should instead just fallback
+        # to 'failed'
+        if source_info['state'] == State.READY:
+            source_state = State.READY
+        else:
+            source_state = State.FAILED
+
         # Send file over
         progress = FileTransferProgress('Copied ', f=self.stderr)
         source = source_client.fetch_contents_blob(source_bundle_uuid)
@@ -1090,6 +1108,7 @@ class BundleCLI(object):
                     'filename': filename,
                     'unpack': unpack,
                     'simplify': False,  # retain original bundle verbatim
+                    'state_on_success': source_state,  # copy bundle state
                 },
                 progress_callback=progress.update)
 

--- a/codalab/lib/codalab_manager.py
+++ b/codalab/lib/codalab_manager.py
@@ -17,7 +17,6 @@ classes based on the configuration in this file:
   cli: returns a BundleCLI
   client: returns a JsonApiClient
   model: returns a BundleModel
-  rpc_server: returns a BundleRPCServer
 
 Imports in this file are deferred to as late as possible because some of these
 modules (ex: the model) depend on heavy-weight library imports (ex: sqlalchemy).

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -4,6 +4,7 @@ import os
 import re
 import sys
 import time
+from itertools import izip
 
 from bottle import abort, get, post, put, delete, local, request, response
 
@@ -106,7 +107,7 @@ def build_bundles_document(bundle_uuids):
 
     # Shim in editable metadata keys
     # Used by the front-end application
-    for bundle, data in zip(bundles, document['data']):
+    for bundle, data in izip(bundles, document['data']):
         json_api_meta(data, {
             'editable_metadata_keys': worksheet_util.get_editable_metadata_fields(
                 get_bundle_subclass(bundle['bundle_type']))
@@ -229,7 +230,7 @@ def _update_bundles():
     bundles = local.model.batch_get_bundles(uuid=bundle_uuids)
 
     # Update bundles
-    for bundle, update in zip(bundles, bundle_updates):
+    for bundle, update in izip(bundles, bundle_updates):
         local.model.update_bundle(bundle, update)
 
     # Get updated bundles

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -138,6 +138,11 @@ def _create_bundles():
     |shadow| - the uuid of the bundle to shadow
     |detached| - True ('1') if should not add new bundle to any worksheet,
                  or False ('0') otherwise. Default is False.
+    |wait_for_upload| - True ('1') if the bundle state should be initialized to
+                        UPLOADING regardless of the bundle type, or False ('0')
+                        otherwise. This prevents run bundles that are being
+                        copied from another instance from being run by the
+                        BundleManager. Default is False.
     """
     worksheet_uuid = request.query.get('worksheet')
     shadow_parent_uuid = request.query.get('shadow')
@@ -170,6 +175,7 @@ def _create_bundles():
         bundle['owner_id'] = request.user.user_id
         bundle['state'] = (State.UPLOADING
                            if issubclass(bundle_class, UploadedBundle)
+                           or query_get_bool('wait_for_upload', False)
                            else State.CREATED)
         bundle.setdefault('metadata', {})['created'] = int(time.time())
         for dep in bundle.setdefault('dependencies', []):

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -380,10 +380,10 @@ def _update_bundle_contents_blob(uuid):
         simplify - (optional) 1 if the uploaded file should be 'simplified' if
                    it is an archive, or 0 otherwise, default is 1
                    (See UploadManager for full explanation of 'simplification')
-        finalize_on_failure - (optional) 1 if bundle state should be set to
-                              'failed' in the case of a failure during upload,
-                              or 0 if the bundle state should not change on
-                              failure. Default is 0.
+        finalize_on_failure - (optional) True ('1') if bundle state should be set
+                              to 'failed' in the case of a failure during upload,
+                              or False ('0') if the bundle state should not
+                              change on failure. Default is False.
         state_on_success - (optional) Update the bundle state to this state if
                            the upload completes successfully. Must be either
                            'ready' or 'failed'. Default is 'ready'.

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -225,7 +225,7 @@ def _update_bundles():
     ).load(request.json, partial=True).data
 
     # Check permissions
-    bundle_uuids = [b['uuid'] for b in bundle_updates]
+    bundle_uuids = [b.pop('uuid') for b in bundle_updates]
     check_bundles_have_all_permission(local.model, request.user, bundle_uuids)
     bundles = local.model.batch_get_bundles(uuid=bundle_uuids)
 

--- a/codalab/rest/schemas.py
+++ b/codalab/rest/schemas.py
@@ -10,9 +10,6 @@ from marshmallow import (
     validate,
     validates_schema,
 )
-from marshmallow import post_dump
-from marshmallow import post_load
-from marshmallow import pre_load
 from marshmallow_jsonapi import Schema, fields
 
 from codalab.bundles import BUNDLE_SUBCLASSES


### PR DESCRIPTION
- Add wait_for_upload flag to `POST /bundles`
  - Update copy_bundles to set wait_for_upload=1.
  - Prevents race condition between upload and job scheduling when copying run bundles between instances.
- Add state_on_success parameter to `PUT /bundles/<uuid>/contents/blob`
  - Update copy_bundles to set state_on_success
  - Properly copies over final states of run bundles
- Add finalize_on_failure parameter to `PUT /bundles/<uuid>/contents/blob`
  - Workers don't want to finalize bundles on upload failures since it will retry, but the CLI does want to finalize bundles, so the flag helps to disambiguate.

Fixes #615