### PR TITLE
Run Docker container as correct user/group.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -32,4 +32,4 @@ test:
     - printf "$CODALAB_USERNAME\n$CODALAB_PASSWORD\n" | sshpass -p "" ./codalab/bin/cl work
     - ./codalab/bin/cl upload -c stuff
     - printf "$CODALAB_USERNAME\n$CODALAB_PASSWORD\n" | sshpass -p "" ./codalab/bin/cl rm ^
-    - ./venv/bin/python test-cli.py all
+    - ./venv/bin/python test-cli.py default

--- a/test-cli.py
+++ b/test-cli.py
@@ -969,6 +969,7 @@ def test(ctx):
     # Should not crash
     run_command([cl, 'ginfo', 'public'])
 
+
 @TestModule.register('docker')
 def test(ctx):
     # Environment variables should load properly in codalab images

--- a/test-cli.py
+++ b/test-cli.py
@@ -237,29 +237,41 @@ class TestModule(object):
     """
     modules = OrderedDict()
 
-    def __init__(self, name, func, description):
+    def __init__(self, name, func, description, default):
         self.name = name
         self.func = func
         self.description = description
+        self.default = default
 
     @classmethod
-    def register(cls, name):
+    def register(cls, name, default=True):
         """Returns a decorator to register new test modules.
 
         The decorator will add a given function as test modules to the registry
         under the name provided here. The function's docstring (PEP 257) will
         be used as the prose description of the test module.
+
+        :param name: name of the test module
+        :param default: True to include in the 'default' module set
         """
         def add_module(func):
-            cls.modules[name] = TestModule(name, func, func.__doc__)
+            cls.modules[name] = TestModule(name, func, func.__doc__, default)
         return add_module
+
+    @classmethod
+    def all_modules(cls):
+        return cls.modules.values()
+
+    @classmethod
+    def default_modules(cls):
+        return filter(lambda m: m.default, cls.modules.itervalues())
 
     @classmethod
     def run(cls, query):
         """Run the modules named in query.
 
