### PR TITLE
Support human readable fields in contents API

### DIFF
--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -1831,12 +1831,14 @@ class BundleCLI(object):
 
         SLEEP_PERIOD = 1.0
 
-        # Wait for the run to start.
-        while True:
-            info = client.fetch('bundles', bundle_uuid)
-            if info['state'] in (State.RUNNING, State.READY, State.FAILED):
-                break
-            time.sleep(SLEEP_PERIOD)
+        # Wait for all files to become ready
+        for subpath in subpaths:
+            while True:
+                try:
+                    target_info = client.fetch_contents_info(bundle_uuid, subpath, 0)
+                    break
+                except NotFoundError:
+                    time.sleep(SLEEP_PERIOD)
 
         info = None
         run_finished = False

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -24,7 +24,6 @@ import os
 import shlex
 import shutil
 import sys
-import subprocess
 import time
 import textwrap
 from contextlib import closing
@@ -1043,8 +1042,6 @@ class BundleCLI(object):
 
         # Do the download.
         target_info = client.fetch_contents_info(target[0], target[1], 0)
-        if target_info is None:
-            raise UsageError('Target doesn\'t exist.')
         if target_info['type'] == 'link':
             raise UsageError('Downloading symlinks is not allowed.')
 
@@ -1116,8 +1113,9 @@ class BundleCLI(object):
         })
 
         # If bundle contents don't exist, finish after just copying metadata
-        target_info = source_client.fetch_contents_info(source_bundle_uuid)
-        if target_info is None:
+        try:
+            target_info = source_client.fetch_contents_info(source_bundle_uuid)
+        except NotFoundError:
             return
 
         # Collect information about how server should unpack
@@ -1750,13 +1748,10 @@ class BundleCLI(object):
     # Helper: shared between info and cat
     def print_target_info(self, client, target, decorate, maxlines=10, fail_if_not_exist=False):
         info = client.fetch_contents_info(target[0], target[1], 1)
-        info_type = info.get('type') if info is not None else None
+        info_type = info.get('type')
 
         if info_type is None:
-            if fail_if_not_exist:
-                raise UsageError('Target doesn\'t exist: %s/%s' % target)
-            else:
-                print >>self.stdout, formatting.verbose_contents_str(None)
+            print >>self.stdout, formatting.verbose_contents_str(None)
 
         if info_type == 'file':
             if decorate:
@@ -1853,13 +1848,12 @@ class BundleCLI(object):
                 # file and if so, initialize the offset.
                 if subpath_is_file[i] is None:
                     target_info = client.fetch_contents_info(bundle_uuid, subpaths[i], 0)
-                    if target_info is not None:
-                        if target_info['type'] == 'file':
-                            subpath_is_file[i] = True
-                            # Go to near the end of the file (TODO: make this match up with lines)
-                            subpath_offset[i] = max(target_info['size'] - 64, 0)
-                        else:
-                            subpath_is_file[i] = False
+                    if target_info['type'] == 'file':
+                        subpath_is_file[i] = True
+                        # Go to near the end of the file (TODO: make this match up with lines)
+                        subpath_offset[i] = max(target_info['size'] - 64, 0)
+                    else:
+                        subpath_is_file[i] = False
 
                 if not subpath_is_file[i]:
                     continue

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -363,6 +363,8 @@ def _fetch_bundle_contents_info(uuid, path=''):
 
     check_bundles_have_read_permission(local.model, request.user, [uuid])
     info = local.download_manager.get_target_info(uuid, path, depth)
+    if info is None:
+        abort(httplib.NOT_FOUND, 'Bundle not found')
 
     def render_human_readable(target_info):
         if 'size' in target_info:

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -335,7 +335,6 @@ def _fetch_bundle_contents_info(uuid, path=''):
     Query parameters:
     - `depth`: recursively fetch subdirectory info up to this depth.
       Default is 0.
-    - `human_readable`: render the file size as a human-readable string
 
     Response format:
     ```
@@ -345,6 +344,7 @@ def _fetch_bundle_contents_info(uuid, path=''):
           "link": "<string representing target if file is a symbolic link>",
           "type": "<file|directory|link>",
           "size": <size of file in bytes>,
+          "size_str": <size of file as a human-readable string>,
           "perm": <unix permission integer>,
           "contents": [
               {
@@ -358,7 +358,6 @@ def _fetch_bundle_contents_info(uuid, path=''):
     ```
     """
     depth = query_get_type(int, 'depth', default=0)
-    human_readable = query_get_bool('human_readable', default=False)
     if depth < 0:
         abort(httplib.BAD_REQUEST, "Depth must be at least 0")
 
@@ -367,12 +366,12 @@ def _fetch_bundle_contents_info(uuid, path=''):
 
     def render_human_readable(target_info):
         if 'size' in target_info:
-            target_info['size'] = formatting.size_str(target_info['size'])
+            target_info['size_str'] = formatting.size_str(target_info['size'])
         if 'contents' in target_info:
             for entry in target_info['contents']:
                 render_human_readable(entry)
-    if human_readable:
-        render_human_readable(info)
+    render_human_readable(info)
+
     return {
         'data': info
     }


### PR DESCRIPTION
Necessary to support UI file browser while maintaining a unified
formatting policy.

Paired with codalab/codalab-worksheets#308

please review