### PR TITLE
Fix exitcode 127 error

### DIFF
--- a/alembic/versions/2017011608_add_email_notifications_37e06c8c5e5d.py
+++ b/alembic/versions/2017011608_add_email_notifications_37e06c8c5e5d.py
@@ -16,6 +16,8 @@ import sqlalchemy as sa
 
 def upgrade():
     op.add_column('user', sa.Column('notifications', sa.Integer(), nullable=False))
+    conn = op.get_bind()
+    conn.execute("UPDATE user SET notifications = 2")
 
 
 def downgrade():

--- a/alembic/versions/2017011608_add_email_notifications_37e06c8c5e5d.py
+++ b/alembic/versions/2017011608_add_email_notifications_37e06c8c5e5d.py
@@ -1,0 +1,22 @@
+"""add email notifications
+
+Revision ID: 37e06c8c5e5d
+Revises: 540856fade99
+Create Date: 2017-01-16 08:08:20.494140
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '37e06c8c5e5d'
+down_revision = '540856fade99'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('user', sa.Column('notifications', sa.Integer(), nullable=False))
+
+
+def downgrade():
+    op.drop_column('user', 'notifications')

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -2589,7 +2589,7 @@ class BundleCLI(object):
         group = client.fetch('groups', args.group_spec)
 
         members = []
-        # group['owner'] may be None (i.e. for the public group)
+        # group['owner'] may be a falsey null-relationship (i.e. for the public group)
         if group['owner']:
             members.append({
                 'role': 'owner',

--- a/codalab/lib/emailer.py
+++ b/codalab/lib/emailer.py
@@ -34,7 +34,7 @@ class SMTPEmailer(Emailer):
         self.port = port
         self.use_tls = use_tls
 
-    def send_email(self, subject, body, recipient, sender=None):
+    def send_email(self, subject, body, recipient, sender=None, mime_type='plain'):
         """
         Send email
 
@@ -57,7 +57,7 @@ class SMTPEmailer(Emailer):
 
             mail_server.login(self.user, self.password)
 
-            message = MIMEText(body)
+            message = MIMEText(body, mime_type)
             message["From"] = sender or self.default_sender
             message["To"] = recipient
             message["Subject"] = subject

--- a/codalab/lib/spec_util.py
+++ b/codalab/lib/spec_util.py
@@ -4,8 +4,6 @@ spec_util contains some simple methods to generate and check names and uuids.
 import re
 import uuid
 
