### PR TITLE
Revival of revivable workers

### DIFF
--- a/codalab/common.py
+++ b/codalab/common.py
@@ -8,7 +8,7 @@ import httplib
 
 # Increment this on the develop branch when develop is merged into master.
 # http://semver.org/
-CODALAB_VERSION = '0.2.15'
+CODALAB_VERSION = '0.2.16'
 
 class IntegrityError(ValueError):
     """
@@ -101,10 +101,12 @@ class State(object):
     RUNNING = 'running'   # Actually running
     READY = 'ready'       # Done running and succeeded
     FAILED = 'failed'     # Done running and failed
+    KILLED = 'killed'     # Killed by user
+    WORKER_OFFLINE = 'worker_offline'
 
     OPTIONS = {CREATED, STAGED, MAKING, WAITING_FOR_WORKER_STARTUP, STARTING, RUNNING, READY, FAILED}
     ACTIVE_STATES = {MAKING, WAITING_FOR_WORKER_STARTUP, STARTING, RUNNING}
-    FINAL_STATES = {READY, FAILED}
+    FINAL_STATES = {READY, FAILED, KILLED}
 
 
 def precondition(condition, message):

--- a/codalab/common.py
+++ b/codalab/common.py
@@ -8,7 +8,7 @@ import httplib
 
 # Increment this on the develop branch when develop is merged into master.
 # http://semver.org/
-CODALAB_VERSION = '0.2.16'
+CODALAB_VERSION = '0.2.15'
 
 class IntegrityError(ValueError):
     """
@@ -102,7 +102,7 @@ class State(object):
     READY = 'ready'       # Done running and succeeded
     FAILED = 'failed'     # Done running and failed
     KILLED = 'killed'     # Killed by user
-    WORKER_OFFLINE = 'worker_offline'
+    WORKER_OFFLINE = 'worker_offline' # Assigned worker has gone offline
 
     OPTIONS = {CREATED, STAGED, MAKING, WAITING_FOR_WORKER_STARTUP, STARTING, RUNNING, READY, FAILED}
     ACTIVE_STATES = {MAKING, WAITING_FOR_WORKER_STARTUP, STARTING, RUNNING}

--- a/codalab/lib/download_manager.py
+++ b/codalab/lib/download_manager.py
@@ -1,9 +1,12 @@
+import logging
+import sys
 from contextlib import closing
 
 from codalab.common import http_error_to_exception, precondition, State, UsageError, NotFoundError
 from codalabworker import download_util
 from codalabworker import file_util
 
+logger = logging.getLogger(__name__)
 
 def retry_if_no_longer_running(f):
     """
@@ -77,8 +80,10 @@ class DownloadManager(object):
                 self._send_read_message(worker, response_socket_id, uuid, path, read_args)
                 with closing(self._worker_model.start_listening(response_socket_id)) as sock:
                     result = self._worker_model.get_json_message(sock, 60)
-                precondition(result is not None, 'Unable to reach worker')
-                if 'error_code' in result:
+                if result is None: # dead workers are a fact of life now
+                    logging.info('Unable to reach worker, bundle state {}'.format(bundle_state))
+                    return None
+                elif 'error_code' in result:
                     raise http_error_to_exception(result['error_code'], result['error_message'])
                 return result['target_info']
             finally:
@@ -225,9 +230,8 @@ class DownloadManager(object):
             'path': path,
             'read_args': read_args,
         }
-        precondition(
-            self._worker_model.send_json_message(worker['socket_id'], message, 60),
-            'Unable to reach worker')
+        if not self._worker_model.send_json_message(worker['socket_id'], message, 60): # dead workers are a fact of life now
+            logging.info('Unable to reach worker')
 
     def _get_read_response_stream(self, response_socket_id):
         with closing(self._worker_model.start_listening(response_socket_id)) as sock:

--- a/codalab/model/worker_model.py
+++ b/codalab/model/worker_model.py
@@ -325,7 +325,8 @@ class WorkerModel(object):
 
                 if not success:
                     # Shouldn't be too expensive just to keep retrying.
-                    time.sleep(0.003)
+                    # TODO: maybe exponential backoff
+                    time.sleep(0.3) # changed from 0.003 to keep from rate-limiting due to dead workers
                     continue
 
                 if not autoretry:

--- a/codalab/rest/workers.py
+++ b/codalab/rest/workers.py
@@ -107,7 +107,7 @@ def check_run_permission(bundle):
 def start_bundle(worker_id, uuid):
     """
     Checks whether the bundle is still assigned to run on the worker with the
