### PR TITLE
Also check for and fail when bundle commands have non-ASCII unicode characters

### DIFF
--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -919,10 +919,13 @@ class BundleModel(object):
         # (Clients should check for this case ahead of time if they want to
         # silently skip over creating bundles that already exist.)
         with self.engine.begin() as connection:
-            result = connection.execute(cl_bundle.insert().values(bundle_value))
-            self.do_multirow_insert(connection, cl_bundle_dependency, dependency_values)
-            self.do_multirow_insert(connection, cl_bundle_metadata, metadata_values)
-            bundle.id = result.lastrowid
+            try:
+                result = connection.execute(cl_bundle.insert().values(bundle_value))
+                self.do_multirow_insert(connection, cl_bundle_dependency, dependency_values)
+                self.do_multirow_insert(connection, cl_bundle_metadata, metadata_values)
+                bundle.id = result.lastrowid
+            except UnicodeError:
+                raise UsageError("Invalid character detected; use ascii characters only.")
 
     def update_bundle(self, bundle, update, connection=None):
         """

--- a/codalab/rest/schemas.py
+++ b/codalab/rest/schemas.py
@@ -182,7 +182,7 @@ class BundleSchema(Schema):
     bundle_type = fields.String(
         validate=validate.OneOf({bsc.BUNDLE_TYPE for bsc in BUNDLE_SUBCLASSES})
     )
-    command = fields.String(allow_none=True)
+    command = fields.String(allow_none=True, validate=validate_ascii)
     data_hash = fields.String()
     state = fields.String()
     owner = fields.Relationship(include_resource_linkage=True, type_='users', attribute='owner_id')

--- a/test-cli.py
+++ b/test-cli.py
@@ -1651,9 +1651,10 @@ def test(ctx):
     check_equals('_', get_info(uuid, 'name'))  # Currently ignores unicode chars for name
     check_equals('你好世界😊', run_command([cl, 'cat', uuid]))
 
-    # Unicode in bundle description and tags
+    # Unicode in bundle description, tags and command
     run_command([cl, 'upload', test_path('a.txt'), '--description', '你好'], 1)
     run_command([cl, 'upload', test_path('a.txt'), '--tags', 'test', '😁'], 1)
+    run_command([cl, 'run', 'echo "fáncy ünicode"'], 1)
 
     # Unicode in edits --> interactive mode not tested, but `cl edit` properly discards
     # edits that introduce unicode.


### PR DESCRIPTION
Should fix #1103 