### PR TITLE
Overwrite existing path instead of failing when downloading dependencies

### DIFF
--- a/worker/codalabworker/local_run/local_dependency_manager.py
+++ b/worker/codalabworker/local_run/local_dependency_manager.py
@@ -310,6 +310,9 @@ class LocalFileSystemDependencyManager(StateTransitioner, BaseDependencyManager)
         """
         Copy the dependency fileobj to its path in the local filesystem
         Overwrite existing files by the same name if found
+        (may happen if filesystem modified outside the dependency manager,
+         for example during an update if the state gets reset but filesystem
+         doesn't get cleared)
         """
         try:
             if os.path.exists(dependency_path):
@@ -388,7 +391,7 @@ class LocalFileSystemDependencyManager(StateTransitioner, BaseDependencyManager)
                     self._downloading[dependency]['success'] = False
                     self._downloading[dependency][
                         'failure_message'
-                    ] = "Depdendency download failed: %s " % str(e)
+                    ] = "Dependency download failed: %s " % str(e)
 
         dependency = dependency_state.dependency
         parent_uuid, parent_path = dependency

--- a/worker/codalabworker/local_run/local_dependency_manager.py
+++ b/worker/codalabworker/local_run/local_dependency_manager.py
@@ -311,6 +311,12 @@ class LocalFileSystemDependencyManager(StateTransitioner, BaseDependencyManager)
         Copy the dependency fileobj to its path in the local filesystem
         """
         try:
+            if os.path.exists(dependency_path):
+                logger.info('Path %s already exists, overwriting', dependency_path)
+                if os.path.isdir(dependency_path):
+                    shutil.rmtree(dependency_path)
+                else:
+                    os.remove(dependency_path)
             if target_type == 'directory':
                 un_tar_directory(fileobj, dependency_path, 'gz')
             else:

--- a/worker/codalabworker/local_run/local_dependency_manager.py
+++ b/worker/codalabworker/local_run/local_dependency_manager.py
@@ -309,6 +309,7 @@ class LocalFileSystemDependencyManager(StateTransitioner, BaseDependencyManager)
     def _store_dependency(self, dependency_path, fileobj, target_type):
         """
         Copy the dependency fileobj to its path in the local filesystem
+        Overwrite existing files by the same name if found
         """
         try:
             if os.path.exists(dependency_path):


### PR DESCRIPTION
Fixes #951 