-    given ID. If so, reports that it's starting to run and returns True.
+    given worker_id. If so, reports that it's starting to run and returns True.
     Otherwise, returns False, meaning the worker shouldn't run the bundle.
     """
     bundle = local.model.get_bundle(uuid)
@@ -121,11 +121,11 @@ def start_bundle(worker_id, uuid):
     return json.dumps(False)
 
 @post('/workers/<worker_id>/resume_bundle/<uuid:re:%s>' % spec_util.UUID_STR,
-      name='worker_start_bundle', apply=AuthenticatedPlugin())
+      name='worker_resume_bundle', apply=AuthenticatedPlugin())
 def resume_bundle(worker_id, uuid):
     """
     Checks whether the bundle is still assigned to run on the worker with the
-    given ID. If so, reports that it's starting to run and returns True.
+    given worker_id. If so, reports that it's starting to run and returns True.
     Otherwise, returns False, meaning the worker shouldn't run the bundle.
     """
     bundle = local.model.get_bundle(uuid)
@@ -134,6 +134,7 @@ def resume_bundle(worker_id, uuid):
     if local.model.resume_bundle(bundle, request.user.user_id, worker_id,
                                 request.json['hostname'],
                                 request.json['start_time']):
+        print 'Resumed bundle %s' % uuid
         return json.dumps(True)
     return json.dumps(False)
 

--- a/codalab/rest/workers.py
+++ b/codalab/rest/workers.py
@@ -120,6 +120,22 @@ def start_bundle(worker_id, uuid):
         return json.dumps(True)
     return json.dumps(False)
 
+@post('/workers/<worker_id>/resume_bundle/<uuid:re:%s>' % spec_util.UUID_STR,
+      name='worker_start_bundle', apply=AuthenticatedPlugin())
+def resume_bundle(worker_id, uuid):
+    """
+    Checks whether the bundle is still assigned to run on the worker with the
+    given ID. If so, reports that it's starting to run and returns True.
+    Otherwise, returns False, meaning the worker shouldn't run the bundle.
+    """
+    bundle = local.model.get_bundle(uuid)
+    check_run_permission(bundle)
+    response.content_type = 'application/json'
+    if local.model.resume_bundle(bundle, request.user.user_id, worker_id,
+                                request.json['hostname'],
+                                request.json['start_time']):
+        return json.dumps(True)
+    return json.dumps(False)
 
 @put('/workers/<worker_id>/update_bundle_metadata/<uuid:re:%s>' % spec_util.UUID_STR,
      name='worker_update_bundle_metadata', apply=AuthenticatedPlugin())

--- a/codalab/worker/bundle_manager.py
+++ b/codalab/worker/bundle_manager.py
@@ -225,11 +225,11 @@ class BundleManager(object):
 
     def _cleanup_dead_workers(self, workers, callback=None):
         """
-        Clean-up workers that we haven't heard from for more than 20 minutes.
+        Clean-up workers that we haven't heard from for more than 30 seconds.
         Such workers probably died without checking out properly.
         """
         for worker in workers.workers():
-            if datetime.datetime.now() - worker['checkin_time'] > datetime.timedelta(minutes=20):
+            if datetime.datetime.now() - worker['checkin_time'] > datetime.timedelta(seconds=30):
                 logger.info('Cleaning up dead worker (%s, %s)', worker['user_id'], worker['worker_id'])
                 self._worker_model.worker_cleanup(worker['user_id'], worker['worker_id'])
                 workers.remove(worker)
@@ -250,15 +250,14 @@ class BundleManager(object):
 
     def _fail_stuck_running_bundles(self, workers):
         """
-        Fails bundles that got stuck in the RUNNING state.
+        Make bundles that got stuck in the RUNNING state into WORKER_OFFLINE state.
         """
         for bundle in self._model.batch_get_bundles(state=State.RUNNING, bundle_type='run'):
             if (not workers.is_running(bundle.uuid) or  # Dead worker.
-                time.time() - bundle.metadata.last_updated > 60 * 60):  # Shouldn't really happen, but let's be safe.
-                failure_message = 'Worker died'
+                time.time() - bundle.metadata.last_updated > 1 * 30):  # Shouldn't really happen, but let's be safe.
+                failure_message = 'Worker offline'
                 logger.info('Failing bundle %s: %s', bundle.uuid, failure_message)
-                self._model.finalize_bundle(bundle, -1, exitcode=None, failure_message=failure_message)
-                workers.restage(bundle.uuid)
+                self._model.set_offline_bundle(bundle)
 
     def _schedule_run_bundles_on_workers(self, workers, user_owned):
         """

