### PR TITLE
Initialize worker docker client ssl context to None by default

### DIFF
--- a/worker/codalabworker/docker_client.py
+++ b/worker/codalabworker/docker_client.py
@@ -68,6 +68,7 @@ class DockerClient(object):
         if self._docker_host:
             self._docker_host = self._docker_host.replace('tcp://', '')
 
+        self._ssl_context = None
         cert_path = os.environ.get('DOCKER_CERT_PATH') or None
         if cert_path:
             self._ssl_context = ssl.create_default_context(


### PR DESCRIPTION
Without this, the worker fails when run in a system where Docker client connects to the Docker daemon through the DOCKER_HOST environment variable, but without TLS. The code was otherwise written to handle this case, but the None check for _ssl_context fails without this initialization.