### PR TITLE
Better Dockerfiles and frontend/server separation in setup.sh

### DIFF
--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -3,13 +3,19 @@ MAINTAINER CodaLab Worksheets <codalab.worksheets@gmail.com>
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt-get update
-RUN apt-get install -y build-essential git
-RUN apt-get install -y libfuse-dev libjpeg-dev
-RUN apt-get install -y libmysqlclient-dev mysql-client
-RUN apt-get install -y python-dev python-pip
-RUN apt-get install -y python-software-properties python-virtualenv software-properties-common
-RUN apt-get install -y zip
+RUN apt-get update; apt-get install -y \
+    build-essential \
+    git \
+    libfuse-dev \
+    libjpeg-dev \
+    libmysqlclient-dev \
+    mysql-client \
+    python-dev \
+    python-pip \
+    python-software-properties \
+    python-virtualenv \
+    software-properties-common \
+    zip;
 
 # Install dependencies
 RUN mkdir /opt/codalab-worksheets
@@ -17,7 +23,6 @@ COPY worker /opt/codalab-worksheets/worker
 COPY requirements.txt /opt/codalab-worksheets
 COPY requirements-server.txt /opt/codalab-worksheets
 COPY setup.sh /opt/codalab-worksheets
-#RUN cd /opt && pip install -r requirements-server.txt
 RUN cd /opt/codalab-worksheets && ./setup.sh server
 
 # Install code

--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -1,14 +1,21 @@
 FROM ubuntu:16.04
 MAINTAINER Percy Liang <pliang@cs.stanford.edu>
 
+ENV DEBIAN_FRONTEND noninteractive
+
 # Install dependencies
-RUN apt-get update
-RUN apt-get install -y python-dev python-pip
+RUN apt-get update; apt-get install -y \
+  python-dev \
+  python-pip;
+
 COPY worker/requirements.txt /opt
-RUN pip install -r /opt/requirements.txt
+RUN pip install --upgrade pip; \
+    pip install -r /opt/requirements.txt;
 
 # Install dependencies again
 COPY worker /opt/worker
-RUN pip install -e /opt/worker
+
+RUN pip install --upgrade pip; \
+    pip install -e /opt/worker;
 
 ENTRYPOINT ["cl-worker"]

--- a/setup.sh
+++ b/setup.sh
@@ -17,9 +17,9 @@ success="${bold}\033[32m"  # green
 # =======================================
 
 # Ensure proper command usage
-if [ "$#" -ne 1 ] || ( [ "$1" != "client" ] && [ "$1" != "server" ] ); then
+if [ "$#" -ne 1 ] || ( [ "$1" != "client" ] && [ "$1" != "server" ] && [ "$1" != "frontend" ] ); then
   echo "Usage:"
-  echo "  $0 [client | server]"
+  echo "  $0 [client | server | frontend]"
   exit 1
 fi
 
@@ -49,6 +49,9 @@ echo -e "${info}[*] Installing Python packages into $env...${reset}"
 if [ "$1" == "server" ]; then
   $env/bin/pip install -r $codalabdir/requirements-server.txt
   $env/bin/pip install -e $codalabdir/worker
+elif [ "$1" == "client" ]; then
+  $env/bin/pip install -r $codalabdir/requirements.txt
+elif [ "$1" == "frontend" ]; then
   echo -e "${info}[*] Running npm build for frontend...${reset}"
   if ! which npm; then
     echo -e "${warning}[!] npm is not found.${reset}"
@@ -56,6 +59,7 @@ if [ "$1" == "server" ]; then
     echo -e "${warning}[!] If you are using Ubuntu run the following to install:${reset}"
     echo
     echo -e "${warning}  sudo apt-get install ${reset}"
+    exit 1
   else
     cd frontend
     npm install
@@ -64,10 +68,8 @@ if [ "$1" == "server" ]; then
     echo -e "${info}  Frontend server installed. You can start server with the following command:${reset}"
     echo
     echo -e "${info}  serve -s build -l 2700${reset}"
-    cd ..
+    exit
   fi
-elif [ "$1" == "client" ]; then
-  $env/bin/pip install -r $codalabdir/requirements.txt
 fi
 
 ( # try


### PR DESCRIPTION
Our dockerfiles were not up to standards in a few places like how they were not doing `apt-get update` and `install` within the same command etc. (full list [here](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/)).

This PR fixes some of these issues and also separates the `server` and `frontend` functionality in the `setup.sh` scripts so that when building the docker images the `npm` dependencies don't have to be installed for the  backend image and backend dependencies for the frontend image.

Should go with updating [the Wiki page](https://github.com/codalab-worksheets/wiki/Server-Setup)