--- a/codalab/worker/default_bundle_manager.py
+++ b/codalab/worker/default_bundle_manager.py
@@ -27,7 +27,7 @@ class DefaultBundleManager(BundleManager):
         # Handle some exceptional cases.
         self._cleanup_dead_workers(workers)
         self._restage_stuck_starting_bundles(workers)
-        self._fail_stuck_running_bundles(workers)
+        self._bring_offline_stuck_running_bundles(workers)
         self._fail_on_too_many_resources(workers)
 
         # Schedule, preferring user-owned workers.
@@ -43,7 +43,7 @@ class DefaultBundleManager(BundleManager):
                             workers.user_owned_workers(self._model.root_user_id))
 
             failure_message = None
-            
+
             request_cpus = self._compute_request_cpus(bundle)
             if request_cpus:
                 max_cpus = max(map(lambda worker: worker['cpus'], workers_list))

--- a/tests/worker/dependency_manager_test.py
+++ b/tests/worker/dependency_manager_test.py
@@ -12,6 +12,7 @@ class DependencyManagerTest(unittest.TestCase):
     def setUp(self):
         self.work_dir = tempfile.mkdtemp()
         self.manager = DependencyManager(self.work_dir, None)
+        self.bundles_dir = os.path.join(self.work_dir, 'bundles')
 
     def tearDown(self):
         remove_path(self.work_dir)
@@ -19,13 +20,13 @@ class DependencyManagerTest(unittest.TestCase):
     def test_load_state(self):
         self.manager.finish_run('uuid1')
         self.manager.finish_run('uuid2')
-        with open(os.path.join(self.work_dir, 'random_file'), 'w'):
+        with open(os.path.join(self.bundles_dir, 'random_file'), 'w'):
             pass
-        self.assertIn('random_file', os.listdir(self.work_dir))
+        self.assertIn('random_file', os.listdir(self.bundles_dir))
         new_manager = DependencyManager(self.work_dir, 1 * 1024 * 1024)
         self.check_state([('uuid1', ''), ('uuid2', '')], new_manager)
-        self.assertIn('state.json', os.listdir(self.work_dir))
-        self.assertNotIn('random_file', os.listdir(self.work_dir))
+        self.assertIn('dependency-state.json', os.listdir(self.work_dir))
+        self.assertNotIn('random_file', os.listdir(self.bundles_dir))
 
     def test_downloading(self):
         self.manager.add_dependency('uuid1', '', 'uuid2')
@@ -33,16 +34,16 @@ class DependencyManagerTest(unittest.TestCase):
         # Check cases that should not block.
         self.check_add_dependency_blocks('uuid1', 'a', 'uuid5', False, True)  # Different path
         self.check_add_dependency_blocks('uuid6', '', 'uuid7', False, True)  # Different UUID
-        
+
         # This call will block until the failed download. Then, it will be asked
         # to retry the download.
         self.check_add_dependency_blocks('uuid1', '', 'uuid3', True, True)
-        
+
         self.manager.finish_download('uuid1', '', False)
         self.check_state([])
         time.sleep(0.01)
 
-        # This call will block until both attempts to download are done. Then, 
+        # This call will block until both attempts to download are done. Then,
         # it will not be asked to retry the download.
         self.check_add_dependency_blocks('uuid1', '', 'uuid4', True, False)
 
@@ -51,9 +52,9 @@ class DependencyManagerTest(unittest.TestCase):
 
     def test_download_path_conflict(self):
         self.assertEqual(self.manager.add_dependency('uuid1', 'a/b_c', 'uuid2')[0],
-                         os.path.join(self.work_dir, 'uuid1_a_b_c'))
+                         os.path.join(self.bundles_dir, 'uuid1_a_b_c'))
         self.assertEqual(self.manager.add_dependency('uuid1', 'a_b/c', 'uuid2')[0],
-                         os.path.join(self.work_dir, 'uuid1_a_b_c_'))
+                         os.path.join(self.bundles_dir, 'uuid1_a_b_c_'))
 
     def test_cleanup(self):
         self.manager = DependencyManager(self.work_dir, 2 * 1024 * 1024)
@@ -62,7 +63,7 @@ class DependencyManagerTest(unittest.TestCase):
         self.manager.add_dependency('uuid1', '', 'uuid100')
 
         self.manager.add_dependency('uuid2', '', 'uuid100') # Downloading, so will not be removed.
-    
+
         self.manager.finish_run('uuid3')  # Used after uuid4, so will be left.
         self.manager.finish_run('uuid4')  # Will be removed.
         self.manager.add_dependency('uuid4', '', 'uuid100')
