### PR TITLE
Keyboard nav bug fix

### DIFF
--- a/codalab/apps/web/static/js/worksheet/table_item_interface.jsx
+++ b/codalab/apps/web/static/js/worksheet/table_item_interface.jsx
@@ -8,26 +8,6 @@ var TableItem = React.createClass({
     },
 
     capture_keys: function() {
-        // Move focus up one
-        /*
-        Mousetrap.bind(['up', 'k'], function(e) {
-            if (this.props.subFocusIndex - 1 < 0)
-              this.props.setFocus(this.props.focusIndex - 1, 'end');  // Move out of this table
-            else
-              this.updateRowIndex(this.props.subFocusIndex - 1);
-        }.bind(this), 'keydown');
-        */
-
-        // Move focus down one
-        /*
-        Mousetrap.bind(['down', 'j'], function() {
-            if (this.props.subFocusIndex + 1 >= this.props.item.interpreted[1].length)
-              this.props.setFocus(this.props.focusIndex + 1, 0);  // Move out of this table
-            else
-              this.updateRowIndex(this.props.subFocusIndex + 1);
-        }.bind(this), 'keydown');
-        */
-
         // Open worksheet in new window/tab
         Mousetrap.bind(['enter'], function(e) {
             window.open(this.refs['row' + this.props.subFocusIndex].props.url, '_blank');

--- a/codalab/apps/web/static/js/worksheet/table_item_interface.jsx
+++ b/codalab/apps/web/static/js/worksheet/table_item_interface.jsx
@@ -9,20 +9,24 @@ var TableItem = React.createClass({
 
     capture_keys: function() {
         // Move focus up one
+        /*
         Mousetrap.bind(['up', 'k'], function(e) {
             if (this.props.subFocusIndex - 1 < 0)
               this.props.setFocus(this.props.focusIndex - 1, 'end');  // Move out of this table
             else
               this.updateRowIndex(this.props.subFocusIndex - 1);
         }.bind(this), 'keydown');
+        */
 
         // Move focus down one
+        /*
         Mousetrap.bind(['down', 'j'], function() {
             if (this.props.subFocusIndex + 1 >= this.props.item.interpreted[1].length)
               this.props.setFocus(this.props.focusIndex + 1, 0);  // Move out of this table
             else
               this.updateRowIndex(this.props.subFocusIndex + 1);
         }.bind(this), 'keydown');
+        */
 
         // Open worksheet in new window/tab
         Mousetrap.bind(['enter'], function(e) {

--- a/codalab/apps/web/static/js/worksheet/worksheet_interface.jsx
+++ b/codalab/apps/web/static/js/worksheet/worksheet_interface.jsx
@@ -452,6 +452,7 @@ var Worksheet = React.createClass({
     // If rawIndexAfterEditMode is defined, this refreshWorksheet is called right after toggling editMode. It should resolve rawIndex to (focusIndex, subFocusIndex) pair.
     refreshWorksheet: function(partialUpdateItems, rawIndexAfterEditMode) {
         if (partialUpdateItems === undefined) {
+          debugger;
           $('#update_progress').show();
           this.setState({updating: true});
           this.state.ws.fetch({

--- a/codalab/apps/web/static/js/worksheet/worksheet_interface.jsx
+++ b/codalab/apps/web/static/js/worksheet/worksheet_interface.jsx
@@ -243,11 +243,7 @@ var Worksheet = React.createClass({
             var subFocusIndex = this.state.subFocusIndex;
             var wsItems = this.state.ws.info.items;
 
-            // TODO Is this first if statement actually necesary?
-            if (focusIndex < 0 || focusIndex > wsItems.length) {
-                // Do nothing
-                return;
-            } else if (wsItems[focusIndex].mode === 'table') {
+            if (focusIndex >= 0 && wsItems[focusIndex].mode === 'table') {
                 // worksheet_item_interface and table_item_interface do the exact same thing anyway right now
                 if (subFocusIndex - 1 < 0) {
                     this.setFocus(focusIndex - 1, 'end'); // Move out of this table to the item above the current table

--- a/codalab/apps/web/static/js/worksheet/worksheet_interface.jsx
+++ b/codalab/apps/web/static/js/worksheet/worksheet_interface.jsx
@@ -237,6 +237,42 @@ var Worksheet = React.createClass({
             this.toggleEditMode();
             return false;
         }.bind(this));
+
+        Mousetrap.bind(['up', 'k'], function(e) {
+            var focusIndex = this.state.focusIndex;
+            var subFocusIndex = this.state.subFocusIndex;
+            var wsItems = this.state.ws.info.items;
+
+            // TODO Is this first if statement actually necesary?
+            if (focusIndex < 0 || focusIndex > wsItems.length) {
+                // Do nothing
+                return;
+            } else if (wsItems[focusIndex].mode === 'table') {
+                // worksheet_item_interface and table_item_interface do the exact same thing anyway right now
+                if (subFocusIndex - 1 < 0) {
+                    this.setFocus(focusIndex - 1, 'end'); // Move out of this table to the item above the current table
+                } else {
+                    this.setFocus(focusIndex, subFocusIndex - 1);
+                }
+            } else { // worksheet_items.jsx
+                this.setFocus(focusIndex - 1, 'end');
+            }
+        }.bind(this), 'keydown');
+
+        Mousetrap.bind(['down', 'j'], function(e) {
+            var focusIndex = this.state.focusIndex;
+            var subFocusIndex = this.state.subFocusIndex;
+            var wsItems = this.state.ws.info.items;
+            if (focusIndex >= 0 && wsItems[focusIndex].mode === 'table') {
+                if (subFocusIndex + 1 >= wsItems[focusIndex].length) {
+                    this.setFocus(focusIndex + 1, 0);
+                } else {
+                    this.setFocus(focusIndex, subFocusIndex + 1);
+                }
+            } else {
+                this.setFocus(focusIndex + 1, 0);
+            }
+        }.bind(this), 'keydown');
     },
 
     toggleEditMode: function(editMode, saveChanges) {
@@ -452,7 +488,6 @@ var Worksheet = React.createClass({
     // If rawIndexAfterEditMode is defined, this refreshWorksheet is called right after toggling editMode. It should resolve rawIndex to (focusIndex, subFocusIndex) pair.
     refreshWorksheet: function(partialUpdateItems, rawIndexAfterEditMode) {
         if (partialUpdateItems === undefined) {
-          debugger;
           $('#update_progress').show();
           this.setState({updating: true});
           this.state.ws.fetch({

--- a/codalab/apps/web/static/js/worksheet/worksheet_item_interface.jsx
+++ b/codalab/apps/web/static/js/worksheet/worksheet_item_interface.jsx
@@ -10,26 +10,6 @@ var WorksheetItem = React.createClass({
     throttledScrollToRow: undefined,
 
     capture_keys: function() {
-        // Move focus up one
-        /*
-        Mousetrap.bind(['up', 'k'], function(e) {
-            if (this.props.subFocusIndex - 1 < 0)
-              this.props.setFocus(this.props.focusIndex - 1, 'end');  // Move out of this table
-            else
-              this.props.setFocus(this.props.focusIndex, this.props.subFocusIndex - 1);
-        }.bind(this), 'keydown');
-        */
-
-        // Move focus down one
-        /*
-        Mousetrap.bind(['down', 'j'], function() {
-            if (this.props.subFocusIndex + 1 >= this._getItems().length)
-              this.props.setFocus(this.props.focusIndex + 1, 0);  // Move out of this table
-            else
-              this.props.setFocus(this.props.focusIndex, this.props.subFocusIndex + 1);
-        }.bind(this), 'keydown');
-        */
-
         // Open worksheet in same tab
         Mousetrap.bind(['enter'], function(e) {
             this.props.openWorksheet(this.refs['row' + this.props.subFocusIndex].props.uuid);

--- a/codalab/apps/web/static/js/worksheet/worksheet_item_interface.jsx
+++ b/codalab/apps/web/static/js/worksheet/worksheet_item_interface.jsx
@@ -11,20 +11,24 @@ var WorksheetItem = React.createClass({
 
     capture_keys: function() {
         // Move focus up one
+        /*
         Mousetrap.bind(['up', 'k'], function(e) {
             if (this.props.subFocusIndex - 1 < 0)
               this.props.setFocus(this.props.focusIndex - 1, 'end');  // Move out of this table
             else
               this.props.setFocus(this.props.focusIndex, this.props.subFocusIndex - 1);
         }.bind(this), 'keydown');
+        */
 
         // Move focus down one
+        /*
         Mousetrap.bind(['down', 'j'], function() {
             if (this.props.subFocusIndex + 1 >= this._getItems().length)
               this.props.setFocus(this.props.focusIndex + 1, 0);  // Move out of this table
             else
               this.props.setFocus(this.props.focusIndex, this.props.subFocusIndex + 1);
         }.bind(this), 'keydown');
+        */
 
         // Open worksheet in same tab
         Mousetrap.bind(['enter'], function(e) {

--- a/codalab/apps/web/static/js/worksheet/worksheet_items.jsx
+++ b/codalab/apps/web/static/js/worksheet/worksheet_items.jsx
@@ -26,25 +26,11 @@ var WorksheetItemList = React.createClass({
               window.open(url, '_blank');
         }.bind(this), 'keydown');
 
-        // Move focus up one
-        /*
-        Mousetrap.bind(['up', 'k'], function() {
-            this.props.setFocus(this.props.focusIndex - 1, 'end');
-        }.bind(this), 'keydown');
-        */
-
         // Move focus to the top
         Mousetrap.bind(['g g'], function() {
             $('body').stop(true).animate({scrollTop: 0}, 'fast');
             this.props.setFocus(-1, 0);
         }.bind(this), 'keydown');
-
-        // Move focus down one
-        /*
-        Mousetrap.bind(['down', 'j'], function() {
-            this.props.setFocus(this.props.focusIndex + 1, 0);
-        }.bind(this), 'keydown');
-        */
 
         // Move focus to the bottom
         Mousetrap.bind(['shift+g'], function() {

--- a/codalab/apps/web/static/js/worksheet/worksheet_items.jsx
+++ b/codalab/apps/web/static/js/worksheet/worksheet_items.jsx
@@ -27,9 +27,11 @@ var WorksheetItemList = React.createClass({
         }.bind(this), 'keydown');
 
         // Move focus up one
+        /*
         Mousetrap.bind(['up', 'k'], function() {
             this.props.setFocus(this.props.focusIndex - 1, 'end');
         }.bind(this), 'keydown');
+        */
 
         // Move focus to the top
         Mousetrap.bind(['g g'], function() {
@@ -38,9 +40,11 @@ var WorksheetItemList = React.createClass({
         }.bind(this), 'keydown');
 
         // Move focus down one
+        /*
         Mousetrap.bind(['down', 'j'], function() {
             this.props.setFocus(this.props.focusIndex + 1, 0);
         }.bind(this), 'keydown');
+        */
 
         // Move focus to the bottom
         Mousetrap.bind(['shift+g'], function() {


### PR DESCRIPTION
Issue: #244 

This code has been tested and does address the bug. Please refer to the issue for a description of the diagnosis and solution. A summary:
- The problem: When the worksheet page updates (after pulling the API for updates), worksheet_items renders once, table_items renders once, then worksheet_items renders a final time. Since Mousetrap uses the last binding command, worksheet_items' binding is executed, even though we want table_items' binding.
- The solution: The up and down key bindings from all of the files were moved into worksheet_interface.jsx, the parent of all of these classes. The original code key binding code was deleted. Now, when an up or down key event fires, it is caught in worksheet_interface, and depending on which item is in focus, the Worksheet's state is updated appropriately.

Extensions:
- [ ] Move all Mousetrap keybindings (see the issue for a list; I think moving 'enter' will be important to avoid a bug with that) into one location so that future bugs similar to this one don't occur.