### PR TITLE
Fail runs that don't specify their resource needs

### DIFF
--- a/codalab/worker/default_bundle_manager.py
+++ b/codalab/worker/default_bundle_manager.py
@@ -34,12 +34,16 @@ class DefaultBundleManager(BundleManager):
         self._schedule_run_bundles_on_workers(workers, user_owned=True)
         self._schedule_run_bundles_on_workers(workers, user_owned=False)
 
-    def _check_resource_failure(self, value, user_fail_string=None, global_fail_string=None, user_max=None, global_max=None):
+    def _check_resource_failure(self, value, user_fail_string=None, global_fail_string=None, user_max=None, global_max=None, minimum_fail_string=None):
         if value:
             if user_max and value > user_max:
                 return user_fail_string % (value, user_max)
             elif global_max and value > global_max:
                 return global_fail_string % (value, global_max)
+        if minimum_fail_string is not None and (value is None or value <= 0):
+            # TODO: Trying to run a malformed run, potentially mimicking a run or runing a macro
+            # from before version 0.2.24. We need to ensure we never hit this case in the future
+            return minimum_fail_string
         return None
 
     def _fail_on_too_many_resources(self, workers):
@@ -58,7 +62,8 @@ class DefaultBundleManager(BundleManager):
             failures.append(self._check_resource_failure(
                     self._compute_request_cpus(bundle),
                     global_fail_string='No workers available with %d CPUs, max available: %d',
-                    global_max=max(map(lambda worker: worker['cpus'], workers_list))))
+                    global_max=max(map(lambda worker: worker['cpus'], workers_list)),
+                    minimum_fail_string='Invalid request_cpus: please request at least 1 cpu. If your mimic/macro has failed with this message, please re-mimic/macro but specify --request-cpus 1 (or greater) as old mimics have been deprecated past version 0.2.24'))
 
             failures.append(self._check_resource_failure(
                     self._compute_request_gpus(bundle),
@@ -70,14 +75,22 @@ class DefaultBundleManager(BundleManager):
                     user_fail_string='Requested more disk (%s) than user disk quota left (%s)',
                     user_max=self._model.get_user_disk_quota_left(bundle.owner_id),
                     global_fail_string='Maximum job disk size (%s) exceeded (%s)',
-                    global_max=self._max_request_disk))
+                    global_max=self._max_request_disk,
+                    minimum_fail_string='Invalid request_disk: please request some disk space. If your mimic/macro has failed with this message, please re-mimic/macro but specify --request-disk 100m (or greater) as old mimics have been deprecated past version 0.2.24'))
 
             failures.append(self._check_resource_failure(
                     self._compute_request_time(bundle),
                     user_fail_string='Requested more time (%s) than user time quota left (%s)',
                     user_max=self._model.get_user_time_quota_left(bundle.owner_id),
                     global_fail_string='Maximum job time (%s) exceeded (%s)',
-                    global_max=self._max_request_time))
+                    global_max=self._max_request_time,
+                    minimum_fail_string='Invalid request_cpus: please request some time. If your mimic/macro has failed with this message, please re-mimic/macro but specify --request-time 1h (or greater) as old mimics have been deprecated past version 0.2.24'))
+
+            failures.append(self._check_resource_failure(
+                    self._compute_request_memory(bundle),
+                    global_fail_string='Maximum memory limit (%s) exceeded (%s)',
+                    global_max=self._max_request_memory,
+                    minimum_fail_string='Invalid request_memory: please request some memory. If your mimic/macro has failed with this message, please re-mimic/macro but specify --request-memory 1g (or greater) as old mimics have been deprecated past version 0.2.24'))
 
             failures = [f for f in failures if f is not None]
 


### PR DESCRIPTION
Hotfix after moving defaults to RunBundle class in version 0.2.24, old runs were corrupted.