@@ -81,8 +82,8 @@ class DependencyManagerTest(unittest.TestCase):
 
         self.check_state([('uuid1', ''), ('uuid3', '')])
         self.assertIn(('uuid2', ''), self.manager._dependencies)
-        self.assertItemsEqual(['uuid1', 'uuid2', 'uuid3', 'state.json'],
-                              os.listdir(self.work_dir))
+        self.assertItemsEqual(['dependency-state.json', 'bundles'], os.listdir(self.work_dir))
+        self.assertItemsEqual(['uuid1', 'uuid2', 'uuid3'], os.listdir(self.bundles_dir))
 
     def check_state(self, expected_targets, manager=None):
         if manager is None:

--- a/tests/worker/dependency_manager_test.py
+++ b/tests/worker/dependency_manager_test.py
@@ -25,7 +25,7 @@ class DependencyManagerTest(unittest.TestCase):
         self.assertIn('random_file', os.listdir(self.bundles_dir))
         new_manager = DependencyManager(self.work_dir, 1 * 1024 * 1024)
         self.check_state([('uuid1', ''), ('uuid2', '')], new_manager)
-        self.assertIn('dependency-state.json', os.listdir(self.work_dir))
+        self.assertIn(DependencyManager.STATE_FILENAME, os.listdir(self.work_dir))
         self.assertNotIn('random_file', os.listdir(self.bundles_dir))
 
     def test_downloading(self):
@@ -82,7 +82,7 @@ class DependencyManagerTest(unittest.TestCase):
 
         self.check_state([('uuid1', ''), ('uuid3', '')])
         self.assertIn(('uuid2', ''), self.manager._dependencies)
-        self.assertItemsEqual(['dependency-state.json', 'bundles'], os.listdir(self.work_dir))
+        self.assertItemsEqual([DependencyManager.STATE_FILENAME, 'bundles'], os.listdir(self.work_dir))
         self.assertItemsEqual(['uuid1', 'uuid2', 'uuid3'], os.listdir(self.bundles_dir))
 
     def check_state(self, expected_targets, manager=None):

--- a/worker/codalabworker/bundle_service_client.py
+++ b/worker/codalabworker/bundle_service_client.py
@@ -135,6 +135,12 @@ class BundleServiceClient(RestClient):
             'POST', self._worker_url_prefix(worker_id) + '/start_bundle/' + uuid,
             data=request_data)
 
