### PR TITLE
Worker robustness improvements

### DIFF
--- a/codalab/bundles/run_bundle.py
+++ b/codalab/bundles/run_bundle.py
@@ -61,3 +61,8 @@ class RunBundle(DerivedBundle):
         return super(RunBundle, cls).construct(
             targets, command, metadata, owner_id, uuid, data_hash, state
         )
+
+    def validate(self):
+        super(RunBundle, self).validate()
+        for dep in self.dependencies:
+            dep.validate(require_child_path=True)

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -1424,8 +1424,6 @@ class BundleCLI(object):
     def do_make_command(self, args):
         client, worksheet_uuid = self.parse_client_worksheet_uuid(args.worksheet_spec)
         targets = self.resolve_key_targets(client, worksheet_uuid, args.target_spec)
-        # Support anonymous make calls by replacing None keys with ''
-        targets = [('' if key is None else key, val) for key, val in targets]
         metadata = self.get_missing_metadata(MakeBundle, args)
         new_bundle = client.create(
             'bundles',

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -100,7 +100,8 @@ BUNDLE_SPEC_FORMAT = '[%s%s]%s' % (
 WORKSHEETS_URL_SEPARATOR = '/worksheets/'
 
 TARGET_SPEC_FORMAT = '%s[%s<subpath within bundle>]' % (BUNDLE_SPEC_FORMAT, os.sep)
-ALIASED_TARGET_SPEC_FORMAT = '[<key>:]' + TARGET_SPEC_FORMAT
+RUN_TARGET_SPEC_FORMAT = '[<key>]:' + TARGET_SPEC_FORMAT
+MAKE_TARGET_SPEC_FORMAT = '[<key>:]' + TARGET_SPEC_FORMAT
 GROUP_SPEC_FORMAT = '(<uuid>|<name>|public)'
 PERMISSION_SPEC_FORMAT = '((n)one|(r)ead|(a)ll)'
 UUID_POST_FUNC = '[0:8]'  # Only keep first 8 characters
@@ -585,10 +586,11 @@ class BundleCLI(object):
         Helper: target_specs is a list of strings which are [<key>]:<target>
         Returns: [(key, (bundle_uuid, subpath)), ...]
         """
+        keys = set()
         targets = []
         target_keys_values = [parse_key_target(spec) for spec in target_specs]
         for key, target_spec in target_keys_values:
-            if key in targets:
+            if key in keys:
                 if key:
                     raise UsageError('Duplicate key: %s' % (key,))
                 else:
@@ -597,6 +599,7 @@ class BundleCLI(object):
                 client, worksheet_uuid, target_spec, allow_remote=False
             )
             targets.append((key, (bundle_uuid, subpath)))
+            keys.add(key)
         return targets
 
     @staticmethod
@@ -1407,7 +1410,7 @@ class BundleCLI(object):
         arguments=(
             Commands.Argument(
                 'target_spec',
-                help=ALIASED_TARGET_SPEC_FORMAT,
+                help=MAKE_TARGET_SPEC_FORMAT,
                 nargs='+',
                 completer=BundlesCompleter,
             ),
@@ -1474,7 +1477,7 @@ class BundleCLI(object):
         arguments=(
             Commands.Argument(
                 'target_spec',
-                help=ALIASED_TARGET_SPEC_FORMAT,
+                help=RUN_TARGET_SPEC_FORMAT,
                 nargs='*',
                 completer=TargetsCompleter,
             ),
@@ -1516,7 +1519,7 @@ class BundleCLI(object):
         arguments=(
             Commands.Argument(
                 'target_spec',
-                help=ALIASED_TARGET_SPEC_FORMAT,
+                help=RUN_TARGET_SPEC_FORMAT,
                 nargs='*',
                 completer=TargetsCompleter,
             ),

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -1424,6 +1424,8 @@ class BundleCLI(object):
     def do_make_command(self, args):
         client, worksheet_uuid = self.parse_client_worksheet_uuid(args.worksheet_spec)
         targets = self.resolve_key_targets(client, worksheet_uuid, args.target_spec)
+        # Support anonymous make calls by replacing None keys with ''
+        targets = [('' if key is None else key, val) for key, val in targets]
         metadata = self.get_missing_metadata(MakeBundle, args)
         new_bundle = client.create(
             'bundles',

--- a/codalab/lib/cli_util.py
+++ b/codalab/lib/cli_util.py
@@ -52,7 +52,7 @@ def parse_key_target(spec):
     """
 
     match = re.match(TARGET_KEY_REGEX, spec)
-    return match.groups() if match else (None, None)
+    return match.groups()
 
 
 def parse_target_spec(spec):

--- a/codalab/lib/spec_util.py
+++ b/codalab/lib/spec_util.py
@@ -24,7 +24,7 @@ HISTORY_RANGE_REGEX = re.compile(
     '(.*\^)([0-9]+)-([0-9]+)'
 )  # Allow ranges foo^1-3 => foo^1 foo^2 foo^3
 BASIC_EMAIL_REGEX = re.compile(r'^[^@]+@[^@]+\.[^@]+$')
-CHILD_PATH_REGEX = re.compile('^[a-zA-Z0-9_\-.]*\Z')
+SUB_PATH_REGEX = re.compile('^[a-zA-Z0-9_\-.]*\Z')
 
 
 def expand_specs(specs):

--- a/codalab/objects/dependency.py
+++ b/codalab/objects/dependency.py
@@ -12,11 +12,18 @@ class Dependency(ORMObject):
     COLUMNS = ('child_uuid', 'child_path', 'parent_uuid', 'parent_path')
     CHILD_PATH_REGEX = re.compile('^[a-zA-Z0-9_\-.]*\Z')
 
-    def validate(self):
+    def validate(self, require_child_path=False):
+        """
+        Validates that the dependency is well formed.
+        :param require_child_path: If True, make sure the child path is not empty
+            This is a needed condition for Run bundles, but not so for Make bundles
+        """
         spec_util.check_uuid(self.child_uuid)
         spec_util.check_uuid(self.parent_uuid)
         if not self.CHILD_PATH_REGEX.match(self.child_path):
             raise UsageError(
-                'child_subpath must match %s, was %s'
+                'child_path must match %s, was %s'
                 % (self.CHILD_PATH_REGEX.pattern, self.child_path)
             )
+        if require_child_path and len(self.child_path) == 0:
+            raise UsageError('child_path empty')

--- a/codalab/objects/dependency.py
+++ b/codalab/objects/dependency.py
@@ -10,7 +10,7 @@ from codalab.model.orm_object import ORMObject
 
 class Dependency(ORMObject):
     COLUMNS = ('child_uuid', 'child_path', 'parent_uuid', 'parent_path')
-    CHILD_PATH_REGEX = re.compile('^[a-zA-Z0-9_\-.]+\Z')
+    CHILD_PATH_REGEX = re.compile('^[a-zA-Z0-9_\-.]*\Z')
 
     def validate(self):
         spec_util.check_uuid(self.child_uuid)

--- a/codalab/objects/dependency.py
+++ b/codalab/objects/dependency.py
@@ -10,7 +10,7 @@ from codalab.model.orm_object import ORMObject
 
 class Dependency(ORMObject):
     COLUMNS = ('child_uuid', 'child_path', 'parent_uuid', 'parent_path')
-    CHILD_PATH_REGEX = re.compile('^[a-zA-Z0-9_\-.]*\Z')
+    CHILD_PATH_REGEX = re.compile('^[a-zA-Z0-9_\-.]+\Z')
 
     def validate(self):
         spec_util.check_uuid(self.child_uuid)

--- a/codalab/rest/schemas.py
+++ b/codalab/rest/schemas.py
@@ -10,7 +10,7 @@ from marshmallow_jsonapi import Schema, fields
 from codalab.common import UsageError
 from codalab.bundles import BUNDLE_SUBCLASSES
 from codalab.lib.bundle_action import BundleAction
-from codalab.lib.spec_util import CHILD_PATH_REGEX, NAME_REGEX, UUID_REGEX
+from codalab.lib.spec_util import SUB_PATH_REGEX, NAME_REGEX, UUID_REGEX
 from codalab.lib.worksheet_util import WORKSHEET_ITEM_TYPES
 from codalab.objects.permission import parse_permission, permission_str
 
@@ -42,8 +42,8 @@ def validate_name(name):
         raise ValidationError('Names must match %s, was %s' % (NAME_REGEX.pattern, name))
 
 
-def validate_child_path(path):
-    if not CHILD_PATH_REGEX.match(path):
+def validate_sub_path(path):
+    if not SUB_PATH_REGEX.match(path):
         raise ValidationError('Child path must match %s, was %s' % (NAME_REGEX.pattern, path))
 
 
@@ -243,7 +243,7 @@ class BundleActionSchema(Schema):
     id = fields.Integer(dump_only=True, default=None)
     uuid = fields.String(validate=validate_uuid)
     type = fields.String(validate=validate.OneOf({BundleAction.KILL, BundleAction.WRITE}))
-    subpath = fields.String(validate=validate_child_path)
+    subpath = fields.String(validate=validate_sub_path)
     string = fields.String()
 
     class Meta:

--- a/codalab/worker/bundle_manager.py
+++ b/codalab/worker/bundle_manager.py
@@ -205,8 +205,8 @@ class BundleManager(object):
                         'Invalid dependency %s'
                         % (path_util.safe_join(dep.parent_uuid, dep.parent_path))
                     )
-                child_suffix = '' if dep.child_path is None else dep.child_path
-                child_path = os.path.normpath(os.path.join(path, child_suffix))
+
+                child_path = os.path.normpath(os.path.join(path, dep.child_path))
                 if not child_path.startswith(path):
                     raise Exception('Invalid key for dependency: %s' % (dep.child_path))
 

--- a/codalab/worker/bundle_manager.py
+++ b/codalab/worker/bundle_manager.py
@@ -205,8 +205,8 @@ class BundleManager(object):
                         'Invalid dependency %s'
                         % (path_util.safe_join(dep.parent_uuid, dep.parent_path))
                     )
