### PR TITLE
Mimic syntax fix

### DIFF
--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -507,6 +507,12 @@ class BundleCLI(object):
     def simple_group_str(info):
         return '%s(%s)' % (contents_str(info.get('name')), info['id'])
 
+    def resolve_bundle_specs(self, default_client, default_worksheet_uuid, target_specs, allow_remote=True):
+        """
+        Wrapper for resolve_target that takes a list of target specs and returns a list of bundle uuids.
+        """
+        return [self.resolve_target(default_client, default_worksheet_uuid, target_specs, allow_remote)[2] for spec in target_specs]
+
     def resolve_target(self, default_client, default_worksheet_uuid, target_spec, allow_remote=True):
         """
         Input: Target spec in the form of
@@ -1406,7 +1412,7 @@ class BundleCLI(object):
         client, worksheet_uuid = self.parse_client_worksheet_uuid(args.worksheet_spec)
         # Resolve all the bundles first, then detach.
         # This is important since some of the bundle specs (^1 ^2) are relative.
-        bundle_uuids = self.resolve_bundle_uuids(client, worksheet_uuid, args.bundle_spec)
+        bundle_uuids = self.resolve_bundle_specs(client, worksheet_uuid, args.bundle_spec)
         worksheet_info = client.fetch('worksheets', worksheet_uuid, params={'include': ['items', 'items.bundle']})
 
         # Number the bundles: c c a b c => 3 2 1 1 1
@@ -1459,7 +1465,7 @@ class BundleCLI(object):
         client, worksheet_uuid = self.parse_client_worksheet_uuid(args.worksheet_spec)
         # Resolve all the bundles first, then delete.
         # This is important since some of the bundle specs (^1 ^2) are relative.
-        bundle_uuids = self.resolve_bundle_uuids(client, worksheet_uuid, args.bundle_spec)
+        bundle_uuids = self.resolve_bundle_specs(client, worksheet_uuid, args.bundle_spec)
         deleted_uuids = client.delete('bundles', bundle_uuids, params={
             'force': args.force,
             'recursive': args.recursive,
@@ -1775,7 +1781,7 @@ class BundleCLI(object):
     )
     def do_netcat_command(self, args):
         client, worksheet_uuid = self.parse_client_worksheet_uuid(args.worksheet_spec)
-        bundle_uuid = self.resolve_bundle_uuids(client, worksheet_uuid, args.bundle_spec)[0]
+        bundle_uuid = self.resolve_bundle_specs(client, worksheet_uuid, args.bundle_spec)[0]
         info = client.netcat(bundle_uuid, port=args.port, data={"message": args.message})
         print >>self.stdout, info['data']
 
@@ -2021,7 +2027,7 @@ class BundleCLI(object):
         Use args.bundles to generate a call to bundle_util.mimic_bundles()
         """
         client, worksheet_uuid = self.parse_client_worksheet_uuid(args.worksheet_spec)
-        bundle_uuids = self.resolve_bundle_uuids(client, worksheet_uuid, args.bundles)
+        bundle_uuids = self.resolve_bundle_specs(client, worksheet_uuid, args.bundles)
         metadata = self.get_provided_metadata(args)
         output_name = metadata.pop('name', None)
 
@@ -2064,7 +2070,7 @@ class BundleCLI(object):
         args.bundle_spec = spec_util.expand_specs(args.bundle_spec)
 
         client, worksheet_uuid = self.parse_client_worksheet_uuid(args.worksheet_spec)
-        bundle_uuids = self.resolve_bundle_uuids(client, worksheet_uuid, args.bundle_spec)
+        bundle_uuids = self.resolve_bundle_specs(client, worksheet_uuid, args.bundle_spec)
         for bundle_uuid in bundle_uuids:
             print >>self.stdout, bundle_uuid
         client.create('bundle-actions', [{
@@ -2638,7 +2644,7 @@ class BundleCLI(object):
         client, worksheet_uuid = self.parse_client_worksheet_uuid(args.worksheet_spec)
         group = client.fetch('groups', args.group_spec)
 
-        bundle_uuids = self.resolve_bundle_uuids(client, worksheet_uuid, args.bundle_spec)
+        bundle_uuids = self.resolve_bundle_specs(client, worksheet_uuid, args.bundle_spec)
         new_permission = parse_permission(args.permission_spec)
 
         client.create('bundle-permissions', [{
@@ -2692,7 +2698,7 @@ class BundleCLI(object):
         args.bundle_spec = spec_util.expand_specs(args.bundle_spec)
         client, worksheet_uuid = self.parse_client_worksheet_uuid(args.worksheet_spec)
 
-        bundle_uuids = self.resolve_bundle_uuids(client, worksheet_uuid, args.bundle_spec)
+        bundle_uuids = self.resolve_bundle_specs(client, worksheet_uuid, args.bundle_spec)
         owner_id = client.fetch('users', args.user_spec)['id']
 
         client.update('bundles', [{

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -511,7 +511,7 @@ class BundleCLI(object):
         """
         Wrapper for resolve_target that takes a list of target specs and returns a list of bundle uuids.
         """
-        return [self.resolve_target(default_client, default_worksheet_uuid, target_specs, allow_remote)[2] for spec in target_specs]
+        return [self.resolve_target(default_client, default_worksheet_uuid, spec, allow_remote)[2] for spec in target_specs]
 
     def resolve_target(self, default_client, default_worksheet_uuid, target_spec, allow_remote=True):
         """

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -1781,7 +1781,7 @@ class BundleCLI(object):
     )
     def do_netcat_command(self, args):
         client, worksheet_uuid = self.parse_client_worksheet_uuid(args.worksheet_spec)
-        bundle_uuid = self.resolve_bundle_specs(client, worksheet_uuid, args.bundle_spec)[0]
+        client, worksheet_uuid, bundle_uuid, subpath = self.resolve_target(client, worksheet_uuid, args.bundle_spec)
         info = client.netcat(bundle_uuid, port=args.port, data={"message": args.message})
         print >>self.stdout, info['data']
 


### PR DESCRIPTION
Earlier we missed to replace a function call for bundle spec resolution for commands like macro, mimic, kill, rm, detach.
This PR replaces that function call with the new wrapper that follows the new spec format of
`instance::worksheet//bundle/subpath`