+    @wrap_exception('Unable to resume bundle in bundle service')
+    def resume_bundle(self, worker_id, uuid, request_data):
+        return self._make_request(
+            'POST', self._worker_url_prefix(worker_id) + '/resume_bundle/' + uuid,
+            data=request_data)
+
     @wrap_exception('Unable to update bundle metadata in bundle service')
     def update_bundle_metadata(self, worker_id, uuid, new_metadata):
         self._make_request(

--- a/worker/codalabworker/dependency_manager.py
+++ b/worker/codalabworker/dependency_manager.py
@@ -16,9 +16,9 @@ class DependencyManager(object):
     runs download the same dependency at the same time. Ensures that the total
     size of all the dependencies doesn't exceed the given limit.
     """
-    STATE_FILENAME = 'dependency-state.json'
+    STATE_FILENAME = 'dependencies-state.json'
 
-    def __init__(self, work_dir, max_work_dir_size_bytes, prevous_runs=[]):
+    def __init__(self, work_dir, max_work_dir_size_bytes, previous_runs=[]):
         self._max_work_dir_size_bytes = max_work_dir_size_bytes
         self._state_file = os.path.join(work_dir, self.STATE_FILENAME)
         self._work_dir = work_dir
@@ -31,14 +31,14 @@ class DependencyManager(object):
         self._paths = set()
 
         if os.path.exists(self._state_file):
-            self._load_state(prevous_runs)
+            self._load_state(previous_runs)
         else:
             remove_path(self._work_dir)
             os.makedirs(self._work_dir, 0770)
             os.makedirs(self._bundles_dir, 0770)
             self._save_state()
 
-    def _load_state(self, prevous_runs):
+    def _load_state(self, previous_runs):
         with open(self._state_file, 'r') as f:
             loaded_state = json.loads(f.read())
 
@@ -49,7 +49,7 @@ class DependencyManager(object):
             self._paths.add(dep.path)
         logger.info('{} dependencies in cache.'.format(len(self._dependencies)))
 
-        for uuid in prevous_runs:
+        for uuid in previous_runs:
             self._paths.add(uuid)
 
         # Remove paths that aren't complete (e.g. interrupted downloads and runs).

--- a/worker/codalabworker/docker_client.py
+++ b/worker/codalabworker/docker_client.py
@@ -516,7 +516,7 @@ nvidia-docker-plugin not available, no GPU support on this worker.
             conn.request('GET', '/containers/%s/json' % container_id)
             inspect_response = conn.getresponse()
             if inspect_response.status == 404:
-                return (True, None, 'Lost by Docker')
+                return (True, None, 'Container {} Lost by Docker'.format(container_id))
             if inspect_response.status != 200:
                 raise DockerException(inspect_response.read())
 

--- a/worker/codalabworker/run.py
+++ b/worker/codalabworker/run.py
@@ -40,6 +40,7 @@ class Run(object):
         self._resources = resources
         self._uuid = bundle['uuid']
         self._container_id = None
+        self._start_time = None # start time of container
 
         self._disk_utilization_lock = threading.Lock()
         self._disk_utilization = 0
@@ -53,6 +54,27 @@ class Run(object):
 
         self._finished_lock = threading.Lock()
         self._finished = False
+
+    def serialize(self):
+        """ Output a dictionary able to be serialized into json """
+        run_info = {
+                'bundle': self._bundle,
+                'bundle_path': self._bundle_path,
+                'resources': self._resources,
+                'container_id': self._container_id,
+                'start_time': self._start_time,
+        }
+        return run_info
+
+    @staticmethod
+    def deserialize(bundle_service, docker, image_manager, worker, run_info):
+        """ Create a new Run object and populate it based on given run_info dictionary """
+        run = Run(bundle_service, docker, image_manager, worker,
+                run_info['bundle'], run_info['bundle_path'], run_info['resources'])
+        run._container_id = run_info['container_id']
+        run._start_time = run_info['start_time']
+        return run
+
 
     def run(self):
         """
@@ -87,6 +109,27 @@ class Run(object):
         threading.Thread(target=Run._start, args=[self]).start()
 
         return True
+
+    def resume(self):
+        # Report that the bundle is running. We note the start time here for
+        # accurate accounting of time used, since the clock on the bundle
+        # service and on the worker could be different.
+        start_message = {
+            'hostname': socket.gethostname(),
+            'start_time': int(self._start_time),
+        }
+        if not self._bundle_service.resume_bundle(self._worker.id, self._uuid,
+                                                 start_message):
+            return False
+
+        # Start a thread for this run.
+        def resume_run(self):
+            Run._safe_update_run_status(self, 'Running')
+            Run._monitor(self)
+
+        logger.debug("resuming bundle {}, container {}".format(self._uuid, self._container_id))
+        threading.Thread(target=resume_run, args=[self]).start()
+
 
     def _safe_update_docker_image(self, docker_image):
         """ Update the docker_image metadata field for the run bundle """

--- a/worker/codalabworker/run.py
+++ b/worker/codalabworker/run.py
@@ -58,11 +58,11 @@ class Run(object):
     def serialize(self):
         """ Output a dictionary able to be serialized into json """
         run_info = {
-                'bundle': self._bundle,
-                'bundle_path': self._bundle_path,
-                'resources': self._resources,
-                'container_id': self._container_id,
-                'start_time': self._start_time,
+            'bundle': self._bundle,
+            'bundle_path': self._bundle_path,
+            'resources': self._resources,
+            'container_id': self._container_id,
+            'start_time': self._start_time,
         }
         return run_info
 

--- a/worker/codalabworker/run.py
+++ b/worker/codalabworker/run.py
@@ -111,13 +111,17 @@ class Run(object):
         return True
 
     def resume(self):
-        # Report that the bundle is running. We note the start time here for
-        # accurate accounting of time used, since the clock on the bundle
-        # service and on the worker could be different.
+        """
+        Report that the bundle is running. We note the start time here for
+        accurate accounting of time used, since the clock on the bundle
+        service and on the worker could be different.
+        """
         start_message = {
             'hostname': socket.gethostname(),
             'start_time': int(self._start_time),
         }
+        logger.debug("Resuming bundle {}, container {}".format(self._uuid, self._container_id))
+
         if not self._bundle_service.resume_bundle(self._worker.id, self._uuid,
                                                  start_message):
             return False
@@ -127,7 +131,6 @@ class Run(object):
             Run._safe_update_run_status(self, 'Running')
             Run._monitor(self)
 
-        logger.debug("resuming bundle {}, container {}".format(self._uuid, self._container_id))
         threading.Thread(target=resume_run, args=[self]).start()
 
 

--- a/worker/codalabworker/worker.py
+++ b/worker/codalabworker/worker.py
@@ -12,6 +12,7 @@ import json
 
 from bundle_service_client import BundleServiceException
 from dependency_manager import DependencyManager
+from worker_state_manager import WorkerStateManager
 from file_util import remove_path, un_tar_directory
 from run import Run
 from docker_image_manager import DockerImageManager
@@ -35,8 +36,6 @@ class Worker(object):
         4) Upgrading the worker.
     """
 
-    STATE_FILENAME = 'worker-state.json'
-
     def __init__(self, id, tag, work_dir, max_work_dir_size_bytes,
                  max_images_bytes, shared_file_system,
                  slots, bundle_service, docker):
@@ -46,25 +45,13 @@ class Worker(object):
         self._bundle_service = bundle_service
         self._docker = docker
         self._slots = slots
-        self._state_file = os.path.join(work_dir, self.STATE_FILENAME)
 
-        # Dictionary from UUID to Run that keeps track of bundles currently
-        # running. These runs are added to this dict inside _run, and removed
-        # when the Run class calls finish_run.
-        self._runs = {}
-        self._runs_lock = threading.Lock()
-
-        self._previous_runs = {}
-        if os.path.exists(self._state_file):
-            self._load_state()
-        else:
-            if not os.path.exists(work_dir):
-                os.makedirs(work_dir, 0770)
-            self._save_state()
+        self._worker_state_manager = WorkerStateManager(work_dir, self.shared_file_system)
 
         if not self.shared_file_system:
             # Manages which dependencies are available.
-            self._dependency_manager = DependencyManager(work_dir, max_work_dir_size_bytes, self._previous_runs.keys())
+            self._dependency_manager = DependencyManager(
+                    work_dir, max_work_dir_size_bytes, self._worker_state_manager.previous_runs.keys())
         self._image_manager = DockerImageManager(self._docker, work_dir, max_images_bytes)
         self._max_images_bytes = max_images_bytes
 
@@ -72,33 +59,6 @@ class Worker(object):
         self._exiting = False
         self._should_upgrade = False
         self._last_checkin_successful = False
-
-    def _load_state(self):
-        with open(self._state_file, 'r') as f:
-            state = json.load(f)
-            for uuid, run_info in state['runs'].items():
-                self._previous_runs[uuid] = run_info
-
-    def _resume_previous_runs(self):
-        with self._runs_lock:
-            for uuid, run_info in self._previous_runs.items():
-                run = Run.deserialize(self._bundle_service, self._docker, self._image_manager, self, run_info)
-                run.resume()
-                self._runs[uuid] = run
-        self._previous_runs = {}
-
-    def _save_state(self):
-        # In case we're initializing the state for the first time
-        state = {
-            'runs': {}
-        }
-
-        with self._runs_lock:
-            for uuid, run in self._runs.items():
-                state['runs'][uuid] = run.serialize()
-
-        with open(self._state_file, 'w') as f:
-            json.dump(state, f)
 
     def run(self):
         if self._max_images_bytes is not None:
@@ -108,9 +68,12 @@ class Worker(object):
 
         while self._should_run():
             try:
-                self._save_state()
                 self._checkin()
-                self._resume_previous_runs()
+                self._worker_state_manager.resume_previous_runs(
+                        lambda run_info: Run.deserialize(
+                            self._bundle_service, self._docker, self._image_manager, self, run_info)
+                )
+                self._worker_state_manager.save_state()
                 if not self._last_checkin_successful:
                     logger.info('Connected! Successful check in.')
                 self._last_checkin_successful = True
@@ -121,7 +84,7 @@ class Worker(object):
                 time.sleep(1)
 
         self._checkout()
-        self._save_state()
+        self._worker_state_manager.save_state()
 
         if self._max_images_bytes is not None:
             self._image_manager.stop_cleanup_thread()
@@ -143,10 +106,7 @@ class Worker(object):
     def _should_run(self):
         if not self._is_exiting():
             return True
-        with self._runs_lock:
-            if self._runs:
-                return True
-        return False
+        return self._worker_state_manager.has_runs()
 
     def _get_memory_bytes(self):
         try:
@@ -203,8 +163,7 @@ class Worker(object):
         run = Run(self._bundle_service, self._docker, self._image_manager, self,
                   bundle, bundle_path, resources)
         if run.run():
-            with self._runs_lock:
-                self._runs[bundle['uuid']] = run
+            self._worker_state_manager.add_run(bundle['uuid'], run)
 
     def add_dependency(self, parent_uuid, parent_path, uuid, loop_callback):
         """
