### PR TITLE
Fixing bug 

### DIFF
--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -130,7 +130,7 @@ def _fetch_bundles():
     if keywords:
         # Handle search keywords
         keywords = resolve_owner_in_keywords(keywords)
-        bundle_uuids = local.model.search_bundle_uuids(request.user.user_id, keywords)
+        search_result = local.model.search_bundles(request.user.user_id, keywords)
     elif specs:
         # Resolve bundle specs
         bundle_uuids = canonicalize.get_bundle_uuids(local.model, request.user, worksheet_uuid, specs)
@@ -141,11 +141,16 @@ def _fetch_bundles():
 
     # Find all descendants down to the provided depth
     if descendant_depth is not None:
-        bundle_uuids = local.model.get_self_and_descendants(bundle_uuids, depth=descendant_depth)
+        if search_result['is_aggregate']:
+            abort(httplib.BAD_REQUEST,
+                  "Cannot combine depth parameter with an aggregate search (.sum or .count)")
+        else:
+            bundle_uuids = search_result['result']
+            bundle_uuids = local.model.get_self_and_descendants(bundle_uuids, depth=descendant_depth)
 
     # Return simple dict if scalar result (e.g. .sum or .count queries)
-    if not isinstance(bundle_uuids, list):
-        return json_api_meta({}, {'result': bundle_uuids})
+    if search_result['is_aggregate']:
+        return json_api_meta({}, {'result': search_result['result']})
 
     return build_bundles_document(bundle_uuids)
 

--- a/codalab/rest/interpret.py
+++ b/codalab/rest/interpret.py
@@ -584,9 +584,12 @@ def expand_raw_item(raw_item):
         if is_search:
             keywords = rest_util.resolve_owner_in_keywords(keywords)
             bundle_uuids = local.model.search_bundle_uuids(request.user.user_id, keywords)
-            bundle_infos = rest_util.get_bundle_infos(bundle_uuids)
-            for bundle_uuid in bundle_uuids:
-                raw_items.append(bundle_item(bundle_infos[bundle_uuid]))
+            if not isinstance(bundle_uuids, list):
+                raw_items.append(markup_item(str(bundle_uuids)))
+            else:
+                bundle_infos = rest_util.get_bundle_infos(bundle_uuids)
+                for bundle_uuid in bundle_uuids:
+                    raw_items.append(bundle_item(bundle_infos[bundle_uuid]))
         elif is_wsearch:
             worksheet_infos = search_worksheets(keywords)
             for worksheet_info in worksheet_infos:

--- a/codalab/rest/interpret.py
+++ b/codalab/rest/interpret.py
@@ -583,10 +583,11 @@ def expand_raw_item(raw_item):
 
         if is_search:
             keywords = rest_util.resolve_owner_in_keywords(keywords)
-            bundle_uuids = local.model.search_bundle_uuids(request.user.user_id, keywords)
-            if not isinstance(bundle_uuids, list):
-                raw_items.append(markup_item(str(bundle_uuids)))
+            search_result = local.model.search_bundles(request.user.user_id, keywords)
+            if search_result['is_aggregate']:
+                raw_items.append(markup_item(search_result['result']))
             else:
+                bundle_uuids = search_result['result']
                 bundle_infos = rest_util.get_bundle_infos(bundle_uuids)
                 for bundle_uuid in bundle_uuids:
                     raw_items.append(bundle_item(bundle_infos[bundle_uuid]))


### PR DESCRIPTION
Fixes bug where the server does not know how to deal with non-list return values from search.
`search_bundle_uuids` will return a single (non-list) number when looking for either a count or a sum; this returns that number as a markdown item, instead of crashing. 