-
-                child_path = os.path.normpath(os.path.join(path, dep.child_path))
+                child_suffix = '' if dep.child_path is None else dep.child_path
+                child_path = os.path.normpath(os.path.join(path, child_suffix))
                 if not child_path.startswith(path):
                     raise Exception('Invalid key for dependency: %s' % (dep.child_path))
 

--- a/codalab_service.py
+++ b/codalab_service.py
@@ -646,11 +646,18 @@ class CodalabServiceManager(object):
                 self.push_image(image)
 
     def test(self):
+        instance = 'http://localhost:%s' % self.args.rest_port
         test_cli.cl = 'codalab/bin/cl'
         test_cli.cl_version = self.args.version
-        success = test_cli.TestModule.run(
-            self.args.tests, 'http://localhost:%s' % self.args.rest_port
+        subprocess.check_call(
+            '%s work %s::' % (test_cli.cl, instance),
+            env={
+                'CODALAB_USERNAME': self.args.codalab_user,
+                'CODALAB_PASSWORD': self.args.codalab_password,
+            },
+            shell=True,
         )
+        success = test_cli.TestModule.run(self.args.tests, instance)
         if not success:
             sys.exit(1)
 

--- a/codalab_service.py
+++ b/codalab_service.py
@@ -648,7 +648,9 @@ class CodalabServiceManager(object):
     def test(self):
         test_cli.cl = 'codalab/bin/cl'
         test_cli.cl_version = self.args.version
-        success = test_cli.TestModule.run(self.args.tests, 'localhost')
+        success = test_cli.TestModule.run(
+            self.args.tests, 'http://localhost:%s' % self.args.rest_port
+        )
         if not success:
             sys.exit(1)
 

--- a/codalab_service.py
+++ b/codalab_service.py
@@ -106,6 +106,54 @@ class CodalabArgs(argparse.Namespace):
             'restart', help='Restart any existing CodaLab service instances'
         )
 