@@ -268,7 +227,7 @@ class Worker(object):
         self._dependency_manager.remove_dependency(parent_uuid, parent_path, uuid)
 
     def _read(self, socket_id, uuid, path, read_args):
-        run = self._get_run(uuid)
+        run = self._worker_state_manager._get_run(uuid)
         if run is None:
             Run.read_run_missing(self._bundle_service, self, socket_id)
         else:
@@ -277,25 +236,20 @@ class Worker(object):
                              args=(run, socket_id, path, read_args)).start()
 
     def _write(self, uuid, subpath, string):
-        run = self._get_run(uuid)
+        run = self._worker_state_manager._get_run(uuid)
         if run is not None:
             run.write(subpath, string)
 
     def _kill(self, uuid):
-        run = self._get_run(uuid)
+        run = self._worker_state_manager._get_run(uuid)
         if run is not None:
             run.kill('Kill requested')
-
-    def _get_run(self, uuid):
-        with self._runs_lock:
-            return self._runs.get(uuid)
 
     def finish_run(self, uuid):
         """
         Registers that the run with the given UUID has finished.
         """
-        with self._runs_lock:
-            del self._runs[uuid]
+        self._worker_state_manager.finish_run(uuid)
         if not self.shared_file_system:
             self._dependency_manager.finish_run(uuid)
 

