### PR TITLE
Force worker to exit when authentication error occurs

### DIFF
--- a/worker/codalabworker/bundle_service_client.py
+++ b/worker/codalabworker/bundle_service_client.py
@@ -39,10 +39,12 @@ def wrap_exception(message):
 
     return decorator
 
+
 class BundleAuthException(RestClientException):
     """
     Exception raised by the BundleServiceClient methods if auth error occurs.
     """
+
 
 class BundleServiceException(RestClientException):
     """
@@ -67,6 +69,10 @@ class BundleServiceClient(RestClient):
 
         base_url += '/rest'
         super(BundleServiceClient, self).__init__(base_url)
+        try:
+            self._authorize()
+        except BundleServiceException as ex:
+            raise BundleAuthException(ex, True)
 
     def _get_access_token(self):
         with self._authorization_lock:

--- a/worker/codalabworker/bundle_service_client.py
+++ b/worker/codalabworker/bundle_service_client.py
@@ -26,10 +26,21 @@ def wrap_exception(message):
                 client_error = json.load(e)
 
                 if client_error['error'] == 'invalid_grant':
-                    raise BundleAuthException(message + ': ' + httplib.responses[e.code] + ' - ' + json.dumps(client_error), True)
+                    raise BundleAuthException(
+                        message
+                        + ': '
+                        + httplib.responses[e.code]
+                        + ' - '
+                        + json.dumps(client_error),
+                        True,
+                    )
                 else:
                     raise BundleServiceException(
-                        message + ': ' + httplib.responses[e.code] + ' - ' + json.dumps(client_error),
+                        message
+                        + ': '
+                        + httplib.responses[e.code]
+                        + ' - '
+                        + json.dumps(client_error),
                         e.code >= 400 and e.code < 500,
                     )
             except (urllib2.URLError, httplib.HTTPException, socket.error) as e:

--- a/worker/codalabworker/main.py
+++ b/worker/codalabworker/main.py
@@ -144,7 +144,11 @@ chmod 600 %s""" % args.password_file
     try:
         bundle_service = BundleServiceClient(args.server, username, password)
     except BundleAuthException as ex:
-        logger.error('Cannot log into the bundle service. Please check your worker credentials: {}'.format(ex))
+        logger.error(
+            'Cannot log into the bundle service. Please check your worker credentials: {}'.format(
+                ex
+            )
+        )
         raise
 
     if not os.path.exists(args.work_dir):

--- a/worker/codalabworker/main.py
+++ b/worker/codalabworker/main.py
@@ -134,26 +134,23 @@ chmod 600 %s""" % args.password_file
     else:
         logging.basicConfig(format='%(asctime)s %(message)s', level=logging.INFO)
 
+    try:
+        bundle_service = BundleServiceClient(args.server, username, password)
+    except BundleAuthException as ex:
+        logger.error('Cannot log into the bundle service. Please check your worker credentials.\n')
+        logger.debug('Auth error: {}'.format(ex))
+        return
+
     max_work_dir_size_bytes = parse_size(args.max_work_dir_size)
     if args.max_image_cache_size is None:
         max_images_bytes = None
     else:
         max_images_bytes = parse_size(args.max_image_cache_size)
 
-    docker_client = DockerClient()
-    try:
-        bundle_service = BundleServiceClient(args.server, username, password)
-    except BundleAuthException as ex:
-        logger.error(
-            'Cannot log into the bundle service. Please check your worker credentials: {}'.format(
-                ex
-            )
-        )
-        raise
-
     if not os.path.exists(args.work_dir):
         logging.debug('Work dir %s doesn\'t exist, creating.', args.work_dir)
         os.makedirs(args.work_dir, 0o770)
+    docker_client = DockerClient()
 
     def create_local_run_manager(worker):
         """

--- a/worker/codalabworker/main.py
+++ b/worker/codalabworker/main.py
@@ -14,7 +14,7 @@ import sys
 import multiprocessing
 import re
 
-from bundle_service_client import BundleServiceClient
+from bundle_service_client import BundleServiceClient, BundleAuthException
 from docker_client import DockerClient
 from formatting import parse_size
 from worker import Worker
@@ -141,7 +141,12 @@ chmod 600 %s""" % args.password_file
         max_images_bytes = parse_size(args.max_image_cache_size)
 
     docker_client = DockerClient()
-    bundle_service = BundleServiceClient(args.server, username, password)
+    try:
+        bundle_service = BundleServiceClient(args.server, username, password)
+    except BundleAuthException as ex:
+        logger.error('Cannot log into the bundle service. Please check your worker credentials: {}'.format(ex))
+        raise
+
     if not os.path.exists(args.work_dir):
         logging.debug('Work dir %s doesn\'t exist, creating.', args.work_dir)
         os.makedirs(args.work_dir, 0o770)

--- a/worker/codalabworker/worker.py
+++ b/worker/codalabworker/worker.py
@@ -5,7 +5,7 @@ import socket
 import httplib
 import sys
 
-from bundle_service_client import BundleServiceException
+from bundle_service_client import BundleServiceException, BundleAuthException
 from download_util import BUNDLE_NO_LONGER_RUNNING_MESSAGE
 from state_committer import JsonStateCommitter
 
@@ -89,7 +89,11 @@ class Worker(object):
             'hostname': socket.gethostname(),
             'runs': self._run_manager.all_runs,
         }
-        response = self._bundle_service.checkin(self.id, request)
+        try:
+            response = self._bundle_service.checkin(self.id, request)
+        except BundleAuthException:
+            self.signal()
+            raise
         if response:
             action_type = response['type']
             logger.debug('Received %s message: %s', action_type, response)

--- a/worker/codalabworker/worker.py
+++ b/worker/codalabworker/worker.py
@@ -5,7 +5,7 @@ import socket
 import httplib
 import sys
 
-from bundle_service_client import BundleServiceException, BundleAuthException
+from bundle_service_client import BundleServiceException
 from download_util import BUNDLE_NO_LONGER_RUNNING_MESSAGE
 from state_committer import JsonStateCommitter
 
@@ -89,11 +89,7 @@ class Worker(object):
             'hostname': socket.gethostname(),
             'runs': self._run_manager.all_runs,
         }
-        try:
-            response = self._bundle_service.checkin(self.id, request)
-        except BundleAuthException:
-            self.signal()
-            raise
+        response = self._bundle_service.checkin(self.id, request)
         if response:
             action_type = response['type']
             logger.debug('Received %s message: %s', action_type, response)


### PR DESCRIPTION
If worker has an authentication error, then throw an exception that also marks the worker as stopped.  
I'm a little iffy about the implementation on this one, @percyliang @bkgoksel, any suggestions? Is there a cleaner way to achieve this that doesn't use exceptions as a de-facto message passing mechanism? 