### PR TITLE
Is not is not recognized by sqlalchemy

### DIFF
--- a/codalab/lib/canonicalize.py
+++ b/codalab/lib/canonicalize.py
@@ -37,7 +37,7 @@ def _parse_relative_bundle_spec(bundle_spec):
         reverse_index = int(m.group(2)) if m.group(2) != '' else 1
         return (bundle_spec, reverse_index)
 
-    # ^3: 3rd to last bundle whose name starts with foo in this worksheet
+    # ^3: 3rd to last bundle
     m = spec_util.HISTORY_REGEX.match(bundle_spec)
     if m:
         bundle_spec = None

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -568,7 +568,7 @@ class BundleModel(object):
                         cl_worksheet_item.c.worksheet_uuid, conditions['worksheet_uuid']
                     ),
                 )
-                clause = and_(clause, cl_worksheet_item.c.bundle_uuid is not None)
+                clause = and_(clause, cl_worksheet_item.c.bundle_uuid.isnot(None))
                 join = cl_worksheet_item.outerjoin(
                     cl_bundle_metadata,
                     cl_worksheet_item.c.bundle_uuid == cl_bundle_metadata.c.bundle_uuid,


### PR DESCRIPTION
Fixing an incorrect comment and fixing the clause that was breaking worksheet-relative bundle references. 

https://stackoverflow.com/questions/16093475/flask-sqlalchemy-querying-a-column-with-not-equals