--- a/worker/codalabworker/worker.py
+++ b/worker/codalabworker/worker.py
@@ -21,6 +21,15 @@ VERSION = 14
 
 logger = logging.getLogger(__name__)
 
+"""
+Resumable Workers
+
+    If the worker process of a worker machine terminates and restarts while a
+    bundle is running, the worker process is able to keep track of the running
+    bundle once again, as long as the state is intact and the bundle container
+    is still running or has finished running.
+"""
+
 class Worker(object):
     """
     This class is responsible for:

--- a/worker/codalabworker/worker.py
+++ b/worker/codalabworker/worker.py
@@ -8,6 +8,7 @@ import threading
 import time
 import traceback
 import re
+import json
 
 from bundle_service_client import BundleServiceException
 from dependency_manager import DependencyManager
@@ -15,7 +16,7 @@ from file_util import remove_path, un_tar_directory
 from run import Run
 from docker_image_manager import DockerImageManager
 
-VERSION = 13
+VERSION = 14
 
 logger = logging.getLogger(__name__)
 
@@ -33,6 +34,9 @@ class Worker(object):
            their dependencies) and the cache of Docker images.
         4) Upgrading the worker.
     """
+
+    STATE_FILENAME = 'worker-state.json'
+
     def __init__(self, id, tag, work_dir, max_work_dir_size_bytes,
                  max_images_bytes, shared_file_system,
                  slots, bundle_service, docker):
@@ -42,23 +46,59 @@ class Worker(object):
         self._bundle_service = bundle_service
         self._docker = docker
         self._slots = slots
-
-        if not self.shared_file_system:
-            # Manages which dependencies are available.
-            self._dependency_manager = DependencyManager(work_dir, max_work_dir_size_bytes)
-        self._image_manager = DockerImageManager(self._docker, work_dir, max_images_bytes)
-        self._max_images_bytes = max_images_bytes
+        self._state_file = os.path.join(work_dir, self.STATE_FILENAME)
 
         # Dictionary from UUID to Run that keeps track of bundles currently
         # running. These runs are added to this dict inside _run, and removed
         # when the Run class calls finish_run.
-        self._runs_lock = threading.Lock()
         self._runs = {}
+        self._runs_lock = threading.Lock()
+
+        self._previous_runs = {}
+        if os.path.exists(self._state_file):
+            self._load_state()
+        else:
+            if not os.path.exists(work_dir):
+                os.makedirs(work_dir, 0770)
+            self._save_state()
+
+        if not self.shared_file_system:
+            # Manages which dependencies are available.
+            self._dependency_manager = DependencyManager(work_dir, max_work_dir_size_bytes, self._previous_runs.keys())
+        self._image_manager = DockerImageManager(self._docker, work_dir, max_images_bytes)
+        self._max_images_bytes = max_images_bytes
 
         self._exiting_lock = threading.Lock()
         self._exiting = False
         self._should_upgrade = False
         self._last_checkin_successful = False
