### PR TITLE
Remove the unicode character from dashboard worksheet template

### DIFF
--- a/codalab/objects/dashboard.ws
+++ b/codalab/objects/dashboard.ws
@@ -2,7 +2,7 @@ Welcome to your **CodaLab Dashboard**, which shows worksheets and bundles
 (programs and datasets) owned by you.  Read the 
 [documentation](https://github.com/codalab/codalab-worksheets/wiki) to 
 learn more. See [this page](https://github.com/codalab/codalab-worksheets/wiki/Worksheet-Markdown)
-to learn more about CodaLab’s markdown syntax. 
+to learn more about CodaLab's markdown syntax. 
 
 ## **My worksheets**
 % wsearch .mine


### PR DESCRIPTION
Remove the unicode character so that dashboard can be generated from the CLI (to enable full local setup process) currently this breaks when we do `cl new dashboard` in the local setup process.