### PR TITLE
Fail bundles with killed dependencies if --allow-failed-dependencies not specified

### DIFF
--- a/codalab/worker/bundle_manager.py
+++ b/codalab/worker/bundle_manager.py
@@ -14,6 +14,7 @@ from codalab.lib import bundle_util, formatting, path_util
 from codalabworker.file_util import remove_path
 from codalabworker.bundle_state import State
 
+
 logger = logging.getLogger(__name__)
 
 WORKER_TIMEOUT_SECONDS = 60
@@ -47,16 +48,12 @@ class BundleManager(object):
 
         def parse(to_value, field):
             return to_value(config[field]) if field in config else None
+        self._max_request_time = parse(formatting.parse_duration, 'max_request_time')
+        self._max_request_memory = parse(formatting.parse_size, 'max_request_memory')
+        self._max_request_disk = parse(formatting.parse_size, 'max_request_disk')
 
-        self._max_request_time = parse(formatting.parse_duration,
-                                       'max_request_time')
-        self._max_request_memory = parse(formatting.parse_size,
-                                         'max_request_memory')
-        self._max_request_disk = parse(formatting.parse_size,
-                                       'max_request_disk')
-
-        logging.basicConfig(
-            format='%(asctime)s %(message)s', level=logging.INFO)
+        logging.basicConfig(format='%(asctime)s %(message)s',
+                            level=logging.INFO)
 
         return self
 
