### PR TITLE
adds coloring to permissions

### DIFF
--- a/codalab/apps/web/static/js/worksheet/worksheet_utils.jsx
+++ b/codalab/apps/web/static/js/worksheet/worksheet_utils.jsx
@@ -3,21 +3,23 @@ function render_permissions(state) {
   // - state.permission_str (what user has)
   // - state.group_permissions (what other people have)
   
-  function permissionToColor(permission) {
+  function permissionToClass(permission) {
     var mapping = {
-      read: 'rgb(255,180,0)', // dark gold
-      all: 'rgb(50,207,50)' // lime green
+      read: 'ws-permission-read',
+      all: 'ws-permission-all'
     };
-    return mapping[permission] || 'red';
+
+    if (mapping.hasOwnProperty(permission)) {
+      return mapping[permission];
+    }
+
+    console.error('Invalid permission:', permission);
+    return '';
   }
 
   function wrapPermissionInColorSpan(permission) {
-    var style = {
-      color: permissionToColor(permission)
-    };
-
     return (
-      <span style={style}>
+      <span className={permissionToClass(permission)}>
         {permission}
       </span>
     );

--- a/codalab/apps/web/static/js/worksheet/worksheet_utils.jsx
+++ b/codalab/apps/web/static/js/worksheet/worksheet_utils.jsx
@@ -2,12 +2,43 @@ function render_permissions(state) {
   // Render permissions:
   // - state.permission_str (what user has)
   // - state.group_permissions (what other people have)
-  var permission_str = 'you(' + (state.permission_str || '?') + ')';
-  permission_str += (state.group_permissions || []).map(function(perm) {
-    return ' ' + perm.group_name + "(" + perm.permission_str + ")";
-  }).join('');
-  permission_str;
-  return permission_str;
+  
+  function permissionToColor(permission) {
+    var mapping = {
+      read: 'rgb(255,180,0)', // dark gold
+      all: 'rgb(50,207,50)' // lime green
+    };
+    return mapping[permission] || 'red';
+  }
+
+  function wrapPermissionInColorSpan(permission) {
+    var style = {
+      color: permissionToColor(permission)
+    };
+
+    return (
+      <span style={style}>
+        {permission}
+      </span>
+    );
+  }
+
+  return (
+    <div>
+      you({wrapPermissionInColorSpan(state.permission_str)})
+      {
+        (state.group_permissions || []).map(
+          function(perm) {
+            return (
+              <span>
+                {' ' + perm.group_name}({wrapPermissionInColorSpan(perm.permission_str)})
+              </span>
+            );
+          }
+        )
+      }
+    </div>
+  );
 }
 
 function shorten_uuid(uuid) {

--- a/codalab/apps/web/static/less/worksheets.less
+++ b/codalab/apps/web/static/less/worksheets.less
@@ -755,3 +755,11 @@ html, body, #worksheet_container {height:100%;}
   margin: 0 !important;
   border-radius: 0 !important;
 }
+
+.ws-permission-read {
+  color: rgb(255,180,0); // dark gold
+}
+
+.ws-permission-all {
+  color: rgb(50,207,50); // lime green
+}


### PR DESCRIPTION
![screenshot 2017-01-25 at 1 03 00 am](https://cloud.githubusercontent.com/assets/5680188/22284020/1c8dfe7e-e29a-11e6-8afb-407aa3aa4a1e.png)
Adds color highlights for permissions in the bundle/worksheets sidebar. "read" is in a dark gold and "all" is in a lime green.
Fixes #209 with https://github.com/codalab/codalab-cli/pull/653.