### PR TITLE
Fix empty-relationship check

### DIFF
--- a/codalab/client/json_api_client.py
+++ b/codalab/client/json_api_client.py
@@ -73,7 +73,9 @@ class JsonApiRelationship(dict):
         self.type_ = type_
         self.id_ = id_
         dict.__init__(self, *args)
-        # Allow attributes to override the type and id keys in the dict
+        # Allow the JSON API resource object "attributes" [not Python instance
+        # attributes] to override the type and id keys in the dict.
+        # The actual type and id will still be accessible as instance attrs.
         self.setdefault('type', type_)
         self.setdefault('id', id_)
 
@@ -82,17 +84,12 @@ class JsonApiRelationship(dict):
         Serialize into relationship linkage dict for JSON API requests.
         Empty relationships should be properly serialized as a null linkage.
         """
-        if self:
-            return {
-                'data': {
-                    'type': self.type_,
-                    'id': self.id_,
-                }
+        return {
+            'data': {
+                'type': self.type_,
+                'id': self.id_,
             }
-        else:
-            return {
-                'data': None
-            }
+        }
 
     def __eq__(self, other):
         return self.type_ == other.type_ and \
@@ -107,23 +104,38 @@ class JsonApiRelationship(dict):
                (self.type_, self.id_, dict.__repr__(self))
 
     def __nonzero__(self):
-        """Implements return value of bool(relationship)"""
-        return self.type_ is not None and self.id_ is not None
-
-    @classmethod
-    def empty(cls):
         """
-        Return an instance of JsonApiRelationship that represents an empty
-        to-one relationship. Note that we have:
-
-            assert bool(JsonApiRelationship.empty()) == False
-
-        Using an empty JsonApiRelationship is required when the client needs
-        to set a to-one relationship to null, otherwise _pack_document will be
-        unable to figure out whether the user is attempting to set an attribute
-        or a relationship to null.
+        Implements value of bool(relationship).
+        Should be true for non-empty relationships.
         """
-        return JsonApiRelationship(type_=None, id_=None)
+        return True
+
+
+class EmptyJsonApiRelationship(JsonApiRelationship):
+    """
+    Represents an empty to-one relationship.
+
+    Note that we have:
+
+        assert bool(EmptyJsonApiRelationship()) == False
+
+    Using an EmptyJsonApiRelationship is required when the client needs
+    to set a to-one relationship to null, otherwise _pack_document will be
+    unable to figure out whether the user is attempting to set an attribute
+    or a relationship to null.
+    """
+    def __init__(self):
+        JsonApiRelationship.__init__(self, None, None)
+
+    def as_linkage(self):
+        return {'data': None}
+
+    def __nonzero__(self):
+        """Empty relationship should be falsey."""
+        return False
+
+    def __repr__(self):
+        return 'EmptyJsonApiRelationship()'
 
 
 class JsonApiClient(RestClient):
@@ -235,7 +247,7 @@ class JsonApiClient(RestClient):
             # Return recursively unpacked object if the data was included in the
             # document, otherwise just return the linkage object
             if linkage is None:
-                return JsonApiRelationship.empty()
+                return EmptyJsonApiRelationship()
             elif (linkage['type'], linkage['id']) in included:
                 # Wrap in a JsonApiRelationship proxy
                 # This allows you to send an unpacked object back up through

--- a/codalab/client/json_api_client.py
+++ b/codalab/client/json_api_client.py
@@ -80,10 +80,7 @@ class JsonApiRelationship(dict):
         self.setdefault('id', id_)
 
     def as_linkage(self):
-        """
-        Serialize into relationship linkage dict for JSON API requests.
-        Empty relationships should be properly serialized as a null linkage.
-        """
+        """Serialize into relationship linkage dict for JSON API requests."""
         return {
             'data': {
                 'type': self.type_,
@@ -128,6 +125,7 @@ class EmptyJsonApiRelationship(JsonApiRelationship):
         JsonApiRelationship.__init__(self, None, None)
 
     def as_linkage(self):
+        """Empty relationships should be serialized as a null linkage."""
         return {'data': None}
 
     def __nonzero__(self):

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -2589,7 +2589,7 @@ class BundleCLI(object):
         group = client.fetch('groups', args.group_spec)
 
         members = []
-        # group['owner'] may be None (i.e. for the public group)
+        # group['owner'] may be a falsey null-relationship (i.e. for the public group)
         if group['owner']:
             members.append({
                 'role': 'owner',

--- a/test-cli.py
+++ b/test-cli.py
@@ -963,6 +963,13 @@ def test(ctx):
         rest_server_proc.kill()
         shutil.rmtree(remote_home)
 
+
+@TestModule.register('groups')
+def test(ctx):
+    # Should not crash
+    run_command([cl, 'ginfo', 'public'])
+
+
 if __name__ == '__main__':
     if len(sys.argv) == 1:
         print('Usage: python %s <module> ... <module>' % sys.argv[0])

--- a/tests/client/json_api_client_test.py
+++ b/tests/client/json_api_client_test.py
@@ -4,8 +4,9 @@ Unit tests for the static methods of the JsonApiClient
 import unittest
 
 from codalab.client.json_api_client import (
+    EmptyJsonApiRelationship,
     JsonApiClient,
-    JsonApiRelationship
+    JsonApiRelationship,
 )
 from codalab.common import PreconditionViolation
 
@@ -48,7 +49,7 @@ class JsonApiClientTest(unittest.TestCase):
     def test_pack_document(self):
         doc = self.client._pack_document({
             'owner': JsonApiRelationship('users', '345'),
-            'friend': JsonApiRelationship.empty(),
+            'friend': EmptyJsonApiRelationship(),
             'id': '123',
             'name': 'hello'
         }, 'bundles')

--- a/tests/client/json_api_client_test.py
+++ b/tests/client/json_api_client_test.py
@@ -48,6 +48,7 @@ class JsonApiClientTest(unittest.TestCase):
     def test_pack_document(self):
         doc = self.client._pack_document({
             'owner': JsonApiRelationship('users', '345'),
+            'friend': JsonApiRelationship.empty(),
             'id': '123',
             'name': 'hello'
         }, 'bundles')
@@ -65,6 +66,9 @@ class JsonApiClientTest(unittest.TestCase):
                             'id': '345',
                             'type': 'users'
                         }
+                    },
+                    'friend': {
+                        'data': None
                     }
                 },
             }


### PR DESCRIPTION
The bug resulted from a change that broke the assumption that null relationships were falsey.

Fixes #619 