### PR TITLE
Authless SMTP support

### DIFF
--- a/codalab/lib/codalab_manager.py
+++ b/codalab/lib/codalab_manager.py
@@ -366,10 +366,11 @@ class CodaLabManager(object):
     @cached
     def emailer(self):
         if 'email' in self.config:
+            # Default to authless SMTP (supported by some servers) if user/password is unspecified.
             return SMTPEmailer(
                 host=self.config['email']['host'],
-                user=self.config['email'].get('user','noreply@codalab.org'),#['user'],
-                password=self.config['email'].get('password',None),#['password'],
+                user=self.config['email'].get('user','noreply@codalab.org'), 
+                password=self.config['email'].get('password',None),
                 use_tls=True,
                 default_sender='CodaLab <noreply@codalab.org>',
                 server_email='noreply@codalab.org',

--- a/codalab/lib/codalab_manager.py
+++ b/codalab/lib/codalab_manager.py
@@ -368,8 +368,8 @@ class CodaLabManager(object):
         if 'email' in self.config:
             return SMTPEmailer(
                 host=self.config['email']['host'],
-                user=self.config['email']['user'],
-                password=self.config['email']['password'],
+                user=self.config['email'].get('user','noreply@codalab.org'),#['user'],
+                password=self.config['email'].get('password',None),#['password'],
                 use_tls=True,
                 default_sender='CodaLab <noreply@codalab.org>',
                 server_email='noreply@codalab.org',

--- a/codalab/lib/emailer.py
+++ b/codalab/lib/emailer.py
@@ -33,6 +33,7 @@ class SMTPEmailer(Emailer):
         self.server_email = server_email
         self.port = port
         self.use_tls = use_tls
+        self.do_login = self.password != None
 
     def send_email(self, subject, body, recipient, sender=None,
                    mime_type='plain', charset='us-ascii'):
@@ -59,7 +60,7 @@ class SMTPEmailer(Emailer):
                 mail_server.starttls()
                 mail_server.ehlo()
 
-            mail_server.login(self.user, self.password)
+            if self.do_login: mail_server.login(self.user, self.password)
 
             message = MIMEText(body, mime_type, charset)
             message["From"] = sender or self.default_sender

--- a/codalab/lib/emailer.py
+++ b/codalab/lib/emailer.py
@@ -19,7 +19,7 @@ class SMTPEmailer(Emailer):
         """
         :param host: SMTP server hostname
         :param user: SMTP user name
-        :param password:  SMTP password
+        :param password:  SMTP password, or None to disable SMTP authentication
         :param default_sender: default 'From' header
         :param server_email: email address to send from
         :param port: SMTP server port
@@ -33,7 +33,7 @@ class SMTPEmailer(Emailer):
         self.server_email = server_email
         self.port = port
         self.use_tls = use_tls
-        self.do_login = self.password != None
+        self.do_login = (self.password != None)
 
     def send_email(self, subject, body, recipient, sender=None,
                    mime_type='plain', charset='us-ascii'):
@@ -60,7 +60,8 @@ class SMTPEmailer(Emailer):
                 mail_server.starttls()
                 mail_server.ehlo()
 
-            if self.do_login: mail_server.login(self.user, self.password)
+            if self.do_login: 
+                mail_server.login(self.user, self.password)
 
             message = MIMEText(body, mime_type, charset)
             message["From"] = sender or self.default_sender

--- a/monitor.py
+++ b/monitor.py
@@ -73,8 +73,9 @@ def send_email(subject, message):
         return
 
     sender_host = sender_info['host']
-    sender_user = sender_info['user']
-    sender_password = sender_info['password']
+    sender_user = sender_info['user'] if 'user' in sender_info else 'noreply@codalab.org'
+    sender_password = sender_info['password'] if 'password' in sender_info else None
+    do_login = sender_password != None
     print 'send_email to %s from %s@%s; subject: %s; message contains %d lines' % \
         (recipient, sender_user, sender_host, subject, len(message))
     s = SMTP(sender_host, 587)
@@ -85,7 +86,7 @@ def send_email(subject, message):
     msg['Subject'] = 'CodaLab on %s: %s' % (hostname, subject)
     msg['To'] = recipient
     msg['From'] = 'noreply@codalab.org'
-    s.login(sender_user, sender_password)
+    if do_login: s.login(sender_user, sender_password)
     s.sendmail(sender_user, recipient, msg.as_string())
     s.quit()
 

--- a/monitor.py
+++ b/monitor.py
@@ -73,9 +73,13 @@ def send_email(subject, message):
         return
 
     sender_host = sender_info['host']
-    sender_user = sender_info['user'] if 'user' in sender_info else 'noreply@codalab.org'
-    sender_password = sender_info['password'] if 'password' in sender_info else None
-    do_login = sender_password != None
+    
+    # Default to authless SMTP (supported by some servers) if user/password is unspecified.
+    #   Default sender_user has to be a valid RFC 822 from-address string for transport (distinct from msg headers)
+    #   Ref: https://docs.python.org/2/library/smtplib.html#smtplib.SMTP.sendmail
+    sender_user = sender_info.get('user', 'noreply@codalab.org') 
+    sender_password = sender_info.get('password', None)
+    do_login = (sender_password != None)
     print 'send_email to %s from %s@%s; subject: %s; message contains %d lines' % \
         (recipient, sender_user, sender_host, subject, len(message))
     s = SMTP(sender_host, 587)
@@ -86,7 +90,8 @@ def send_email(subject, message):
     msg['Subject'] = 'CodaLab on %s: %s' % (hostname, subject)
     msg['To'] = recipient
     msg['From'] = 'noreply@codalab.org'
-    if do_login: s.login(sender_user, sender_password)
+    if do_login: 
+        s.login(sender_user, sender_password)
     s.sendmail(sender_user, recipient, msg.as_string())
     s.quit()
 


### PR DESCRIPTION
Some SMTP servers don't require u/p authentication; these flags allow such a server to be used with CodaLab.