### PR TITLE
Remove worker checkout

### DIFF
--- a/codalab/rest/workers.py
+++ b/codalab/rest/workers.py
@@ -40,16 +40,6 @@ def checkin(worker_id):
         return local.worker_model.get_json_message(sock, WAIT_TIME_SECS)
 
 
-@post('/workers/<worker_id>/checkout',
-      name='worker_checkout', apply=AuthenticatedPlugin())
-def checkout(worker_id):
-    """
-    Checks out from the bundle service, cleaning up any state related to the
-    worker.
-    """
-    local.worker_model.worker_cleanup(request.user.user_id, worker_id)
-
-
 def check_reply_permission(worker_id, socket_id):
     """
     Checks if the authenticated user running a worker with the given ID can

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -407,11 +407,6 @@ Checks in with the bundle service, storing information about the worker.
 Waits for a message for the worker for WAIT_TIME_SECS seconds. Returns the
 message or None if there isn't one.
 
-### `POST /workers/<worker_id>/checkout`
-
-Checks out from the bundle service, cleaning up any state related to the
-worker.
-
 ### `POST /workers/<worker_id>/reply/<socket_id:int>`
 
 Replies with a single JSON message to the given socket ID.

--- a/worker/codalabworker/bundle_service_client.py
+++ b/worker/codalabworker/bundle_service_client.py
@@ -104,11 +104,6 @@ class BundleServiceClient(RestClient):
             'POST', self._worker_url_prefix(worker_id) + '/checkin',
             data=request_data)
 
-    @wrap_exception('Unable to check out from bundle service')
-    def checkout(self, worker_id):
-        return self._make_request(
-            'POST', self._worker_url_prefix(worker_id) + '/checkout')
-
     @wrap_exception('Unable to reply to message from bundle service')
     def reply(self, worker_id, socket_id, message):
         self._make_request(

--- a/worker/codalabworker/worker.py
+++ b/worker/codalabworker/worker.py
@@ -144,7 +144,6 @@ class Worker(object):
                 traceback.print_exc()
                 time.sleep(1)
 
-        self._checkout()
         self._worker_state_manager.save_state()
 
         if self._max_images_bytes is not None:
@@ -370,12 +369,6 @@ class Worker(object):
         self._worker_state_manager.finish_run(uuid)
         if not self.shared_file_system:
             self._dependency_manager.finish_run(uuid)
-
-    def _checkout(self):
-        try:
-            self._bundle_service.checkout(self.id)
-        except BundleServiceException:
-            traceback.print_exc()
 
     def _upgrade(self):
         logger.debug('Upgrading')


### PR DESCRIPTION
Since workers now get automagically cleaned up after not checking in with the server for 30 seconds, code paths for worker checkout are no longer necessary.