### PR TITLE
Improve Torque scheduler

### DIFF
--- a/codalab/worker/torque_bundle_manager.py
+++ b/codalab/worker/torque_bundle_manager.py
@@ -180,6 +180,7 @@ class TorqueBundleManager(BundleManager):
             command = self._torque_ssh_command(
                 ['qsub',
                  '-k', 'n',  # do not keep stdout/stderr streams (we redirect them manually to the configured log_dir)
+                 '-d', '/tmp',  # avoid chdir permission problems, worker won't do anything in working directory anyway
                  '-v', ','.join([k + '=' + v for k, v in script_env.iteritems()])] +
                 resource_args +
                 ['-S', '/bin/bash', os.path.join(self._torque_worker_code_dir, 'worker.sh')])

--- a/codalab/worker/torque_bundle_manager.py
+++ b/codalab/worker/torque_bundle_manager.py
@@ -150,10 +150,11 @@ class TorqueBundleManager(BundleManager):
             }
             
             command = self._torque_ssh_command(
-                ['qsub', '-o', '/dev/null', '-e', '/dev/null',
+                ['qsub',
+                 '-k', 'n',  # do not keep stdout/stderr streams (we redirect them manually to the configured log_dir)
                  '-v', ','.join([k + '=' + v for k, v in script_env.iteritems()])] +
                 resource_args +
-                [ '-S', '/bin/bash', os.path.join(self._torque_worker_code_dir, 'worker.sh')])
+                ['-S', '/bin/bash', os.path.join(self._torque_worker_code_dir, 'worker.sh')])
             
             try:
                 job_handle = subprocess.check_output(command, stderr=subprocess.STDOUT).strip()


### PR DESCRIPTION
Following Jimmy's advice:

- use `-k n` instead of `-e /dev/null -o /dev/null` to disable recording stdout/stderr streams (we redirect them manually to log files in NFS in `worker.sh`, so we don't need to capture stdout/stderr through PBS)
- set workdir for torque job to `/tmp` to avoid chdir permissions problems. the job doesn't use the working directory anyway
- allow configurable throttle on `qsub` requests, since torque scheduler sometimes has trouble keeping up with many consecutive requests.
- fire `qsub` requests in a different thread to avoid impact on latency of other operations

@percyliang please review