### PR TITLE
Add bz2 decompression support

### DIFF
--- a/codalab/client/json_api_client.py
+++ b/codalab/client/json_api_client.py
@@ -10,7 +10,6 @@ from codalab.common import (
     UsageError,
 )
 from codalabworker.rest_client import RestClient, RestClientException
-from codalabworker.file_util import un_gzip_stream
 
 
 def wrap_exception(message):

--- a/codalab/lib/zip_util.py
+++ b/codalab/lib/zip_util.py
@@ -14,13 +14,14 @@ from codalab.lib import path_util
 from codalabworker.file_util import (
     gzip_file,
     tar_gzip_directory,
+    un_bz2_file,
     un_gzip_stream,
     un_tar_directory,
 )
 
 
 # Files with these extensions are considered archive.
-ARCHIVE_EXTS = ['.tar.gz', '.tgz', '.tar.bz2', '.zip', '.gz']
+ARCHIVE_EXTS = ['.tar.gz', '.tgz', '.tar.bz2', '.zip', '.gz', '.bz2']
 
 
 def path_is_archive(path):
@@ -63,6 +64,8 @@ def unpack(ext, source, dest_path):
                 un_tar_directory(source, dest_path, 'gz')
             elif ext == '.tar.bz2':
                 un_tar_directory(source, dest_path, 'bz2')
+            elif ext == '.bz2':
+                un_bz2_file(source, dest_path)
             elif ext == '.gz':
                 with open(dest_path, 'wb') as f:
                     shutil.copyfileobj(un_gzip_stream(source), f)

--- a/tests/worker/file_util_test.py
+++ b/tests/worker/file_util_test.py
@@ -1,8 +1,9 @@
 import os
 import tempfile
 import unittest
+import bz2
 
-from codalabworker.file_util import gzip_file, gzip_string, remove_path, tar_gzip_directory, un_gzip_stream, un_gzip_string, un_tar_directory
+from codalabworker.file_util import gzip_file, gzip_string, remove_path, tar_gzip_directory, un_gzip_stream, un_bz2_file, un_gzip_string, un_tar_directory
 
 
 class FileUtilTest(unittest.TestCase):
@@ -35,12 +36,21 @@ class FileUtilTest(unittest.TestCase):
 
     def test_gzip_stream(self):
         with tempfile.NamedTemporaryFile(delete=False) as temp_file:
-            self.addCleanup(lambda: os.remove(temp_file.name))    
+            self.addCleanup(lambda: os.remove(temp_file.name))
             temp_file.write('contents')
             name = temp_file.name
 
         self.assertEquals(un_gzip_stream(gzip_file(name)).read(), 'contents')
 
+    def test_bz2_file(self):
+        with tempfile.NamedTemporaryFile(delete=False) as source, tempfile.NamedTemporaryFile(delete=False) as temp_file_2:
+            self.addCleanup(lambda: os.remove(source.name))
+            destination = temp_file_2.name
+            self.addCleanup(lambda: os.remove(destination))
+            source.write(bz2.compress('contents'))
+            un_bz2_file(source, destination)
+            self.assertEquals(temp_file_2.read(), 'contents')
+
     def test_gzip_string(self):
         self.assertEqual(un_gzip_string(gzip_string('contents')), 'contents')
-    
+

--- a/tests/worker/file_util_test.py
+++ b/tests/worker/file_util_test.py
@@ -43,13 +43,18 @@ class FileUtilTest(unittest.TestCase):
         self.assertEquals(un_gzip_stream(gzip_file(name)).read(), 'contents')
 
     def test_bz2_file(self):
-        with tempfile.NamedTemporaryFile(delete=False) as source, tempfile.NamedTemporaryFile(delete=False) as temp_file_2:
-            self.addCleanup(lambda: os.remove(source.name))
-            destination = temp_file_2.name
-            self.addCleanup(lambda: os.remove(destination))
-            source.write(bz2.compress('contents'))
-            un_bz2_file(source, destination)
-            self.assertEquals(temp_file_2.read(), 'contents')
+        source_write = tempfile.NamedTemporaryFile(delete=False)
+        self.addCleanup(lambda: os.remove(source_write.name))
+        source_write.write(bz2.compress('contents'))
+        source_write.flush()
+        source_read = open(source_write.name, 'r')
+        destination = tempfile.NamedTemporaryFile(delete=False)
+        self.addCleanup(lambda: os.remove(destination.name))
+        un_bz2_file(source_read, destination.name)
+        self.assertEquals(destination.read(), 'contents')
+        source_write.close()
+        source_read.close()
+        destination.close()
 
     def test_gzip_string(self):
         self.assertEqual(un_gzip_string(gzip_string('contents')), 'contents')


### PR DESCRIPTION
Decompresses bz2 files automatically while keeping the previous .tar.bz2 decompressing logic the same. 
Tested on:
* 10MB -> 13MB file: working
* 130MB -> 170MB file: working
* 1.1GB -> 30GB file: working
* 14GB -> 60GB file: working