-from marshmallow import ValidationError
-
 from codalab.common import (
   precondition,
   UsageError,
@@ -59,24 +57,6 @@ def check_uuid(uuid_str):
 def check_name(name):
     if not NAME_REGEX.match(name):
         raise UsageError('Names must match %s, was %s' % (NAME_REGEX.pattern, name))
-
-
-def validate_uuid(uuid_str):
-    """
-    Raise a ValidationError if the uuid does not conform to its regex.
-    """
-    if not UUID_REGEX.match:
-        raise ValidationError('uuids must match %s, was %s' % (UUID_REGEX.pattern, uuid_str))
-
-
-def validate_name(name):
-    if not NAME_REGEX.match(name):
-        raise ValidationError('Names must match %s, was %s' % (NAME_REGEX.pattern, name))
-
-
-def validate_child_path(path):
-    if not CHILD_PATH_REGEX.match(path):
-        raise ValidationError('Child path must match %s, was %s' % (NAME_REGEX.pattern, path))
 
 
 def check_id(owner_id):

--- a/codalab/lib/worksheet_util.py
+++ b/codalab/lib/worksheet_util.py
@@ -443,7 +443,9 @@ def interpret_file_genpath(client, target_cache, bundle_uuid, genpath, post):
                 contents = client.head_target(target, MAX_LINES)
                 contents = map(base64.b64decode, contents)
 
-            if all('\t' in x for x in contents):
+            if len(contents) == 0:
+              info = ''
+            elif all('\t' in x for x in contents):
                 # Tab-separated file (key\tvalue\nkey\tvalue...)
                 info = {}
                 for x in contents:
@@ -631,11 +633,11 @@ def interpret_items(schemas, raw_items):
     Each interpreted item has a focusIndex, and possibly consists of a list of
     table rows (indexed by subFocusIndex).  Here is an example:
       --- Raw ---                   --- Interpreted ---
-      rawIndex                                         (focusIndex, subFocusIndex)  
+      rawIndex                                         (focusIndex, subFocusIndex)
       0        % display table
       1        [bundle]             [table - row 0     (0, 0)
       2        [bundle]                    - row 1]    (0, 1)
-      3        
+      3
       4        hello                [markup            (1, 0)
       5        world                       ]
       6        [worksheet]          [worksheet]        (2, 0)
@@ -1036,4 +1038,3 @@ def interpret_wsearch(client, data):
 def check_worksheet_not_frozen(worksheet):
     if worksheet.frozen:
         raise PermissionError('Cannot mutate frozen worksheet %s(%s).' % (worksheet.uuid, worksheet.name))
-

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -44,7 +44,7 @@ from codalab.model.tables import (
     group as cl_group,
     group_bundle_permission as cl_group_bundle_permission,
     group_object_permission as cl_group_worksheet_permission,
-    NOTIFICATIONS_IMPORTANT,
+    NOTIFICATIONS_GENERAL,
     GROUP_OBJECT_PERMISSION_ALL,
     GROUP_OBJECT_PERMISSION_READ,
     GROUP_OBJECT_PERMISSION_NONE,
@@ -1700,7 +1700,7 @@ class BundleModel(object):
         return row is not None and row.is_active
 
     def add_user(self, username, email, first_name, last_name, password,
-                 affiliation, notifications=NOTIFICATIONS_IMPORTANT,
+                 affiliation, notifications=NOTIFICATIONS_GENERAL,
                  user_id=None, is_verified=False):
         """
         Create a brand new unverified user.

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -44,6 +44,7 @@ from codalab.model.tables import (
     group as cl_group,
     group_bundle_permission as cl_group_bundle_permission,
     group_object_permission as cl_group_worksheet_permission,
+    NOTIFICATIONS_IMPORTANT,
     GROUP_OBJECT_PERMISSION_ALL,
     GROUP_OBJECT_PERMISSION_READ,
     GROUP_OBJECT_PERMISSION_NONE,
@@ -1699,7 +1700,8 @@ class BundleModel(object):
         return row is not None and row.is_active
 
     def add_user(self, username, email, first_name, last_name, password,
-                 affiliation, user_id=None, is_verified=False):
+                 affiliation, notifications=NOTIFICATIONS_IMPORTANT,
+                 user_id=None, is_verified=False):
         """
         Create a brand new unverified user.
         :param username:
@@ -1718,6 +1720,7 @@ class BundleModel(object):
                 "user_id": user_id,
                 "user_name": username,
                 "email": email,
+                "notifications": notifications,
                 "last_login": None,
                 "is_active": True,
                 "first_name": first_name,

--- a/codalab/model/tables.py
+++ b/codalab/model/tables.py
@@ -203,6 +203,11 @@ event = Table(
   sqlite_autoincrement=True,
 )
 
+# A notifications value is one of the following:
+NOTIFICATIONS_NONE      = 0x00  # Receive no notifications
+NOTIFICATIONS_IMPORTANT = 0x01  # Receive only important notifications
+NOTIFICATIONS_GENERAL   = 0x02  # Receive general notifications (new features)
+
 # Store information about users.
 user = Table(
   'user',
@@ -213,7 +218,7 @@ user = Table(
   Column('user_id', String(63), nullable=False),
   Column('user_name', String(63), nullable=False, unique=True),
   Column('email', String(254), nullable=False, unique=True),  # Length of 254 to be compliant with RFC3696/5321
-  Column('notifications', Integer, nullable=False, default=0),  # Encodes what email user wants to receive
+  Column('notifications', Integer, nullable=False, default=NOTIFICATIONS_GENERAL),  # Which emails user wants to receive
   Column('last_login', DateTime),  # Null if user has never logged in
   Column('is_active', Boolean, nullable=False, default=True),  # Set to False instead of deleting users to maintain foreign key integrity
   Column('first_name', String(30, convert_unicode=True)),
@@ -238,11 +243,6 @@ user = Table(
   UniqueConstraint('user_id', name='uix_1'),
   sqlite_autoincrement=True,
 )
-
-# A notifications value is one of the following:
-NOTIFICATIONS_NONE      = 0x00  # Receive no notifications
-NOTIFICATIONS_IMPORTANT = 0x01  # Receive only important notifications
-NOTIFICATIONS_GENERAL   = 0x02  # Receive general notifications (new features)
 
 # Stores (email) verification keys
 user_verification = Table(

--- a/codalab/model/tables.py
+++ b/codalab/model/tables.py
@@ -213,6 +213,7 @@ user = Table(
   Column('user_id', String(63), nullable=False),
   Column('user_name', String(63), nullable=False, unique=True),
   Column('email', String(254), nullable=False, unique=True),  # Length of 254 to be compliant with RFC3696/5321
+  Column('notifications', Integer, nullable=False, default=0),  # Encodes what email user wants to receive
   Column('last_login', DateTime),  # Null if user has never logged in
   Column('is_active', Boolean, nullable=False, default=True),  # Set to False instead of deleting users to maintain foreign key integrity
   Column('first_name', String(30, convert_unicode=True)),
@@ -237,6 +238,11 @@ user = Table(
   UniqueConstraint('user_id', name='uix_1'),
   sqlite_autoincrement=True,
 )
+
+# A notifications value is one of the following:
+NOTIFICATIONS_NONE      = 0x00  # Receive no notifications
+NOTIFICATIONS_IMPORTANT = 0x01  # Receive only important notifications
+NOTIFICATIONS_GENERAL   = 0x02  # Receive general notifications (new features)
 
 # Stores (email) verification keys
 user_verification = Table(
@@ -314,8 +320,8 @@ chat = Table(
   Column('sender_user_id', String(63), nullable=True),  # Who sent it?
   Column('recipient_user_id', String(63), nullable=True),  # Who received it?
   Column('message', Text, nullable=False),  # What's the content of the chat?
-  Column('worksheet_uuid', String(63), nullable=True), # What is the id of the worksheet that the sender is on? 
-  Column('bundle_uuid', String(63), nullable=True), # What is the id of the bundle that the sender is on? 
+  Column('worksheet_uuid', String(63), nullable=True), # What is the id of the worksheet that the sender is on?
+  Column('bundle_uuid', String(63), nullable=True), # What is the id of the bundle that the sender is on?
   sqlite_autoincrement=True,
 )
 

--- a/codalab/objects/permission.py
+++ b/codalab/objects/permission.py
@@ -1,8 +1,6 @@
 '''
 Defines ORM classes for groups and permissions.
 '''
-from marshmallow import fields, ValidationError
-
 from codalab.model.orm_object import ORMObject
 from codalab.common import (
     NotFoundError,
@@ -23,47 +21,6 @@ from codalab.model.tables import (
 )
 from codalab.model.util import LikeQuery
 
-
-class PermissionSpec(fields.Field):
-    def _serialize(self, value, attr, obj):
-        try:
-            return permission_str(value)
-        except UsageError as e:
-            raise ValidationError(e.message)
-
-    def _deserialize(self, value, attr, data):
-        try:
-            return parse_permission(value)
-        except UsageError as e:
-            raise ValidationError(e.message)
-
-
-# TODO(sckoo): delete when REST API is complete
-class Group(ORMObject):
-    '''
-    Defines a group object which is used to assign permissions to a set of users.
-    '''
-    COLUMNS = ('uuid', 'name', 'owner_id', 'user_defined')
-
-    def validate(self):
-        '''
-        Check a number of basic conditions that would indicate serious errors if
-        they do not hold. Right now, validation only checks this worksheet's uuid
-        and its name.
-        '''
-        spec_util.check_uuid(self.uuid)
-        spec_util.check_name(self.name)
-        precondition(isinstance(self.owner_id, basestring), 'Invalid value: owner_id.')
-        precondition(isinstance(self.user_defined, bool), 'Invalid value: user_defined.')
-
-    def __repr__(self):
-        return 'Group(uuid=%r, name=%r)' % (self.uuid, self.name)
-
-    def update_in_memory(self, row, strict=False):
-        if strict:
-            if 'uuid' not in row:
-                row['uuid'] = spec_util.generate_uuid()
-        super(Group, self).update_in_memory(row)
 
 ############################################################
 

--- a/codalab/objects/user.py
+++ b/codalab/objects/user.py
@@ -12,10 +12,11 @@ from codalab.lib.crypt_util import (
     constant_time_compare,
 )
 from codalab.model.orm_object import ORMObject
+from codalab.model.tables import NOTIFICATIONS_NONE
 
 
 class User(ORMObject):
-    COLUMNS = ('user_id', 'user_name', 'email', 'last_login', 'is_active', 'first_name', 'last_name', 'date_joined',
+    COLUMNS = ('user_id', 'user_name', 'email', 'notifications', 'last_login', 'is_active', 'first_name', 'last_name', 'date_joined',
                'is_verified', 'is_superuser', 'password', 'time_quota', 'time_used', 'disk_quota', 'disk_used',
                'affiliation', 'url')
 
@@ -107,6 +108,7 @@ PUBLIC_USER = User({
     "user_id": None,  # sentinel for BundleModel methods indicating public user
     "user_name": 'public',
     "email": None,
+    "notifications": NOTIFICATIONS_NONE,
     "last_login": None,
     "is_active": True,
     "first_name": None,

--- a/codalab/rest/account.py
+++ b/codalab/rest/account.py
@@ -115,10 +115,9 @@ def do_signup():
         affiliation = None
 
     # Create unverified user
-    SEND_SOME_NOTIFICATIONS = 2
     _, verification_key = local.model.add_user(
         username, email, first_name, last_name, 
-        password, affiliation, SEND_SOME_NOTIFICATIONS
+        password, affiliation,
     )
 
     # Send key

--- a/codalab/rest/schemas.py
+++ b/codalab/rest/schemas.py
@@ -201,6 +201,7 @@ class UserSchema(Schema):
 
 class AuthenticatedUserSchema(UserSchema):
     email = fields.String()
+    notifications = fields.Integer()
     time_quota = fields.Integer()
     time_used = fields.Integer()
     disk_quota = fields.Integer()

--- a/codalab/rest/schemas.py
+++ b/codalab/rest/schemas.py
@@ -12,12 +12,44 @@ from marshmallow import (
 )
 from marshmallow_jsonapi import Schema, fields
 
+from codalab.common import UsageError
 from codalab.bundles import BUNDLE_SUBCLASSES
 from codalab.lib.bundle_action import BundleAction
-from codalab.lib.spec_util import validate_child_path, validate_uuid, \
-    validate_name
+from codalab.lib.spec_util import CHILD_PATH_REGEX, NAME_REGEX, UUID_REGEX
 from codalab.lib.worksheet_util import WORKSHEET_ITEM_TYPES
-from codalab.objects.permission import PermissionSpec
+from codalab.objects.permission import parse_permission, permission_str
+
+
+class PermissionSpec(fields.Field):
+    def _serialize(self, value, attr, obj):
+        try:
+            return permission_str(value)
+        except UsageError as e:
+            raise ValidationError(e.message)
+
+    def _deserialize(self, value, attr, data):
+        try:
+            return parse_permission(value)
+        except UsageError as e:
+            raise ValidationError(e.message)
+
+
+def validate_uuid(uuid_str):
+    """
+    Raise a ValidationError if the uuid does not conform to its regex.
+    """
+    if not UUID_REGEX.match:
+        raise ValidationError('uuids must match %s, was %s' % (UUID_REGEX.pattern, uuid_str))
+
+
+def validate_name(name):
+    if not NAME_REGEX.match(name):
+        raise ValidationError('Names must match %s, was %s' % (NAME_REGEX.pattern, name))
+
+
+def validate_child_path(path):
+    if not CHILD_PATH_REGEX.match(path):
+        raise ValidationError('Child path must match %s, was %s' % (NAME_REGEX.pattern, path))
 
 
 class WorksheetItemSchema(Schema):

--- a/codalab/server/rest_server.py
+++ b/codalab/server/rest_server.py
@@ -258,7 +258,11 @@ def run_rest_server(manager, debug, num_processes, num_threads):
                            "please upgrade it by running `git pull` from where "
                            "you installed it.")
 
+    # Look for templates in codalab-cli/views
     bottle.TEMPLATE_PATH = [os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), 'views')]
+
+    # Increase the request body size limit to 8 MiB
+    bottle.BaseRequest.MEMFILE_MAX = 8 * 1024 * 1024
 
     # We use gunicorn to create a server with multiple processes, since in
     # Python a single process uses at most 1 CPU due to the Global Interpreter

--- a/codalab/worker/bundle_manager.py
+++ b/codalab/worker/bundle_manager.py
@@ -8,7 +8,6 @@ import threading
 import time
 import traceback
 
-from codalab.bundles.derived_bundle import DerivedBundle
 from codalab.common import State
 from codalab.lib import bundle_util, formatting, path_util
 from worker.file_util import remove_path

--- a/docker/python/Dockerfile
+++ b/docker/python/Dockerfile
@@ -35,13 +35,6 @@ RUN pip install pyyaml
 RUN pip install pandas
 RUN pip install sympy
 RUN pip install scikit-tensor
-RUN pip install cvxopt
 RUN pip install jupyter
 
-# Dev version of Theano to make keras work
-RUN apt-get install -y git
-RUN pip install --upgrade --no-deps git+git://github.com/Theano/Theano.git
-#RUN python -c "import theano; theano.test()"  # Takes too long
-RUN python `python -c "import os, theano; print os.path.dirname(theano.__file__)"`/misc/check_blas.py
-
-RUN pip install keras
+RUN pip install nltk

--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -1,3 +1,7 @@
+alembic==0.8.2
+bottle==0.12.9
 futures==3.0.5
 gunicorn==19.4.5
+marshmallow-jsonapi==0.6.0
+oauthlib==1.0.3
 MySQL-python==1.2.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,6 @@
 argcomplete==1.1.0
-bottle==0.12.9
 PyYAML==3.11
-SQLAlchemy==1.0.8
-alembic==0.8.2
-marshmallow-jsonapi==0.6.0
-oauthlib==1.0.3
 psutil==3.3.0
 six==1.10.0
+SQLAlchemy==1.0.8
 watchdog==0.8.3

--- a/scripts/send-email-notifications.py
+++ b/scripts/send-email-notifications.py
@@ -1,0 +1,118 @@
+"""
+Sends email notifications to users with notifications set to a certain
+threshold.  Keeps track of partial progress in a file.
+
+    venv/bin/python scripts/send_email.py \
+        --subject "Hello World" \
+        --body-file body.html \
+        --sent-file sent.jsonl \
+        --threshold 1 \
+        --doit
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+
+sys.path.append('.')
+from sqlalchemy import select
+from codalab.lib.codalab_manager import CodaLabManager
+from codalab.model.tables import user as cl_user
+
+HEADER = ['user_name', 'email', 'first_name', 'last_name', 'notifications']
+
+def get_to_send_list(model, threshold):
+    """Returns the list of (name, email) tuples with a given threshold.
+    These are the ones we need to send to."""
+    with model.engine.begin() as conn:
+        rows = conn.execute(
+            select([
+                cl_user.c.user_name,
+                cl_user.c.email,
+                cl_user.c.first_name,
+                cl_user.c.last_name,
+                cl_user.c.notifications,
+            ])
+            .where(cl_user.c.notifications >= threshold)).fetchall()
+        return [dict(zip(HEADER, row)) for row in rows if row.email]
+
+
+def get_sent_list(sent_file):
+    """Return the list of (name, email) tuples that we've already sent to."""
+    results = []
+    if os.path.exists(sent_file):
+        for line in open(sent_file):
+            info = json.loads(line)
+            results.append(info)
+    return results
+
+def main(args):
+    manager = CodaLabManager()
+    model = manager.model()
+
+    # Get the the message
+    subject = args.subject
+    with open(args.body_file) as f:
+        body_template = f.read()
+    mime_type = 'html' if args.body_file.endswith('.html') else 'plain'
+
+    # Figure out who we want to send
+    to_send_list = get_to_send_list(model, args.threshold)
+    sent_list = get_sent_list(args.sent_file)
+    sent_emails = set(info['email'] for info in sent_list)
+    pending_to_send_list = [info for info in to_send_list if info['email'] not in sent_emails]
+    print 'Already sent %d emails, %d to go' % (len(sent_list), len(pending_to_send_list))
+
+    for i, info in enumerate(pending_to_send_list):
+        if args.only_email and args.only_email != info['email']:
+            continue
+
+        # Derived fields
+        info['greeting_name'] = info['first_name'] or info['last_name'] or info['user_name']
+        info['full_name'] = ' '.join([x for x in [info['first_name'], info['last_name']] if x])
+        info['email_description'] = '%s <%s>' % (info['full_name'], info['email']) if info['full_name'] else info['email']
+        info['sent_time'] = time.time()
+
+        print 'Sending %s/%s (%s>=%s, doit=%s): [%s] %s' % \
+            (i, len(pending_to_send_list), info['notifications'], args.threshold, args.doit, info['user_name'], info['email_description'])
+
+        # Apply template to get body of message
+        body = body_template
+        for field, value in info.items():
+            body = body.replace('{{' + field + '}}', str(value or ''))
+
+        if args.verbose >= 1:
+            print 'To      : %s' % info['email_description']
+            print 'Subject : %s' % subject
+            print body
+            print '-------'
+
+        if not args.doit:
+            continue
+
+        # Send the actual email
+        manager.emailer.send_email(
+            recipient=info['email_description'],
+            subject=subject,
+            body=body,
+            mime_type=mime_type,
+        )
+
+        # Record that we sent
+        with open(args.sent_file, 'a') as f:
+            print >>f, json.dumps(info)
+            f.flush()
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--threshold', help='Send emails to people with this threshold', type=int, required=True)
+    parser.add_argument('--doit', help='Actually sends emails', action='store_true')
+    parser.add_argument('--subject', help='Subject of email', required=True)
+    parser.add_argument('--body-file', help='File containing body of email to be sent', required=True)
+    parser.add_argument('--sent-file', help='File that keeps track of who we\'ve already sent email to ', required=True)
+    parser.add_argument('--only-email', help='Only send to this email')
+    parser.add_argument('--verbose', help='Show more information', type=int, default=0)
+    args = parser.parse_args()
+    main(args)

--- a/scripts/send-email-notifications.py
+++ b/scripts/send-email-notifications.py
@@ -81,7 +81,7 @@ def main(args):
         # Apply template to get body of message
         body = body_template
         for field, value in info.items():
-            body = body.replace('{{' + field + '}}', str(value or ''))
+            body = body.replace('{{' + field + '}}', unicode(value or ''))
 
         if args.verbose >= 1:
             print 'To      : %s' % info['email_description']

--- a/test-cli.py
+++ b/test-cli.py
@@ -963,6 +963,13 @@ def test(ctx):
         rest_server_proc.kill()
         shutil.rmtree(remote_home)
 
+
+@TestModule.register('groups')
+def test(ctx):
+    # Should not crash
+    run_command([cl, 'ginfo', 'public'])
+
+
 if __name__ == '__main__':
     if len(sys.argv) == 1:
         print('Usage: python %s <module> ... <module>' % sys.argv[0])

--- a/tests/client/json_api_client_test.py
+++ b/tests/client/json_api_client_test.py
@@ -4,8 +4,9 @@ Unit tests for the static methods of the JsonApiClient
 import unittest
 
 from codalab.client.json_api_client import (
+    EmptyJsonApiRelationship,
     JsonApiClient,
-    JsonApiRelationship
+    JsonApiRelationship,
 )
 from codalab.common import PreconditionViolation
 
@@ -48,6 +49,7 @@ class JsonApiClientTest(unittest.TestCase):
     def test_pack_document(self):
         doc = self.client._pack_document({
             'owner': JsonApiRelationship('users', '345'),
+            'friend': EmptyJsonApiRelationship(),
             'id': '123',
             'name': 'hello'
         }, 'bundles')
@@ -65,6 +67,9 @@ class JsonApiClientTest(unittest.TestCase):
                             'id': '345',
                             'type': 'users'
                         }
+                    },
+                    'friend': {
+                        'data': None
                     }
                 },
             }

--- a/tests/objects/user_test.py
+++ b/tests/objects/user_test.py
@@ -2,11 +2,13 @@ import unittest
 import datetime
 
 from codalab.objects.user import User
+from codalab.model.tables import NOTIFICATIONS_IMPORTANT
 
 user = User({
     "user_id": 1,
     "user_name": "test",
     "email": "test@test.com",
+    "notifications": NOTIFICATIONS_IMPORTANT,
     "last_login": datetime.datetime.now(),
     "is_active": True,
     "first_name": None,

--- a/worker/docker_client.py
+++ b/worker/docker_client.py
@@ -272,7 +272,7 @@ No ldconfig found. Not loading libcuda libraries.
             + '\'(%s) >stdout 2>stderr\'' % command.replace('\'', '\'"\'"\''),
             # Ensure that any created files are owned by the user/group that
             # owns the bundle directory, not root.
-            'chown -R $U_ID:$G_ID %s' % docker_bundle_path,
+            #'chown -R $U_ID:$G_ID %s' % docker_bundle_path,
         ]
 
         # Set up the volumes.

--- a/worker/docker_client.py
+++ b/worker/docker_client.py
@@ -43,27 +43,21 @@ class DockerClient(object):
 
     GPU Support
     -----------
-    DockerClient tries its best to support runs that require GPUs.
+    DockerClient relies on nvidia-docker-plugin for runs that require GPUs.
     During initialization, DockerClient checks to see if nvidia-docker-plugin
     is available on the host machine by contacting the REST API at the default
     address `localhost:3476`. If the plugin is available, then DockerClient will
     query the REST API for information about the volumes and devices that it
     should specify in the Docker container creation request.
 
-    If the plugin is not available, we do a bit of manual work to attempt to
-    support GPU jobs. In particular, DockerClient will query `ldconfig` to
-    see if libcuda is available on the host machine, then if it is available,
-    manually mount `libcuda.so` and NVIDIA character devices in the containers.
-    Many GPU jobs will require more than just libcuda, so it is recommended that
-    you install nvidia-docker on the host machines of workers that should
-    support GPU jobs.
+    If you want your worker to support GPU jobs, make sure to install
+    nvidia-docker on the host machine. You can find the project and installation
+    instructions on GitHub:
+    https://github.com/NVIDIA/nvidia-docker
     """
     # Where to look for nvidia-docker-plugin
     # https://github.com/NVIDIA/nvidia-docker/wiki/nvidia-docker-plugin
     NV_HOST = 'localhost:3476'
-
-    # Where to mount libcuda inside the container
-    LIBCUDA_DIR = '/usr/lib/x86_64-linux-gnu/'
 
     def __init__(self):
         self._docker_host = os.environ.get('DOCKER_HOST') or None
@@ -95,37 +89,13 @@ to run the worker from the Docker shell.
         # Check if nvidia-docker-plugin is available
         try:
             self._test_nvidia_docker()
-        except DockerException as e:
+        except DockerException:
             print >> sys.stderr, """
-nvidia-docker-plugin not available, defaulting to basic GPU support.
+nvidia-docker-plugin not available, no GPU support on this worker.
 """
             self._use_nvidia_docker = False
-            self._init_libcuda()
         else:
             self._use_nvidia_docker = True
-            self._nvidia_device_files = []
-            self._libcuda = None
-
-    def _init_libcuda(self):
-        """Initialize to provide limited GPU support."""
-        # Find the libcuda library.
-        try:
-            self._libcuda = None
-            for lib in subprocess.check_output(['/sbin/ldconfig', '-p']).split('\n'):
-                if 'x86-64' in lib and lib.endswith('libcuda.so'):
-                    self._libcuda = os.path.realpath(lib.split(' => ')[-1])
-        except OSError:
-            # ldconfig isn't available on Mac OS X. Let's just say that we
-            # don't support libcuda on Mac.
-            print >> sys.stderr, """
-No ldconfig found. Not loading libcuda libraries.
-"""
-
-        # Find all the NVIDIA device files.
-        self._nvidia_device_files = []
-        for filename in os.listdir('/dev'):
-            if filename.startswith('nvidia'):
-                self._nvidia_device_files.append(os.path.join('/dev', filename))
 
     def _create_nvidia_docker_connection(self):
         return httplib.HTTPConnection(self.NV_HOST)
@@ -242,21 +212,7 @@ No ldconfig found. Not loading libcuda libraries.
                         request_network, dependencies):
         # Set up the command.
         docker_bundle_path = '/' + uuid
-        libcuda_commands = []
-        if self._libcuda is not None:
-            # Set up the libcuda.so symlinks.
-            libcuda_commands = [
-                'rm -f %s %s' % (os.path.join(self.LIBCUDA_DIR, 'libcuda.so.1'),
-                                 os.path.join(self.LIBCUDA_DIR, 'libcuda.so')),
-                'ln -s %s %s' % (os.path.basename(self._libcuda),
-                                 os.path.join(self.LIBCUDA_DIR, 'libcuda.so.1')),
-                'ln -s %s %s' % ('libcuda.so.1',
-                                 os.path.join(self.LIBCUDA_DIR, 'libcuda.so')),
-            ]
-        docker_commands = libcuda_commands + [
-            'ldconfig',
-            'U_ID=$(stat -c %%u %s)' % docker_bundle_path,
-            'G_ID=$(stat -c %%g %s)' % docker_bundle_path,
+        docker_commands = [
             'BASHRC=$(pwd)/.bashrc',
             # We pass several commands for bash to execute as a single
             # argument (i.e. all commands appear in quotes with no spaces
@@ -270,32 +226,18 @@ No ldconfig found. Not loading libcuda libraries.
             + '"cd %s; "' % docker_bundle_path
             + '"export HOME=%s; "' % docker_bundle_path
             + '\'(%s) >stdout 2>stderr\'' % command.replace('\'', '\'"\'"\''),
-            # Ensure that any created files are owned by the user/group that
-            # owns the bundle directory, not root.
-            #'chown -R $U_ID:$G_ID %s' % docker_bundle_path,
         ]
 
         # Set up the volumes.
-        volume_bindings = []
-        if self._libcuda is not None:
-            volume_bindings.append('%s:%s:ro' % (
-                self._libcuda,
-                os.path.join(self.LIBCUDA_DIR, os.path.basename(self._libcuda))))
-        volume_bindings.append('%s:%s' % (bundle_path, docker_bundle_path))
+        volume_bindings = ['%s:%s' % (bundle_path, docker_bundle_path)]
         for dependency_path, docker_dependency_path in dependencies:
             volume_bindings.append('%s:%s:ro' % (
                 os.path.abspath(dependency_path),
                 docker_dependency_path))
 
-        # Set up GPU devices manually.
-        devices = []
-        for device in self._nvidia_device_files:
-            devices.append({
-                'PathOnHost': device,
-                'PathInContainer': device,
-                'CgroupPermissions': 'mrw'})
-
         # Get user/group that owns the bundle directory
+        # Then we can ensure that any created files are owned by the user/group
+        # that owns the bundle directory, not root.
         bundle_stat = os.stat(bundle_path)
         uid = bundle_stat.st_uid
         gid = bundle_stat.st_gid
@@ -307,7 +249,6 @@ No ldconfig found. Not loading libcuda libraries.
             'User': '%s:%s' % (uid, gid),
             'HostConfig': {
                 'Binds': volume_bindings,
-                'Devices': devices,
                 },
         }
         if self._use_nvidia_docker:
@@ -395,7 +336,7 @@ No ldconfig found. Not loading libcuda libraries.
             if not inspect_json['State']['Running']:
                 # If the logs are nonempty, then something might have gone
                 # wrong with the commands run before the user command,
-                # such as ldconfig.
+                # such as bash or cd.
                 _, stderr = self._get_logs(container_id)
                 # Strip non-ASCII chars since failure_message is not Unicode
                 if len(stderr) > 0:

--- a/worker/docker_client.py
+++ b/worker/docker_client.py
@@ -295,10 +295,16 @@ No ldconfig found. Not loading libcuda libraries.
                 'PathInContainer': device,
                 'CgroupPermissions': 'mrw'})
 
+        # Get user/group that owns the bundle directory
+        bundle_stat = os.stat(bundle_path)
+        uid = bundle_stat.st_uid
+        gid = bundle_stat.st_gid
+
         # Create the container.
         create_request = {
             'Cmd': ['bash', '-c', '; '.join(docker_commands)],
             'Image': docker_image,
+            'User': '%s:%s' % (uid, gid),
             'HostConfig': {
                 'Binds': volume_bindings,
                 'Devices': devices,
@@ -391,7 +397,12 @@ No ldconfig found. Not loading libcuda libraries.
                 # wrong with the commands run before the user command,
                 # such as ldconfig.
                 _, stderr = self._get_logs(container_id)
-                return (True, inspect_json['State']['ExitCode'], stderr or None)
+                # Strip non-ASCII chars since failure_message is not Unicode
+                if len(stderr) > 0:
+                    failure_msg = stderr.encode('ascii', 'ignore')
+                else:
+                    failure_msg = None
+                return (True, inspect_json['State']['ExitCode'], failure_msg)
             return (False, None, None)
 
     @wrap_exception('Unable to delete Docker container')

--- a/worker/docker_client.py
+++ b/worker/docker_client.py
@@ -254,23 +254,24 @@ No ldconfig found. Not loading libcuda libraries.
             ]
         docker_commands = libcuda_commands + [
             'ldconfig',
-            'BASHRC=$(pwd)/.bashrc',
-            # Run as the user that owns the bundle directory. That way
-            # any new files are created as that user and not root.
             'U_ID=$(stat -c %%u %s)' % docker_bundle_path,
             'G_ID=$(stat -c %%g %s)' % docker_bundle_path,
-            'sudo -u \\#$U_ID -g \\#$G_ID -n bash -c ' +
-            # We pass several commands for bash to execute as the user as a
-            # single argument (i.e. all commands appear in quotes with no spaces
+            'BASHRC=$(pwd)/.bashrc',
+            # We pass several commands for bash to execute as a single
+            # argument (i.e. all commands appear in quotes with no spaces
             # outside the quotes). The first commands appear in double quotes
             # since we want environment variables to be expanded. The last
-            # appears in single quotes since we do not. The expansion there, if
-            # any, should happen when bash executes it. Note, since the user's
-            # command can have single quotes we need to escape them.
-            '"[ -e $BASHRC ] && . $BASHRC; "' +
-            '"cd %s; "' % docker_bundle_path +
-            '"export HOME=%s; "' % docker_bundle_path +
-            '\'(%s) >stdout 2>stderr\'' % command.replace('\'', '\'"\'"\''),
+            # appears in single quotes since we do not. The expansion there,
+            # if any, should happen when bash executes it. Note, since the
+            # user's command can have single quotes we need to escape them.
+            'bash -c '
+            + '"[ -e $BASHRC ] && . $BASHRC; "'
+            + '"cd %s; "' % docker_bundle_path
+            + '"export HOME=%s; "' % docker_bundle_path
+            + '\'(%s) >stdout 2>stderr\'' % command.replace('\'', '\'"\'"\''),
+            # Ensure that any created files are owned by the user/group that
+            # owns the bundle directory, not root.
+            'chown -R $U_ID:$G_ID %s' % docker_bundle_path,
         ]
 
         # Set up the volumes.

--- a/worker/docker_client.py
+++ b/worker/docker_client.py
@@ -39,7 +39,31 @@ class DockerException(Exception):
 class DockerClient(object):
     """
     Methods for talking to Docker.
+
+    GPU Support
+    -----------
+    DockerClient tries its best to support runs that require GPUs.
+    During initialization, DockerClient checks to see if nvidia-docker-plugin
+    is available on the host machine by contacting the REST API at the default
+    address `localhost:3476`. If the plugin is available, then DockerClient will
+    query the REST API for information about the volumes and devices that it
+    should specify in the Docker container creation request.
+
+    If the plugin is not available, we do a bit of manual work to attempt to
+    support GPU jobs. In particular, DockerClient will query `ldconfig` to
+    see if libcuda is available on the host machine, then if it is available,
+    manually mount `libcuda.so` and NVIDIA character devices in the containers.
+    Many GPU jobs will require more than just libcuda, so it is recommended that
+    you install nvidia-docker on the host machines of workers that should
+    support GPU jobs.
     """
+    # Where to look for nvidia-docker-plugin
+    # https://github.com/NVIDIA/nvidia-docker/wiki/nvidia-docker-plugin
+    NV_HOST = 'localhost:3476'
+
+    # Where to mount libcuda inside the container
+    LIBCUDA_DIR = '/usr/lib/x86_64-linux-gnu/'
+
     def __init__(self):
         self._docker_host = os.environ.get('DOCKER_HOST') or None
         if self._docker_host:
@@ -67,6 +91,22 @@ to run the worker from the Docker shell.
 """
             raise
 
+        # Check if nvidia-docker-plugin is available
+        try:
+            self._test_nvidia_docker()
+        except DockerException as e:
+            print >> sys.stderr, """
+nvidia-docker-plugin not available, defaulting to basic GPU support.
+"""
+            self._use_nvidia_docker = False
+            self._init_libcuda()
+        else:
+            self._use_nvidia_docker = True
+            self._nvidia_device_files = []
+            self._libcuda = None
+
+    def _init_libcuda(self):
+        """Initialize to provide limited GPU support."""
         # Find the libcuda library.
         try:
             self._libcuda = None
@@ -86,6 +126,9 @@ No ldconfig found. Not loading libcuda libraries.
             if filename.startswith('nvidia'):
                 self._nvidia_device_files.append(os.path.join('/dev', filename))
 
+    def _create_nvidia_docker_connection(self):
+        return httplib.HTTPConnection(self.NV_HOST)
+
     def _create_connection(self):
         if self._docker_host:
             if self._ssl_context:
@@ -93,6 +136,45 @@ No ldconfig found. Not loading libcuda libraries.
                                                context=self._ssl_context)
             return httplib.HTTPConnection(self._docker_host)
         return DockerUnixConnection()
+
+    def _test_nvidia_docker(self):
+        """Throw exception if nvidia-docker-plugin is not available."""
+        try:
+            with closing(self._create_nvidia_docker_connection()) as conn:
+                conn.request('GET', '/v1.0/gpu/status/json')
+                status_response = conn.getresponse()
+                if status_response.status != 200:
+                    raise DockerException(status_response.read())
+                try:
+                    json.loads(status_response.read())
+                except:
+                    raise DockerException('Invalid json response')
+        except Exception as e:
+            raise DockerException(e.message)
+
+    def _add_nvidia_docker_arguments(self, request):
+        """Add the arguments supplied by nvidia-docker-plugin REST API"""
+        with closing(self._create_nvidia_docker_connection()) as conn:
+            conn.request('GET', '/v1.0/docker/cli/json')
+            cli_response = conn.getresponse()
+            if cli_response.status != 200:
+                raise DockerException(cli_response.read())
+            cli_args = json.loads(cli_response.read())
+
+        # Build device jsons
+        devices = [{
+            "PathOnHost": device_path,
+            "PathInContainer": device_path,
+            "CgroupPermissions": "mrw",
+        } for device_path in cli_args['Devices']]
+
+        # Set configurations in request json
+        host_config = request.setdefault('HostConfig', {})
+        host_config.setdefault('Binds', []).extend(cli_args['Volumes'])
+        host_config.setdefault('Devices', []).extend(devices)
+        host_config['VolumeDriver'] = cli_args['VolumeDriver']
+
+        return request
 
     @wrap_exception('Unable to use Docker')
     def test(self):
@@ -157,20 +239,18 @@ No ldconfig found. Not loading libcuda libraries.
     @wrap_exception('Unable to start Docker container')
     def start_container(self, bundle_path, uuid, command, docker_image,
                         request_network, dependencies):
-        LIBCUDA_DIR = '/usr/lib/x86_64-linux-gnu/'
-
         # Set up the command.
         docker_bundle_path = '/' + uuid
         libcuda_commands = []
         if self._libcuda is not None:
             # Set up the libcuda.so symlinks.
             libcuda_commands = [
-                'rm -f %s %s' % (os.path.join(LIBCUDA_DIR, 'libcuda.so.1'),
-                                 os.path.join(LIBCUDA_DIR, 'libcuda.so')),
+                'rm -f %s %s' % (os.path.join(self.LIBCUDA_DIR, 'libcuda.so.1'),
+                                 os.path.join(self.LIBCUDA_DIR, 'libcuda.so')),
                 'ln -s %s %s' % (os.path.basename(self._libcuda),
-                                 os.path.join(LIBCUDA_DIR, 'libcuda.so.1')),
+                                 os.path.join(self.LIBCUDA_DIR, 'libcuda.so.1')),
                 'ln -s %s %s' % ('libcuda.so.1',
-                                 os.path.join(LIBCUDA_DIR, 'libcuda.so')),
+                                 os.path.join(self.LIBCUDA_DIR, 'libcuda.so')),
             ]
         docker_commands = libcuda_commands + [
             'ldconfig',
@@ -198,14 +278,14 @@ No ldconfig found. Not loading libcuda libraries.
         if self._libcuda is not None:
             volume_bindings.append('%s:%s:ro' % (
                 self._libcuda,
-                os.path.join(LIBCUDA_DIR, os.path.basename(self._libcuda))))
+                os.path.join(self.LIBCUDA_DIR, os.path.basename(self._libcuda))))
         volume_bindings.append('%s:%s' % (bundle_path, docker_bundle_path))
         for dependency_path, docker_dependency_path in dependencies:
             volume_bindings.append('%s:%s:ro' % (
                 os.path.abspath(dependency_path),
                 docker_dependency_path))
 
-        # Set up the devices.
+        # Set up GPU devices manually.
         devices = []
         for device in self._nvidia_device_files:
             devices.append({
@@ -222,8 +302,11 @@ No ldconfig found. Not loading libcuda libraries.
                 'Devices': devices,
                 },
         }
+        if self._use_nvidia_docker:
+            self._add_nvidia_docker_arguments(create_request)
         if not request_network:
             create_request['HostConfig']['NetworkMode'] = 'none'
+
         with closing(self._create_connection()) as create_conn:
             create_conn.request('POST', '/containers/create',
                                 json.dumps(create_request),

--- a/worker/docker_client.py
+++ b/worker/docker_client.py
@@ -5,6 +5,7 @@ import logging
 import os
 import socket
 import ssl
+import struct
 import subprocess
 import sys
 
@@ -389,8 +390,8 @@ No ldconfig found. Not loading libcuda libraries.
                 # If the logs are nonempty, then something might have gone
                 # wrong with the commands run before the user command,
                 # such as ldconfig.
-                failure_msg = self._get_logs(container_id) or None
-                return (True, inspect_json['State']['ExitCode'], failure_msg)
+                _, stderr = self._get_logs(container_id)
+                return (True, inspect_json['State']['ExitCode'], stderr or None)
             return (False, None, None)
 
     @wrap_exception('Unable to delete Docker container')
@@ -403,13 +404,30 @@ No ldconfig found. Not loading libcuda libraries.
                 raise DockerException(delete_response.read())
 
     def _get_logs(self, container_id):
-        """Read stdout and stderr of the given container."""
+        """
+        Read stdout and stderr of the given container.
+
+        The stream is encoded in a format defined here:
+        https://docs.docker.com/engine/api/v1.20/#/attach-to-a-container
+        """
         with closing(self._create_connection()) as conn:
             conn.request('GET', '/containers/%s/logs?stdout=1&stderr=1' % container_id)
             logs_response = conn.getresponse()
             if logs_response.status == 500:
                 raise DockerException(logs_response.read())
-            return logs_response.read()
+            contents = logs_response.read()
+            stderr = []
+            stdout = []
+            start = 0
+            while start < len(contents):
+                fp, size = struct.unpack('>BxxxL', contents[start:start+8])
+                payload = contents[start+8:start+8+size]
+                if fp == 1:
+                    stdout.append(payload)
+                elif fp == 2:
+                    stderr.append(payload)
+                start += 8 + size
+            return ''.join(stdout), ''.join(stderr)
 
 
 class DockerUnixConnection(httplib.HTTPConnection, object):

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -13,7 +13,7 @@ from dependency_manager import DependencyManager
 from file_util import remove_path, un_gzip_stream, un_tar_directory
 from run import Run
 
-VERSION = 6
+VERSION = 7
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Update docker container preamble commands to use chown instead of sudo to ensure proper file permissions. Most newer docker images don't have the sudo command, causing a 'command not found' error.

Also added an additional docker request to fetch container logs at the end of a run to check for any error messages that were previously missed (such as 'sudo: command not found').

Fixes codalab/codalab-worksheets#224