### PR TITLE
CPU-only run bundles prioritize workers without GPUs

### DIFF
--- a/codalab/worker/bundle_manager.py
+++ b/codalab/worker/bundle_manager.py
@@ -318,10 +318,6 @@ class BundleManager(object):
                 # We don't know how to handle this type of request queue
                 # argument.
                 return []
-        else: 
-            # if no tag specified, filter out workers that have a tag -- only jobs that 
-            # specifically request a tag will run on the workers with that tag
-            workers_list = filter(lambda worker: worker['tag'] == request_queue, workers_list)
 
         # Sort workers list according to these keys in the following succession:
         #  - if the bundle doesn't request GPUs (only requests CPUs), prioritize workers that don't have GPUs


### PR DESCRIPTION
Tested on dev with a GPU worker. Ran `cl run date`, which ran on a CPU-only worker. Then ran `cl run date --request-gpus 1`, which ran on a worker with GPUs.

Code for excluding workers by tag was not included in this PR because of ongoing discussions.