### PR TITLE
DO NOT MERGE

### DIFF
--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -2123,6 +2123,12 @@ class BundleCLI(object):
                     'bundle_spec', help=BUNDLE_SPEC_FORMAT, nargs=1, completer=BundlesCompleter
                 ),
                 Commands.Argument(
+                    '-l',
+                    '--levels',
+                    default=100,
+                    help="Number of levels of ancestors to show (default: 100).",
+                ),
+                Commands.Argument(
                     '-w',
                     '--worksheet-spec',
                     help='Operate on this worksheet (%s).' % WORKSHEET_SPEC_FORMAT,
@@ -2134,18 +2140,18 @@ class BundleCLI(object):
         args.bundle_spec = spec_util.expand_specs(args.bundle_spec)
         client, worksheet_uuid = self.parse_client_worksheet_uuid(args.worksheet_spec)
 
-        # bundles = client.fetch(
-        #     'bundles',
-        #     params={
-        #         'specs': args.bundle_spec,
-        #         'worksheet': worksheet_uuid,
-        #         'include': ['owner']
-        #                    + (['children', 'group_permissions', 'host_worksheets'] if args.verbose else []),
-        #     },
-        # )
+        print >>self.stdout, "levels", args.levels
+        bundles = client.fetch(
+            'bundles',
+            params={
+                'specs': args.bundle_spec,
+                'worksheet': worksheet_uuid,
+                'levels': args.levels,
+            },
+        )
 
         print >>self.stdout, "HERRO WORLD!"
-        # print >>self.stdout, bundles
+        print >>self.stdout, bundles
 
     @Commands.command(
         'mount',

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -114,6 +114,7 @@ BUNDLE_COMMANDS = (
     'search',
     'ls',
     'info',
+    'ancestors',
     'cat',
     'wait',
     'download',
@@ -2113,6 +2114,38 @@ class BundleCLI(object):
                     continue
                 print >>self.stdout, wrap(item['name'])
                 self.print_target_info(client, bundle_uuid, item['name'], head=10)
+
+    @Commands.command(
+        'ancestors',
+        help='Show entire history of dependencies for a bundle.',
+        arguments=(
+                Commands.Argument(
+                    'bundle_spec', help=BUNDLE_SPEC_FORMAT, nargs=1, completer=BundlesCompleter
+                ),
+                Commands.Argument(
+                    '-w',
+                    '--worksheet-spec',
+                    help='Operate on this worksheet (%s).' % WORKSHEET_SPEC_FORMAT,
+                    completer=WorksheetsCompleter,
+                ),
+        ),
+    )
+    def do_ancestors_command(self, args):
+        args.bundle_spec = spec_util.expand_specs(args.bundle_spec)
+        client, worksheet_uuid = self.parse_client_worksheet_uuid(args.worksheet_spec)
+
+        # bundles = client.fetch(
+        #     'bundles',
+        #     params={
+        #         'specs': args.bundle_spec,
+        #         'worksheet': worksheet_uuid,
+        #         'include': ['owner']
+        #                    + (['children', 'group_permissions', 'host_worksheets'] if args.verbose else []),
+        #     },
+        # )
+
+        print >>self.stdout, "HERRO WORLD!"
+        # print >>self.stdout, bundles
 
     @Commands.command(
         'mount',

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -103,6 +103,7 @@ def _fetch_bundles():
     specs = query_get_list('specs')
     worksheet_uuid = request.query.get('worksheet')
     descendant_depth = query_get_type(int, 'depth', None)
+    ancestor_level = query_get_type(int, 'level', None)
 
     if keywords:
         # Handle search keywords
@@ -124,9 +125,14 @@ def _fetch_bundles():
             "Request must include either 'keywords' " "or 'specs' query parameter",
         )
 
-    # Find all descendants down to the provided depth
+    # Find all relatives (descendants or ancestors) within the provided levels
+    relative_uuids = set()
     if descendant_depth is not None:
-        bundle_uuids = local.model.get_self_and_descendants(bundle_uuids, depth=descendant_depth)
+        relative_uuids.update(local.model.get_self_and_descendants(bundle_uuids, depth=descendant_depth))
+    if ancestor_level is not None:
+        relative_uuids.update(local.model.get_self_and_ancestors(bundle_uuids, level=ancestor_level))
+    if len(relative_uuids) > 0:
+        bundle_uuids = list(relative_uuids)
 
     return build_bundles_document(bundle_uuids)
 


### PR DESCRIPTION
This CLI command shows the entire history of dependencies for a bundle.

- Current logic makes a separate API call for each ancestor bundle uuid.
- REST API and `BundleModel` have been adapted for future performance refactor.