### PR TITLE
Make Content-Disposition headers include "attachment"

### DIFF
--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -531,7 +531,7 @@ def _fetch_bundle_contents_blob(uuid, path=''):
     # Set headers.
     response.set_header('Content-Type', mimetype or 'text/plain')
     response.set_header('Content-Encoding', 'gzip' if gzipped_stream else 'identity')
-    response.set_header('Content-Disposition', 'filename="%s"' % filename)
+    response.set_header('Content-Disposition', 'attachment; filename="%s"' % filename)
     response.set_header('Target-Type', target_info['type'])
 
     return fileobj

--- a/codalab/rest/workers.py
+++ b/codalab/rest/workers.py
@@ -196,7 +196,7 @@ def code():
     """
     Returns .tar.gz archive containing the code of the worker.
     """
-    response.set_header('Content-Disposition', 'filename="code.tar.gz"')
+    response.set_header('Content-Disposition', 'attachment; filename="code.tar.gz"')
     response.set_header('Content-Type', 'application/gzip')
     codalab_cli = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
     code_dir = os.path.join(codalab_cli, 'worker', 'codalabworker')


### PR DESCRIPTION
The previous version was technically in violation of the RFC,
so we have an HTTP client that was complaining about it.