@@ -99,8 +96,8 @@ class BundleManager(object):
             2) Staging any bundles that have all ready dependencies.
         """
         bundles = self._model.batch_get_bundles(state=State.CREATED)
-        parent_uuids = set(dep.parent_uuid for bundle in bundles
-                           for dep in bundle.dependencies)
+        parent_uuids = set(
+            dep.parent_uuid for bundle in bundles for dep in bundle.dependencies)
         parents = self._model.batch_get_bundles(uuid=parent_uuids)
 
         all_parent_states = {parent.uuid: parent.state for parent in parents}
@@ -112,12 +109,11 @@ class BundleManager(object):
             parent_uuids = set(dep.parent_uuid for dep in bundle.dependencies)
 
             try:
-                check_bundles_have_read_permission(self._model,
-                                                   self._model.get_user(
-                                                       bundle.owner_id),
-                                                   parent_uuids)
+                check_bundles_have_read_permission(self._model, self._model.get_user(bundle.owner_id), parent_uuids)
             except PermissionError as e:
-                bundles_to_fail.append((bundle, str(e)))
+                bundles_to_fail.append(
+                    (bundle, str(e))
+                )
                 continue
 
             missing_uuids = parent_uuids - all_parent_uuids
@@ -127,10 +123,8 @@ class BundleManager(object):
                      'Missing parent bundles: %s' % ', '.join(missing_uuids)))
                 continue
 
-            parent_states = {
-                uuid: all_parent_states[uuid]
-                for uuid in parent_uuids
-            }
+            parent_states = {uuid: all_parent_states[uuid]
+                             for uuid in parent_uuids}
 
             acceptable_states = [State.READY]
             if bundle.metadata.allow_failed_dependencies:
@@ -139,42 +133,35 @@ class BundleManager(object):
             else:
                 failed_uuids = [
                     uuid for uuid, state in parent_states.iteritems()
-                    if state == State.FAILED
-                ]
+                    if state == State.FAILED]
                 if failed_uuids:
-                    bundles_to_fail.append((
-                        bundle,
-                        'Parent bundles failed: %s' % ', '.join(failed_uuids)))
+                    bundles_to_fail.append(
+                        (bundle,
+                         'Parent bundles failed: %s' % ', '.join(failed_uuids)))
                     continue
 
-            if all(state in acceptable_states
-                   for state in parent_states.itervalues()):
+            if all(state in acceptable_states for state in parent_states.itervalues()):
                 bundles_to_stage.append(bundle)
 
         for bundle, failure_message in bundles_to_fail:
             logger.info('Failing bundle %s: %s', bundle.uuid, failure_message)
             self._model.update_bundle(
-                bundle, {
-                    'state': State.FAILED,
-                    'metadata': {
-                        'failure_message': failure_message
-                    }
-                })
+                bundle, {'state': State.FAILED,
+                         'metadata': {'failure_message': failure_message}})
         for bundle in bundles_to_stage:
             logger.info('Staging %s', bundle.uuid)
-            self._model.update_bundle(bundle, {'state': State.STAGED})
+            self._model.update_bundle(
+                bundle, {'state': State.STAGED})
 
     def _make_bundles(self):
         # Re-stage any stuck bundles. This would happen if the bundle manager
         # died.
-        for bundle in self._model.batch_get_bundles(
-                state=State.MAKING, bundle_type='make'):
+        for bundle in self._model.batch_get_bundles(state=State.MAKING, bundle_type='make'):
             if not self._is_making_bundle(bundle.uuid):
                 logger.info('Re-staging make bundle %s', bundle.uuid)
                 self._model.update_bundle(bundle, {'state': State.STAGED})
 
-        for bundle in self._model.batch_get_bundles(
-                state=State.STAGED, bundle_type='make'):
+        for bundle in self._model.batch_get_bundles(state=State.STAGED, bundle_type='make'):
             logger.info('Making bundle %s', bundle.uuid)
             self._model.update_bundle(bundle, {'state': State.MAKING})
             with self._make_uuids_lock:
@@ -182,8 +169,8 @@ class BundleManager(object):
             # Making a bundle could take time, so do the work in a separate
             # thread to ensure quick scheduling.
             threading.Thread(
-                target=BundleManager._make_bundle, args=[self,
-                                                         bundle]).start()
+                target=BundleManager._make_bundle, args=[self, bundle]
+            ).start()
 
     def _is_making_bundles(self):
         with self._make_uuids_lock:
@@ -195,8 +182,7 @@ class BundleManager(object):
 
     def _make_bundle(self, bundle):
         try:
-            path = os.path.normpath(
-                self._bundle_store.get_bundle_location(bundle.uuid))
+            path = os.path.normpath(self._bundle_store.get_bundle_location(bundle.uuid))
 
             deps = []
             for dep in bundle.dependencies:
@@ -204,17 +190,17 @@ class BundleManager(object):
                     self._bundle_store.get_bundle_location(dep.parent_uuid))
                 dependency_path = os.path.normpath(
                     os.path.join(parent_bundle_path, dep.parent_path))
-                if (not dependency_path.startswith(parent_bundle_path)
-                        or (not os.path.islink(dependency_path)
-                            and not os.path.exists(dependency_path))):
+                if (not dependency_path.startswith(parent_bundle_path) or
+                    (not os.path.islink(dependency_path) and
+                     not os.path.exists(dependency_path))):
                     raise Exception('Invalid dependency %s' % (
                         path_util.safe_join(dep.parent_uuid, dep.parent_path)))
 
                 child_path = os.path.normpath(
                     os.path.join(path, dep.child_path))
                 if not child_path.startswith(path):
-                    raise Exception('Invalid key for dependency: %s' %
-                                    (dep.child_path))
+                    raise Exception('Invalid key for dependency: %s' % (
+                        dep.child_path))
 
                 deps.append((dependency_path, child_path))
 
@@ -225,21 +211,16 @@ class BundleManager(object):
             else:
                 os.mkdir(path)
                 for dependency_path, child_path in deps:
-                    path_util.copy(
-                        dependency_path, child_path, follow_symlinks=False)
+                    path_util.copy(dependency_path, child_path, follow_symlinks=False)
 
-            self._upload_manager.update_metadata_and_save(
-                bundle, enforce_disk_quota=True)
+            self._upload_manager.update_metadata_and_save(bundle, enforce_disk_quota=True)
             logger.info('Finished making bundle %s', bundle.uuid)
             self._model.update_bundle(bundle, {'state': State.READY})
         except Exception as e:
             logger.info('Failing bundle %s: %s', bundle.uuid, str(e))
-            self._model.update_bundle(bundle, {
-                'state': State.FAILED,
-                'metadata': {
-                    'failure_message': str(e)
-                }
-            })
+            self._model.update_bundle(
+                bundle, {'state': State.FAILED,
+                         'metadata': {'failure_message': str(e)}})
         finally:
             with self._make_uuids_lock:
                 self._make_uuids.remove(bundle.uuid)
@@ -250,13 +231,9 @@ class BundleManager(object):
         Such workers probably died without checking out properly.
         """
         for worker in workers.workers():
-            if datetime.datetime.now(
-            ) - worker['checkin_time'] > datetime.timedelta(
-                    seconds=WORKER_TIMEOUT_SECONDS):
-                logger.info('Cleaning up dead worker (%s, %s)',
-                            worker['user_id'], worker['worker_id'])
-                self._worker_model.worker_cleanup(worker['user_id'],
-                                                  worker['worker_id'])
+            if datetime.datetime.now() - worker['checkin_time'] > datetime.timedelta(seconds=WORKER_TIMEOUT_SECONDS):
+                logger.info('Cleaning up dead worker (%s, %s)', worker['user_id'], worker['worker_id'])
+                self._worker_model.worker_cleanup(worker['user_id'], worker['worker_id'])
                 workers.remove(worker)
                 if callback is not None:
                     callback(worker)
