### PR TITLE
fixes problem with persisting stale bundle contents data in sidebar b…

### DIFF
--- a/codalab/apps/web/static/js/bundle/bundle_interface.jsx
+++ b/codalab/apps/web/static/js/bundle/bundle_interface.jsx
@@ -95,19 +95,21 @@ let Bundle = React.createClass({
       } else if (info.type === 'directory') {
         // Get stdout/stderr (important to set things to null).
         var fetchRequests = [];
+        var stateUpdate = {
+          fileContents: null
+        };
         ['stdout', 'stderr'].forEach(function (name) {
           if (info.contents.some((entry) => entry.name === name)) {
             fetchRequests.push(this.fetchFileSummary(this.props.uuid, '/' + name).then(function (blob) {
-              var stateUpdate = {};
               stateUpdate[name] = blob;
-              this.setState(stateUpdate);
             }));
           } else {
-            var stateUpdate = {};
             stateUpdate[name] = null;
-            this.setState(stateUpdate);
           }
         }.bind(this));
+        $.when.apply($, fetchRequests).then(() => {
+          this.setState(stateUpdate);
+        });
         return $.when(fetchRequests);
       }
     }).fail(function (xhr, status, err) {


### PR DESCRIPTION
fixes problem with persisting stale bundle contents data in sidebar by setting fileContents to null; also refactors state updating code so there are fewer setState() calls

Fixes #353 