### PR TITLE
Better test coverage for target parsing and runs

### DIFF
--- a/test-cli.py
+++ b/test-cli.py
@@ -847,6 +847,12 @@ def test(ctx):
     check_contains('hello', run_command([cl, 'run', 'echo hello', '--tail']))
     # invalid child path
     run_command([cl, 'run', 'not/allowed:' + uuid, 'date'], expected_exit_code=1)
+    # make sure special characters in the name of a bundle don't break
+    special_name = random_name() + '-dashed.dotted'
+    special_uuid = run_command([cl, 'run', 'echo hello', '-n', special_name])
+    dependent = run_command([cl, 'run', ':%s' % special_name, 'cat %s/stdout' % special_name])
+    wait(dependent)
+    check_equals('hello', run_command([cl, 'cat', dependent+'/stdout']))
 
     # test running with a reference to this worksheet
     source_worksheet_full = current_worksheet()

--- a/tests/lib/cli_util_test.py
+++ b/tests/lib/cli_util_test.py
@@ -4,8 +4,62 @@ from codalab.lib import cli_util
 from codalab.common import UsageError
 
 class CLIUtilTest(unittest.TestCase):
+    def test_parse_key_target(self):
+        cases = [
+                ('a:b', ('a', 'b')),
+                (':b', ('', 'b')),
+                ('b', (None, 'b')),
+                ('dash-key:https://worksheets.codalab.org::some-worksheet//some-bundle-2.dirname/this/is/a/path.txt',
+                    ('dash-key', 'https://worksheets.codalab.org::some-worksheet//some-bundle-2.dirname/this/is/a/path.txt')),
+                (':https://worksheets.codalab.org::some-worksheet//some-bundle-2.dirname/this/is/a/path.txt',
+                    ('', 'https://worksheets.codalab.org::some-worksheet//some-bundle-2.dirname/this/is/a/path.txt')),
+                ('prod::some-worksheet//some-bundle-2.dirname/this/is/a/path.txt',
+                    (None, 'prod::some-worksheet//some-bundle-2.dirname/this/is/a/path.txt')),
+                ('dash-key:some-worksheet//some-bundle-2.dirname/this/is/a/path.txt',
+                    ('dash-key', 'some-worksheet//some-bundle-2.dirname/this/is/a/path.txt')),
+                (':some-worksheet//some-bundle-2.dirname/this/is/a/path.txt',
+                    ('', 'some-worksheet//some-bundle-2.dirname/this/is/a/path.txt')),
+                ('some-worksheet//some-bundle-2.dirname/this/is/a/path.txt',
+                    (None, 'some-worksheet//some-bundle-2.dirname/this/is/a/path.txt')),
+                ('dash-key:some-bundle-2.dirname/this/is/a/path.txt',
+                    ('dash-key', 'some-bundle-2.dirname/this/is/a/path.txt')),
+                (':some-bundle-2.dirname/this/is/a/path.txt',
+                    ('', 'some-bundle-2.dirname/this/is/a/path.txt')),
+                ('some-bundle-2.dirname/this/is/a/path.txt',
+                    (None, 'some-bundle-2.dirname/this/is/a/path.txt')),
+                ('dash-key:some-bundle-2.dirname',
+                    ('dash-key', 'some-bundle-2.dirname')),
+                (':some-bundle-2.dirname',
+                    ('', 'some-bundle-2.dirname')),
+                ('some-bundle-2.dirname',
+                    (None, 'some-bundle-2.dirname'))
+                ]
+        for spec, expected_parse in cases:
+            self.assertEqual(cli_util.parse_key_target(spec), expected_parse)
+
+    def test_parse_target_spec(self):
+        cases = [
+                ('https://worksheets.codalab.org::some-worksheet//some-bundle-2.dirname/this/is/a/path.txt',
+                    ('https://worksheets.codalab.org', 'some-worksheet', 'some-bundle-2.dirname', 'this/is/a/path.txt')),
+                ('some-worksheet//some-bundle-2.dirname/this/is/a/path.txt',
+                    (None, 'some-worksheet', 'some-bundle-2.dirname', 'this/is/a/path.txt')),
+                ('some-bundle-2.dirname/this/is/a/path.txt',
+                    (None, None, 'some-bundle-2.dirname', 'this/is/a/path.txt')),
+                ('some-bundle-2.dirname',
+                    (None, None, 'some-bundle-2.dirname', None)),
+                ('prod::bundle',
+                    ('prod', None, 'bundle', None)),
+                ('worksheet//bundle',
+                    (None, 'worksheet', 'bundle', None)),
+                ('bundle/path',
+                    (None, None, 'bundle', 'path'))
+                ]
+        for spec, expected_parse in cases:
+            self.assertEqual(cli_util.parse_target_spec(spec), expected_parse)
+
     def test_desugar(self):
         self.assertEqual(cli_util.desugar_command([], 'echo hello'), ([], 'echo hello'))
+        self.assertEqual(cli_util.desugar_command([':a-bundle'], 'run a-bundle'), (["a-bundle:a-bundle"], 'run a-bundle'))
         self.assertEqual(cli_util.desugar_command(['a:b'], 'echo %b:c%'), (['a:b', 'b:c'], 'echo b'))
         self.assertEqual(cli_util.desugar_command(['a:b'], 'echo %c%'), (['a:b', 'b2:c'], 'echo b2'))
         self.assertEqual(cli_util.desugar_command(['a:b'], 'echo %:c%'), (['a:b', 'c:c'], 'echo c'))


### PR DESCRIPTION
Unit tests for key target spec parsing and couple more run integration tests.
To prevent cases where we break basic run syntax in the future.