### PR TITLE
Adds 'npm run watch' command

### DIFF
--- a/codalab/apps/web/gulpfile.js
+++ b/codalab/apps/web/gulpfile.js
@@ -25,6 +25,13 @@ gulp.task('less', function () {
     .pipe(gulp.dest('static/css'));
 });
 
+// Watches files and runs compile tasks if they are changed
+gulp.task('watch', function(){
+  gulp.watch('static/js/**/*.jsx', ['jsx']);
+  gulp.watch('static/less/*.less', ['less']);
+})
+
+
 // Cleanup compiled jsx
 gulp.task('clean', function() {
     del(['static/dist']);

--- a/codalab/apps/web/package.json
+++ b/codalab/apps/web/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "bower": "bower install",
     "build": "gulp jsx && gulp less",
+    "watch": "gulp watch",
     "clean": "gulp clean",
     "jsx": "gulp jsx",
     "less": "gulp less",


### PR DESCRIPTION
Adds new npm run command calls watch, which calls the gulp task watch. The gulp task runs the jsx and less compilation tasks whenever the relevant source files change.