@@ -266,11 +243,9 @@ class BundleManager(object):
         Moves bundles that got stuck in the STARTING state back to the STAGED
         state so that they can be scheduled to run again.
         """
-        for bundle in self._model.batch_get_bundles(
-                state=State.STARTING, bundle_type='run'):
-            if (not workers.is_running(bundle.uuid)
-                    or time.time() - bundle.metadata.last_updated >
-                    5 * 60):  # Run message went missing.
+        for bundle in self._model.batch_get_bundles(state=State.STARTING, bundle_type='run'):
+            if (not workers.is_running(bundle.uuid) or
+                    time.time() - bundle.metadata.last_updated > 5 * 60):  # Run message went missing.
                 logger.info('Re-staging run bundle %s', bundle.uuid)
                 if self._model.restage_bundle(bundle):
                     workers.restage(bundle.uuid)
@@ -279,25 +254,13 @@ class BundleManager(object):
         """
         Acknowledges recently finished bundles to workers so they can discard run information
         """
-        for bundle in self._model.batch_get_bundles(
-                state=State.FINALIZING, bundle_type='run'):
+        for bundle in self._model.batch_get_bundles(state=State.FINALIZING, bundle_type='run'):
             worker = workers.get_bundle_worker(bundle.uuid)
-            if worker is None:
-                logger.info('Bringing bundle offline %s: %s', bundle.uuid,
-                            'No worker claims bundle')
-                self._model.set_offline_bundle(bundle)
-            elif self._worker_model.send_json_message(
-                    worker['socket_id'], {
-                        'type': 'mark_finalized',
-                        'uuid': bundle.uuid
-                    }, 0.2):
-                logger.info('Acknowleded finalization of run bundle %s',
-                            bundle.uuid)
-                self._model.finish_bundle(bundle)
-            else:
-                logger.info(
-                    'Cannot reach worker for bundle %s to finalize, will try next time',
-                    bundle.uuid)
+            if (worker is not None and
+                    self._worker_model.send_json_message(worker['socket_id'], {'type': 'mark_finalized', 'uuid': bundle.uuid}, 0.2)):
+
+                    logger.info('Acknowleded finalization of run bundle %s', bundle.uuid)
+                    self._model.finish_bundle(bundle)
 
     def _bring_offline_stuck_running_bundles(self, workers):
         """
@@ -305,20 +268,14 @@ class BundleManager(object):
         Bundles in WORKER_OFFLINE state can be moved back to the RUNNING or PREPARING state if a
         worker resumes the bundle indicating that it's still in one of those states.
         """
-        active_bundles = self._model.batch_get_bundles(
-            state=State.RUNNING,
-            bundle_type='run') + self._model.batch_get_bundles(
-                state=State.PREPARING, bundle_type='run')
-        now = time.time()
-        for bundle in active_bundles:
+        for bundle in self._model.batch_get_bundles(state=State.RUNNING, bundle_type='run') + self._model.batch_get_bundles(state=State.PREPARING, bundle_type='run'):
             failure_message = None
             if not workers.is_running(bundle.uuid):
                 failure_message = 'No worker claims bundle'
-            if now - bundle.metadata.last_updated > WORKER_TIMEOUT_SECONDS:
+            if time.time() - bundle.metadata.last_updated > WORKER_TIMEOUT_SECONDS:
                 failure_message = 'Worker offline'
             if failure_message is not None:
-                logger.info('Bringing bundle offline %s: %s', bundle.uuid,
-                            failure_message)
+                logger.info('Bringing bundle offline %s: %s', bundle.uuid, failure_message)
                 self._model.set_offline_bundle(bundle)
 
     def _schedule_run_bundles_on_workers(self, workers, user_owned):
@@ -327,13 +284,11 @@ class BundleManager(object):
         True, then schedules on workers run by the owner of each bundle.
         Otherwise, uses CodaLab-owned workers, which have user ID root_user_id.
         """
-        for bundle in self._model.batch_get_bundles(
-                state=State.STAGED, bundle_type='run'):
+        for bundle in self._model.batch_get_bundles(state=State.STAGED, bundle_type='run'):
             if user_owned:
                 workers_list = workers.user_owned_workers(bundle.owner_id)
             else:
-                workers_list = workers.user_owned_workers(
-                    self._model.root_user_id)
+                workers_list = workers.user_owned_workers(self._model.root_user_id)
 
             workers_list = self._filter_and_sort_workers(workers_list, bundle)
 
@@ -372,30 +327,28 @@ class BundleManager(object):
         # Filter by CPUs.
         request_cpus = self._compute_request_cpus(bundle)
         if request_cpus:
-            workers_list = filter(
-                lambda worker: worker['cpus'] >= request_cpus, workers_list)
+            workers_list = filter(lambda worker: worker['cpus'] >= request_cpus,
+                                  workers_list)
 
         # Filter by GPUs.
         request_gpus = self._compute_request_gpus(bundle)
         if request_gpus:
