### PR TITLE
Add a kill when idle flag to the worker

### DIFF
--- a/worker/codalabworker/local_run/local_run_manager.py
+++ b/worker/codalabworker/local_run/local_run_manager.py
@@ -30,15 +30,15 @@ class LocalRunManager(BaseRunManager):
 
     def __init__(
         self,
-        worker,
-        docker,
-        image_manager,
-        dependency_manager,
-        commit_file,
-        cpuset,
-        gpuset,
-        work_dir,
-        docker_network_prefix='codalab_worker_network',
+        worker,  # type: Worker
+        docker,  # type: DockerClient
+        image_manager,  # type: DockerImageManager
+        dependency_manager,  # type: LocalFileSystemDependencyManager
+        commit_file,  # type: str
+        cpuset,  # type: Set[str]
+        gpuset,  # type: Set[str]
+        work_dir,  # type: str
+        docker_network_prefix='codalab_worker_network',  # type: str
     ):
         self._worker = worker
         self._state_committer = JsonStateCommitter(commit_file)

--- a/worker/codalabworker/main.py
+++ b/worker/codalabworker/main.py
@@ -96,6 +96,11 @@ def main():
         '--verbose', action='store_true', help='Whether to output verbose log messages.'
     )
     parser.add_argument(
+        '--kill-when-idle',
+        action='store_true',
+        help='If specified the worker quits if it finds itself with no jobs after a checkin',
+    )
+    parser.add_argument(
         '--id',
         default='%s(%d)' % (socket.gethostname(), os.getpid()),
         help='Internal use: ID to use for the worker.',
@@ -186,6 +191,7 @@ chmod 600 %s""" % args.password_file
         args.id,
         args.tag,
         args.work_dir,
+        args.kill_when_idle,
         bundle_service,
     )
 

--- a/worker/codalabworker/main.py
+++ b/worker/codalabworker/main.py
@@ -96,7 +96,7 @@ def main():
         '--verbose', action='store_true', help='Whether to output verbose log messages.'
     )
     parser.add_argument(
-        '--kill-when-idle',
+        '--exit-when-idle',
         action='store_true',
         help='If specified the worker quits if it finds itself with no jobs after a checkin',
     )
@@ -191,7 +191,7 @@ chmod 600 %s""" % args.password_file
         args.id,
         args.tag,
         args.work_dir,
-        args.kill_when_idle,
+        args.exit_when_idle,
         bundle_service,
     )
 

--- a/worker/codalabworker/worker.py
+++ b/worker/codalabworker/worker.py
@@ -31,7 +31,7 @@ class Worker(object):
         worker_id,  # type: str
         tag,  # type: str
         work_dir,  # type: str
-        kill_when_idle,  # type: str
+        exit_when_idle,  # type: str
         bundle_service,  # type: BundleServiceClient
     ):
         self.id = worker_id
@@ -39,7 +39,7 @@ class Worker(object):
         self._tag = tag
         self._work_dir = work_dir
         self._bundle_service = bundle_service
-        self._kill_when_idle = kill_when_idle
+        self._exit_when_idle = exit_when_idle
         self._stop = False
         self._last_checkin_successful = False
         self._run_manager = create_run_manager(self)
@@ -51,7 +51,7 @@ class Worker(object):
                 self._run_manager.process_runs()
                 self._run_manager.save_state()
                 if (
-                    self._kill_when_idle
+                    self._exit_when_idle
                     and self._last_checkin_successful
                     and len(self._run_manager.all_runs) == 0
                 ):

--- a/worker/codalabworker/worker.py
+++ b/worker/codalabworker/worker.py
@@ -24,12 +24,22 @@ but they expect the platform specific RunManagers they use to implement a common
 
 
 class Worker(object):
-    def __init__(self, create_run_manager, commit_file, worker_id, tag, work_dir, bundle_service):
+    def __init__(
+        self,
+        create_run_manager,  # type: Callable[[Worker], BaseRunManager]
+        commit_file,  # type: str
+        worker_id,  # type: str
+        tag,  # type: str
+        work_dir,  # type: str
+        kill_when_idle,  # type: str
+        bundle_service,  # type: BundleServiceClient
+    ):
         self.id = worker_id
         self._state_committer = JsonStateCommitter(commit_file)
         self._tag = tag
         self._work_dir = work_dir
         self._bundle_service = bundle_service
+        self._kill_when_idle = kill_when_idle
         self._stop = False
         self._last_checkin_successful = False
         self._run_manager = create_run_manager(self)
@@ -40,6 +50,13 @@ class Worker(object):
             try:
                 self._run_manager.process_runs()
                 self._run_manager.save_state()
+                if (
+                    self._kill_when_idle
+                    and self._last_checkin_successful
+                    and len(self._run_manager.all_runs) == 0
+                ):
+                    self._stop = True
+                    break
                 self._checkin()
                 self._run_manager.save_state()
 


### PR DESCRIPTION
When the flag is specified, the worker checks whether it has any assigned/unfinished runs before each check-in (except for the first check-in).

If there are no more runs, it quits.

The Slurm worker invokes one-off worker scripts for the user whenever there are staged jobs for that user. There are three separate kinds of workers: CPU(john), low-priority GPU (jag-low) and high-priority GPU (jag-hi). 