### PR TITLE
Collect stderr in monitor

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -127,13 +127,10 @@ durations = defaultdict(list)  # Command => durations for that command
 def run_command(args, soft_time_limit=15, hard_time_limit=60, include_output=True):
     # We cap the running time to hard_time_limit, but print out an error if we exceed soft_time_limit.
     start_time = time.time()
-    try:
-        args = ['timeout', '%ss' % hard_time_limit] + args
-        output = subprocess.check_output(args)
-        exitcode = 0
-    except subprocess.CalledProcessError, e:
-        output = e.output
-        exitcode = e.returncode
+    args = ['timeout', '%ss' % hard_time_limit] + args
+    proc = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    output, err_output = proc.communicate()
+    exitcode = proc.returncode
     end_time = time.time()
 
     # Add to the list
@@ -148,9 +145,14 @@ def run_command(args, soft_time_limit=15, hard_time_limit=60, include_output=Tru
     # Abstract away the concrete uuids
     simple_args = ['0x*' if arg.startswith('0x') else arg for arg in args]
 
+    # Include stderr in output if returncode != 0
+    full_output = output
+    if exitcode != 0:
+        full_output += err_output
+
     message = '>> %s (exit code %s, time %.2fs [limit: %ds,%ds]; avg %.2fs; max %.2fs)\n%s' % \
         (' '.join(args), exitcode, duration, soft_time_limit, hard_time_limit,
-        average_duration, max_duration, output if include_output else '')
+        average_duration, max_duration, full_output if include_output else '')
     if exitcode == 0:
         logs(message)
     else:


### PR DESCRIPTION
Use Popen.communicate() so we can get both stdout and stderr, and as separate strings.

Previously, the monitor error notification emails did not include stderr in the output dump.