-            workers_list = filter(
-                lambda worker: worker['gpus'] >= request_gpus, workers_list)
+            workers_list = filter(lambda worker: worker['gpus'] >= request_gpus,
+                                  workers_list)
 
         # Filter by memory.
         request_memory = self._compute_request_memory(bundle)
         if request_memory:
-            workers_list = filter(
-                lambda worker: worker['memory_bytes'] >= request_memory,
-                workers_list)
+            workers_list = filter(lambda worker: worker['memory_bytes'] >= request_memory,
+                                  workers_list)
 
         # Filter by tag.
         request_queue = bundle.metadata.request_queue
         if request_queue:
             tagm = re.match('tag=(.+)', request_queue)
             if tagm:
-                workers_list = filter(
-                    lambda worker: worker['tag'] == tagm.group(1),
-                    workers_list)
+                workers_list = filter(lambda worker: worker['tag'] == tagm.group(1),
+                                      workers_list)
             else:
                 # We don't know how to handle this type of request queue
                 # argument.
@@ -414,20 +367,16 @@ class BundleManager(object):
         # is not a problem for the performance of the jobs themselves, this can
         # cause one worker to collect a disproportionate number of dependencies
         # in its cache.
-        needed_deps = set(
-            map(lambda dep: (dep.parent_uuid, dep.parent_path),
-                bundle.dependencies))
+        needed_deps = set(map(lambda dep: (dep.parent_uuid, dep.parent_path),
+                              bundle.dependencies))
 
         def get_sort_key(worker):
             deps = set(worker['dependencies'])
             worker_id = worker['worker_id']
 
             # if the bundle doesn't request GPUs (only request CPUs), prioritize workers that don't have GPUs
-            gpu_priority = self._compute_request_gpus(
-                bundle) or not has_gpu[worker_id]
-            return (gpu_priority, len(needed_deps & deps), worker['cpus'],
-                    random.random())
-
+            gpu_priority = self._compute_request_gpus(bundle) or not has_gpu[worker_id]
+            return (gpu_priority, len(needed_deps & deps), worker['cpus'], random.random())
         workers_list.sort(key=get_sort_key, reverse=True)
 
         return workers_list
@@ -437,8 +386,7 @@ class BundleManager(object):
         Tries to start running the bundle on the given worker, returning False
         if that failed.
         """
-        if self._model.set_starting_bundle(bundle, worker['user_id'],
-                                           worker['worker_id']):
+        if self._model.set_starting_bundle(bundle, worker['user_id'], worker['worker_id']):
             workers.set_starting(bundle.uuid, worker)
             if self._worker_model.shared_file_system and worker['user_id'] == self._model.root_user_id:
                 # On a shared file system we create the path here to avoid NFS
@@ -447,8 +395,7 @@ class BundleManager(object):
                 remove_path(path)
                 os.mkdir(path)
             if self._worker_model.send_json_message(
-                    worker['socket_id'],
-                    self._construct_run_message(worker, bundle), 0.2):
+               worker['socket_id'], self._construct_run_message(worker, bundle), 0.2):
                 logger.info('Starting run bundle %s', bundle.uuid)
                 return True
             else:
@@ -525,16 +472,11 @@ class BundleManager(object):
         """
         message = {}
         message['type'] = 'run'
-        message['bundle'] = bundle_util.bundle_to_bundle_info(
-            self._model, bundle)
+        message['bundle'] = bundle_util.bundle_to_bundle_info(self._model, bundle)
         if self._worker_model.shared_file_system and worker['user_id'] == self._model.root_user_id:
-            message['bundle'][
-                'location'] = self._bundle_store.get_bundle_location(
-                    bundle.uuid)
+            message['bundle']['location'] = self._bundle_store.get_bundle_location(bundle.uuid)
             for dependency in message['bundle']['dependencies']:
-                dependency[
-                    'location'] = self._bundle_store.get_bundle_location(
-                        dependency['parent_uuid'])
+                dependency['location'] = self._bundle_store.get_bundle_location(dependency['parent_uuid'])
 
         # Figure out the resource requirements.
         resources = message['resources'] = {}

