### PR TITLE
Fix autocomplete

### DIFF
--- a/codalab/lib/completers.py
+++ b/codalab/lib/completers.py
@@ -116,7 +116,7 @@ def UnionCompleter(*completers):
 # TODO: https://github.com/codalab/codalab-cli/issues/223
 class TargetsCompleter(CodaLabCompleter):
     def __call__(self, prefix, action=None, parsed_args=None):
-        key, target = cli_util.parse_key_target(prefix, allow_incomplete=True)
+        key, target = cli_util.parse_key_target(prefix)
         if target is None:
             return ()
 


### PR DESCRIPTION
Before: Commands that used the TargetsCompleter class for autocompletion (run, docker, mount, cat), did not have functioning autocompletion. 
So if you had a bundle in your worksheet called "bundle-name", and typed in "cl run bundl" and hit tab, nothing would happen. 
After: Autocompletion works as expected for the aforementioned commands. So hitting tab for "cl run bundl" will complete it to "cl run bundle-name"