### PR TITLE
Don't strip trailing spaces in markdown

### DIFF
--- a/codalab/lib/worksheet_util.py
+++ b/codalab/lib/worksheet_util.py
@@ -219,7 +219,7 @@ def request_lines(worksheet_info):
 
     lines = editor_util.open_and_edit(suffix='.md', template=template)
     # Process the result
-    form_result = [line.rstrip() for line in lines]
+    form_result = [line.rstrip('\n') for line in lines]
     if form_result == template_lines:
         raise UsageError('No change made; aborting')
     return form_result


### PR DESCRIPTION
Trailing spaces are actually useful in markdown, as double spaces indicate line breaks without creating `<p>` elements, which add additional space between lines.  So, we shouldn't strip trailing spaces, only newlines.

Dunno what your policies are w.r.t. pull requests, but I already made the change locally so I figured I'd just send this.