--- a/codalab/worker/bundle_manager.py
+++ b/codalab/worker/bundle_manager.py
@@ -139,13 +139,12 @@ class BundleManager(object):
             else:
                 failed_uuids = [
                     uuid for uuid, state in parent_states.iteritems()
-                    if state == State.FAILED or state == State.KILLED
+                    if state == State.FAILED
                 ]
                 if failed_uuids:
                     bundles_to_fail.append((
                         bundle,
-                        'Parent bundles failed: %s (please use the --allow-failed-dependencies flag if you want to run with failed dependencies)'
-                        % ', '.join(failed_uuids)))
+                        'Parent bundles failed: %s' % ', '.join(failed_uuids)))
                     continue
 
             if all(state in acceptable_states

--- a/codalab/worker/bundle_manager.py
+++ b/codalab/worker/bundle_manager.py
@@ -14,7 +14,6 @@ from codalab.lib import bundle_util, formatting, path_util
 from codalabworker.file_util import remove_path
 from codalabworker.bundle_state import State
 
-
 logger = logging.getLogger(__name__)
 
 WORKER_TIMEOUT_SECONDS = 60
@@ -48,12 +47,16 @@ class BundleManager(object):
 
         def parse(to_value, field):
             return to_value(config[field]) if field in config else None
-        self._max_request_time = parse(formatting.parse_duration, 'max_request_time')
-        self._max_request_memory = parse(formatting.parse_size, 'max_request_memory')
-        self._max_request_disk = parse(formatting.parse_size, 'max_request_disk')
 
-        logging.basicConfig(format='%(asctime)s %(message)s',
-                            level=logging.INFO)
+        self._max_request_time = parse(formatting.parse_duration,
+                                       'max_request_time')
+        self._max_request_memory = parse(formatting.parse_size,
+                                         'max_request_memory')
+        self._max_request_disk = parse(formatting.parse_size,
+                                       'max_request_disk')
+
+        logging.basicConfig(
+            format='%(asctime)s %(message)s', level=logging.INFO)
 
         return self
 
@@ -96,8 +99,8 @@ class BundleManager(object):
             2) Staging any bundles that have all ready dependencies.
         """
         bundles = self._model.batch_get_bundles(state=State.CREATED)
-        parent_uuids = set(
-            dep.parent_uuid for bundle in bundles for dep in bundle.dependencies)
+        parent_uuids = set(dep.parent_uuid for bundle in bundles
+                           for dep in bundle.dependencies)
         parents = self._model.batch_get_bundles(uuid=parent_uuids)
 
         all_parent_states = {parent.uuid: parent.state for parent in parents}
@@ -109,11 +112,12 @@ class BundleManager(object):
             parent_uuids = set(dep.parent_uuid for dep in bundle.dependencies)
 
             try:
-                check_bundles_have_read_permission(self._model, self._model.get_user(bundle.owner_id), parent_uuids)
+                check_bundles_have_read_permission(self._model,
+                                                   self._model.get_user(
+                                                       bundle.owner_id),
+                                                   parent_uuids)
             except PermissionError as e:
-                bundles_to_fail.append(
-                    (bundle, str(e))
-                )
+                bundles_to_fail.append((bundle, str(e)))
                 continue
 
             missing_uuids = parent_uuids - all_parent_uuids
@@ -123,8 +127,10 @@ class BundleManager(object):
                      'Missing parent bundles: %s' % ', '.join(missing_uuids)))
                 continue
 
-            parent_states = {uuid: all_parent_states[uuid]
-                             for uuid in parent_uuids}
+            parent_states = {
+                uuid: all_parent_states[uuid]
+                for uuid in parent_uuids
+            }
 
             acceptable_states = [State.READY]
             if bundle.metadata.allow_failed_dependencies:
@@ -133,35 +139,42 @@ class BundleManager(object):
             else:
                 failed_uuids = [
                     uuid for uuid, state in parent_states.iteritems()
-                    if state == State.FAILED]
+                    if state == State.FAILED
+                ]
                 if failed_uuids:
-                    bundles_to_fail.append(
-                        (bundle,
-                         'Parent bundles failed: %s' % ', '.join(failed_uuids)))
+                    bundles_to_fail.append((
+                        bundle,
+                        'Parent bundles failed: %s' % ', '.join(failed_uuids)))
                     continue
 
-            if all(state in acceptable_states for state in parent_states.itervalues()):
+            if all(state in acceptable_states
+                   for state in parent_states.itervalues()):
                 bundles_to_stage.append(bundle)
 
         for bundle, failure_message in bundles_to_fail:
             logger.info('Failing bundle %s: %s', bundle.uuid, failure_message)
             self._model.update_bundle(
-                bundle, {'state': State.FAILED,
-                         'metadata': {'failure_message': failure_message}})
+                bundle, {
+                    'state': State.FAILED,
+                    'metadata': {
+                        'failure_message': failure_message
+                    }
+                })
         for bundle in bundles_to_stage:
             logger.info('Staging %s', bundle.uuid)
-            self._model.update_bundle(
-                bundle, {'state': State.STAGED})
+            self._model.update_bundle(bundle, {'state': State.STAGED})
 
     def _make_bundles(self):
         # Re-stage any stuck bundles. This would happen if the bundle manager
         # died.
-        for bundle in self._model.batch_get_bundles(state=State.MAKING, bundle_type='make'):
+        for bundle in self._model.batch_get_bundles(
+                state=State.MAKING, bundle_type='make'):
             if not self._is_making_bundle(bundle.uuid):
                 logger.info('Re-staging make bundle %s', bundle.uuid)
                 self._model.update_bundle(bundle, {'state': State.STAGED})
 
-        for bundle in self._model.batch_get_bundles(state=State.STAGED, bundle_type='make'):
+        for bundle in self._model.batch_get_bundles(
+                state=State.STAGED, bundle_type='make'):
             logger.info('Making bundle %s', bundle.uuid)
             self._model.update_bundle(bundle, {'state': State.MAKING})
             with self._make_uuids_lock:
@@ -169,8 +182,8 @@ class BundleManager(object):
             # Making a bundle could take time, so do the work in a separate
             # thread to ensure quick scheduling.
             threading.Thread(
-                target=BundleManager._make_bundle, args=[self, bundle]
-            ).start()
+                target=BundleManager._make_bundle, args=[self,
+                                                         bundle]).start()
 
     def _is_making_bundles(self):
         with self._make_uuids_lock:
@@ -182,7 +195,8 @@ class BundleManager(object):
 
     def _make_bundle(self, bundle):
         try:
-            path = os.path.normpath(self._bundle_store.get_bundle_location(bundle.uuid))
+            path = os.path.normpath(
+                self._bundle_store.get_bundle_location(bundle.uuid))
 
             deps = []
             for dep in bundle.dependencies:
@@ -190,17 +204,17 @@ class BundleManager(object):
                     self._bundle_store.get_bundle_location(dep.parent_uuid))
                 dependency_path = os.path.normpath(
                     os.path.join(parent_bundle_path, dep.parent_path))
-                if (not dependency_path.startswith(parent_bundle_path) or
-                    (not os.path.islink(dependency_path) and
-                     not os.path.exists(dependency_path))):
+                if (not dependency_path.startswith(parent_bundle_path)
+                        or (not os.path.islink(dependency_path)
+                            and not os.path.exists(dependency_path))):
                     raise Exception('Invalid dependency %s' % (
                         path_util.safe_join(dep.parent_uuid, dep.parent_path)))
 
                 child_path = os.path.normpath(
                     os.path.join(path, dep.child_path))
                 if not child_path.startswith(path):
-                    raise Exception('Invalid key for dependency: %s' % (
-                        dep.child_path))
+                    raise Exception('Invalid key for dependency: %s' %
+                                    (dep.child_path))
 
                 deps.append((dependency_path, child_path))
 
@@ -211,16 +225,21 @@ class BundleManager(object):
             else:
                 os.mkdir(path)
                 for dependency_path, child_path in deps:
-                    path_util.copy(dependency_path, child_path, follow_symlinks=False)
+                    path_util.copy(
+                        dependency_path, child_path, follow_symlinks=False)
 
-            self._upload_manager.update_metadata_and_save(bundle, enforce_disk_quota=True)
+            self._upload_manager.update_metadata_and_save(
+                bundle, enforce_disk_quota=True)
             logger.info('Finished making bundle %s', bundle.uuid)
             self._model.update_bundle(bundle, {'state': State.READY})
         except Exception as e:
             logger.info('Failing bundle %s: %s', bundle.uuid, str(e))
-            self._model.update_bundle(
-                bundle, {'state': State.FAILED,
-                         'metadata': {'failure_message': str(e)}})
+            self._model.update_bundle(bundle, {
+                'state': State.FAILED,
+                'metadata': {
+                    'failure_message': str(e)
+                }
+            })
         finally:
             with self._make_uuids_lock:
                 self._make_uuids.remove(bundle.uuid)
@@ -231,9 +250,13 @@ class BundleManager(object):
         Such workers probably died without checking out properly.
         """
         for worker in workers.workers():