+        #  CLIENT SETTINGS
+
+        for cmd in [start_cmd, run_cmd, test_cmd]:
+            cmd.add_argument(
+                '--codalab-user',
+                type=str,
+                help='Codalab username for the Codalab admin user',
+                default=argparse.SUPPRESS,
+            )
+            cmd.add_argument(
+                '--codalab-password',
+                type=str,
+                help='Codalab password for the Codalab admin user',
+                default=argparse.SUPPRESS,
+            )
+            cmd.add_argument(
+                '--rest-port',
+                type=str,
+                help='Port for the REST server to listen on (by default it is not exposed to the host machine)',
+                default=argparse.SUPPRESS,
+            )
+
+            # MYSQL SETTINGS
+
+            cmd.add_argument(
+                '--external-db-url',
+                help='if specified, use this database uri instead of starting a local mysql container',
+                default=argparse.SUPPRESS,
+            )
+            cmd.add_argument(
+                '--mysql-port',
+                type=str,
+                help='Port for the MYSQL database to listen on (by default it is not exposed to the host machine)',
+                default=argparse.SUPPRESS,
+            )
+            cmd.add_argument(
+                '--mysql-user',
+                type=str,
+                help='MYSQL username for the Codalab MYSQL client',
+                default=argparse.SUPPRESS,
+            )
+            cmd.add_argument(
+                '--mysql-password',
+                type=str,
+                help='MYSQL password for the Codalab MYSQL client',
+                default=argparse.SUPPRESS,
+            )
+
         #  BUILD SETTINGS
 
         for cmd in [build_cmd, start_cmd, run_cmd]:
