### PR TITLE
Dennis error message

### DIFF
--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -2952,7 +2952,7 @@ class BundleCLI(object):
 
     def _fail_if_headless(self, args):
         if self.headless:
-            raise UsageError('Cannot execute CLI command "%s" because you are using a headless CLI.' % args.command)
+            raise UsageError('You are only allowed to execute command "%s" from the CLI.' % args.command)
 
     def _fail_if_not_local(self, args):
         if 'localhost' not in self.manager.current_client().address:

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -2952,7 +2952,7 @@ class BundleCLI(object):
 
     def _fail_if_headless(self, args):
         if self.headless:
-            raise UsageError('Cannot execute CLI command: %s' % args.command)
+            raise UsageError('Cannot execute CLI command "%s" because you are using a headless CLI.' % args.command)
 
     def _fail_if_not_local(self, args):
         if 'localhost' not in self.manager.current_client().address:


### PR DESCRIPTION
Makes the error message clearer that the reason we are unable to to execute this command is because it is being run from the web CLI.