### PR TITLE
Increase default num processes to 8

### DIFF
--- a/codalab/config/templates/supervisor.conf
+++ b/codalab/config/templates/supervisor.conf
@@ -36,7 +36,7 @@ umask = 002
 
 [program:restserver]
 environment = PYTHONPATH="{{BUNDLE_SERVICE_CODE_PATH}}"
-command={{BUNDLE_SERVICE_VIRTUAL_ENV}}/bin/python {{BUNDLE_SERVICE_CODE_PATH}}/codalab/bin/cl.py server -p 4
+command={{BUNDLE_SERVICE_VIRTUAL_ENV}}/bin/python {{BUNDLE_SERVICE_CODE_PATH}}/codalab/bin/cl.py server -p 8
 stdout_logfile = {{LOGS_PATH}}/restserver.log
 stderr_logfile = {{LOGS_PATH}}/restserver-err.log
 directory={{BUNDLE_SERVICE_CODE_PATH}}


### PR DESCRIPTION
Increases number of threads to 8 * 50 = 400.

This is within the `2-4 x $(NUM_CORES)` range specified in the Gunicorn documentation: http://docs.gunicorn.org/en/latest/settings.html#workers

Looking at wsprod with `htop` it looks like the REST server threads are quite lightweight so the memory impact shouldn't be a problem.

We will deploy this on wstest first to test it out.

Address #256 