### PR TITLE
fixes display content with bad path bug

### DIFF
--- a/codalab/apps/web/static/js/worksheet/contents_item_interface.jsx
+++ b/codalab/apps/web/static/js/worksheet/contents_item_interface.jsx
@@ -16,6 +16,11 @@ var ContentsItem = React.createClass({
 
     render: function() {
         var className = 'type-contents' + (this.props.focused ? ' focused' : '');
+        if (!this.props.item.interpreted) {
+            return (
+              <div></div>
+            );
+        }
         var contents = this.props.item.interpreted.join('');
         var bundleInfo = this.props.item.bundle_info;
         return(


### PR DESCRIPTION
Fixes #354 

The problem was that for content directives that didn't have the right path, the `interpreted` field was `null`, and there was no check in the code to see if it was not null. I simply added a check for `null` that would return an empty div element.

Question: What should be the expected behavior? I think the ideal would be to notify the user about the line with the invalid path, so I propose displaying an item that's simply an error message, saying something like: "0x5ab911b does not have path /output".