### PR TITLE
List CLI commands when `cl` executed with no arguments

### DIFF
--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -176,10 +176,14 @@ class CodaLabArgumentParser(argparse.ArgumentParser):
     def error(self, message):
         # Adapted from original:
         # https://hg.python.org/cpython/file/2.7/Lib/argparse.py
-        self.print_usage(self.cli.stderr)
-        if self.cli.headless:
+        if len(sys.argv) == 1:
+            self.print_help()
+            self.exit(2)
+        elif self.cli.headless:
+            self.print_usage(self.cli.stderr)
             raise UsageError(message)
         else:
+            self.print_usage(self.cli.stderr)
             self.exit(2, '%s: error: %s\n' % (self.prog, message))
 
 


### PR DESCRIPTION
I thought that this method of checking the number of arguments when argparse errors was the best method to give a help message to users. There are some other proposed ways of doing so on this StackOverflow post: http://stackoverflow.com/questions/4042452/display-help-message-with-python-argparse-when-script-is-called-without-any-argu. Let me know if you think one is better than the other.