### PR TITLE
Display boolean bundle metadata

### DIFF
--- a/codalab/apps/web/static/js/bundle/bundle_interface.jsx
+++ b/codalab/apps/web/static/js/bundle/bundle_interface.jsx
@@ -100,7 +100,7 @@ function createRow(bundle_info, bundleMetadataChanged, key, value) {
   else {
     return (<tr>
       <th><span>{key}</span></th>
-      <td><span>{value}</span></td>
+      <td><span>{String(value)}</span></td>
     </tr>);
   }
 }


### PR DESCRIPTION
http://stackoverflow.com/questions/38337262/cannot-render-boolean-value-in-jsx

Fixes #238