### PR TITLE
Use standard docker library for pulls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ script:
   - printf "$CODALAB_USERNAME\n$CODALAB_PASSWORD\n" > /home/travis/.codalab/root.password
   - chmod 600 /home/travis/.codalab/root.password
   - sleep 15
-  - ./worker/codalabworker/worker.sh --server http://127.0.0.1:2900 --work-dir /home/travis/.codalab/worker-scratch --slots 4 --password-file /home/travis/.codalab/root.password --verbose &
+  - (source ./venv/bin/activate && ./worker/codalabworker/worker.sh --server http://127.0.0.1:2900 --work-dir /home/travis/.codalab/worker-scratch --slots 4 --password-file /home/travis/.codalab/root.password --verbose &)
   - printf "$CODALAB_USERNAME\n$CODALAB_PASSWORD\n" | sshpass -p "" ./codalab/bin/cl work
   - ./codalab/bin/cl upload -c stuff
   - printf "$CODALAB_USERNAME\n$CODALAB_PASSWORD\n" | sshpass -p "" ./codalab/bin/cl rm ^

--- a/worker/requirements.txt
+++ b/worker/requirements.txt
@@ -6,3 +6,4 @@ six==1.10.0
 SQLAlchemy==1.0.8
 watchdog==0.8.3
 fusepy==2.0.4
+docker==2.5.1


### PR DESCRIPTION
Recreated version of [this PR](https://github.com/codalab/codalab-cli/pull/810) which passes the new travis tests: 

> The docker repository we're using requires authentication, which happens client-side. The standard docker python package includes support for this functionality (in particular, using docker credential helpers), so we started using it for pulling images.

The first commit is the actual change, the second fixes CI. (The worker.sh script needs to run inside the virtualenv so it can use the python deps installed for the worker; I think it was just luck this wasn't a problem before. If you like we could just activate the virtualenv at the top and drop all the ./venv/bin paths everywhere.)