### PR TITLE
If --request-docker-image does not come with a tag, default to "latest"

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -32,4 +32,5 @@ test:
     - printf "$CODALAB_USERNAME\n$CODALAB_PASSWORD\n" | sshpass -p "" ./codalab/bin/cl work
     - ./codalab/bin/cl upload -c stuff
     - printf "$CODALAB_USERNAME\n$CODALAB_PASSWORD\n" | sshpass -p "" ./codalab/bin/cl rm ^
-    - ./venv/bin/python test-cli.py default
+    - ./venv/bin/python test-cli.py default:
+        timeout: 1200

--- a/circle.yml
+++ b/circle.yml
@@ -32,5 +32,4 @@ test:
     - printf "$CODALAB_USERNAME\n$CODALAB_PASSWORD\n" | sshpass -p "" ./codalab/bin/cl work
     - ./codalab/bin/cl upload -c stuff
     - printf "$CODALAB_USERNAME\n$CODALAB_PASSWORD\n" | sshpass -p "" ./codalab/bin/cl rm ^
-    - ./venv/bin/python test-cli.py default:
-        timeout: 1200
+    - ./venv/bin/python test-cli.py default

--- a/worker/codalabworker/docker_client.py
+++ b/worker/codalabworker/docker_client.py
@@ -253,7 +253,7 @@ nvidia-docker-plugin not available, no GPU support on this worker.
     def download_image(self, docker_image, loop_callback):
         if len(docker_image.split(":")) < 2:
             logger.debug('Missing tag/digest on request docker image "%s", defaulting to latest', docker_image)
-            docker_image = ":".join([docker_image, "latest"])
+            docker_image = ':'.join([docker_image, 'latest'])
 
         logger.debug('Downloading Docker image %s', docker_image)
         with closing(self._create_connection()) as conn:

--- a/worker/codalabworker/docker_client.py
+++ b/worker/codalabworker/docker_client.py
@@ -248,8 +248,13 @@ nvidia-docker-plugin not available, no GPU support on this worker.
                 for action, target in line.items():
                     logger.debug('docker image %s: %s', action.lower(), target)
 
+    ''' Download the specified docker image with tag/digest. If no tag is specified, downloads the latest '''
     @wrap_exception('Unable to download Docker image')
     def download_image(self, docker_image, loop_callback):
+        if len(docker_image.split(":")) < 2:
+            logger.debug('Missing tag/digest on request docker image "%s", defaulting to latest', docker_image)
+            docker_image = ":".join([docker_image, "latest"])
+
         logger.debug('Downloading Docker image %s', docker_image)
         with closing(self._create_connection()) as conn:
             conn.request('POST',

--- a/worker/codalabworker/worker.py
+++ b/worker/codalabworker/worker.py
@@ -15,7 +15,7 @@ from file_util import remove_path, un_tar_directory
 from run import Run
 from docker_image_manager import DockerImageManager
 
-VERSION = 12
+VERSION = 13
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Rather than downloading every version/tag of the image
Also update worker version to 13

Fixes #793