### PR TITLE
Support nvidia-docker

### DIFF
--- a/codalab/worker/bundle_manager.py
+++ b/codalab/worker/bundle_manager.py
@@ -8,7 +8,6 @@ import threading
 import time
 import traceback
 
-from codalab.bundles.derived_bundle import DerivedBundle
 from codalab.common import State
 from codalab.lib import bundle_util, formatting, path_util
 from worker.file_util import remove_path

--- a/worker/docker_client.py
+++ b/worker/docker_client.py
@@ -71,7 +71,7 @@ to run the worker from the Docker shell.
         try:
             self._libcuda = None
             for lib in subprocess.check_output(['/sbin/ldconfig', '-p']).split('\n'):
-                if 'x86-64' in lib and lib.endswith('libcuda.so'):
+                if 'x86-64' not in lib and lib.endswith('libcuda.so'):
                     self._libcuda = os.path.realpath(lib.split(' => ')[-1])
         except OSError:
             # ldconfig isn't available on Mac OS X. Let's just say that we

--- a/worker/docker_client.py
+++ b/worker/docker_client.py
@@ -136,7 +136,7 @@ nvidia-docker-plugin not available, defaulting to basic GPU support.
         devices = [{
             "PathOnHost": device_path,
             "PathInContainer": device_path,
-            "CgroupPermissions": "mrw",  # FIXME: is this correct?
+            "CgroupPermissions": "mrw",
         } for device_path in cli_args['Devices']]
 
         # Set configurations in request json

--- a/worker/docker_client.py
+++ b/worker/docker_client.py
@@ -94,14 +94,8 @@ No ldconfig found. Not loading libcuda libraries.
 nvidia-docker-plugin not available, defaulting to basic GPU support.
 """
             self._use_nvidia_docker = False
-            # DEBUG
-            with open('/tmp/sckoo_test_output', 'wb') as outfile:
-                outfile.write(e.message + '\n')
         else:
             self._use_nvidia_docker = True
-            # DEBUG
-            with open('/tmp/sckoo_test_output', 'wb') as outfile:
-                outfile.write('nvidia-docker-plugin available')
 
     def _create_nvidia_docker_connection(self):
         return httplib.HTTPConnection("localhost:3476")

--- a/worker/docker_client.py
+++ b/worker/docker_client.py
@@ -86,6 +86,10 @@ No ldconfig found. Not loading libcuda libraries.
             if filename.startswith('nvidia'):
                 self._nvidia_device_files.append(os.path.join('/dev', filename))
 
+        # DEBUG
+        self._use_nvidia_docker = False
+        return
+
         # Check if nvidia-docker-plugin is available
         try:
             self._test_nvidia_docker()

--- a/worker/docker_client.py
+++ b/worker/docker_client.py
@@ -265,8 +265,8 @@ nvidia-docker-plugin not available, defaulting to basic GPU support.
                 docker_dependency_path))
 
         # Set up GPU devices manually.
+        devices = []
         if not self._use_nvidia_docker:
-            devices = []
             for device in self._nvidia_device_files:
                 devices.append({
                     'PathOnHost': device,

--- a/worker/docker_client.py
+++ b/worker/docker_client.py
@@ -58,6 +58,7 @@ class DockerClient(object):
     support GPU jobs.
     """
     # Where to look for nvidia-docker-plugin
+    # https://github.com/NVIDIA/nvidia-docker/wiki/nvidia-docker-plugin
     NV_HOST = 'localhost:3476'
 
     # Where to mount libcuda inside the container

--- a/worker/docker_client.py
+++ b/worker/docker_client.py
@@ -117,7 +117,7 @@ nvidia-docker-plugin not available, defaulting to basic GPU support.
     def _test_nvidia_docker(self):
         try:
             with closing(self._create_nvidia_docker_connection()) as conn:
-                conn.request('GET', '/v1.0/gpu/status')
+                conn.request('GET', '/v1.0/gpu/status/json')
                 status_response = conn.getresponse()
                 if status_response.status != 200:
                     raise DockerException(status_response.read())

--- a/worker/docker_client.py
+++ b/worker/docker_client.py
@@ -89,13 +89,19 @@ No ldconfig found. Not loading libcuda libraries.
         # Check if nvidia-docker-plugin is available
         try:
             self._test_nvidia_docker()
-        except DockerException:
+        except DockerException as e:
             print >> sys.stderr, """
 nvidia-docker-plugin not available, defaulting to basic GPU support.
 """
             self._use_nvidia_docker = False
+            # DEBUG
+            with open('/tmp/sckoo_test_output', 'wb') as outfile:
+                outfile.write(e.message + '\n')
         else:
             self._use_nvidia_docker = True
+            # DEBUG
+            with open('/tmp/sckoo_test_output', 'wb') as outfile:
+                outfile.write('nvidia-docker-plugin available')
 
     def _create_nvidia_docker_connection(self):
         return httplib.HTTPConnection("localhost:3476")
@@ -280,10 +286,6 @@ nvidia-docker-plugin not available, defaulting to basic GPU support.
             self._add_nvidia_docker_arguments(create_request)
         if not request_network:
             create_request['HostConfig']['NetworkMode'] = 'none'
-
-        # DEBUG
-        with open('/tmp/sckoo_test_output', 'wb') as outfile:
-            json.dump(create_request, outfile)
 
         with closing(self._create_connection()) as create_conn:
             create_conn.request('POST', '/containers/create',

--- a/worker/docker_client.py
+++ b/worker/docker_client.py
@@ -86,10 +86,6 @@ No ldconfig found. Not loading libcuda libraries.
             if filename.startswith('nvidia'):
                 self._nvidia_device_files.append(os.path.join('/dev', filename))
 
-        # DEBUG
-        self._use_nvidia_docker = False
-        return
-
         # Check if nvidia-docker-plugin is available
         try:
             self._test_nvidia_docker()

--- a/worker/docker_client.py
+++ b/worker/docker_client.py
@@ -280,6 +280,11 @@ nvidia-docker-plugin not available, defaulting to basic GPU support.
             self._add_nvidia_docker_arguments(create_request)
         if not request_network:
             create_request['HostConfig']['NetworkMode'] = 'none'
+
+        # DEBUG
+        with open('/tmp/sckoo_test_output', 'wb') as outfile:
+            json.dump(create_request, outfile)
+
         with closing(self._create_connection()) as create_conn:
             create_conn.request('POST', '/containers/create',
                                 json.dumps(create_request),

--- a/worker/docker_client.py
+++ b/worker/docker_client.py
@@ -71,7 +71,7 @@ to run the worker from the Docker shell.
         try:
             self._libcuda = None
             for lib in subprocess.check_output(['/sbin/ldconfig', '-p']).split('\n'):
-                if 'x86-64' not in lib and lib.endswith('libcuda.so'):
+                if 'x86-64' in lib and lib.endswith('libcuda.so'):
                     self._libcuda = os.path.realpath(lib.split(' => ')[-1])
         except OSError:
             # ldconfig isn't available on Mac OS X. Let's just say that we

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -13,7 +13,7 @@ from dependency_manager import DependencyManager
 from file_util import remove_path, un_gzip_stream, un_tar_directory
 from run import Run
 
-VERSION = 6
+VERSION = 7
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Use nvidia-docker-plugin if available to set up the container creation request for GPU support. Otherwise, fall back to original hacks for GPU support.

Motivation for using nvidia-docker as opposed to other custom fixes:
https://github.com/NVIDIA/nvidia-docker/wiki/Why%20NVIDIA%20Docker

For more information about what nvidia-docker provides:
https://github.com/NVIDIA/nvidia-docker/wiki/Internals

Fixes #591 