-            if datetime.datetime.now() - worker['checkin_time'] > datetime.timedelta(seconds=WORKER_TIMEOUT_SECONDS):
-                logger.info('Cleaning up dead worker (%s, %s)', worker['user_id'], worker['worker_id'])
-                self._worker_model.worker_cleanup(worker['user_id'], worker['worker_id'])
+            if datetime.datetime.now(
+            ) - worker['checkin_time'] > datetime.timedelta(
+                    seconds=WORKER_TIMEOUT_SECONDS):
+                logger.info('Cleaning up dead worker (%s, %s)',
+                            worker['user_id'], worker['worker_id'])
+                self._worker_model.worker_cleanup(worker['user_id'],
+                                                  worker['worker_id'])
                 workers.remove(worker)
                 if callback is not None:
                     callback(worker)
@@ -243,9 +266,11 @@ class BundleManager(object):
         Moves bundles that got stuck in the STARTING state back to the STAGED
         state so that they can be scheduled to run again.
         """
-        for bundle in self._model.batch_get_bundles(state=State.STARTING, bundle_type='run'):
-            if (not workers.is_running(bundle.uuid) or
-                    time.time() - bundle.metadata.last_updated > 5 * 60):  # Run message went missing.
+        for bundle in self._model.batch_get_bundles(
+                state=State.STARTING, bundle_type='run'):
+            if (not workers.is_running(bundle.uuid)
+                    or time.time() - bundle.metadata.last_updated >
+                    5 * 60):  # Run message went missing.
                 logger.info('Re-staging run bundle %s', bundle.uuid)
                 if self._model.restage_bundle(bundle):
                     workers.restage(bundle.uuid)
@@ -254,13 +279,25 @@ class BundleManager(object):
         """
         Acknowledges recently finished bundles to workers so they can discard run information
         """
-        for bundle in self._model.batch_get_bundles(state=State.FINALIZING, bundle_type='run'):
+        for bundle in self._model.batch_get_bundles(
+                state=State.FINALIZING, bundle_type='run'):
             worker = workers.get_bundle_worker(bundle.uuid)
-            if (worker is not None and
-                    self._worker_model.send_json_message(worker['socket_id'], {'type': 'mark_finalized', 'uuid': bundle.uuid}, 0.2)):
-
-                    logger.info('Acknowleded finalization of run bundle %s', bundle.uuid)
-                    self._model.finish_bundle(bundle)
+            if worker is None:
+                logger.info('Bringing bundle offline %s: %s', bundle.uuid,
+                            'No worker claims bundle')
+                self._model.set_offline_bundle(bundle)
+            elif self._worker_model.send_json_message(
+                    worker['socket_id'], {
+                        'type': 'mark_finalized',
+                        'uuid': bundle.uuid
+                    }, 0.2):
+                logger.info('Acknowleded finalization of run bundle %s',
+                            bundle.uuid)
+                self._model.finish_bundle(bundle)
+            else:
+                logger.info(
+                    'Cannot reach worker for bundle %s to finalize, will try next time',
+                    bundle.uuid)
 
     def _bring_offline_stuck_running_bundles(self, workers):
         """
