### PR TITLE
codalab-cli fails to upload archive on windows

### DIFF
--- a/codalab/lib/zip_util.py
+++ b/codalab/lib/zip_util.py
@@ -152,7 +152,7 @@ def pack_files_for_upload(sources, should_unpack, follow_symlinks,
             }
         elif path_is_archive(source):
             return {
-                'fileobj': open(source),
+                'fileobj': open(source, mode='rb'),
                 'filename': filename,
                 'filesize': os.path.getsize(source),
                 'should_unpack': should_unpack,
@@ -168,7 +168,7 @@ def pack_files_for_upload(sources, should_unpack, follow_symlinks,
             }
         else:
             return {
-                'fileobj': open(source),
+                'fileobj': open(source, mode='rb'),
                 'filename': filename,
                 'filesize': os.path.getsize(source),
                 'should_unpack': False,


### PR DESCRIPTION
**Problem:** Couldn't upload a bundle archive to my worksheet on codalab from Windows command prompt. 

**Example**: Upload fails pretty soon but a bundle id is returned
```
>cl upload -w worksheetid -p bundle.zip
Preparing upload archive...
Uploading bundle.zip to https://codalab.xyz.com
Sent 0.06MiB / 852.52MiB (0.0%) [0.11MiB/sec]
0x5b1d277eadb54ea58e71fea117f7aa3c
```

Paired with @jder to resolve this issue. The solution is to open files in binary mode. The `read()` method silently fails possibly due to Windows encountering what it thinks is an undefined character. This doesn't surface in Python2.7 but when we attempted to `open()` and `read()` the same `bundle.zip` in Python3.6 the `read()` method failed with the following error message:
`UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 75: character maps to <undefined>`

(opening the file with encoding set to `mbcs` in Python3+ also resolved it for me)