### PR TITLE
Improve competition script

### DIFF
--- a/scripts/competitiond.py
+++ b/scripts/competitiond.py
@@ -623,10 +623,9 @@ class Competition(object):
                     'num_period_submissions': 0,
                     'created': bundle['metadata']['created'],
                 }
-
             leaderboard.append({
                 'bundle': bundle,
-                'scores': scores,
+                'scores': scores[bundle['id']],
                 'submission': submission_info,
             })
 


### PR DESCRIPTION
- Allow orphaned evaluation bundles (i.e. evaluation bundles don't need to have a corresponding submission bundle, which means that you can tag evaluation bundles manually to be included in the leaderboard even though they weren't created by the script itself)
- Fix authentication bugs: properly indicate when username/password is incorrect, and don't include username and password in the outputted leaderboard JSON
- Properly handle the case where submissions involve multi-step pipelines that need to be mimicked.
- Cosmetic code changes