### PR TITLE
Report remote from within worker

### DIFF
--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -744,7 +744,7 @@ class BundleModel(object):
 
             return True
 
-    def start_bundle(self, bundle, user_id, worker_id, start_time):
+    def start_bundle(self, bundle, user_id, worker_id, start_time, remote):
         """
         Marks the bundle as running but only if it is still scheduled to run
         on the given worker (done by checking the worker_run table). Returns
@@ -760,7 +760,7 @@ class BundleModel(object):
 
             bundle_update = {
                 'state': State.PREPARING,
-                'metadata': {'started': start_time, 'last_updated': start_time},
+                'metadata': {'started': start_time, 'last_updated': start_time, 'remote': remote},
             }
             self.update_bundle(bundle, bundle_update, connection)
 
@@ -789,9 +789,7 @@ class BundleModel(object):
 
             if state == State.FINALIZING:
                 # update bundle metadata using resume_bundle one last time before finalizing it
-                self.resume_bundle(
-                    bundle, bundle_update, row, user_id, worker_id, connection
-                )
+                self.resume_bundle(bundle, bundle_update, row, user_id, worker_id, connection)
                 return self.finalize_bundle(
                     bundle,
                     user_id,

--- a/codalab/rest/workers.py
+++ b/codalab/rest/workers.py
@@ -124,8 +124,8 @@ def start_bundle(worker_id, uuid):
         bundle,
         request.user.user_id,
         worker_id,
-        request.json["hostname"],
-        request.json["start_time"],
+        start_time=request.json["start_time"],
+        remote=request.json["hostname"],
     ):
         print("Started bundle %s" % uuid)
         return json.dumps(True)

--- a/codalab/rest/workers.py
+++ b/codalab/rest/workers.py
@@ -37,9 +37,7 @@ def checkin(worker_id):
     for uuid, run in request.json["runs"].items():
         try:
             bundle = local.model.get_bundle(uuid)
-            local.model.bundle_checkin(
-                bundle, run, request.user.user_id, worker_id, request.json["hostname"]
-            )
+            local.model.bundle_checkin(bundle, run, request.user.user_id, worker_id)
         except Exception:
             pass
 

--- a/worker/codalabworker/local_run/local_run_manager.py
+++ b/worker/codalabworker/local_run/local_run_manager.py
@@ -323,6 +323,7 @@ class LocalRunManager(BaseRunManager):
                     'docker_image': run_state.docker_image,
                     'info': run_state.info,
                     'state': LocalRunStage.WORKER_STATE_TO_SERVER_STATE[run_state.stage],
+                    'remote': self._worker.id
                 }
                 for bundle_uuid, run_state in self._runs.items()
             }

--- a/worker/codalabworker/local_run/local_run_manager.py
+++ b/worker/codalabworker/local_run/local_run_manager.py
@@ -323,7 +323,7 @@ class LocalRunManager(BaseRunManager):
                     'docker_image': run_state.docker_image,
                     'info': run_state.info,
                     'state': LocalRunStage.WORKER_STATE_TO_SERVER_STATE[run_state.stage],
-                    'remote': self._worker.id
+                    'remote': self._worker.id,
                 }
                 for bundle_uuid, run_state in self._runs.items()
             }


### PR DESCRIPTION
For each run, have the `RunManager` report the `remote` field rather than determining it with server-side logic (ie. just picking the hostname of the worker machine).

This PR picks the `id` of the worker as the field to be reported for local docker workers.

Needed to fix #1036 for the Slurm worker