### PR TITLE
Increase timeout limit of cl wait in monitor py

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -311,7 +311,9 @@ while True:
             uuid = run_command(
                 ['cl', 'run', 'stress-test.pl:' + upload_uuid, 'perl stress-test.pl 5 10 10']
             )
-            run_command(['cl', 'wait', uuid], 30, 300)  # Running might take a while
+            run_command(
+                ['cl', 'wait', uuid], 30, 3600
+            )  # Running might take a while (includes staged time)
             run_command(['cl', 'rm', upload_uuid, uuid])
 
     except Exception as e:

--- a/monitor.py
+++ b/monitor.py
@@ -312,7 +312,7 @@ while True:
                 ['cl', 'run', 'stress-test.pl:' + upload_uuid, 'perl stress-test.pl 5 10 10']
             )
             run_command(
-                ['cl', 'wait', uuid], 30, 3600
+                ['cl', 'wait', uuid], 600, 3600
             )  # Running might take a while (includes staged time)
             run_command(['cl', 'rm', upload_uuid, uuid])
 


### PR DESCRIPTION
Increases soft limit from 30 seconds to 10 min and hard limit from 5 minutes to 1 hour
Soft limit increase is for better tolerating when the bundle is staged for a few minutes, and hard limit increase is to avoid failing the subsequent rm command in edge cases when bundle can stay staged for longer.