### PR TITLE
Refactor key, target parsing and resolving logic

### DIFF
--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -544,7 +544,7 @@ class BundleCLI(object):
     def resolve_key_targets(self, client, worksheet_uuid, target_specs):
         """
         Helper: target_specs is a list of strings which are [<key>]:<target>
-        Returns: List<Tuple<key, Tuple<bundle_uuid, subpath>>>
+        Returns: [(key, (bundle_uuid, subpath)), ...]
         """
         targets = []
         target_keys_values = [parse_key_target(spec) for spec in target_specs]

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -2093,13 +2093,14 @@ class BundleCLI(object):
             for bundle_spec in args.item_spec:
                 if '//' in bundle_spec:
                     source_worksheet_spec, source_bundle_spec = tuple(bundle_spec.split('//', 1))
-                    source_client, source_ws = self.parse_spec(source_worksheet_spec)
+                    source_client, source_worksheet = self.parse_spec(source_worksheet_spec)
+                    source_worksheet_uuid = self.resolve_worksheet_uuid(source_client, None, source_worksheet)
                 else:
                     source_client, source_bundle_spec = self.parse_spec(bundle_spec)
                     # a base_worksheet_uuid is only applicable if we're on the source client
-                    source_ws = curr_worksheet_uuid if source_client is curr_client else None
+                    source_worksheet_uuid = curr_worksheet_uuid if source_client is curr_client else None
 
