### PR TITLE
checks for null values

### DIFF
--- a/codalab/apps/web/static/js/worksheet/worksheet_side_panel.jsx
+++ b/codalab/apps/web/static/js/worksheet/worksheet_side_panel.jsx
@@ -121,7 +121,7 @@ let WorksheetSidePanel = React.createClass({
         var clickAction = 'DEFAULT';
         if (!this.props.userInfo) {
           clickAction = 'SIGN_IN_REDIRECT';
-        } else if (!this.props.ws.info.edit_permission) {
+        } else if (this.props.ws.info && !this.props.ws.info.edit_permission) {
           clickAction = 'DISABLED';
         }
 


### PR DESCRIPTION
There was a bug in the code where, as a logged in user who didn't have permission to a worksheet, when you tried creating a new worksheet, there would be a null value that caused an error. Related to PR #357 