### PR TITLE
Make default time and disk quotas whatever the user has left

### DIFF
--- a/codalab/bundles/run_bundle.py
+++ b/codalab/bundles/run_bundle.py
@@ -24,9 +24,9 @@ class RunBundle(DerivedBundle):
     # Don't format metadata specs
     # fmt: off
     METADATA_SPECS.append(MetadataSpec('request_docker_image', basestring, 'Which docker image (either tag or digest, e.g., codalab/ubuntu:1.9) we wish to use.', completer=DockerImagesCompleter, hide_when_anonymous=True, default='codalab/ubuntu:1.9'))
-    METADATA_SPECS.append(MetadataSpec('request_time', basestring, 'Amount of time (e.g., 3, 3m, 3h, 3d) allowed for this run. Defaults to user time quota left.', formatting='duration'))
+    METADATA_SPECS.append(MetadataSpec('request_time', basestring, 'Amount of time (e.g., 3, 3m, 3h, 3d) allowed for this run. Defaults to user time quota left.', formatting='duration', default=None))
     METADATA_SPECS.append(MetadataSpec('request_memory', basestring, 'Amount of memory (e.g., 3, 3k, 3m, 3g, 3t) allowed for this run.', formatting='size', default='2g'))
-    METADATA_SPECS.append(MetadataSpec('request_disk', basestring, 'Amount of disk space (e.g., 3, 3k, 3m, 3g, 3t) allowed for this run. Defaults to user disk quota left.', formatting='size'))
+    METADATA_SPECS.append(MetadataSpec('request_disk', basestring, 'Amount of disk space (e.g., 3, 3k, 3m, 3g, 3t) allowed for this run. Defaults to user disk quota left.', formatting='size', default=None))
     METADATA_SPECS.append(MetadataSpec('request_cpus', int, 'Number of CPUs allowed for this run.', default=1))
     METADATA_SPECS.append(MetadataSpec('request_gpus', int, 'Number of GPUs allowed for this run.', default=0))
     METADATA_SPECS.append(MetadataSpec('request_queue', basestring, 'Submit run to this job queue.', hide_when_anonymous=True, default=None))

--- a/codalab/bundles/run_bundle.py
+++ b/codalab/bundles/run_bundle.py
@@ -24,9 +24,9 @@ class RunBundle(DerivedBundle):
     # Don't format metadata specs
     # fmt: off
     METADATA_SPECS.append(MetadataSpec('request_docker_image', basestring, 'Which docker image (either tag or digest, e.g., codalab/ubuntu:1.9) we wish to use.', completer=DockerImagesCompleter, hide_when_anonymous=True, default='codalab/ubuntu:1.9'))
-    METADATA_SPECS.append(MetadataSpec('request_time', basestring, 'Amount of time (e.g., 3, 3m, 3h, 3d) allowed for this run.', formatting='duration', default='1d'))
+    METADATA_SPECS.append(MetadataSpec('request_time', basestring, 'Amount of time (e.g., 3, 3m, 3h, 3d) allowed for this run. Defaults to user time quota left.', formatting='duration'))
     METADATA_SPECS.append(MetadataSpec('request_memory', basestring, 'Amount of memory (e.g., 3, 3k, 3m, 3g, 3t) allowed for this run.', formatting='size', default='2g'))
-    METADATA_SPECS.append(MetadataSpec('request_disk', basestring, 'Amount of disk space (e.g., 3, 3k, 3m, 3g, 3t) allowed for this run.', formatting='size', default='4g'))
+    METADATA_SPECS.append(MetadataSpec('request_disk', basestring, 'Amount of disk space (e.g., 3, 3k, 3m, 3g, 3t) allowed for this run. Defaults to user disk quota left.', formatting='size'))
     METADATA_SPECS.append(MetadataSpec('request_cpus', int, 'Number of CPUs allowed for this run.', default=1))
     METADATA_SPECS.append(MetadataSpec('request_gpus', int, 'Number of GPUs allowed for this run.', default=0))
     METADATA_SPECS.append(MetadataSpec('request_queue', basestring, 'Submit run to this job queue.', hide_when_anonymous=True, default=None))

--- a/codalab/worker/bundle_manager.py
+++ b/codalab/worker/bundle_manager.py
@@ -460,21 +460,19 @@ class BundleManager(object):
     def _compute_request_disk(self, bundle):
         """
         Compute the disk limit used for scheduling the run.
-        The default of 4g is for backwards compatibilty for
-        runs from before when we added client-side defaults
+        The default is however much disk quota the user has left.
         """
         if not bundle.metadata.request_disk:
-            return formatting.parse_size('4g')
+            return (self._model.get_user_disk_quota_left(bundle.owner_id),)
         return formatting.parse_size(bundle.metadata.request_disk)
 
     def _compute_request_time(self, bundle):
         """
         Compute the time limit used for scheduling the run.
-        The default of 1d is for backwards compatibilty for
-        runs from before when we added client-side defaults
+        The default is however much time quota the user has left.
         """
         if not bundle.metadata.request_time:
-            return formatting.parse_duration('1d')
+            return (self._model.get_user_time_quota_left(bundle.owner_id),)
         return formatting.parse_duration(bundle.metadata.request_time)
 
     def _get_docker_image(self, bundle):

--- a/codalab/worker/bundle_manager.py
+++ b/codalab/worker/bundle_manager.py
@@ -463,7 +463,7 @@ class BundleManager(object):
         The default is however much disk quota the user has left.
         """
         if not bundle.metadata.request_disk:
-            return (self._model.get_user_disk_quota_left(bundle.owner_id),)
+            return self._model.get_user_disk_quota_left(bundle.owner_id) - 1
         return formatting.parse_size(bundle.metadata.request_disk)
 
     def _compute_request_time(self, bundle):
@@ -472,7 +472,7 @@ class BundleManager(object):
         The default is however much time quota the user has left.
         """
         if not bundle.metadata.request_time:
-            return (self._model.get_user_time_quota_left(bundle.owner_id),)
+            return self._model.get_user_time_quota_left(bundle.owner_id) - 1
         return formatting.parse_duration(bundle.metadata.request_time)
 
     def _get_docker_image(self, bundle):


### PR DESCRIPTION
Previously some runs would just fail as default values would be  > user quota left, this prevents that pain point.