-                source_bundle_uuid = self.resolve_bundle_uuid(source_client, source_ws, source_bundle_spec)
+                source_bundle_uuid = self.resolve_bundle_uuid(source_client, source_worksheet_uuid, source_bundle_spec)
 
                 # copy (or add only if bundle already exists on destination)
                 self.copy_bundle(source_client, source_bundle_uuid,

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -1181,6 +1181,8 @@ class BundleCLI(object):
     def do_make_command(self, args):
         client, worksheet_uuid = self.parse_client_worksheet_uuid(args.worksheet_spec)
         targets = self.resolve_key_targets(client, worksheet_uuid, args.target_spec)
+        # Support anonymous make calls by replacing None keys with ''
+        targets = [('' if key is None else key, val) for key, val in targets]
         metadata = self.get_missing_metadata(MakeBundle, args)
         new_bundle = client.create(
             'bundles',

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -1760,6 +1760,9 @@ class BundleCLI(object):
 
     # Helper: shared between info and cat
     def print_target_info(self, client, bundle_uuid, subpath, head=None, tail=None):
+        # target spec parsing returns None for subpath if it doesn't exist but API
+        # calls below break if subpath is None, thus we convert to empty string
+        subpath = '' if subpath is None else subpath
         info = client.fetch_contents_info(bundle_uuid, subpath, 1)
         info_type = info.get('type')
 

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -539,6 +539,9 @@ class BundleCLI(object):
         # Resolve the bundle_spec to a particular bundle_uuid.
         bundle_uuid = BundleCLI.resolve_bundle_uuid(client, worksheet_uuid, bundle_spec)
 
+        # Rest of CLI treats empty string as no subpath and can't handle subpath being None
+        subpath = '' if subpath is None else subpath
+
         return (client, worksheet_uuid, bundle_uuid, subpath)
 
     def resolve_key_targets(self, client, worksheet_uuid, target_specs):
@@ -1760,9 +1763,6 @@ class BundleCLI(object):
 
     # Helper: shared between info and cat
     def print_target_info(self, client, bundle_uuid, subpath, head=None, tail=None):
-        # target spec parsing returns None for subpath if it doesn't exist but API
-        # calls below break if subpath is None, thus we convert to empty string
-        subpath = '' if subpath is None else subpath
         info = client.fetch_contents_info(bundle_uuid, subpath, 1)
         info_type = info.get('type')
 

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -2091,11 +2091,15 @@ class BundleCLI(object):
 
         elif args.item_type == 'bundle':
             for bundle_spec in args.item_spec:
-                source_client, source_spec = self.parse_spec(bundle_spec)
+                if '//' in bundle_spec:
+                    source_worksheet_spec, source_bundle_spec = tuple(bundle_spec.split('//', 1))
+                    source_client, source_ws = self.parse_spec(source_worksheet_spec)
+                else:
+                    source_client, source_bundle_spec = self.parse_spec(bundle_spec)
+                    # a base_worksheet_uuid is only applicable if we're on the source client
+                    source_ws = curr_worksheet_uuid if source_client is curr_client else None
 
-                # a base_worksheet_uuid is only applicable if we're on the source client
-                base_worksheet_uuid = curr_worksheet_uuid if source_client is curr_client else None
-                source_bundle_uuid = self.resolve_bundle_uuid(source_client, base_worksheet_uuid, source_spec)
+                source_bundle_uuid = self.resolve_bundle_uuid(source_client, source_ws, source_bundle_spec)
 
                 # copy (or add only if bundle already exists on destination)
                 self.copy_bundle(source_client, source_bundle_uuid,

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -1683,13 +1683,13 @@ class BundleCLI(object):
 
         print >>self.stdout, wrap('contents')
         bundle_uuid = info['uuid']
-        info = self.print_target_info(client, (bundle_uuid, ''), head=10)
+        info = self.print_target_info(client, bundle_uuid, '', head=10)
         if info is not None and info['type'] == 'directory':
             for item in info['contents']:
                 if item['name'] not in ['stdout', 'stderr']:
                     continue
                 print >>self.stdout, wrap(item['name'])
-                self.print_target_info(client, (bundle_uuid, item['name']), head=10)
+                self.print_target_info(client, bundle_uuid, item['name'], head=10)
 
     @Commands.command(
         'mount',
@@ -1756,7 +1756,7 @@ class BundleCLI(object):
 
         default_client, default_worksheet_uuid = self.parse_client_worksheet_uuid(args.worksheet_spec)
         client, worksheet_uuid, bundle_uuid, subpath = self.resolve_target(default_client, default_worksheet_uuid, args.target_spec)
-        self.print_target_info(client, (bundle_uuid, subpath), head=args.head, tail=args.tail)
+        self.print_target_info(client, bundle_uuid, subpath, head=args.head, tail=args.tail)
 
     # Helper: shared between info and cat
     def print_target_info(self, client, bundle_uuid, subpath, head=None, tail=None):
@@ -2303,7 +2303,7 @@ class BundleCLI(object):
                     if maxlines:
                         maxlines = int(maxlines)
                     try:
-                        self.print_target_info(client, data, head=maxlines)
+                        self.print_target_info(client, data[0], data[1], head=maxlines)
                     except UsageError, e:
                         print >>self.stdout, 'ERROR:', e
                 else:

--- a/codalab/lib/cli_util.py
+++ b/codalab/lib/cli_util.py
@@ -2,6 +2,12 @@ import re
 
 from codalab.common import precondition, UsageError
 
+INSTANCE_SEPARATOR = "::"
+WORKSHEET_SEPARATOR = "//"
+
+TARGET_KEY_REGEX = r"(?<=^)(?:([^:]*?)\:(?!:))?(.*(?=$))"
+TARGET_REGEX = r"(?<=^)(?:(.*?)\:\:)?(?:(.*?)\/\/)?(.+?)(?:\/(.*?))?(?=$)"
+
 
 def nested_dict_get(obj, *args, **kwargs):
     """
@@ -13,7 +19,7 @@ def nested_dict_get(obj, *args, **kwargs):
     And turns them into:
         safe_get(bundle_info, 'owner', 'user_name')
 
-    :param o: dict-like object to 'get' value from
+    :param obj: dict-like object to 'get' value from
     :param args: variable list of nested keys
     :param kwargs: supports the kwarg 'default' to specify the default value to
                    return if any of the keys don't exist. (default is None)
@@ -29,33 +35,40 @@ def nested_dict_get(obj, *args, **kwargs):
     except (KeyError, TypeError):
         return default
 
-def parse_target_spec(spec):
+def parse_key_target(spec):
     """
-    Helper: takes in a target spec in the form of
+    Parses a keyed target spec into its key and the rest of the target spec
+    :param spec: a target spec in the form of
         [[<key>]:][<instance>::][<worksheet_spec>//]<bundle_spec>[/<subpath>]
     where <bundle_spec> is required and the rest are optional.
-    Returns a (<key>, <value_spec>) tuple where <value_spec> is everything after
-        the key and <key> is one of the following:
-        - if <spec> starts with '<key>:', <key> is returned as the key
-        - if <spec> starts with ':' (without a key before the ':'),
-            <bundle_spec>[/subpath] is returned as the key
-        - if <spec> doesn't include a ':', empty string is returned as the key
+
+    :return: a tuple of the following in that order:
+        - <key>: (<key> if present,
+                    empty string if ':' in spec but no <key>,
+                    None otherwise)
+        - <value> (where value is everyhing after a <key>: (or everything if no key specified)
     """
-    key = ''
-    value_spec = ''
-    if '::' in spec:
-        prefix, suffix = spec.split('::')
-    else:
-        prefix, suffix = spec, None
-    if ':' in prefix:  # :<value_spec> or <key>:<value_spec>
-        key, bundle_prefix = prefix.split(':', 1)
-        value_spec = bundle_prefix if suffix is None else bundle_prefix + "::" + suffix
-        if key == '':
-            bundle_spec = value_spec.split('//', 1)[1] if '//' in value_spec else value_spec
-            key = bundle_spec
-    else:  # <value_spec>
-        value_spec = spec
-    return key, value_spec
+
+    match = re.match(TARGET_KEY_REGEX, spec)
+    return match.groups() if match else (None, None)
+
+
+def parse_target_spec(spec):
+    """
+    Parses a (non-keyed) target spec into its components
+        :param spec: a target spec in the form of
+            [<instance>::][<worksheet_spec>//]<bundle_spec>[/<subpath>]
+    where <bundle_spec> is required and the rest are optional.
+
+    :return: a tuple of the following in that order:
+        - <instance>
+        - <worksheet_spec>
+        - <bundle_spec>
+        - <subpath>
+    """
+
+    match = re.match(TARGET_REGEX, spec)
+    return match.groups() if match else (None, None, None, None)
 
 def desugar_command(orig_target_spec, command):
     """
@@ -76,9 +89,8 @@ def desugar_command(orig_target_spec, command):
     val2key = {}  # e.g., a.txt => b1 (use first key)
 
     def get(dep):  # Return the key
-        key, val = parse_target_spec(dep)
+        key, val = parse_key_target(dep)
         if key == '':
-            val = dep
             if val in val2key:
                 key = val2key[val]
             else:

--- a/codalab/lib/cli_util.py
+++ b/codalab/lib/cli_util.py
@@ -90,15 +90,14 @@ def desugar_command(orig_target_spec, command):
 
     def get(dep):  # Return the key
         key, val = parse_key_target(dep)
+        __import__('pdb').set_trace()
         if key == '':
             # key only matches empty string if ':' present
             _, _, bundle, subpath = parse_target_spec(val)
             key = subpath if subpath is not None else bundle
         elif key is None:
             # key only returns None if ':' not present in original spec
-            if val in val2key:
-                key = val2key[val]
-            key = 'b' + str(len(target_spec) + 1)  # new key
+            key = val2key[val] if val in val2key else 'b' + str(len(target_spec) + 1)
 
         if val not in val2key:
             val2key[val] = key

--- a/codalab/lib/cli_util.py
+++ b/codalab/lib/cli_util.py
@@ -91,10 +91,14 @@ def desugar_command(orig_target_spec, command):
     def get(dep):  # Return the key
         key, val = parse_key_target(dep)
         if key == '':
+            # key only matches empty string if ':' present
+            _, _, bundle, subpath = parse_target_spec(val)
+            key = subpath if subpath is not None else bundle
+        elif key is None:
+            # key only returns None if ':' not present in original spec
             if val in val2key:
                 key = val2key[val]
-            else:
-                key = 'b' + str(len(target_spec) + 1)  # new key
+            key = 'b' + str(len(target_spec) + 1)  # new key
 
         if val not in val2key:
             val2key[val] = key

--- a/codalab/lib/cli_util.py
+++ b/codalab/lib/cli_util.py
@@ -90,7 +90,6 @@ def desugar_command(orig_target_spec, command):
 
     def get(dep):  # Return the key
         key, val = parse_key_target(dep)
-        __import__('pdb').set_trace()
         if key == '':
             # key only matches empty string if ':' present
             _, _, bundle, subpath = parse_target_spec(val)


### PR DESCRIPTION
* Write a unified, regex-based, robust `key:target` parsing function in `cli_util`
* Write a unified, regex-based, robust `instance::worksheet//bundle/sub/path` parsing function in `cli_util`
* Refactor all target parsing cli methods in `bundle_cli` to use these methods when determining targets (including `cl add bundle`, enabling // syntax support for that method as well)
* Update `desugar_command` to work with these methods

