### PR TITLE
Fix for displaying [Object object] for empty files

### DIFF
--- a/codalab/lib/worksheet_util.py
+++ b/codalab/lib/worksheet_util.py
@@ -443,7 +443,9 @@ def interpret_file_genpath(client, target_cache, bundle_uuid, genpath, post):
                 contents = client.head_target(target, MAX_LINES)
                 contents = map(base64.b64decode, contents)
 
-            if all('\t' in x for x in contents):
+            if isinstance(contents, list) and len(contents) == 0:
+              info = ''
+            elif all('\t' in x for x in contents):
                 # Tab-separated file (key\tvalue\nkey\tvalue...)
                 info = {}
                 for x in contents:
@@ -460,8 +462,6 @@ def interpret_file_genpath(client, target_cache, bundle_uuid, genpath, post):
                     except:
                         # Plain text file
                         info = ''.join(contents)
-            if not info: # info is an empty dictionary
-                info = None
         else:
             info = None
         target_cache[target] = info

--- a/codalab/lib/worksheet_util.py
+++ b/codalab/lib/worksheet_util.py
@@ -460,6 +460,8 @@ def interpret_file_genpath(client, target_cache, bundle_uuid, genpath, post):
                     except:
                         # Plain text file
                         info = ''.join(contents)
+            if not info: # info is an empty dictionary
+                info = None
         else:
             info = None
         target_cache[target] = info

--- a/codalab/lib/worksheet_util.py
+++ b/codalab/lib/worksheet_util.py
@@ -443,7 +443,7 @@ def interpret_file_genpath(client, target_cache, bundle_uuid, genpath, post):
                 contents = client.head_target(target, MAX_LINES)
                 contents = map(base64.b64decode, contents)
 
-            if isinstance(contents, list) and len(contents) == 0:
+            if not contents: # contents is empty list
               info = ''
             elif all('\t' in x for x in contents):
                 # Tab-separated file (key\tvalue\nkey\tvalue...)

--- a/codalab/lib/worksheet_util.py
+++ b/codalab/lib/worksheet_util.py
@@ -443,7 +443,7 @@ def interpret_file_genpath(client, target_cache, bundle_uuid, genpath, post):
                 contents = client.head_target(target, MAX_LINES)
                 contents = map(base64.b64decode, contents)
 
-            if not contents: # contents is empty list
+            if len(contents) == 0:
               info = ''
             elif all('\t' in x for x in contents):
                 # Tab-separated file (key\tvalue\nkey\tvalue...)
@@ -633,11 +633,11 @@ def interpret_items(schemas, raw_items):
     Each interpreted item has a focusIndex, and possibly consists of a list of
     table rows (indexed by subFocusIndex).  Here is an example:
       --- Raw ---                   --- Interpreted ---
-      rawIndex                                         (focusIndex, subFocusIndex)  
+      rawIndex                                         (focusIndex, subFocusIndex)
       0        % display table
       1        [bundle]             [table - row 0     (0, 0)
       2        [bundle]                    - row 1]    (0, 1)
-      3        
+      3
       4        hello                [markup            (1, 0)
       5        world                       ]
       6        [worksheet]          [worksheet]        (2, 0)
@@ -1038,4 +1038,3 @@ def interpret_wsearch(client, data):
 def check_worksheet_not_frozen(worksheet):
     if worksheet.frozen:
         raise PermissionError('Cannot mutate frozen worksheet %s(%s).' % (worksheet.uuid, worksheet.name))
-


### PR DESCRIPTION
Issue description: https://github.com/codalab/codalab-worksheets/issues/222

The problem I found was that in the interpret_file_gen() function, an info dictionary is built with information that is later used to form the output string, but when the info dictionary is an empty dictionary it is not properly processed. So, I simply set info to None if it is an empty dictionary.

Some things I would like comments on:
- [ ] Should I set info to None at the position I have it now or instead after line 470? I see arguments as to why that would be the more appropriate place for this code.
- [ ] Should I unit test this change? The test coverage on this file doesn't seem to cover this function yet: https://github.com/codalab/codalab-cli/blob/f33ff172db28f592aac97cf75c0911040ac3bf22/tests/lib/worksheet_util_test.py.

@percyliang @kashizui 