### PR TITLE
Ignore default ignored files like DS_Store everywhere

### DIFF
--- a/codalab/lib/upload_manager.py
+++ b/codalab/lib/upload_manager.py
@@ -11,7 +11,7 @@ class UploadManager(object):
     """
     def __init__(self, bundle_model, bundle_store):
         # exclude these patterns by default
-        DEFAULT_EXCLUDE_PATTERNS = ['\.DS_Store', '__MACOSX', '^\._.*']
+        DEFAULT_EXCLUDE_PATTERNS = ['.DS_Store', '__MACOSX', '^\._.*']
         self._bundle_model = bundle_model
         self._bundle_store = bundle_store
         self._default_exclude_patterns = DEFAULT_EXCLUDE_PATTERNS

--- a/codalab/lib/upload_manager.py
+++ b/codalab/lib/upload_manager.py
@@ -10,11 +10,12 @@ class UploadManager(object):
     the associated bundle metadata in the database.
     """
     def __init__(self, bundle_model, bundle_store):
+        # exclude these patterns by default
+        DEFAULT_EXCLUDE_PATTERNS = ['\.DS_Store', '__MACOSX', '^\._.*']
         self._bundle_model = bundle_model
         self._bundle_store = bundle_store
+        self._default_exclude_patterns = DEFAULT_EXCLUDE_PATTERNS
 
-    # exclude these patterns by default
-    DEFAULT_EXCLUDE_PATTERNS = ['\.DS_Store', '__MACOSX', '^\._.*']
 
     def upload_to_bundle_store(self, bundle, sources, follow_symlinks, exclude_patterns, remove_sources, git, unpack, simplify_archives):
         """
@@ -39,7 +40,7 @@ class UploadManager(object):
         - If |git|, then each source is replaced with the result of running 'git clone |source|'
         - If |unpack| is True or a source is an archive (zip, tar.gz, etc.), then unpack the source.
         """
-        exclude_patterns = DEFAULT_EXCLUDE_PATTERNS + exclude_patterns
+        exclude_patterns = self._default_exclude_patterns + exclude_patterns
         bundle_path = self._bundle_store.get_bundle_location(bundle.uuid)
         try:
             path_util.make_directory(bundle_path)
@@ -128,11 +129,10 @@ class UploadManager(object):
         if len(files) == 1:
             self._simplify_directory(path, files[0])
 
-    # ... ignore files that match any of the default ignore patterns
-    IGNORE_FILE_MATCHERS = [re.compile(s) for s in DEFAULT_EXCLUDE_PATTERNS]
 
     def _ignore_file_in_archive(self, filename):
-        return any([matcher.match(filename) for matcher in self.IGNORE_FILE_MATCHERS])
+        matchers = [re.compile(s) for s in self._default_exclude_patterns]
+        return any([matcher.match(filename) for matcher in matchers])
 
     def _simplify_directory(self, path, child_path=None):
         """

--- a/codalab/lib/upload_manager.py
+++ b/codalab/lib/upload_manager.py
@@ -40,7 +40,7 @@ class UploadManager(object):
         - If |git|, then each source is replaced with the result of running 'git clone |source|'
         - If |unpack| is True or a source is an archive (zip, tar.gz, etc.), then unpack the source.
         """
-        exclude_patterns = self._default_exclude_patterns + exclude_patterns
+        exclude_patterns = self._default_exclude_patterns + exclude_patterns if exclude_patterns else self._default_exclude_patterns
         bundle_path = self._bundle_store.get_bundle_location(bundle.uuid)
         try:
             path_util.make_directory(bundle_path)

--- a/tests/lib/upload_manager_test.py
+++ b/tests/lib/upload_manager_test.py
@@ -32,7 +32,7 @@ class UploadManagerTest(unittest.TestCase):
             FakeBundle(), sources,
             follow_symlinks, exclude_patterns, remove_sources,
             git, unpack, simplify_archives)
-    
+
     def test_single_local_path(self):
         source = os.path.join(self.temp_dir, 'filename')
         self.write_string_to_file('testing', source)
@@ -42,12 +42,14 @@ class UploadManagerTest(unittest.TestCase):
 
     def test_ignored_files(self):
         dsstore_file = os.path.join(self.temp_dir, '.DS_Store')
+        macosx_file = os.path.join(self.temp_dir, '__MACOSX')
         self.write_string_to_file('testing', dsstore_file)
         source = os.path.join(self.temp_dir, 'filename')
         self.write_string_to_file('testing', source)
         self.do_upload([self.temp_dir])
         self.assertTrue(os.path.exists(os.path.join(self.bundle_location, 'filename')))
         self.assertFalse(os.path.exists(os.path.join(self.bundle_location, '.DS_Store')))
+        self.assertFalse(os.path.exists(os.path.join(self.bundle_location, '__MACOSX')))
         self.check_file_contains_string(os.path.join(self.bundle_location, 'filename'), 'testing')
 
     def test_single_local_gzip_path(self):
@@ -56,7 +58,7 @@ class UploadManagerTest(unittest.TestCase):
         self.do_upload([source], unpack=True)
         self.assertTrue(os.path.exists(source))
         self.check_file_contains_string(self.bundle_location, 'testing')
-        
+
     def test_single_local_tar_gz_path_simplify_archives(self):
         source_dir = os.path.join(self.temp_dir, 'source_dir')
         os.mkdir(source_dir)

--- a/tests/lib/upload_manager_test.py
+++ b/tests/lib/upload_manager_test.py
@@ -40,6 +40,16 @@ class UploadManagerTest(unittest.TestCase):
         self.assertTrue(os.path.exists(source))
         self.check_file_contains_string(self.bundle_location, 'testing')
 
+    def test_ignored_files(self):
+        dsstore_file = os.path.join(self.temp_dir, '.DS_Store')
+        self.write_string_to_file('testing', dsstore_file)
+        source = os.path.join(self.temp_dir, 'filename')
+        self.write_string_to_file('testing', source)
+        self.do_upload([self.temp_dir])
+        self.assertTrue(os.path.exists(os.path.join(self.bundle_location, 'filename')))
+        self.assertFalse(os.path.exists(os.path.join(self.bundle_location, '.DS_Store')))
+        self.check_file_contains_string(os.path.join(self.bundle_location, 'filename'), 'testing')
+
     def test_single_local_gzip_path(self):
         source = os.path.join(self.temp_dir, 'filename.gz')
         self.write_string_to_file(gzip_string('testing'), source)


### PR DESCRIPTION
We already had a list of filename patterns that we excluded when they were located in archives that were uploaded, Generalized that logic to basically always exclude those patterns by default, whether they're uploaded from within archives or uploaded from within directories.

Didn't add any new patterns for now. Let's see if anything else comes up.

Fixes: #381 #842 