### PR TITLE
Remove spacing when bundle row is expanded

### DIFF
--- a/frontend/src/components/worksheets/items/TableItem/BundleRow.js
+++ b/frontend/src/components/worksheets/items/TableItem/BundleRow.js
@@ -264,7 +264,7 @@ class BundleRow extends Component {
                         </TableCell>
                     </TableRow>
                 )}
-                {(showDetail || showNewUpload == -1 || showNewRun == -1) && (
+                {(showNewUpload == -1 || showNewRun == -1) && (
                     <TableRow className={classes.spacerAbove} />
                 )}
                 <TableRow
@@ -339,7 +339,7 @@ class BundleRow extends Component {
                         </TableCell>
                     </TableRow>
                 )}
-                {(showDetail || showNewUpload == 1 || showNewRun == 1) && (
+                {(showNewUpload == 1 || showNewRun == 1) && (
                     <TableRow className={classes.spacerBelow} />
                 )}
                 {showNewUpload === 1 && (


### PR DESCRIPTION
So now it looks like this (without any extra empty space between rows):

![image](https://user-images.githubusercontent.com/1689183/59404920-6192db00-8d5d-11e9-8815-c4e9cbab7f8b.png)
