### PR TITLE
Report unallocated memory only

### DIFF
--- a/codalab/worker/default_bundle_manager.py
+++ b/codalab/worker/default_bundle_manager.py
@@ -50,12 +50,6 @@ class DefaultBundleManager(BundleManager):
                 if request_cpus > max_cpus:
                     failure_message = 'No workers with enough CPUs'
 
-            request_memory = self._compute_request_memory(bundle)
-            if request_memory:
-                max_memory = max(map(lambda worker: worker['memory_bytes'], workers_list))
-                if request_memory > max_memory:
-                    failure_message = 'No workers with enough memory'
-
             if failure_message is not None:
                 logger.info('Failing %s: %s', bundle.uuid, failure_message)
                 self._model.update_bundle(

--- a/worker/codalabworker/run.py
+++ b/worker/codalabworker/run.py
@@ -504,3 +504,11 @@ class Run(object):
     def _set_finished(self):
         with self._finished_lock:
             self._finished = True
+
+    @property
+    def requested_memory_bytes(self):
+        """
+        If request_memory is defined, then return that.
+        Otherwise, this run's memory usage does not get checked, so return inf.
+        """
+        return self._resources['request_memory'] or float('inf')

--- a/worker/codalabworker/worker.py
+++ b/worker/codalabworker/worker.py
@@ -117,14 +117,20 @@ class Worker(object):
             return True
         return self._worker_state_manager.has_runs()
 
-    def _get_memory_bytes(self):
+    def _get_installed_memory_bytes(self):
         try:
             return os.sysconf('SC_PAGE_SIZE') * os.sysconf('SC_PHYS_PAGES')
         except ValueError:
             # Fallback to sysctl when os.sysconf('SC_PHYS_PAGES') fails on OS X
             return int(check_output(['sysctl', '-n', 'hw.memsize']).strip())
 
-    def _get_gpu_count(self):
+    def _get_allocated_memory_bytes(self):
+        return sum(self._worker_state_manager.map_runs(lambda run: run.requested_memory_bytes))
+
+    def _get_memory_bytes(self):
+        return max(0, self._get_installed_memory_bytes() - self._get_allocated_memory_bytes())
+
+u   def _get_gpu_count(self):
         if not self._docker._use_nvidia_docker:
             return 0
 

--- a/worker/codalabworker/worker_state_manager.py
+++ b/worker/codalabworker/worker_state_manager.py
@@ -53,6 +53,10 @@ class WorkerStateManager(object):
         with self._runs_lock:
             self._runs[uuid] = run
 
+    def map_runs(self, process):
+        with self._runs_lock:
+            return [process(run) for run in self._runs.itervalues()]
+
     def resume_previous_runs(self, run_deserializer):
         if self.shared_file_system:
             return


### PR DESCRIPTION
First pass solution to #584 
Have workers report only allocated memory, while defining the potential memory usage of runs that don't have request_memory specified to be infinite.

Essentially implements:

jobs without request_memory:
* min: 0
* max: infty

jobs with request_memory:
* min: request_memory
* max: request_memory

```
for each job:
    for each worker:
        if worker.memory >= job.min_memory:
            worker.memory = max(0, worker.memory - job.max_memory)
            schedule(job, worker)
            break
``` 

One remaining problem here is that "free-for-all" jobs will still get scheduled on workers that already have "explicit" jobs (#584). To keep it simple, can fix this with appropriate if-statements in the scheduler code.