@@ -268,14 +305,20 @@ class BundleManager(object):
         Bundles in WORKER_OFFLINE state can be moved back to the RUNNING or PREPARING state if a
         worker resumes the bundle indicating that it's still in one of those states.
         """
-        for bundle in self._model.batch_get_bundles(state=State.RUNNING, bundle_type='run') + self._model.batch_get_bundles(state=State.PREPARING, bundle_type='run'):
+        active_bundles = self._model.batch_get_bundles(
+            state=State.RUNNING,
+            bundle_type='run') + self._model.batch_get_bundles(
+                state=State.PREPARING, bundle_type='run')
+        now = time.time()
+        for bundle in active_bundles:
             failure_message = None
             if not workers.is_running(bundle.uuid):
                 failure_message = 'No worker claims bundle'
-            if time.time() - bundle.metadata.last_updated > WORKER_TIMEOUT_SECONDS:
+            if now - bundle.metadata.last_updated > WORKER_TIMEOUT_SECONDS:
                 failure_message = 'Worker offline'
             if failure_message is not None:
-                logger.info('Bringing bundle offline %s: %s', bundle.uuid, failure_message)
+                logger.info('Bringing bundle offline %s: %s', bundle.uuid,
+                            failure_message)
                 self._model.set_offline_bundle(bundle)
 
     def _schedule_run_bundles_on_workers(self, workers, user_owned):
@@ -284,11 +327,13 @@ class BundleManager(object):
         True, then schedules on workers run by the owner of each bundle.
         Otherwise, uses CodaLab-owned workers, which have user ID root_user_id.
         """
-        for bundle in self._model.batch_get_bundles(state=State.STAGED, bundle_type='run'):
+        for bundle in self._model.batch_get_bundles(
+                state=State.STAGED, bundle_type='run'):
             if user_owned:
                 workers_list = workers.user_owned_workers(bundle.owner_id)
             else:
-                workers_list = workers.user_owned_workers(self._model.root_user_id)
+                workers_list = workers.user_owned_workers(
+                    self._model.root_user_id)
 
             workers_list = self._filter_and_sort_workers(workers_list, bundle)
 
@@ -327,28 +372,30 @@ class BundleManager(object):
         # Filter by CPUs.
         request_cpus = self._compute_request_cpus(bundle)
         if request_cpus:
-            workers_list = filter(lambda worker: worker['cpus'] >= request_cpus,
-                                  workers_list)
+            workers_list = filter(
+                lambda worker: worker['cpus'] >= request_cpus, workers_list)
 
         # Filter by GPUs.
         request_gpus = self._compute_request_gpus(bundle)
         if request_gpus:
-            workers_list = filter(lambda worker: worker['gpus'] >= request_gpus,
-                                  workers_list)
+            workers_list = filter(
+                lambda worker: worker['gpus'] >= request_gpus, workers_list)
 
         # Filter by memory.
         request_memory = self._compute_request_memory(bundle)
         if request_memory:
