### PR TITLE
Worker dep managers fix

### DIFF
--- a/codalab/rest/workers.py
+++ b/codalab/rest/workers.py
@@ -35,12 +35,15 @@ def checkin(worker_id):
         request.json['dependencies'])
 
     for uuid, run in request.json['runs'].items():
-        bundle = local.model.get_bundle(uuid)
-        local.model.bundle_checkin(bundle,
-                                   run,
-                                   request.user.user_id,
-                                   worker_id,
-                                   request.json['hostname'])
+        try:
+            bundle = local.model.get_bundle(uuid)
+            local.model.bundle_checkin(bundle,
+                                       run,
+                                       request.user.user_id,
+                                       worker_id,
+                                       request.json['hostname'])
+        except Exception:
+            pass
 
     with closing(local.worker_model.start_listening(socket_id)) as sock:
         return local.worker_model.get_json_message(sock, WAIT_TIME_SECS)

--- a/worker/codalabworker/local_run/local_dependency_manager.py
+++ b/worker/codalabworker/local_run/local_dependency_manager.py
@@ -156,7 +156,8 @@ class LocalFileSystemDependencyManager(StateTransitioner,
         Deletes oldest failed dependencies first and then oldest finished dependencies.
         Doesn't touch downloading dependencies.
         """
-        while True:
+        deleting = True
+        while deleting:
             with self._lock:
                 bytes_used = sum(
                     dep.size_bytes for dep in self._dependencies.values())
@@ -191,7 +192,7 @@ class LocalFileSystemDependencyManager(StateTransitioner,
                         logger.info(
                             'Dependency quota full but there are only downloading dependencies, not cleaning up until downloads are over'
                         )
-                        break
+                        deleting = False
                     try:
                         self._paths.remove(
                             self._dependencies[dep_to_remove].path)
@@ -199,7 +200,7 @@ class LocalFileSystemDependencyManager(StateTransitioner,
                         if dep_to_remove:
                             del self._dependencies[dep_to_remove]
                 else:
-                    break
+                    deleting = False
 
     def has(self, dependency):
         """
@@ -222,7 +223,7 @@ class LocalFileSystemDependencyManager(StateTransitioner,
                     dependency=dependency,
                     path=self._assign_path(dependency),
                     size_bytes=0,
-                    dependents=set((uuid)),
+                    dependents=set([uuid]),
                     last_used=now,
                     message="Starting download",
                     killed=False)

--- a/worker/codalabworker/local_run/local_dependency_manager.py
+++ b/worker/codalabworker/local_run/local_dependency_manager.py
@@ -156,8 +156,7 @@ class LocalFileSystemDependencyManager(StateTransitioner,
         Deletes oldest failed dependencies first and then oldest finished dependencies.
         Doesn't touch downloading dependencies.
         """
-        deleting = True
-        while deleting:
+        while True:
             with self._lock:
                 bytes_used = sum(
                     dep.size_bytes for dep in self._dependencies.values())
@@ -192,7 +191,7 @@ class LocalFileSystemDependencyManager(StateTransitioner,
                         logger.info(
                             'Dependency quota full but there are only downloading dependencies, not cleaning up until downloads are over'
                         )
-                        deleting = False
+                        break
                     try:
                         self._paths.remove(
                             self._dependencies[dep_to_remove].path)
@@ -200,7 +199,7 @@ class LocalFileSystemDependencyManager(StateTransitioner,
                         if dep_to_remove:
                             del self._dependencies[dep_to_remove]
                 else:
-                    deleting = False
+                    break
 
     def has(self, dependency):
         """


### PR DESCRIPTION
Fixes a few more issues with new workers:
* Fixes a bug in dependency state tracking that prevented dependencies from getting cleaned up properly
* Fixes a bug in worker REST server where if the worker tried to check in with a run that didn't exist anymore, the entire checkin failed.