### PR TITLE
Preserve file permissions for single files after upload

### DIFF
--- a/codalab/lib/zip_util.py
+++ b/codalab/lib/zip_util.py
@@ -163,10 +163,14 @@ def pack_files_for_upload(sources, should_unpack, follow_symlinks,
                 'should_unpack': True,
                 'should_simplify': False,
             }
-        else:
+        else: # path is single file
+            archived = tar_gzip_directory(
+                source, follow_symlinks=follow_symlinks,
+                exclude_patterns=exclude_patterns
+            )
             return {
-                'fileobj': open(source),
-                'filename': filename,
+                'fileobj': archived,
+                'filename': filename + '.tar.gz',
                 'filesize': os.path.getsize(source),
                 'should_unpack': False,
                 'should_simplify': False,

--- a/codalab/lib/zip_util.py
+++ b/codalab/lib/zip_util.py
@@ -16,6 +16,7 @@ from codalabworker.file_util import (
     tar_gzip_directory,
     un_gzip_stream,
     un_tar_directory,
+    tar_single_file,
 )
 
 
@@ -164,16 +165,19 @@ def pack_files_for_upload(sources, should_unpack, follow_symlinks,
                 'should_simplify': False,
             }
         else: # path is single file
+            """
             archived = tar_gzip_directory(
                 source, follow_symlinks=follow_symlinks,
                 exclude_patterns=exclude_patterns
             )
+            """
+            archived = tar_single_file(source)
             return {
                 'fileobj': archived,
                 'filename': filename + '.tar.gz',
                 'filesize': os.path.getsize(source),
-                'should_unpack': False,
-                'should_simplify': False,
+                'should_unpack': True,
+                'should_simplify': True,
             }
 
     # Build archive file incrementally from all sources

--- a/worker/codalabworker/docker_client.py
+++ b/worker/codalabworker/docker_client.py
@@ -310,7 +310,7 @@ nvidia-docker-plugin not available, no GPU support on this worker.
         # Set up the volumes.
         volume_bindings = ['%s:%s' % (bundle_path, docker_bundle_path)]
         for dependency_path, docker_dependency_path in dependencies:
-            volume_bindings.append('%s:%s:ro' % (
+            volume_bindings.append('%s:%s' % (
                 os.path.abspath(dependency_path),
                 docker_dependency_path))
 
@@ -401,9 +401,10 @@ nvidia-docker-plugin not available, no GPU support on this worker.
         # Set up the volumes.
         volume_bindings = ['%s:%s' % (bundle_path, docker_bundle_path)]
         for dependency_path, docker_dependency_path in dependencies:
-            volume_bindings.append('%s:%s:ro' % (
+            volume_bindings.append('%s:%s' % (
                 os.path.abspath(dependency_path),
                 docker_dependency_path))
+        print volume_bindings
         return volume_bindings
 
     @wrap_exception('Unable to start Docker container')

--- a/worker/codalabworker/file_util.py
+++ b/worker/codalabworker/file_util.py
@@ -38,6 +38,8 @@ def tar_gzip_directory(directory_path, follow_symlinks=False,
     except subprocess.CalledProcessError as e:
         raise IOError(e.output)
 
+def tar_single_file(fileobj, file_path, compressions=''):
+    pass
 
 def un_tar_directory(fileobj, directory_path, compression=''):
     """

--- a/worker/codalabworker/file_util.py
+++ b/worker/codalabworker/file_util.py
@@ -38,8 +38,16 @@ def tar_gzip_directory(directory_path, follow_symlinks=False,
     except subprocess.CalledProcessError as e:
         raise IOError(e.output)
 
-def tar_single_file(fileobj, file_path, compressions=''):
-    pass
+def tar_single_file(file_path):
+    abs_path = os.path.abspath(file_path)
+    base_dir_path = os.path.dirname(abs_path)
+    file_basename = os.path.basename(abs_path)
+    args = ['tar', 'czfp', '-', file_basename, '-C', base_dir_path]
+    try:
+        proc = subprocess.Popen(args, stdout=subprocess.PIPE)
+        return proc.stdout
+    except subprocess.CalledProcessError as e:
+        raise IOError(e.output)
 
 def un_tar_directory(fileobj, directory_path, compression=''):
     """

--- a/worker/codalabworker/file_util.py
+++ b/worker/codalabworker/file_util.py
@@ -43,6 +43,7 @@ def tar_single_file(file_path):
     base_dir_path = os.path.dirname(abs_path)
     file_basename = os.path.basename(abs_path)
     args = ['tar', 'czfp', '-', file_basename, '-C', base_dir_path]
+    print args
     try:
         proc = subprocess.Popen(args, stdout=subprocess.PIPE)
         return proc.stdout

--- a/worker/codalabworker/file_util.py
+++ b/worker/codalabworker/file_util.py
@@ -20,7 +20,7 @@ def tar_gzip_directory(directory_path, follow_symlinks=False,
     exclude_patterns: Any directory entries with the given names at any depth in
                       the directory structure are excluded.
     """
-    args = ['tar', 'czf', '-', '-C', directory_path]
+    args = ['tar', 'czfp', '-', '-C', directory_path]
     if follow_symlinks:
         args.append('-h')
     if exclude_patterns:

--- a/worker/codalabworker/file_util.py
+++ b/worker/codalabworker/file_util.py
@@ -65,6 +65,7 @@ def un_tar_directory(fileobj, directory_path, compression=''):
         for member in tar:
             # Make sure that there is no trickery going on (see note in
             # TarFile.extractall() documentation.
+            print member.name, member.mode
             member_path = os.path.realpath(os.path.join(directory_path, member.name))
             if not member_path.startswith(directory_path):
                 raise tarfile.TarError('Archive member extracts outside the directory.')


### PR DESCRIPTION
NOT READY FOR MERGING

I'm able to tar, upload, and extract single files now, but the file permissions are changing either during or after upload. @fabeschan @percyliang any thoughts on what could be going wrong? I'm wondering if Docker permissioning could be causing the issue?

The file permission for `exec.sh` is 509 both when I upload it as a single file and when I upload it in a directory. But when I try an execute it, it works in the case of a directory but not in the case of a single file. Here's an example of the permissions for the directory upload case (-rwxrwxr-x): http://138.197.208.207:8000/bundles/0xa8ec4a579fbe4deb94cbdcc3ab4f87cb/. Here's an example of the permissions for the single file upload case (-rw-r--r--): http://138.197.208.207:8000/bundles/0xe0d18b3e063c443b89f42744c1b2384e/.

I'm also curious what a 509 file permission stands for. As far as I can tell, the maximum digit is supposed to be 7.