### PR TITLE
Don't allow the relegation of a group owner to non-admin status

### DIFF
--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -2747,6 +2747,7 @@ class BundleCLI(object):
         ],
         arguments=(
             Commands.Argument('user_spec', nargs='?', help='Username or id of user to show [default: the authenticated user]'),
+            Commands.Argument('-f', '--field', help='Print out these comma-separated fields.'),
         ),
     )
     def do_uinfo_command(self, args):
@@ -2758,34 +2759,42 @@ class BundleCLI(object):
             user = client.fetch('user')
         else:
             user = client.fetch('users', args.user_spec)
-        self.print_user_info(user)
+        self.print_user_info(user, args.field)
 
-    def print_user_info(self, user):
-        def print_attribute(key, value):
+    def print_user_info(self, user, fields):
+        def print_attribute(key, user):
+            # These fields will not be returned by the server if the
+            # authenticated user is not root, so don't crash if you can't read them
+            if key in ('last_login', 'email', 'time', 'disk'):
+                try:
+                    if key == 'time':
+                        value = formatting.ratio_str(
+                            formatting.duration_str,
+                            user['time_used'],
+                            user['time_quota'])
+                    elif key == 'disk':
+                        value = formatting.ratio_str(
+                            formatting.size_str,
+                            user['disk_used'],
+                            user['disk_quota'])
+                    else:
+                        value = user[key]
+                except KeyError:
+                    pass
+            else:
+                value = user.get(key, None)
+
             print >>self.stdout, u'{:<15}: {}'.format(key, value).encode('utf-8')
 
-        for key in ('id', 'user_name', 'first_name', 'last_name',
-                    'affiliation', 'url', 'date_joined'):
-            print_attribute(key, user.get(key, None))
+        default_fields = ('id', 'user_name', 'first_name', 'last_name',
+                    'affiliation', 'url', 'date_joined', 'last_login',
+                    'email', 'time', 'disk')
 
-        # These fields will not be returned by the server if the
-        # authenticated user is not root, so stop early on first KeyError
-        try:
-            for key in ('last_login', 'email'):
-                print_attribute(key, user[key])
+        fields = fields.split(',') if fields else default_fields
 
-            print_attribute(
-                'time', formatting.ratio_str(
-                    formatting.duration_str,
-                    user['time_used'],
-                    user['time_quota']))
+        for field in fields:
+            print_attribute(field, user)
 
-            print_attribute(
-                'disk', formatting.ratio_str(formatting.size_str,
-                                             user['disk_used'],
-                                             user['disk_quota']))
-        except KeyError:
-            pass
 
     #############################################################################
     # Local-only commands follow!

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -2762,7 +2762,7 @@ class BundleCLI(object):
         self.print_user_info(user, args.field)
 
     def print_user_info(self, user, fields):
-        def print_attribute(key, user):
+        def print_attribute(key, user, should_pretty_print):
             # These fields will not be returned by the server if the
             # authenticated user is not root, so don't crash if you can't read them
             if key in ('last_login', 'email', 'time', 'disk'):
@@ -2784,16 +2784,23 @@ class BundleCLI(object):
             else:
                 value = user.get(key, None)
 
-            print >>self.stdout, u'{:<15}: {}'.format(key, value).encode('utf-8')
+            if should_pretty_print:
+                print >>self.stdout, u'{:<15}: {}'.format(key, value).encode('utf-8')
+            else:
+                print >>self.stdout, value.encode('utf-8')
 
         default_fields = ('id', 'user_name', 'first_name', 'last_name',
                     'affiliation', 'url', 'date_joined', 'last_login',
                     'email', 'time', 'disk')
-
-        fields = fields.split(',') if fields else default_fields
+        if fields:
+            should_pretty_print = False
+            fields = fields.split(',')
+        else:
+            should_pretty_print = True
+            fields = default_fields
 
         for field in fields:
-            print_attribute(field, user)
+            print_attribute(field, user, should_pretty_print)
 
 
     #############################################################################

