### PR TITLE
Fix dev mode

### DIFF
--- a/codalab_service.py
+++ b/codalab_service.py
@@ -180,7 +180,7 @@ class CodalabArgs(argparse.Namespace):
                 default=argparse.SUPPRESS,
             )
             cmd.add_argument(
-                '--dev-images',
+                '--dev',
                 '-d',
                 action='store_true',
                 help='If specified, use dev versions of images',


### PR DESCRIPTION
It seems like a change done in #1218 broke dev mode because running with the `-d` argument ended up changing `args.dev_images` instead of `args.dev` (which the start script needed). This PR reverts that particular change.