+
+    def _load_state(self):
+        with open(self._state_file, 'r') as f:
+            state = json.load(f)
+            for uuid, run_info in state['runs'].items():
+                self._previous_runs[uuid] = run_info
+
+    def _resume_previous_runs(self):
+        with self._runs_lock:
+            for uuid, run_info in self._previous_runs.items():
+                run = Run.deserialize(self._bundle_service, self._docker, self._image_manager, self, run_info)
+                run.resume()
+                self._runs[uuid] = run
+        self._previous_runs = {}
+
+    def _save_state(self):
+        # In case we're initializing the state for the first time
+        state = {
+            'runs': {}
+        }
+
+        with self._runs_lock:
+            for uuid, run in self._runs.items():
+                state['runs'][uuid] = run.serialize()
+
+        with open(self._state_file, 'w') as f:
+            json.dump(state, f)
 
     def run(self):
         if self._max_images_bytes is not None:
@@ -68,7 +108,9 @@ class Worker(object):
 
         while self._should_run():
             try:
+                self._save_state()
                 self._checkin()
+                self._resume_previous_runs()
                 if not self._last_checkin_successful:
                     logger.info('Connected! Successful check in.')
                 self._last_checkin_successful = True
@@ -79,6 +121,7 @@ class Worker(object):
                 time.sleep(1)
 
         self._checkout()
+        self._save_state()
 
         if self._max_images_bytes is not None:
             self._image_manager.stop_cleanup_thread()

--- a/worker/codalabworker/worker_state_manager.py
+++ b/worker/codalabworker/worker_state_manager.py
@@ -1,0 +1,81 @@
+import threading
+import os
+import time
+import traceback
+import logging
+import json
+
+from formatting import size_str
+
+logger = logging.getLogger(__name__)
+
+class WorkerStateManager(object):
+    """
+    Manages the state of Runs on the worker
+    DependencyManager should be instantiated before DockerImageManager, to
+    ensure that the work directory already exists.
+    """
+    STATE_FILENAME = 'worker-state.json'
+
+    def __init__(self, work_dir, shared_file_system=False):
+        self._state_file = os.path.join(work_dir, self.STATE_FILENAME)
+        self._lock = threading.Lock()
+
+        # Dictionary from UUID to Run that keeps track of bundles currently
+        # running. These runs are added to this dict inside _run, and removed
+        # when the Run class calls finish_run.
+        self._runs = {}
+        self._runs_lock = threading.Lock()
+
+        self.previous_runs = {}
+        if not os.path.exists(self._state_file):
+            if not os.path.exists(work_dir):
+                os.makedirs(work_dir, 0770)
+            self.save_state()
+        self.load_state()
+
+    def _get_run(self, uuid):
+        with self._runs_lock:
+            return self._runs.get(uuid)
+
+    def has_runs(self):
+        with self._lock:
+            return True if self._runs else False
+
+    def finish_run(self, uuid):
+        with self._runs_lock:
+            del self._runs[uuid]
+
+    def add_run(self, uuid, run):
+        with self._runs_lock:
+            self._runs[uuid] = run
+
+    def resume_previous_runs(self, run_deserializer):
+        with self._runs_lock:
+            for uuid, run_info in self.previous_runs.items():
+                run = run_deserializer(run_info)
+                run.resume()
+                self._runs[uuid] = run
+        self.previous_runs = {}
+
+    def load_state(self):
+        with self._lock:
+            with open(self._state_file, 'r') as f:
+                state = json.load(f)
+                for uuid, run_info in state['runs'].items():
+                    self.previous_runs[uuid] = run_info
+
+    def save_state(self):
+        # In case we're initializing the state for the first time
+        state = {
+            'runs': {}
+        }
+
+        with self._lock:
+            for uuid, run in self._runs.items():
+                state['runs'][uuid] = run.serialize()
+
+            with open(self._state_file, 'w') as f:
+                json.dump(state, f)
+
+

--- a/worker/codalabworker/worker_state_manager.py
+++ b/worker/codalabworker/worker_state_manager.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 class WorkerStateManager(object):
     """
-    Manages the state of Runs on the worker
+    Manages the state of Runs on the worker.
     DependencyManager should be instantiated before DockerImageManager, to
     ensure that the work directory already exists.
     """


### PR DESCRIPTION
Revival of resumable workers

If the worker process of a worker machine terminates and restarts while a bundle is running, the worker process is able to keep track of the running bundle once again, as long as the state is intact and the bundle container is still running or has finished running.

- Add bundle 'killed' and 'worker_offline' states
- Worker is considered dead and will be cleaned up after 30 seconds without checkin
- Worker checkout is now optional
- Worker Run objects can now be serialized and deserialized
- REFACTOR: Worker Run objects are now delegated to a WorkerStateManager