@@ -168,11 +216,6 @@ class CodalabArgs(argparse.Namespace):
             default=argparse.SUPPRESS,
         )
         start_cmd.add_argument(
-            '--external-db-url',
-            help='If specified, use this database URI instead of starting a local mysql container',
-            default=argparse.SUPPRESS,
-        )
-        start_cmd.add_argument(
             '--test-build',
             '-t',
             action='store_true',
@@ -206,30 +249,6 @@ class CodalabArgs(argparse.Namespace):
             '--mysql-root-password',
             type=str,
             help='Root password for the database',
-            default=argparse.SUPPRESS,
-        )
-        start_cmd.add_argument(
-            '--mysql-user',
-            type=str,
-            help='MYSQL username for the Codalab MYSQL client',
-            default=argparse.SUPPRESS,
-        )
-        start_cmd.add_argument(
-            '--mysql-password',
-            type=str,
-            help='MYSQL password for the Codalab MYSQL client',
-            default=argparse.SUPPRESS,
-        )
-        start_cmd.add_argument(
-            '--codalab-user',
-            type=str,
-            help='Codalab username for the Codalab admin user',
-            default=argparse.SUPPRESS,
-        )
-        start_cmd.add_argument(
-            '--codalab-password',
-            type=str,
-            help='Codalab password for the Codalab admin user',
             default=argparse.SUPPRESS,
         )
 
@@ -277,21 +296,9 @@ class CodalabArgs(argparse.Namespace):
             default=argparse.SUPPRESS,
         )
         start_cmd.add_argument(
-            '--rest-port',
-            type=str,
-            help='Port for the REST server to listen on (by default it is not exposed to the host machine)',
-            default=argparse.SUPPRESS,
-        )
-        start_cmd.add_argument(
             '--frontend-port',
             type=str,
             help='Port for the React server to listen on (by default it is not exposed to the host machine)',
-            default=argparse.SUPPRESS,
-        )
-        start_cmd.add_argument(
-            '--mysql-port',
-            type=str,
-            help='Port for the MYSQL database to listen on (by default it is not exposed to the host machine)',
             default=argparse.SUPPRESS,
         )
 
