### PR TITLE
Adding referer url to the help emails

### DIFF
--- a/codalab/rest/help.py
+++ b/codalab/rest/help.py
@@ -20,6 +20,7 @@ def send_help_message():
     support_email = local.config['server']['support_email']
     username = request.user.user_name
     user_email = request.user.email
+    originUrl = request.get_header('Referer')
 
     first_name = request.user.first_name if request.user.first_name else ''
     last_name = request.user.last_name if request.user.last_name else ''
@@ -28,7 +29,8 @@ def send_help_message():
 
     local.emailer.send_email(
         subject="Message from %s" % user_email,
-        body=template('help_message_to_codalab_body', real_name=real_name, username=username, email=user_email, message=message),
+        body=template('help_message_to_codalab_body', real_name=real_name, username=username,
+                      email=user_email, message=message, originUrl=originUrl),
         recipient=support_email,
         sender=user_email,
         charset='utf-8',

--- a/views/help_message_to_codalab_body.tpl
+++ b/views/help_message_to_codalab_body.tpl
@@ -2,4 +2,4 @@ User {{!username}} ({{!email}}) ({{!real_name}}) has sent the following message 
 
 {{!message}}
 
-
+The message was sent from {{originUrl}}.


### PR DESCRIPTION
Before: help emails only contained the identity of the requester, as well as the message they sent.  
After: help emails also include a direct link to the url that the help message was sent from. This will help us resolve help emails without as much back and forth. 