### PR TITLE
Remove web terminal shortcuts / verbiage on help screen

### DIFF
--- a/frontend/src/components/worksheets/ExtraWorksheetHTML.js
+++ b/frontend/src/components/worksheets/ExtraWorksheetHTML.js
@@ -14,14 +14,14 @@ let ExtraWorksheetHTML = () => (
         <div id='glossaryModal' className='modal' data-keyboard='true' tabIndex='-1'>
             <div className='modal-dialog'>
                 <div className='modal-content'>
-                    <div className='modal-header'>
+                    <div className='modal-header' style={{borderBottom: 0}}>
                         <button type='button' className='close' data-dismiss='modal'>
                             <span aria-hidden='true'>&times;</span>
                             <span className='sr-only'>Close</span>
                         </button>
                         <h4>Keyboard Shortcuts</h4>
                     </div>
-                    <div className='modal-body'>
+                    <div className='modal-body' style={{paddingTop: 0}}>
                         <table className='table table-striped'>
                             <tbody>
                                 <tr>

--- a/frontend/src/components/worksheets/ExtraWorksheetHTML.js
+++ b/frontend/src/components/worksheets/ExtraWorksheetHTML.js
@@ -22,18 +22,8 @@ let ExtraWorksheetHTML = () => (
                         <h4>Keyboard Shortcuts</h4>
                     </div>
                     <div className='modal-body'>
-                        <a href='http://terminal.jcubic.pl/api_reference.php' target='_blank'>
-                            {' '}
-                            More shortcuts for web terminal (see Keyboard shortcuts section){' '}
-                        </a>
                         <table className='table table-striped'>
                             <tbody>
-                                <tr>
-                                    <td>
-                                        <kbd>shift+c</kbd>
-                                    </td>
-                                    <td>Show/hide web terminal</td>
-                                </tr>
                                 <tr>
                                     <td>
                                         <kbd>e</kbd>


### PR DESCRIPTION
Help modal UI improvements:
- Remove web terminal verbiage
- Remove double grey lines at the top

Old:

![image](https://user-images.githubusercontent.com/1689183/59983426-38cbda80-95d4-11e9-8e86-341700a1b65d.png)


New:
![image](https://user-images.githubusercontent.com/1689183/59983414-04f0b500-95d4-11e9-949c-b6c96b2bb4ca.png)