-            workers_list = filter(lambda worker: worker['memory_bytes'] >= request_memory,
-                                  workers_list)
+            workers_list = filter(
+                lambda worker: worker['memory_bytes'] >= request_memory,
+                workers_list)
 
         # Filter by tag.
         request_queue = bundle.metadata.request_queue
         if request_queue:
             tagm = re.match('tag=(.+)', request_queue)
             if tagm:
-                workers_list = filter(lambda worker: worker['tag'] == tagm.group(1),
-                                      workers_list)
+                workers_list = filter(
+                    lambda worker: worker['tag'] == tagm.group(1),
+                    workers_list)
             else:
                 # We don't know how to handle this type of request queue
                 # argument.
@@ -367,16 +414,20 @@ class BundleManager(object):
         # is not a problem for the performance of the jobs themselves, this can
         # cause one worker to collect a disproportionate number of dependencies
         # in its cache.
-        needed_deps = set(map(lambda dep: (dep.parent_uuid, dep.parent_path),
-                              bundle.dependencies))
+        needed_deps = set(
+            map(lambda dep: (dep.parent_uuid, dep.parent_path),
+                bundle.dependencies))
 
         def get_sort_key(worker):
             deps = set(worker['dependencies'])
             worker_id = worker['worker_id']
 
             # if the bundle doesn't request GPUs (only request CPUs), prioritize workers that don't have GPUs
-            gpu_priority = self._compute_request_gpus(bundle) or not has_gpu[worker_id]
-            return (gpu_priority, len(needed_deps & deps), worker['cpus'], random.random())
+            gpu_priority = self._compute_request_gpus(
+                bundle) or not has_gpu[worker_id]
+            return (gpu_priority, len(needed_deps & deps), worker['cpus'],
+                    random.random())
+
         workers_list.sort(key=get_sort_key, reverse=True)
 
         return workers_list
@@ -386,7 +437,8 @@ class BundleManager(object):
         Tries to start running the bundle on the given worker, returning False
         if that failed.
         """
-        if self._model.set_starting_bundle(bundle, worker['user_id'], worker['worker_id']):
+        if self._model.set_starting_bundle(bundle, worker['user_id'],
+                                           worker['worker_id']):
             workers.set_starting(bundle.uuid, worker)
             if self._worker_model.shared_file_system and worker['user_id'] == self._model.root_user_id:
                 # On a shared file system we create the path here to avoid NFS
@@ -395,7 +447,8 @@ class BundleManager(object):
                 remove_path(path)
                 os.mkdir(path)
             if self._worker_model.send_json_message(
-               worker['socket_id'], self._construct_run_message(worker, bundle), 0.2):
+                    worker['socket_id'],
+                    self._construct_run_message(worker, bundle), 0.2):
                 logger.info('Starting run bundle %s', bundle.uuid)
                 return True
             else:
@@ -472,11 +525,16 @@ class BundleManager(object):
         """
         message = {}
         message['type'] = 'run'
-        message['bundle'] = bundle_util.bundle_to_bundle_info(self._model, bundle)
+        message['bundle'] = bundle_util.bundle_to_bundle_info(
+            self._model, bundle)
         if self._worker_model.shared_file_system and worker['user_id'] == self._model.root_user_id:
-            message['bundle']['location'] = self._bundle_store.get_bundle_location(bundle.uuid)
+            message['bundle'][
+                'location'] = self._bundle_store.get_bundle_location(
+                    bundle.uuid)
             for dependency in message['bundle']['dependencies']:
-                dependency['location'] = self._bundle_store.get_bundle_location(dependency['parent_uuid'])
+                dependency[
+                    'location'] = self._bundle_store.get_bundle_location(
+                        dependency['parent_uuid'])
 
         # Figure out the resource requirements.
         resources = message['resources'] = {}

--- a/codalab/worker/bundle_manager.py
+++ b/codalab/worker/bundle_manager.py
@@ -139,12 +139,13 @@ class BundleManager(object):
             else:
                 failed_uuids = [
                     uuid for uuid, state in parent_states.iteritems()
-                    if state == State.FAILED
+                    if state == State.FAILED or state == State.KILLED
                 ]
                 if failed_uuids:
                     bundles_to_fail.append((
                         bundle,
-                        'Parent bundles failed: %s' % ', '.join(failed_uuids)))
+                        'Parent bundles failed: %s (please use the --allow-failed-dependencies flag if you want to run with failed dependencies)'
+                        % ', '.join(failed_uuids)))
                     continue
 
             if all(state in acceptable_states


### PR DESCRIPTION
Right now these bundles are left in `created` stage forever.

This PR has a large diff because of auto code formatting.