### PR TITLE
fixes escape key, inconsistent rendering

### DIFF
--- a/codalab/apps/web/static/js/worksheet/worksheet_interface.jsx
+++ b/codalab/apps/web/static/js/worksheet/worksheet_interface.jsx
@@ -222,7 +222,6 @@ var Worksheet = React.createClass({
                 $('#glossaryModal').modal('hide');
             }
             ContextMenuMixin.closeContextMenu();
-            self.setState({escCount: self.state.escCount + 1});
         });
 
         Mousetrap.bind(['shift+r'], function(e) {


### PR DESCRIPTION
It's not clear to me why this fix works. I have reasons and tests to show that the correct behavior is being achieved. PRs. Please suggest other reasons / tests I can use. Plan of action: Since I don't have 100% confidence that the PR doesn't break anything, I'm thinking that I'll deploy both this change and my large search bar / user profile change to worksheets-dev and we'll really test it before deploying both 

fixes #330

Reasons why this fix works:
- This is the commit where the comment about the `escCount` hack was added: https://github.com/codalab/codalab-worksheets/commit/98fb9f1f6558458a97fbfa9bbd98d2400389ceaa. The purpose seems to be to manually trigger a re-render in some of some components (namely, of the New Worksheet Modal and the Worksheet Side Panel) whenever the "escape" key is entered. But it's unclear to me why those two components need to be reset in such a hacky manner...

Tests:
- Highlighting a run bundle, clicking and opening the web terminal, then hitting "esc" key, whether once or multiple times. Hitting "a" still copies the command into the web terminal.
- Highlighting a run bundle, then clicking any of "Upload", "New Run", or "New Worksheet", hitting "esc" key, then typing "a" copies the command into the web terminal.

Before merging:
- strip out all of the other uses of `escCount` -- if this is the correct fix, then it's not useful having `escCount` anymore since it's not actually changing anywhere else. In a Redux-based world, would be good to centralize all of this logic in one reducer. Adding to doc now.