-        query should be a list of strings, each of which is either 'all'
-        or the name of an existing test module.
+        query should be a list of strings, each of which is either 'all',
+        'default', or the name of an existing test module.
         """
         # Might prompt user for password
         subprocess.call([cl, 'work'])
@@ -268,7 +280,9 @@ class TestModule(object):
         modules_to_run = []
         for name in query:
             if name == 'all':
-                modules_to_run.extend(cls.modules.values())
+                modules_to_run.extend(cls.all_modules())
+            elif name == 'default':
+                modules_to_run.extend(cls.default_modules())
             elif name in cls.modules:
                 modules_to_run.append(cls.modules[name])
             else:
@@ -970,8 +984,11 @@ def test(ctx):
     run_command([cl, 'ginfo', 'public'])
 
 
-@TestModule.register('docker')
+@TestModule.register('docker', default=False)
 def test(ctx):
+    """
+    Check that certain Docker containers work with the CodaLab workers.
+    """
     # Environment variables should load properly in codalab images
     uuid = run_command([cl, 'run', '--request-docker-image=codalab/ubuntu:1.9', 'echo $SCALA_HOME'])
     wait(uuid)
@@ -985,7 +1002,7 @@ if __name__ == '__main__':
     if len(sys.argv) == 1:
         print('Usage: python %s <module> ... <module>' % sys.argv[0])
         print('This test will modify your current instance by creating temporary worksheets and bundles, but these should be deleted.')
-        print('Modules: all ' + ' '.join(TestModule.modules.keys()))
+        print('Modules: default all ' + ' '.join(TestModule.modules.keys()))
     else:
         success = TestModule.run(sys.argv[1:])
         if not success:

--- a/test-cli.py
+++ b/test-cli.py
@@ -969,6 +969,16 @@ def test(ctx):
     # Should not crash
     run_command([cl, 'ginfo', 'public'])
 
+@TestModule.register('docker')
+def test(ctx):
+    # Environment variables should load properly in codalab images
+    uuid = run_command([cl, 'run', '--request-docker-image=codalab/ubuntu:1.9', 'echo $SCALA_HOME'])
+    wait(uuid)
+    check_equals('/opt/scala/current', run_command([cl, 'cat', uuid+'/stdout']))
+    uuid = run_command([cl, 'run', '--request-docker-image=codalab/torch:1.1','echo $LUA_PATH'])
+    wait(uuid)
+    check_contains('/user/.luarocks/share/lua/5.1/?.lua', run_command([cl, 'cat', uuid+'/stdout']))
+
 
 if __name__ == '__main__':
     if len(sys.argv) == 1:

--- a/worker/docker_client.py
+++ b/worker/docker_client.py
@@ -44,20 +44,17 @@ class DockerClient(object):
 
     GPU Support
     -----------
-    DockerClient tries its best to support runs that require GPUs.
+    DockerClient relies on nvidia-docker-plugin for runs that require GPUs.
     During initialization, DockerClient checks to see if nvidia-docker-plugin
     is available on the host machine by contacting the REST API at the default
     address `localhost:3476`. If the plugin is available, then DockerClient will
     query the REST API for information about the volumes and devices that it
     should specify in the Docker container creation request.
 
-    If the plugin is not available, we do a bit of manual work to attempt to
-    support GPU jobs. In particular, DockerClient will query `ldconfig` to
-    see if libcuda is available on the host machine, then if it is available,
-    manually mount `libcuda.so` and NVIDIA character devices in the containers.
-    Many GPU jobs will require more than just libcuda, so it is recommended that
-    you install nvidia-docker on the host machines of workers that should
-    support GPU jobs.
+    If you want your worker to support GPU jobs, make sure to install
+    nvidia-docker on the host machine. You can find the project and installation
+    instructions on GitHub:
+    https://github.com/NVIDIA/nvidia-docker
 
     DockerClient will read the CUDA_VISIBLE_DEVICES environment variable and
     only mount the GPU device corresponding to the indices listed in the
@@ -66,9 +63,6 @@ class DockerClient(object):
     # Where to look for nvidia-docker-plugin
     # https://github.com/NVIDIA/nvidia-docker/wiki/nvidia-docker-plugin
     NV_HOST = 'localhost:3476'
-
-    # Where to mount libcuda inside the container
-    LIBCUDA_DIR = '/usr/lib/x86_64-linux-gnu/'
 
     def __init__(self):
         self._docker_host = os.environ.get('DOCKER_HOST') or None
@@ -106,50 +100,13 @@ to run the worker from the Docker shell.
         # Check if nvidia-docker-plugin is available
         try:
             self._test_nvidia_docker()
-        except DockerException as e:
+        except DockerException:
             print >> sys.stderr, """