--- a/codalab/rest/groups.py
+++ b/codalab/rest/groups.py
@@ -116,7 +116,7 @@ def add_group_members(group_spec):
 def add_group_members_helper(group_spec, is_admin):
     user_ids = get_resource_ids(request.json, 'users')
     group_info = get_group_info(group_spec, need_admin=True,
-                                access_all_groups=False)['uuid']
+                                access_all_groups=False)
     group_uuid = group_info['uuid']
     group_owner = group_info['owner_id']
     if group_owner in user_ids:

--- a/test-cli.py
+++ b/test-cli.py
@@ -81,8 +81,8 @@ def current_user():
     Does so by parsing the output of `cl uinfo` which by default returns the info
     of the current user
     """
-    user_id = run_command([cl, 'uinfo', '-f', 'id']).split(':')[1].strip()
-    user_name = run_command([cl, 'uinfo', '-f', 'user_name']).split(':')[1].strip()
+    user_id = run_command([cl, 'uinfo', '-f', 'id'])
+    user_name = run_command([cl, 'uinfo', '-f', 'user_name'])
     return user_id, user_name
 
 

--- a/test-cli.py
+++ b/test-cli.py
@@ -87,6 +87,14 @@ def current_user():
     return user_id, user_name
 
 
+def get_uuid(line):
+    """
+    Returns the uuid from a line where the uuid is between parentheses
+    """
+    m = re.search(".*\((0x[a-z0-9]+)\)", line)
+    assert m is not None
+    return m.group(1)
+
 
 def sanitize(string):
     try:
@@ -1145,17 +1153,19 @@ def test(ctx):
 def test(ctx):
     # Should not crash
     run_command([cl, 'ginfo', 'public'])
+
     user_id, user_name = current_user()
     # Create new group
     group_name = random_name()
-    uuid = run_command([cl, 'gnew', group_name])
-    ctx.collect_group(uuid)
-    # Check that you are added to your own group
-    my_groups = run_command([cl, 'gls'])
-    check_contains(group_name, my_groups)
+    group_uuid_line = run_command([cl, 'gnew', group_name])
+    group_uuid = get_uuid(group_uuid_line)
+    ctx.collect_group(group_uuid)
 
+    # Check that you are added to your own group
     group_info = run_command([cl, 'ginfo', group_name])
     check_contains(user_name, group_info)
+    my_groups = run_command([cl, 'gls'])
+    check_contains(group_name, my_groups)
 
     # Try to relegate yourself to non-admin status
     run_command([cl, 'uadd', user_name, group_name], expected_exit_code=1)

--- a/test-cli.py
+++ b/test-cli.py
@@ -77,13 +77,12 @@ def current_worksheet():
 
 def current_user():
     """
-    Return the uuid and username of the current username in a tuple
+    Return the uuid and username of the current user in a tuple
     Does so by parsing the output of `cl uinfo` which by default returns the info
     of the current user
     """
-    my_name = run_command([cl, 'uinfo'])
-    user_id = my_name.split('\n')[0].split(':')[1].strip()
-    user_name = my_name.split('\n')[1].split(':')[1].strip()
+    user_id = run_command([cl, 'uinfo', '-f', 'id']).split(':')[1].strip()
+    user_name = run_command([cl, 'uinfo', '-f', 'user_name']).split(':')[1].strip()
     return user_id, user_name
 
 
@@ -1170,7 +1169,7 @@ def test(ctx):
     # Try to relegate yourself to non-admin status
     run_command([cl, 'uadd', user_name, group_name], expected_exit_code=1)
 
-    # TODO: Test other group membeship semantics:
+    # TODO: Test other group membership semantics:
     # - removing a group
     # - adding new members
     # - adding an admin


### PR DESCRIPTION
Currently this is allowed (by any admin calling `uadd` with the group owner's user spec, detailed in #866 ), this should disable that, even by the group owner itself.

Also adds a test for this (and adds groups as a cleanable resource to the test harness)

This is the most egregious group permissioning  issue we have at the moment. In the future we might want to think about separating the `uadd` semantics so it only adds new members and move the admin status change to a different method.