### PR TITLE
fixes escaping problem and uses the correct email as the user email

### DIFF
--- a/codalab/rest/help.py
+++ b/codalab/rest/help.py
@@ -24,7 +24,7 @@ def fetch_help():
 
     local.emailer.send_email(
         subject="Message from %s" % user_email,
-        body=template('help_message_to_codalab_body', username=username, email=support_email, message=message),
+        body=template('help_message_to_codalab_body', username=username, email=user_email, message=message),
         recipient=support_email,
         sender=user_email
     )

--- a/views/help_message_to_codalab_body.tpl
+++ b/views/help_message_to_codalab_body.tpl
@@ -1,5 +1,5 @@
-User {{username}} ({{email}}) has sent the following message to CodaLab via the help box:
+User {{!username}} ({{!email}}) has sent the following message to CodaLab via the help box:
 
-{{message}}
+{{!message}}
 
 


### PR DESCRIPTION
Notes on escaping: The bottle template engine allows strings to not be escaped by prepending a `!` to the expression. See documentation here: https://bottlepy.org/docs/dev/stpl.html

The email address was changed from `support_email` to `user_email`