### PR TITLE
Docker image removal revamp

### DIFF
--- a/worker/codalabworker/docker_utils.py
+++ b/worker/codalabworker/docker_utils.py
@@ -16,10 +16,11 @@ from formatting import parse_size
 MIN_API_VERSION = '1.17'
 NVIDIA_RUNTIME = 'nvidia'
 DEFAULT_RUNTIME = 'runc'
+DEFAULT_TIMEOUT = 720
 
 
 logger = logging.getLogger(__name__)
-client = docker.from_env()
+client = docker.from_env(timeout=DEFAULT_TIMEOUT)
 
 
 def wrap_exception(message):

--- a/worker/codalabworker/local_run/docker_image_manager.py
+++ b/worker/codalabworker/local_run/docker_image_manager.py
@@ -102,7 +102,10 @@ class DockerImageManager:
                     entry_to_remove.digest,
                 )
                 try:
-                    self._docker.images.remove(entry_to_remove.id)
+                    image_to_delete = self._docker.images.get(entry_to_remove.id)
+                    tags_to_delete = image_to_delete.tags
+                    for tag in tags_to_delete:
+                        self._docker.images.remove(tag)
                     # if we successfully removed the image also remove its cache entry
                     del self._image_cache[entry_to_remove.digest]
                 except docker.errors.APIError as err:

--- a/worker/codalabworker/local_run/docker_image_manager.py
+++ b/worker/codalabworker/local_run/docker_image_manager.py
@@ -180,13 +180,13 @@ class DockerImageManager:
                         status = ImageAvailabilityState(
                             digest=digest,
                             stage=DependencyStage.READY,
-                            message=self._downloading[image_spec]['status'],
+                            message=self._downloading[image_spec]['message'],
                         )
                     else:
                         status = ImageAvailabilityState(
                             digest=None,
                             stage=DependencyStage.FAILED,
-                            message=self._downloading[image_spec]['status'],
+                            message=self._downloading[image_spec]['message'],
                         )
                     self._downloading.remove(image_spec)
                     return status

--- a/worker/codalabworker/local_run/docker_image_manager.py
+++ b/worker/codalabworker/local_run/docker_image_manager.py
@@ -186,7 +186,7 @@ class DockerImageManager:
                     logger.debug('Download for Docker image %s complete', image_spec)
                     self._downloading[image_spec]['success'] = True
                     self._downloading[image_spec]['message'] = "Downloading image"
-                except docker.errors.APIError as ex:
+                except (docker.errors.APIError, docker.errors.ImageNotFound) as ex:
                     logger.debug('Download for Docker image %s failed: %s', image_spec, ex)
                     self._downloading[image_spec]['success'] = False
                     self._downloading[image_spec]['message'] = "Can't download image: {}".format(ex)

--- a/worker/codalabworker/local_run/docker_image_manager.py
+++ b/worker/codalabworker/local_run/docker_image_manager.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 ImageAvailabilityState = namedtuple('ImageAvailabilityState', ['digest', 'stage', 'message'])
 # Stores information relevant about caching about docker images
 ImageCacheEntry = namedtuple(
-    'ImageCacheEntry', ['id', 'digest', 'dependents', 'last_used', 'virtual_size', 'marginal_size']
+    'ImageCacheEntry', ['id', 'digest', 'last_used', 'virtual_size', 'marginal_size']
 )
 
 
