### PR TITLE
Make compression API saner

### DIFF
--- a/codalab/client/json_api_client.py
+++ b/codalab/client/json_api_client.py
@@ -569,12 +569,8 @@ class JsonApiClient(RestClient):
             params['head'] = head
         if tail is not None:
             params['tail'] = tail
-        response = self._make_request('GET', request_path, headers=headers,
-                                      query_params=params, return_response=True)
-
-        if response.headers.get('Content-Encoding') == 'gzip':
-            return un_gzip_stream(response)
-        return response
+        return self._make_request('GET', request_path, headers=headers,
+                                  query_params=params, return_response=True)
 
     @wrap_exception('Unable to upload contents of bundle {1}')
     def upload_contents_blob(self, bundle_id, fileobj=None, params=None,

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -374,9 +374,11 @@ def _fetch_bundle_contents_blob(uuid, path=''):
     For files, if the request has an Accept-Encoding header containing gzip,
     then the returned file is gzipped. Otherwise, the file is returned as-is.
 
-    HTTP headers:
+    HTTP Request headers:
     - `Range: bytes=<start>-<end>`: fetch bytes from the range
       `[<start>, <end>)`.
+    - `Accept-Encoding: <encoding>`: indicate that the client can accept
+      encoding `<encoding>`. Currently only `gzip` encoding is supported.
 
     Query parameters:
     - `head`: number of lines to fetch from the beginning of the file.
@@ -385,6 +387,18 @@ def _fetch_bundle_contents_blob(uuid, path=''):
       Default is 0, meaning to fetch the entire file.
     - `max_line_length`: maximum number of characters to fetch from each line,
       if either `head` or `tail` is specified. Default is 128.
+
+    HTTP Response headers (for single-file targets):
+    - `Content-Disposition: filename=<bundle name or target filename>`
+    - `Content-Type: <guess of mimetype based on file extension>`
+    - `Content-Encoding: [gzip|identity]`
+    - `Target-Type: file`
+
+    HTTP Response headers (for directories):
+    - `Content-Disposition: filename=<bundle or directory name>.tar.gz`
+    - `Content-Type: application/gzip`
+    - `Content-Encoding: identity`
+    - `Target-Type: directory`
     """
     byte_range = get_request_range()
     head_lines = query_get_type(int, 'head', default=0)

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -497,7 +497,7 @@ Response format:
   "data": {
       "name": "<name of file or directory>",
       "link": "<string representing target if file is a symbolic link>",
-      "type": "<file|directory>",
+      "type": "<file|directory|link>",
       "size": <size of file in bytes>,
       "contents": {
         "name": ...,
@@ -522,7 +522,7 @@ Response format:
   "data": {
       "name": "<name of file or directory>",
       "link": "<string representing target if file is a symbolic link>",
-      "type": "<file|directory>",
+      "type": "<file|directory|link>",
       "size": <size of file in bytes>,
       "contents": {
         "name": ...,
@@ -543,9 +543,11 @@ the directory.
 For files, if the request has an Accept-Encoding header containing gzip,
 then the returned file is gzipped. Otherwise, the file is returned as-is.
 
-HTTP headers:
+HTTP Request headers:
 - `Range: bytes=<start>-<end>`: fetch bytes from the range
   `[<start>, <end>)`.
+- `Accept-Encoding: <encoding>`: indicate that the client can accept
+  encoding `<encoding>`. Currently only `gzip` encoding is supported.
 
 Query parameters:
 - `head`: number of lines to fetch from the beginning of the file.
@@ -554,6 +556,18 @@ Query parameters:
   Default is 0, meaning to fetch the entire file.
 - `max_line_length`: maximum number of characters to fetch from each line,
   if either `head` or `tail` is specified. Default is 128.
+
+HTTP Response headers (for single-file targets):
+- `Content-Disposition: filename=<bundle name or target filename>`
+- `Content-Type: <guess of mimetype based on file extension>`
+- `Content-Encoding: [gzip|identity]`
+- `Target-Type: file`
+
+HTTP Response headers (for directories):
+- `Content-Disposition: filename=<bundle or directory name>.tar.gz`
+- `Content-Type: application/gzip`
+- `Content-Encoding: identity`
+- `Target-Type: directory`
 
 ### `GET /bundles/<uuid:re:0x[0-9a-f]{32}>/contents/blob/`
 
@@ -565,9 +579,11 @@ the directory.
 For files, if the request has an Accept-Encoding header containing gzip,
 then the returned file is gzipped. Otherwise, the file is returned as-is.
 
-HTTP headers:
+HTTP Request headers:
 - `Range: bytes=<start>-<end>`: fetch bytes from the range
   `[<start>, <end>)`.
+- `Accept-Encoding: <encoding>`: indicate that the client can accept
+  encoding `<encoding>`. Currently only `gzip` encoding is supported.
 
 Query parameters:
 - `head`: number of lines to fetch from the beginning of the file.
@@ -576,6 +592,18 @@ Query parameters:
   Default is 0, meaning to fetch the entire file.
 - `max_line_length`: maximum number of characters to fetch from each line,
   if either `head` or `tail` is specified. Default is 128.
+
+HTTP Response headers (for single-file targets):
+- `Content-Disposition: filename=<bundle name or target filename>`
+- `Content-Type: <guess of mimetype based on file extension>`
+- `Content-Encoding: [gzip|identity]`
+- `Target-Type: file`
+
+HTTP Response headers (for directories):
+- `Content-Disposition: filename=<bundle or directory name>.tar.gz`
+- `Content-Type: application/gzip`
+- `Content-Encoding: identity`
+- `Target-Type: directory`
 
 ### `PUT /bundles/<uuid:re:0x[0-9a-f]{32}>/contents/blob/`
 

--- a/test-cli.py
+++ b/test-cli.py
@@ -267,8 +267,7 @@ def temp_instance():
     finally:
         # Kill any processes started in reverse order
         if worker_proc:
-            worker_proc.terminate()
-            worker_proc.wait()
+            worker_proc.kill()
         if bundle_manager_proc:
             bundle_manager_proc.kill()
         if rest_server_proc:

--- a/test-cli.py
+++ b/test-cli.py
@@ -105,8 +105,25 @@ def get_info(uuid, key):
     return run_command([cl, 'info', '-f', key, uuid])
 
 
-def wait_until_running(uuid):
-    while get_info(uuid, 'state') != 'running':
+def wait_until_running(uuid, timeout_seconds=100):
+    start_time = time.time()
+    while True:
+        if time.time() - start_time > 100:
+            raise AssertionError('timeout while waiting for %s to run' % uuid)
+        state = get_info(uuid, 'state')
+        # Break when running or one of the final states
+        if state in {'running', 'ready', 'failed'}:
+            assert state == 'running', "waiting for 'running' state, but got '%s'" % state
+            return
+        time.sleep(0.5)
+
+
+def wait_for_contents(uuid, substring, timeout_seconds=100):
+    while True:
+        if time.time() - start_time > 100:
+            raise AssertionError('timeout while waiting for %s to run' % uuid)
+        if substring in run_command([cl, 'cat', uuid]):
+            return True
         time.sleep(0.5)
 
 
@@ -827,8 +844,7 @@ def test(ctx):
     # killed.
     for running in [True, False]:
         # Wait for the output to appear. Also, tests cat on a directory.
-        while 'done' not in run_command([cl, 'cat', uuid]):
-            time.sleep(0.5)
+        wait_for_contents(uuid, substring='done', timeout=60)
 
         # Info has only the first 10 lines
         info_output = run_command([cl, 'info', uuid, '--verbose'])

--- a/test-cli.py
+++ b/test-cli.py
@@ -844,7 +844,7 @@ def test(ctx):
     # killed.
     for running in [True, False]:
         # Wait for the output to appear. Also, tests cat on a directory.
-        wait_for_contents(uuid, substring='done', timeout=60)
+        wait_for_contents(uuid, substring='done', timeout_seconds=60)
 
         # Info has only the first 10 lines
         info_output = run_command([cl, 'info', uuid, '--verbose'])

--- a/test-cli.py
+++ b/test-cli.py
@@ -119,6 +119,7 @@ def wait_until_running(uuid, timeout_seconds=100):
 
 
 def wait_for_contents(uuid, substring, timeout_seconds=100):
+    start_time = time.time()
     while True:
         if time.time() - start_time > 100:
             raise AssertionError('timeout while waiting for %s to run' % uuid)

--- a/worker/bundle_service_client.py
+++ b/worker/bundle_service_client.py
@@ -168,6 +168,4 @@ class BundleServiceClient(RestClient):
         response = self._make_request(
             'GET', '/bundles/' + uuid + '/contents/blob/' + path,
             headers={'Accept-Encoding': 'gzip'}, return_response=True)
-        match = re.match('filename="(.*)"',
-                         response.headers['Content-Disposition'])
-        return (response, match.group(1))
+        return response, response.headers.get('Target-Type')

--- a/worker/file_util.py
+++ b/worker/file_util.py
@@ -105,6 +105,15 @@ def un_gzip_stream(fileobj):
 
         def close(self):
             self._fileobj.close()
+
+        def __getattr__(self, name):
+            """
+            Proxy any methods/attributes besides read() and close() to the
+            fileobj (for example, if we're wrapping an HTTP response object.)
+            Behavior is undefined if other file methods such as tell() are
+            attempted through this proxy.
+            """
+            return getattr(self._fileobj, name)
     
     # Note, that we don't use gzip.GzipFile or the gunzip shell command since
     # they require the input file-like object to support either tell() or

--- a/worker/rest_client.py
+++ b/worker/rest_client.py
@@ -60,7 +60,7 @@ class RestClient(object):
             # Content-Encoding header.
             response = urllib2.urlopen(request)
             encoding = response.headers.get('Content-Encoding')
-            if not encoding:
+            if not encoding or encoding == 'identity':
                 return response
             elif encoding == 'gzip':
                 return un_gzip_stream(response)

--- a/worker/run.py
+++ b/worker/run.py
@@ -197,6 +197,7 @@ class Run(object):
             self._image_manager.touch_image(digest)
 
         except Exception as e:
+            logger.exception('Failed while starting run')
             self._finish(failure_message=str(e))
             self._worker.finish_run(self._uuid)
             return

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -182,9 +182,11 @@ class Worker(object):
             logger.debug('Downloading dependency %s/%s', parent_uuid, parent_path)
             try:
                 download_success = False
-                fileobj, filename = (
+                fileobj, target_type = (
                     self._bundle_service.get_bundle_contents(parent_uuid, parent_path))
                 with closing(fileobj):
+                    # "Bug" the fileobj's read function so that we can keep
+                    # track of the number of bytes downloaded so far.
                     old_read_method = fileobj.read
                     bytes_downloaded = [0]
                     def interruptable_read(*args, **kwargs):
@@ -194,7 +196,7 @@ class Worker(object):
                         return data
                     fileobj.read = interruptable_read
 
-                    self._store_dependency(dependency_path, fileobj, filename)
+                    self._store_dependency(dependency_path, fileobj, target_type)
                     download_success = True
             finally:
                 logger.debug('Finished downloading dependency %s/%s', parent_uuid, parent_path)
@@ -203,13 +205,13 @@ class Worker(object):
 
         return dependency_path
 
-    def _store_dependency(self, dependency_path, fileobj, filename):
+    def _store_dependency(self, dependency_path, fileobj, target_type):
         try:
-            if filename.endswith('.tar.gz'):
+            if target_type == 'directory':
                 un_tar_directory(fileobj, dependency_path, 'gz')
             else:
                 with open(dependency_path, 'wb') as f:
-                    shutil.copyfileobj(un_gzip_stream(fileobj), f)
+                    shutil.copyfileobj(fileobj, f)
         except:
             remove_path(dependency_path)
             raise

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -15,7 +15,7 @@ from file_util import remove_path, un_gzip_stream, un_tar_directory
 from run import Run
 from docker_image_manager import DockerImageManager
 
-VERSION = 10
+VERSION = 11
 
 logger = logging.getLogger(__name__)
 

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -11,13 +11,14 @@ import re
 
 from bundle_service_client import BundleServiceException
 from dependency_manager import DependencyManager
-from file_util import remove_path, un_gzip_stream, un_tar_directory
+from file_util import remove_path, un_tar_directory
 from run import Run
 from docker_image_manager import DockerImageManager
 
 VERSION = 11
 
 logger = logging.getLogger(__name__)
+
 
 class Worker(object):
     """


### PR DESCRIPTION
Fixes #708

Problem: Conflation of a "transport" layer detail with "application"
layer detail, namely compression, since we compress bundles on the fly
during transfer. (Usage of "transport" and "application" are only by
analogy and don't actually correspond to the OSI stack.)

Bug #1: bundles that are gzip archives accidentally get unzipped on
worker
- Tarred directories currently indicated by filename
  (Content-Disposition)
- not safe when the file itself is a unextracted tar gz, should probably
  be some additional header
- SOLUTION: Target-Type header indicates directory|file, and so if a
  bundle is an archive and should be kept packed on the worker, this can
  be indicated by "Target-Type: file".

Bug #2: bundles that are ZIP archives
- ZIP archives are already compressed, so server skips the compression
  worker client doesn't check Content-Encoding header and always assumes
  bundles are gzipped, so attempts to gunzip the ZIP archive and fails
- SOLUTION: Worker decompresses streams ONLY if Content-Encoding
  indicates so.

Server Policy:
- Single-file bundles (including packed archives of directories):
    - Content-Disposition: filename=[bundle name or target filename]
        - regardless of content encoding, since that is akin to a
          "transport" layer detail, while filename is more an
          "application" layer detail
    - Content-Type: [guess based on filename]
        - make sure NOT to user mimetypes.guess_type, which will ignore
          compression file extensions like ".gz" in determining mimetype
          (considering it to be the "encoding" instead)
    - Content-Encoding:
        - gzip if client accepts gzip
            - Should ALWAYS compress for simplicity, since the case
              where a bundle is already compressed is rare.
            - Helps disambiguate the case where
            - We also have no control over compression of the user
        - identity otherwise
            - send raw file, archive or not, if client doesn't accept
              gzip
    - Target-Type: file
- Directories:
    - Content-Disposition: filename=[bundle name or directory
      name].tar.gz
        - Always send a gzipped archive
    - Content-Type: application/gzip
    - Content-Encoding: identity
    - Target-Type: directory
        - Need some way to indicate to CodaLab-specific clients that it
          is a directory, to differentiate it from bundles that are
          packed archives, since the filename will be the same. (This
          does not matter to browsers, which for all extents and
          purposes should treat directory downloads as just a gzip
          archive. Hence the filename definition above.)

Client Policy:
- Content-Disposition:
    - CLI (and browser) should use filename when saving to disk
    - Worker should not need to know the filename.
- Content-Type:
    - only matters for the browser or other clients that care about how
      to render the contents (for example, display contents as a new tab
      for text, or trigger a download for binary data?)
- Content-Encoding:
    - gzip: unzip on the fly, transparently to the user of the client
      class/library. The actual object is the unzipped stream.
    - identity: return raw stream
- Target-Type:
    - file: application treats returned stream (potentially after
      decoding) as a file [the file itself might be an archive but that
      should be irrelevant to the application]
    - directory: application treats returned stream as a ".tar.gz" file
      to be unpacked as a directory