### PR TITLE
Remove support for commands in worksheets markdown

### DIFF
--- a/codalab/client/json_api_client.py
+++ b/codalab/client/json_api_client.py
@@ -617,7 +617,7 @@ class JsonApiClient(RestClient):
 
     @wrap_exception('Unable to update worksheet')
     def update_worksheet_raw(self, worksheet_id, lines):
-        return self._make_request(
+        self._make_request(
             method='POST',
             path='/worksheets/%s/raw' % worksheet_id,
-            data='\n'.join(lines))['data']['commands']
+            data='\n'.join(lines))

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -2207,32 +2207,8 @@ class BundleCLI(object):
                 lines = worksheet_util.request_lines(worksheet_info)
 
             # Update worksheet
-            commands = client.update_worksheet_raw(worksheet_info['id'], lines)
+            client.update_worksheet_raw(worksheet_info['id'], lines)
             print >>self.stdout, 'Saved worksheet items for %s(%s).' % (worksheet_info['name'], worksheet_info['uuid'])
-
-            # Batch the rm commands so that we can handle the recursive
-            # dependencies properly (and it's faster).
-            rm_bundle_uuids = []
-            rest_commands = []
-            for command in commands:
-                if command[0] == 'rm' and len(command) == 2:
-                    rm_bundle_uuids.append(command[1])
-                else:
-                    rest_commands.append(command)
-            commands = rest_commands
-            if len(rm_bundle_uuids) > 0:
-                commands.append(['rm'] + rm_bundle_uuids)
-
-            # Execute the commands that the user put into the worksheet.
-            for command in commands:
-                # Make sure to do it with respect to this worksheet!
-                spec = client.address + '::' + worksheet_uuid
-                if command[0] in ('ls', 'print'):
-                    command.append(spec)
-                else:
-                    command.extend(['--worksheet-spec', spec])
-                print >>self.stdout, '=== Executing: %s' % ' '.join(command)
-                self.do_command(command)
 
     @staticmethod
     def unpack_item(item):

--- a/codalab/lib/worksheet_util.py
+++ b/codalab/lib/worksheet_util.py
@@ -214,11 +214,8 @@ def parse_worksheet_form(form_result, model, user, worksheet_uuid):
     Input: form_result is a list of lines.
     Return (list of (bundle_info, subworksheet_info, value, type) tuples, commands to execute)
     """
-
     def get_line_type(line):
-        if line.startswith('!'):  # Run commands
-            return 'command'
-        elif line.startswith('//'):
+        if line.startswith('//'):
             return 'comment'
         elif BUNDLE_REGEX.match(line) is not None:
             return TYPE_BUNDLE
@@ -242,16 +239,9 @@ def parse_worksheet_form(form_result, model, user, worksheet_uuid):
     # bundle_uuids = {line_i: bundle_uuid, ...}
     bundle_uuids = dict(zip(bundle_specs[0], canonicalize.get_bundle_uuids(model, user, worksheet_uuid, bundle_specs[1])))
 
-    commands = []
     items = []
     for line_i, (line_type, line) in enumerate(izip(line_types, form_result)):
-        if line_type == 'command':
-            command = formatting.string_to_tokens(line[1:].strip())
-            # The user can specify '!<command> ^', which perform actions on the previous bundle.
-            # Replace ^ with the reference to the last bundle.
-            command = [(bundle_uuids[-1][1] if arg == '^' else arg) for arg in command]
-            commands.append(command)
-        elif line_type == 'comment':
+        if line_type == 'comment':
             comment = line[2:]
             items.append(directive_item([DIRECTIVE_CHAR, comment]))
         elif line_type == TYPE_BUNDLE:
@@ -273,7 +263,7 @@ def parse_worksheet_form(form_result, model, user, worksheet_uuid):
         else:
             raise RuntimeError("Invalid line type %s: this should not happen." % line_type)
 
-    return items, commands
+    return items
 
 
 def is_file_genpath(genpath):

--- a/codalab/rest/legacy.py
+++ b/codalab/rest/legacy.py
@@ -254,9 +254,8 @@ class BundleService(object):
         Replace worksheet |uuid| with the raw contents given by |lines|.
         """
         worksheet_info = get_worksheet_info(uuid, fetch_items=True, legacy=True)
-        new_items, commands = worksheet_util.parse_worksheet_form(lines, local.model, request.user, worksheet_info['uuid'])
+        new_items = worksheet_util.parse_worksheet_form(lines, local.model, request.user, worksheet_info['uuid'])
         update_worksheet_items(worksheet_info, new_items)
-        # Note: commands are ignored
 
     def get_bundle_file_contents(self, uuid):
         """

--- a/codalab/rest/worksheets.py
+++ b/codalab/rest/worksheets.py
@@ -120,17 +120,14 @@ def create_worksheets():
     return WorksheetSchema(many=True).dump(worksheets).data
 
 
+@put('/worksheets/<uuid:re:%s>/raw' % spec_util.UUID_STR)
 @post('/worksheets/<uuid:re:%s>/raw' % spec_util.UUID_STR)
 def update_worksheet_raw(uuid):
     lines = request.body.read().split(os.linesep)
-    new_items, commands = worksheet_util.parse_worksheet_form(lines, local.model, request.user, uuid)
+    new_items = worksheet_util.parse_worksheet_form(lines, local.model, request.user, uuid)
     worksheet_info = get_worksheet_info(uuid, fetch_items=True)
     update_worksheet_items(worksheet_info, new_items)
-    return {
-        'data': {
-            'commands': commands
-        }
-    }
+    response.status = 204  # Success, No Content
 
 
 @patch('/worksheets', apply=AuthenticatedPlugin())
@@ -343,7 +340,7 @@ def set_worksheet_permission(worksheet, group_uuid, permission):
 def populate_worksheet(worksheet, name, title):
     file_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../objects/' + name + '.ws')
     lines = [line.rstrip() for line in open(file_path, 'r').readlines()]
-    items, commands = worksheet_util.parse_worksheet_form(lines, local.model, request.user, worksheet.uuid)
+    items = worksheet_util.parse_worksheet_form(lines, local.model, request.user, worksheet.uuid)
     info = get_worksheet_info(worksheet.uuid, fetch_items=True)
     update_worksheet_items(info, items)
     update_worksheet_metadata(worksheet.uuid, {'title': title})


### PR DESCRIPTION
Lines prepended with a bang (!) are now just interpreted as markdown.

Addresses codalab/codalab-worksheets#56