@@ -91,45 +91,35 @@ class DockerImageManager:
         """
         while not self._stop:
             time.sleep(self._sleep_secs)
-            with self._lock:
-                all_entries = set(self._image_cache.values())
-                total_disk_used = sum(cache_entry.virtual_size for cache_entry in all_entries)
-                # Only delete entries that don't have dependents (ie not in use)
-                deletable_entries = filter(lambda x: not x.dependents, all_entries)
-                deletable_disk_used = sum(
-                    cache_entry.virtual_size for cache_entry in deletable_entries
+            deletable_entries = set(self._image_cache.values())
+            disk_use = sum(cache_entry.virtual_size for cache_entry in deletable_entries)
+            while disk_use > self._max_image_cache_size:
+                entry_to_remove = min(deletable_entries, key=lambda entry: entry.last_used)
+                logger.info(
+                    'Disk use (%s) > max cache size (%s), pruning image: %s',
+                    disk_use,
+                    self._max_image_cache_size,
+                    entry_to_remove.digest,
                 )
-                if total_disk_used - deletable_disk_used > self._max_image_cache_size:
+                try:
+                    self._docker.images.remove(entry_to_remove.id)
+                    # if we successfully removed the image also remove its cache entry
+                    del self._image_cache[entry_to_remove.digest]
+                except docker.errors.APIError as err:
+                    # Maybe we can't delete this image because its container is still running
+                    # (think a run that takes 4 days so this is the oldest image but still in use)
+                    # In that case we just continue with our lives, hoping it will get deleted once
+                    # it's no longer in use and the cache becomes full again
                     logger.error(
-                        'Size of docker images in use (%d) greater than docker disk use quota (%d)',
-                        total_disk_used - deletable_disk_used,
-                        self._max_image_cache_size,
+                        "Cannot remove image %s from cache: %s", entry_to_remove.digest, err
                     )
-                while deletable_disk_used > self._max_image_cache_size:
-                    entry_to_remove = min(deletable_entries, key=lambda entry: entry.last_used)
-                    logger.info(
-                        'Deletable disk use (%s) > max cache size (%s), pruning image: %s',
-                        deletable_disk_used,
-                        self._max_image_cache_size,
-                        entry_to_remove.digest,
-                    )
-                    try:
-                        self._docker.images.remove(entry_to_remove.id, force=True)
-                        # if we successfully removed the image also remove its cache entry
-                        del self._image_cache[entry_to_remove.digest]
-                    except docker.errors.APIError as err:
-                        # We should not really hit this case so log it
-                        logger.error(
-                            "Cannot remove image %s from cache: %s", entry_to_remove.digest, err
-                        )
-                    deletable_entries.remove(entry_to_remove)
-                    deletable_disk_used = sum(entry.virtual_size for entry in deletable_entries)
+                deletable_entries.remove(entry_to_remove)
+                disk_use = sum(entry.virtual_size for entry in deletable_entries)
         logger.debug("Stopping docker image manager cleanup")
 
-    def get(self, uuid, image_spec):
+    def get(self, image_spec):
         """
         Request the docker image for the run with uuid, registering uuid as a dependent of this docker image
