### PR TITLE
Accept GPU UUIDs as gpuset args to allow proper isolation in Slurm

### DIFF
--- a/worker/codalabworker/docker_utils.py
+++ b/worker/codalabworker/docker_utils.py
@@ -66,18 +66,19 @@ def get_available_runtime():
 @wrap_exception('Problem getting NVIDIA devices')
 def get_nvidia_devices():
     """
-    Returns the index of each NVIDIA device if NVIDIA runtime is available.
+    Returns a Dict[index, UUID] of all NVIDIA devices available to docker
     Raises docker.errors.ContainerError if GPUs are unreachable,
            docker.errors.ImageNotFound if the CUDA image cannot be pulled
            docker.errors.APIError if another server error occurs
     """
     cuda_image = 'nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04'
     client.images.pull(cuda_image)
-    nvidia_command = 'nvidia-smi --query-gpu=index --format=csv,noheader'
+    nvidia_command = 'nvidia-smi --query-gpu=index,uuid --format=csv,noheader'
     output = client.containers.run(
         cuda_image, nvidia_command, runtime=NVIDIA_RUNTIME, detach=False, stdout=True, remove=True
     )
-    return output.split()
+    # Get newline delimited gpu-index, gpu-uuid list
+    return {gpu.split(', ')[0]: gpu.split(', ')[1] for gpu in output.split()}
 
 
 @wrap_exception('Unable to fetch Docker container ip')

--- a/worker/codalabworker/docker_utils.py
+++ b/worker/codalabworker/docker_utils.py
@@ -78,7 +78,8 @@ def get_nvidia_devices():
         cuda_image, nvidia_command, runtime=NVIDIA_RUNTIME, detach=False, stdout=True, remove=True
     )
     # Get newline delimited gpu-index, gpu-uuid list
-    return {gpu.split(', ')[0]: gpu.split(', ')[1] for gpu in output.split()}
+    print(output.split('\n')[:-1])
+    return {gpu.split(',')[0].strip(): gpu.split(',')[1].strip() for gpu in output.split('\n')[:-1]}
 
 
 @wrap_exception('Unable to fetch Docker container ip')

--- a/worker/codalabworker/main.py
+++ b/worker/codalabworker/main.py
@@ -243,7 +243,7 @@ def parse_gpuset_args(arg):
         return set()
 
     try:
-        all_gpus = docker_utils.get_nvidia_devices() # Dict[GPU index: GPU UUID]
+        all_gpus = docker_utils.get_nvidia_devices()  # Dict[GPU index: GPU UUID]
     except docker_utils.DockerException:
         all_gpus = {}
 


### PR DESCRIPTION
Using IDs as the old gpuset arg did would not allow us to do this since the  Slurm isolation changes the IDs job launching users see and the IDs docker containers see. Using UUID we can enforce the Slurm GPU limitations if the users pass the IDs of the GPUs slurm assigns to them when launching the worker