### PR TITLE
Web CLI cat support

### DIFF
--- a/codalab/client/json_api_client.py
+++ b/codalab/client/json_api_client.py
@@ -572,7 +572,7 @@ class JsonApiClient(RestClient):
 
     @wrap_exception('Unable to fetch contents blob of bundle {1}')
     def fetch_contents_blob(self, bundle_id, target_path='', range_=None,
-                            head=None, tail=None):
+                            head=None, tail=None, truncation_text=None):
         """
         Returns a file-like object for the target on the given bundle.
 
@@ -593,6 +593,8 @@ class JsonApiClient(RestClient):
             params['head'] = head
         if tail is not None:
             params['tail'] = tail
+        if truncation_text is not None:
+            params['truncation_text'] = truncation_text
         return self._make_request('GET', request_path, headers=headers,
                                   query_params=params, return_response=True)
 

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -1788,7 +1788,6 @@ class BundleCLI(object):
         ),
     )
     def do_cat_command(self, args):
-        self._fail_if_headless(args)  # Files might be too big
 
         default_client, default_worksheet_uuid = self.parse_client_worksheet_uuid(args.worksheet_spec)
         client, worksheet_uuid, bundle_uuid, subpath = self.resolve_target(default_client, default_worksheet_uuid, args.target_spec)
@@ -1808,6 +1807,12 @@ class BundleCLI(object):
                 kwargs['head'] = head
             if tail is not None:
                 kwargs['tail'] = tail
+
+            if self.headless:
+                if head is None or kwargs['head'] > 100:
+                    print >>self.stdout, 'Truncating output to first 100 lines.'
+                    kwargs['head'] = head
+                    
             contents = client.fetch_contents_blob(bundle_uuid, subpath, **kwargs)
             with closing(contents):
                 shutil.copyfileobj(contents, self.stdout)

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -1808,14 +1808,18 @@ class BundleCLI(object):
             if tail is not None:
                 kwargs['tail'] = tail
 
+            # uses the same parameters as the front-end bundle interface
             if self.headless:
-                if head is None or kwargs['head'] > 100:
-                    print >>self.stdout, 'Truncating output to first 100 lines.'
-                    kwargs['head'] = head
-                    
+                kwargs['head'] = 50
+                kwargs['tail'] = 50
+                kwargs['truncation_text'] = '\n... truncated ...\n\n'
+
             contents = client.fetch_contents_blob(bundle_uuid, subpath, **kwargs)
             with closing(contents):
                 shutil.copyfileobj(contents, self.stdout)
+
+            if self.headless:
+                print >>self.stdout, '--Web CLI detected, truncated output to first 50 and last 50 lines.--'
 
         def size(x):
             t = x.get('type', '???')


### PR DESCRIPTION
Before: cat command would not work in the web CLI.
After: cat command displays what is printed in the side panel under contents.