-        :param uuid: UUID of the run that needs this docker image
         :param image_spec: Repo image_spec of docker image being requested
         :returns: A DockerAvailabilityState object with the state of the docker image
         """
@@ -137,20 +127,13 @@ class DockerImageManager:
             image = self._docker.images.get(image_spec)
             digest = image.attrs.get('RepoDigests', [image_spec])[0]
             with self._lock:
-                if digest in self._image_cache:
-                    old_entry = self._image_cache[digest]
-                    new_entry = old_entry._replace(last_used=time.time())
-                    new_entry.dependents.add(uuid)
-                else:
-                    new_entry = ImageCacheEntry(
-                        id=image.id,
-                        digest=digest,
-                        dependents=set([uuid]),
-                        last_used=time.time(),
-                        virtual_size=image.attrs['VirtualSize'],
-                        marginal_size=image.attrs['Size'],
-                    )
-                self._image_cache[digest] = new_entry
+                self._image_cache[digest] = ImageCacheEntry(
+                    id=image.id,
+                    digest=digest,
+                    last_used=time.time(),
+                    virtual_size=image.attrs['VirtualSize'],
+                    marginal_size=image.attrs['Size'],
+                )
             # We can remove the download thread if it still exists
             if image_spec in self._downloading:
                 self._downloading.remove(image_spec)
@@ -163,36 +146,6 @@ class DockerImageManager:
             return ImageAvailabilityState(
                 digest=None, stage=DependencyStage.FAILED, message=str(ex)
             )
-
-    def release(self, uuid, image_spec):
-        """
-        Register that the run with uuid doesn't need the docker image anymore
-        :param uuid: UUID of the run that doesn't need this docker image anymore
-        :param image_spec: Repo image_spec of docker image being requested
-        """
-        try:
-            image = self._docker.images.get(image_spec)
-            digest = image.attrs.get('RepoDigests', [image_spec])[0]
-            with self._lock:
-                try:
-                    self._image_cache[digest].dependents.remove(uuid)
-                except KeyError:
-                    # Don't have this image in cache anymore, log and pass
-                    logger.error(
-                        "Image (%s) that was in use by run (%s) was not found in cache at release time.",
-                        image_spec,
-                        uuid,
-                    )
-                except ValueError:
-                    # This bundle wasn't in dependents, log and pass
-                    logger.error(
-                        "Run (%s) was not found in image (%s)'s dependents at release time even though it used it.",
-                        uuid,
-                        image_spec,
-                    )
-        except docker.errors.ImageNotFound:
-            # We don't have the image so no need to do anything
-            pass
 
     def _pull_or_report(self, image_spec):
         if image_spec in self._downloading:

--- a/worker/codalabworker/local_run/local_run_state.py
+++ b/worker/codalabworker/local_run/local_run_state.py
@@ -174,7 +174,7 @@ class LocalRunStateMachine(StateTransitioner):
 
         # get the docker image
         docker_image = run_state.resources['docker_image']
-        image_state = self.docker_image_manager.get(bundle_uuid, docker_image)
+        image_state = self.docker_image_manager.get(docker_image)
         if image_state.stage == DependencyStage.DOWNLOADING:
             status_messages.append(
                 'Pulling docker image: ' + (image_state.message or docker_image or "")
@@ -397,7 +397,6 @@ class LocalRunStateMachine(StateTransitioner):
                     traceback.print_exc()
                     time.sleep(1)
 
-        self.docker_image_manager.release(bundle_uuid, run_state.resources['docker_image'])
         for dep in run_state.bundle['dependencies']:
             self.dependency_manager.release(bundle_uuid, (dep['parent_uuid'], dep['parent_path']))
 

--- a/worker/codalabworker/local_run/local_run_state.py
+++ b/worker/codalabworker/local_run/local_run_state.py
@@ -174,7 +174,7 @@ class LocalRunStateMachine(StateTransitioner):
 
         # get the docker image
         docker_image = run_state.resources['docker_image']
-        image_state = self.docker_image_manager.get(docker_image)
+        image_state = self.docker_image_manager.get(bundle_uuid, docker_image)
         if image_state.stage == DependencyStage.DOWNLOADING:
             status_messages.append(
                 'Pulling docker image: ' + (image_state.message or docker_image or "")
@@ -397,6 +397,7 @@ class LocalRunStateMachine(StateTransitioner):
                     traceback.print_exc()
                     time.sleep(1)
 
+        self.docker_image_manager.release(bundle_uuid, run_state.resources['docker_image'])
         for dep in run_state.bundle['dependencies']:
             self.dependency_manager.release(bundle_uuid, (dep['parent_uuid'], dep['parent_path']))
 


### PR DESCRIPTION
Force deletes docker images, uses a register/release dependent
mechanism to avoid deleting images of running containers.

Needed to handle the following edge case:

1. Someone requests a docker image (tensorflow:gpu-latest)
2. Someone requests the same docker image under a different tag (tensorflow:1.12.0-gpu)
3. The time comes to clear this image from the cache

The cache stores the image using the digest (tensorflow@sha256...) but we cannot delete images by digest (due to https://github.com/moby/moby/issues/24688). As a result, we delete images by id (can't get repo/tag since repo/tag -> id is a many-to-one relationship).

However, if docker image pull was called more than once for a given image under different tags (ie tensorflow:gpu-latest and tensorflow:1.12.0-gpu), then docker does not allow removing this image by id because it is referred to by more than one repository/tag, UNLESS the --force option is specified.

However, adding the --force option means we risk deleting images of running containers, so now the docker image manager needs to keep track of which images are currently being used by some run. 

To do so, this PR adds a mechanism by which the docker image manager also saves which runs are using a given image and avoids calling remove on those images until the run manager explicitly calls release when the container is stopped.