### PR TITLE
Fix sidebar problems

### DIFF
--- a/codalab/apps/web/static/js/bundle/bundle_interface.jsx
+++ b/codalab/apps/web/static/js/bundle/bundle_interface.jsx
@@ -100,7 +100,7 @@ function createRow(bundle_info, bundleMetadataChanged, key, value) {
   else {
     return (<tr>
       <th><span>{key}</span></th>
-      <td><span>{String(value)}</span></td>
+      <td><span>{typeof(value) === 'boolean' ? String(value) : value}</span></td>
     </tr>);
   }
 }
@@ -177,7 +177,7 @@ function renderHeader(bundle_info, bundleMetadataChanged) {
     {bundle_header}
     <table className="bundle-meta table">
       <tbody>
-        {rows}
+        {rows.map(function(elem) {return elem;})}
         <tr>
           <th><span>download</span></th>
           <td>

--- a/codalab/apps/web/static/js/worksheet/worksheet_utils.jsx
+++ b/codalab/apps/web/static/js/worksheet/worksheet_utils.jsx
@@ -75,7 +75,7 @@ function render_permissions(state) {
           function(perm) {
             return (
               <span>
-                {' ' + perm.group_name}({wrapPermissionInColorSpan(perm.permission_str)})
+                {' '}{perm.group_name}{'('}{wrapPermissionInColorSpan(perm.permission_str)}{')'}
               </span>
             );
           }


### PR DESCRIPTION
Fixes the following issues relating to the worksheet sidebar:

- Permissions displaying as [Object object] for bundles and subworksheets
  - Relevant issue: #274 - includes discussion of subworksheets
- Bundle's state in the worksheet is [Object object]

The fix for subworksheets required fetching new data. I chose to implement a "quick fix" that's based on the existing code for fetching bundle information. This way of fetching data is not the best way to do so in React because it does not clearly show direction of information flow from the user's click to populating the sidebar with data. The beginning of a better implementation is in the branch (max-fixes-sidebar)[https://github.com/codalab/codalab-worksheets/tree/max-fixes-sidebar]. It will take many more hours before that implementation is complete, so I chose to implement this approach instead.