### PR TITLE
Run thread periodically resumes a running bundle

### DIFF
--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -710,7 +710,6 @@ class BundleModel(object):
                 # The user deleted the bundle.
                 return False
             if row.state != State.WORKER_OFFLINE: # this should never happen
-                print "Warning: resume_bundle is called on a bundle that is not of state OFFLINE"
                 return False
 
             worker_run_row = {
@@ -723,7 +722,7 @@ class BundleModel(object):
             bundle_update = {
                 'state': State.RUNNING,
                 'metadata': {
-                    'last_updated': start_time,
+                    'last_updated': int(time.time()),
                 },
             }
             self.update_bundle(bundle, bundle_update, connection)

--- a/codalab/rest/workers.py
+++ b/codalab/rest/workers.py
@@ -134,7 +134,6 @@ def resume_bundle(worker_id, uuid):
     if local.model.resume_bundle(bundle, request.user.user_id, worker_id,
                                 request.json['hostname'],
                                 request.json['start_time']):
-        print 'Resumed bundle %s' % uuid
         return json.dumps(True)
     return json.dumps(False)
 

--- a/codalab/worker/bundle_manager.py
+++ b/codalab/worker/bundle_manager.py
@@ -252,10 +252,12 @@ class BundleManager(object):
     def _bring_offline_stuck_running_bundles(self, workers):
         """
         Make bundles that got stuck in the RUNNING state into WORKER_OFFLINE state.
+        Bundles in WORKER_OFFLINE state can be moved back to the RUNNING state if a
+        worker resumes the bundle, indicating that it's still RUNNING.
         """
         for bundle in self._model.batch_get_bundles(state=State.RUNNING, bundle_type='run'):
             if (not workers.is_running(bundle.uuid) or  # Dead worker.
-                time.time() - bundle.metadata.last_updated > WORKER_TIMEOUT_SECONDS):  # Shouldn't really happen, but let's be safe.
+                time.time() - bundle.metadata.last_updated > WORKER_TIMEOUT_SECONDS):
                 failure_message = 'Worker offline'
                 logger.info('Failing bundle %s: %s', bundle.uuid, failure_message)
                 self._model.set_offline_bundle(bundle)

--- a/worker/codalabworker/run.py
+++ b/worker/codalabworker/run.py
@@ -25,8 +25,11 @@ class Run(object):
         2) Starting the Docker container.
         3) Reporting running container resource utilization to the bundle
            service, and killing the container if it uses too many resources.
-        4) Handling any messages related to the run.
-        5) Reporting to the bundle service that the run has finished.
+        4) Periodically informing the server that the job is still running (think of this as a heartbeat,
+           if the server does not receive one for more than WORKER_TIMEOUT_SECONDS, the job is moved to
+           the WORKER_OFFLINE state)
+        5) Handling any messages related to the run.
+        6) Reporting to the bundle service that the run has finished.
     """
     def __init__(self, bundle_service, docker, image_manager, worker,
                  bundle, bundle_path, resources):

--- a/worker/codalabworker/run.py
+++ b/worker/codalabworker/run.py
@@ -262,6 +262,7 @@ class Run(object):
             else:
                 report = False
             self._check_and_report_resource_utilization(report)
+            self.resume()
 
             # TODO(klopyrev): Upload the contents of the running bundle to the
             #                 bundle service every few hours, so that they are

--- a/worker/codalabworker/run.py
+++ b/worker/codalabworker/run.py
@@ -120,7 +120,6 @@ class Run(object):
             'hostname': socket.gethostname(),
             'start_time': int(self._start_time),
         }
-        logger.debug("Resuming bundle {}, container {}".format(self._uuid, self._container_id))
 
         if not self._bundle_service.resume_bundle(self._worker.id, self._uuid,
                                                  start_message):
@@ -262,7 +261,11 @@ class Run(object):
             else:
                 report = False
             self._check_and_report_resource_utilization(report)
-            self.resume()
+
+            try:
+                self.resume()
+            except BundleServiceException:
+                pass
 
             # TODO(klopyrev): Upload the contents of the running bundle to the
             #                 bundle service every few hours, so that they are


### PR DESCRIPTION
If a server goes offline for more than 30 seconds for any reason (most typically during re-deployments), then running bundles will be treated as offline. To avoid this from happening, every run thread periodically attempts to resume a running bundle. So now this acts like a heartbeat.