-nvidia-docker-plugin not available, defaulting to basic GPU support.
+nvidia-docker-plugin not available, no GPU support on this worker.
 """
             self._use_nvidia_docker = False
-            self._init_libcuda()
         else:
             self._use_nvidia_docker = True
-            self._nvidia_device_files = []
-            self._libcuda = None
-
-    def _init_libcuda(self):
-        """Initialize to provide limited GPU support."""
-        # Find the libcuda library.
-        try:
-            self._libcuda = None
-            for lib in subprocess.check_output(['/sbin/ldconfig', '-p']).split('\n'):
-                if 'x86-64' in lib and lib.endswith('libcuda.so'):
-                    self._libcuda = os.path.realpath(lib.split(' => ')[-1])
-        except OSError:
-            # ldconfig isn't available on Mac OS X. Let's just say that we
-            # don't support libcuda on Mac.
-            print >> sys.stderr, """
-No ldconfig found. Not loading libcuda libraries.
-"""
-
-        # Find all the NVIDIA device files.
-        self._nvidia_device_files = []
-        for filename in os.listdir('/dev'):
-            m = re.match(r'nvidia(\d+)', filename)
-            if m is None:
-                continue
-            device_idx = m.group(1)
-            if self._cuda_visible_devices is None or \
-                    device_idx in self._cuda_visible_devices:
-                self._nvidia_device_files.append(os.path.join('/dev', filename))
-                if self._cuda_visible_devices is not None:
-                    self._cuda_visible_devices.remove(device_idx)
-
-        # Check that all requested devices are used
-        if self._cuda_visible_devices is not None and \
-                len(self._cuda_visible_devices) > 0:
-            raise DockerException('NVIDIA devices not found: ' +
-                                  ','.join(self._cuda_visible_devices))
 
     def _create_nvidia_docker_connection(self):
         return httplib.HTTPConnection(self.NV_HOST)
@@ -266,21 +223,7 @@ No ldconfig found. Not loading libcuda libraries.
                         request_network, dependencies):
         # Set up the command.
         docker_bundle_path = '/' + uuid
-        libcuda_commands = []
-        if self._libcuda is not None:
-            # Set up the libcuda.so symlinks.
-            libcuda_commands = [
-                'rm -f %s %s' % (os.path.join(self.LIBCUDA_DIR, 'libcuda.so.1'),
-                                 os.path.join(self.LIBCUDA_DIR, 'libcuda.so')),
-                'ln -s %s %s' % (os.path.basename(self._libcuda),
-                                 os.path.join(self.LIBCUDA_DIR, 'libcuda.so.1')),
-                'ln -s %s %s' % ('libcuda.so.1',
-                                 os.path.join(self.LIBCUDA_DIR, 'libcuda.so')),
-            ]
-        docker_commands = libcuda_commands + [
-            'ldconfig',
-            'U_ID=$(stat -c %%u %s)' % docker_bundle_path,
-            'G_ID=$(stat -c %%g %s)' % docker_bundle_path,
+        docker_commands = [
             'BASHRC=$(pwd)/.bashrc',
             # We pass several commands for bash to execute as a single
             # argument (i.e. all commands appear in quotes with no spaces
@@ -294,32 +237,18 @@ No ldconfig found. Not loading libcuda libraries.
             + '"cd %s; "' % docker_bundle_path
             + '"export HOME=%s; "' % docker_bundle_path
             + '\'(%s) >stdout 2>stderr\'' % command.replace('\'', '\'"\'"\''),
-            # Ensure that any created files are owned by the user/group that
-            # owns the bundle directory, not root.
-            #'chown -R $U_ID:$G_ID %s' % docker_bundle_path,
         ]
 
         # Set up the volumes.
-        volume_bindings = []
-        if self._libcuda is not None:
-            volume_bindings.append('%s:%s:ro' % (
-                self._libcuda,
-                os.path.join(self.LIBCUDA_DIR, os.path.basename(self._libcuda))))
-        volume_bindings.append('%s:%s' % (bundle_path, docker_bundle_path))
+        volume_bindings = ['%s:%s' % (bundle_path, docker_bundle_path)]
         for dependency_path, docker_dependency_path in dependencies:
             volume_bindings.append('%s:%s:ro' % (
                 os.path.abspath(dependency_path),
                 docker_dependency_path))
 
-        # Set up GPU devices manually.
-        devices = []
-        for device in self._nvidia_device_files:
-            devices.append({
-                'PathOnHost': device,
-                'PathInContainer': device,
-                'CgroupPermissions': 'mrw'})
-
         # Get user/group that owns the bundle directory
+        # Then we can ensure that any created files are owned by the user/group
+        # that owns the bundle directory, not root.
         bundle_stat = os.stat(bundle_path)
         uid = bundle_stat.st_uid
         gid = bundle_stat.st_gid
@@ -331,7 +260,6 @@ No ldconfig found. Not loading libcuda libraries.
             'User': '%s:%s' % (uid, gid),
             'HostConfig': {
                 'Binds': volume_bindings,
-                'Devices': devices,
                 },
         }
         if self._use_nvidia_docker:
@@ -419,7 +347,7 @@ No ldconfig found. Not loading libcuda libraries.
             if not inspect_json['State']['Running']:
                 # If the logs are nonempty, then something might have gone
                 # wrong with the commands run before the user command,
-                # such as ldconfig.
+                # such as bash or cd.
                 _, stderr = self._get_logs(container_id)
                 # Strip non-ASCII chars since failure_message is not Unicode
                 if len(stderr) > 0:

--- a/worker/docker_client.py
+++ b/worker/docker_client.py
@@ -296,7 +296,7 @@ No ldconfig found. Not loading libcuda libraries.
             + '\'(%s) >stdout 2>stderr\'' % command.replace('\'', '\'"\'"\''),
             # Ensure that any created files are owned by the user/group that
             # owns the bundle directory, not root.
-            'chown -R $U_ID:$G_ID %s' % docker_bundle_path,
+            #'chown -R $U_ID:$G_ID %s' % docker_bundle_path,
         ]
 
         # Set up the volumes.

--- a/worker/docker_client.py
+++ b/worker/docker_client.py
@@ -410,8 +410,11 @@ No ldconfig found. Not loading libcuda libraries.
             
             inspect_json = json.loads(inspect_response.read())
             if not inspect_json['State']['Running']:
-                logs = self._get_logs(container_id)
-                return (True, inspect_json['State']['ExitCode'], logs or None)
+                # If the logs are nonempty, then something might have gone
+                # wrong with the commands run before the user command,
+                # such as ldconfig.
+                failure_msg = self._get_logs(container_id) or None
+                return (True, inspect_json['State']['ExitCode'], failure_msg)
             return (False, None, None)
 
     @wrap_exception('Unable to delete Docker container')
@@ -424,6 +427,7 @@ No ldconfig found. Not loading libcuda libraries.
                 raise DockerException(delete_response.read())
 
     def _get_logs(self, container_id):
+        """Read stdout and stderr of the given container."""
         with closing(self._create_connection()) as conn:
             conn.request('GET', '/containers/%s/logs?stdout=1&stderr=1' % container_id)
             logs_response = conn.getresponse()

--- a/worker/docker_client.py
+++ b/worker/docker_client.py
@@ -278,23 +278,24 @@ No ldconfig found. Not loading libcuda libraries.
             ]
         docker_commands = libcuda_commands + [
             'ldconfig',
-            'BASHRC=$(pwd)/.bashrc',
-            # Run as the user that owns the bundle directory. That way
-            # any new files are created as that user and not root.
             'U_ID=$(stat -c %%u %s)' % docker_bundle_path,
             'G_ID=$(stat -c %%g %s)' % docker_bundle_path,
-            'sudo -u \\#$U_ID -g \\#$G_ID -n bash -c ' +
-            # We pass several commands for bash to execute as the user as a
-            # single argument (i.e. all commands appear in quotes with no spaces
+            'BASHRC=$(pwd)/.bashrc',
+            # We pass several commands for bash to execute as a single
+            # argument (i.e. all commands appear in quotes with no spaces
             # outside the quotes). The first commands appear in double quotes
             # since we want environment variables to be expanded. The last
-            # appears in single quotes since we do not. The expansion there, if
-            # any, should happen when bash executes it. Note, since the user's
-            # command can have single quotes we need to escape them.
-            '"[ -e $BASHRC ] && . $BASHRC; "' +
-            '"cd %s; "' % docker_bundle_path +
-            '"export HOME=%s; "' % docker_bundle_path +
-            '\'(%s) >stdout 2>stderr\'' % command.replace('\'', '\'"\'"\''),
+            # appears in single quotes since we do not. The expansion there,
+            # if any, should happen when bash executes it. Note, since the
+            # user's command can have single quotes we need to escape them.
+            'bash -c '
+            + '"[ -e $BASHRC ] && . $BASHRC; "'
+            + '"cd %s; "' % docker_bundle_path
+            + '"export HOME=%s; "' % docker_bundle_path
+            + '\'(%s) >stdout 2>stderr\'' % command.replace('\'', '\'"\'"\''),
+            # Ensure that any created files are owned by the user/group that
+            # owns the bundle directory, not root.
+            'chown -R $U_ID:$G_ID %s' % docker_bundle_path,
         ]
 
         # Set up the volumes.

--- a/worker/docker_client.py
+++ b/worker/docker_client.py
@@ -410,8 +410,9 @@ No ldconfig found. Not loading libcuda libraries.
             
             inspect_json = json.loads(inspect_response.read())
             if not inspect_json['State']['Running']:
-                return (True, inspect_json['State']['ExitCode'], None)
-            return (False, None, None)   
+                logs = self._get_logs(container_id)
+                return (True, inspect_json['State']['ExitCode'], logs or None)
+            return (False, None, None)
 
     @wrap_exception('Unable to delete Docker container')
     def delete_container(self, container_id):
@@ -421,6 +422,14 @@ No ldconfig found. Not loading libcuda libraries.
             delete_response = conn.getresponse()
             if delete_response.status == 500:
                 raise DockerException(delete_response.read())
+
+    def _get_logs(self, container_id):
+        with closing(self._create_connection()) as conn:
+            conn.request('GET', '/containers/%s/logs?stdout=1&stderr=1' % container_id)
+            logs_response = conn.getresponse()
+            if logs_response.status == 500:
+                raise DockerException(logs_response.read())
+            return logs_response.read()
 
 
 class DockerUnixConnection(httplib.HTTPConnection, object):


### PR DESCRIPTION
- Remove use of `sudo`, and replace with an explicit user/group specification in the container creation request. `sudo` is not available on all Docker images (i.e. it is not bundled with the ubuntu base image), so calls to `sudo` can cause an exitcode 127 error. Use of `sudo` also bulldozed environment variable defined in docker images (#537)
- Fetch container logs at the end of a run to check for any error messages that were previously missed (such as 'sudo: command not found'), will speed up debugging in the future.
- Remove libcuda hacks to avoid call to `ldconfig`.
- Separate out 'default' set of test-cli modules.

Fixes codalab/codalab-worksheets#224
Fixes #537 

Created new PR to replace #643 and merge into develop instead.

Tested it on a test CodaLab instance on NLP server. Works with anaconda image, and runs as the current user and group without error.

```
bundle_type               : run
uuid                      : 0x29e6032baac34d8fa7e7ad4fe9c7c972
data_hash                 : 0x5a4b5e843062f04564d35179243a6eb1e3baadc9
state                     : ready
command                   : id
owner                     : codalab(0)
name                      : run-id
created                   : 2017-01-21 23:46:32
data_size                 : 4.0k
allow_failed_dependencies : False
request_docker_image      : continuumio/anaconda:latest
request_cpus              : 0
request_gpus              : 0
request_priority          : 0
request_network           : False
time                      : 1.2s
time_user                 : 0.0s
time_system               : 0.0s
memory                    : 112k
memory_max                : 112k
started                   : 2017-01-21 23:46:36
last_updated              : 2017-01-21 23:46:38
run_status                : Finished
exitcode                  : 0
job_handle                : 1146928.scail.stanford.edu
remote                    : john9.stanford.edu
children:
host_worksheets:
  home-codalab(0x17d5d92d660c44d89a17441ef36266d9)
permission: all
group_permissions:
  public(0x5940c2):read
=== contents preview ===
name    perm  size
------------------
stderr  0644     0
stdout  0644    33
=== stdout preview ===
uid=16356 gid=20004 groups=20004
=== stderr preview ===
```

Also confirmed that environment variables defined in Docker images are now visible:
```
bundle_type               : run
uuid                      : 0xff9b96b8e61943afbef1da2c548e4274
data_hash                 : <none>
state                     : running
command                   : bash -c "echo $ENVTEST"
owner                     : codalab(0)
name                      : run-bash
created                   : 2017-01-22 01:52:47
data_size                 : 4.0k
allow_failed_dependencies : False
request_docker_image      : sckoo/envtest:latest
request_cpus              : 0
request_gpus              : 0
request_priority          : 0
request_network           : False
time                      : 8.7s
time_user                 : 0.0s
time_system               : 0.0s
memory                    : 268k
memory_max                : 268k
started                   : 2017-01-22 01:52:52
last_updated              : 2017-01-22 01:53:01
run_status                : Running
job_handle                : 1147404.scail.stanford.edu
remote                    : john9.stanford.edu
children:
host_worksheets:
  home-codalab(0x17d5d92d660c44d89a17441ef36266d9)
permission: all
group_permissions:
  public(0x5940c2):read
=== contents preview ===
name    perm  size
------------------
stderr  0644     0
stdout  0644     5
=== stdout preview ===
GOOD
=== stderr preview ===
```