@@ -649,12 +656,32 @@ class CodalabServiceManager(object):
         instance = 'http://localhost:%s' % self.args.rest_port
         test_cli.cl = 'codalab/bin/cl'
         test_cli.cl_version = self.args.version
+        codalab_client_env = {
+            'CODALAB_USERNAME': self.args.codalab_user,
+            'CODALAB_PASSWORD': self.args.codalab_password,
+        }
+        if self.args.external_db_url:
+            mysql_url = 'mysql://%s:%s@%s/codalab_bundles' % (
+                self.args.mysql_user,
+                self.args.mysql_password,
+                self.args.external_db_url,
+            )
+        else:
+            if not self.args.mysql_port:
+                raise('ERROR: Tests fired without an external DB URL or MYSQL port exposed to host, "events" tests will fail.')
+            mysql_url = 'mysql://%s:%s@localhost:%s/codalab_bundles' % (
+                self.args.mysql_user,
+                self.args.mysql_password,
+                self.args.mysql_port,
+            )
+        subprocess.check_call(
+            '%s config server/engine_url %s' % (test_cli.cl, mysql_url),
+            env=codalab_client_env,
+            shell=True,
+        )
         subprocess.check_call(
             '%s work %s::' % (test_cli.cl, instance),
-            env={
-                'CODALAB_USERNAME': self.args.codalab_user,
-                'CODALAB_PASSWORD': self.args.codalab_password,
-            },
+            env=codalab_client_env,
             shell=True,
         )
         success = test_cli.TestModule.run(self.args.tests, instance)

--- a/worker/codalabworker/docker_utils.py
+++ b/worker/codalabworker/docker_utils.py
@@ -209,6 +209,15 @@ def get_container_stats(container):
     return stats
 
 
+@wrap_exception('Unable to check Docker API for container')
+def container_exists(container):
+    try:
+        client.containers.get(container.id)
+        return True
+    except docker.errors.NotFound:
+        return False
+
+
 @wrap_exception('Unable to check Docker container status')
 def check_finished(container):
     # Unfortunately docker SDK doesn't update the status of Container objects

--- a/worker/codalabworker/fsm.py
+++ b/worker/codalabworker/fsm.py
@@ -34,7 +34,7 @@ class StateTransitioner(object):
         if state.stage in self._terminal_states:
             return state
         try:
-            self._transition_functions[state.stage](state)
+            return self._transition_functions[state.stage](state)
         except Exception as ex:
             if state.stage in self._exception_handlers:
                 return self._exception_handlers[state.stage](state, ex)

--- a/worker/codalabworker/local_run/docker_image_manager.py
+++ b/worker/codalabworker/local_run/docker_image_manager.py
@@ -125,7 +125,7 @@ class DockerImageManager:
 
     def get(self, image_spec):
         """
-        Request the docker image for the run with uuid, registering uuid as a dependent of this docker image
+        Request the docker image, starting its download if it's not available on the system
         :param image_spec: Repo image_spec of docker image being requested
         :returns: A DockerAvailabilityState object with the state of the docker image
         """

--- a/worker/codalabworker/local_run/local_run_state.py
+++ b/worker/codalabworker/local_run/local_run_state.py
@@ -434,8 +434,7 @@ class LocalRunStateMachine(StateTransitioner):
                     finished, _, _ = docker_utils.check_finished(run_state.container)
                     if finished:
                         run_state.container.remove(force=True)
-                        run_state.container_id = None
-                        run_state.container = None
+                        run_state = run_state._replace(container_id=None, container=None)
                         break
                     else:
                         run_state.container.kill()


### PR DESCRIPTION
1. Make sure dependency child paths are nonempty 08778cb : should fix #1154 
2. Fix docker image manager docstring method 6b77c79 : should fix #1006 
3. More robust exception handling in worker (catch any unhandled exception for each run and only fail the run instead of crashing) 2959473
4. Connect to the correct local instance when launching tests from the service script ad43130 & 11a53da