### PR TITLE
Clear state properly for bundles without any bundle content

### DIFF
--- a/codalab/apps/web/static/js/bundle/bundle_interface.jsx
+++ b/codalab/apps/web/static/js/bundle/bundle_interface.jsx
@@ -117,7 +117,7 @@ let Bundle = React.createClass({
       if (xhr.status != 404) {
         this.setState({bundleInfo: null, fileContents: null, stdout: null, stderr: null, errorMessages: this.state.errorMessages.concat([xhr.responseText])});
       } else {
-        // if contents aren't available yet, then clear stdout and stderr also. 
+        // If contents aren't available yet, then also clear stdout and stderr. 
         this.setState({fileContents: null, stdout: null, stderr: null});
       }
     });

--- a/codalab/apps/web/static/js/bundle/bundle_interface.jsx
+++ b/codalab/apps/web/static/js/bundle/bundle_interface.jsx
@@ -117,7 +117,8 @@ let Bundle = React.createClass({
       if (xhr.status != 404) {
         this.setState({bundleInfo: null, fileContents: null, stdout: null, stderr: null, errorMessages: this.state.errorMessages.concat([xhr.responseText])});
       } else {
-        this.setState({fileContents: null});
+        // if contents aren't available yet, then clear stdout and stderr also. 
+        this.setState({fileContents: null, stdout: null, stderr: null});
       }
     });
   },


### PR DESCRIPTION
Before: 
If you click on a finished run bundle, you would see the stdout of that bundle, for example "hello world". Then, if you clicked on a staged or created bundle, it would not remove the stdout "hello world", because the stdout and stderr state variables in the Bundle view were not getting removed. 

After: 
The stdout and stderr should properly disappear. 