### PR TITLE
Dashboard redirect

### DIFF
--- a/frontend/src/CodalabApp.js
+++ b/frontend/src/CodalabApp.js
@@ -15,6 +15,7 @@ import { ChangeEmail, ChangeEmailSuccess } from './components/ChangeEmail';
 import VerifySuccess from './components/VerifySuccess';
 import VerifyError from './components/VerifyError';
 import Worksheet from './components/worksheets/Worksheet';
+import WorksheetNameSearch from './components/worksheets/WorksheetNameSearch';
 import {
     PasswordReset,
     PasswordResetSent,
@@ -84,6 +85,7 @@ function CodalabApp() {
                             />
                             <PrivateRoute path='/account/profile' component={UserInfo} />
                             <Route path='/worksheets/:uuid' component={Worksheet} />
+                            <Route path='/worksheets' component={WorksheetNameSearch} />
                             <Route path='/bundles/:uuid' component={BundleRoute} />
                             <Route component={PageNotFound} />
                         </Switch>

--- a/frontend/src/CodalabApp.js
+++ b/frontend/src/CodalabApp.js
@@ -41,11 +41,8 @@ function CodalabApp() {
 
                         {/*Main Content.*/}
                         <Switch>
-                            <Route
-                                path='/'
-                                exact
-                                render={(props) => <HomePage {...props} auth={fakeAuth} />}
-                            />
+                            <Route path='/' exact render={(props) => <HomePage {...props} auth={fakeAuth} redirectAuthToDashboard={true} />} />
+                            <Route path='/home' exact render={(props) => <HomePage {...props} auth={fakeAuth} redirectAuthToDashboard={false} />} />
                             <Route path='/account/signup/success' component={SignUpSuccess} />
                             <Route path='/account/verify/error' component={VerifyError} />
                             <Route

--- a/frontend/src/components/Bundle.js
+++ b/frontend/src/components/Bundle.js
@@ -188,7 +188,7 @@ class Bundle extends React.Component<
             // Still loading
             return (
                 <div id='bundle-message' className='bundle-detail'>
-                    <img src={'${process.env.PUBLIC_URL}/img/Preloader_Small.gif'} /> Loading
+                    <img src={`${process.env.PUBLIC_URL}/img/Preloader_Small.gif`} /> Loading
                     bundle...
                 </div>
             );

--- a/frontend/src/components/ChangeEmail.js
+++ b/frontend/src/components/ChangeEmail.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import Immutable from 'seamless-immutable';
-import { Redirect } from 'react-router-dom';
+import { NavLink } from 'react-router-dom';
 import SubHeader from './SubHeader';
 import ContentWrapper from './ContentWrapper';
 import queryString from 'query-string';
@@ -47,7 +47,7 @@ export class ChangeEmail extends React.Component {
                 <ContentWrapper>
                     {!this.props.auth.isAuthenticated && (
                         <p>
-                            Please <a href='/account/login'>sign in</a> first before updating your
+                            Please <NavLink to='/account/login'>sign in</NavLink> first before updating your
                             email address.
                         </p>
                     )}

--- a/frontend/src/components/Login.js
+++ b/frontend/src/components/Login.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import Immutable from 'seamless-immutable';
-import { Redirect } from 'react-router-dom';
+import { Redirect, NavLink } from 'react-router-dom';
 import SubHeader from './SubHeader';
 import ContentWrapper from './ContentWrapper';
 import queryString from 'query-string';
@@ -82,10 +82,10 @@ class Login extends React.Component {
                         {/* the above is almost certainly wrong, not sure how to fix*/}
                     </form>
                     <p>
-                        <a href='/account/signup'>Don't have an account? Sign up!</a>
+                        <NavLink to='/account/signup'>Don't have an account? Sign up!</NavLink>
                     </p>
                     <p>
-                        <a href='/account/reset'>Forgot your password?</a>
+                        <NavLink to='/account/reset'>Forgot your password?</NavLink>
                     </p>
                     <a
                         href=''

--- a/frontend/src/components/NavBar.js
+++ b/frontend/src/components/NavBar.js
@@ -134,7 +134,7 @@ class NavBar extends React.Component<{
                 <AppBar color='default'>
                     <Toolbar>
                         <div className={classes.logoContainer}>
-                            <Link to=''>
+                            <Link to='/home'>
                                 <img
                                     src={`${process.env.PUBLIC_URL}/img/codalab-logo.png`}
                                     className={classes.logo}

--- a/frontend/src/components/NavBar.js
+++ b/frontend/src/components/NavBar.js
@@ -2,6 +2,7 @@ import * as React from 'react';
 import classNames from 'classnames';
 import $ from 'jquery';
 
+import { Link } from 'react-router-dom';
 import { withStyles } from '@material-ui/core/styles';
 import { MuiThemeProvider } from '@material-ui/core/styles';
 import AppBar from '@material-ui/core/AppBar';
@@ -133,22 +134,26 @@ class NavBar extends React.Component<{
                 <AppBar color='default'>
                     <Toolbar>
                         <div className={classes.logoContainer}>
-                            <a href='/' target='_self'>
+                            <Link to=''>
                                 <img
                                     src={`${process.env.PUBLIC_URL}/img/codalab-logo.png`}
                                     className={classes.logo}
                                     alt='CodaLab'
                                 />
-                            </a>
+                            </Link>
                         </div>
                         {!this.props.auth.isAuthenticated && (
                             <React.Fragment>
-                                <Button color='inherit' href='/account/signup'>
-                                    Sign Up
-                                </Button>
-                                <Button color='inherit' href='/account/login'>
+                                <Link to='/account/signup'>
+                                    <Button color='inherit' href='/account/signup'>
+                                        Sign Up
+                                    </Button>
+                                </Link>
+                                <Link to='/account/login'>
+                                    <Button color='inherit'>
                                     Login
-                                </Button>
+                                    </Button>
+                                </Link>
                             </React.Fragment>
                         )}
                         {this.props.auth.isAuthenticated && (

--- a/frontend/src/components/NavBar.js
+++ b/frontend/src/components/NavBar.js
@@ -158,9 +158,11 @@ class NavBar extends React.Component<{
                         )}
                         {this.props.auth.isAuthenticated && (
                             <React.Fragment>
-                                <Button color="primary" href='/rest/worksheets/?name=dashboard'>
-                                    Dashboard
-                                </Button>
+                                <Link to='/worksheets?name=dashboard'>
+                                    <Button color="primary">
+                                        Dashboard
+                                    </Button>
+                                </Link>
                                 <Tooltip title='New Worksheet'>
                                     <IconButton
                                         onClick={() => this.setState({ newWorksheetShowDialog: true })}>
@@ -170,9 +172,11 @@ class NavBar extends React.Component<{
                             </React.Fragment>
                         )}
                         <Tooltip title='Gallery'>
-                            <IconButton href='/rest/worksheets/?name=home'>
-                                <GalleryIcon />
-                            </IconButton>
+                            <Link to='/worksheets?name=home'>
+                                <IconButton>
+                                    <GalleryIcon />
+                                </IconButton>
+                            </Link>
                         </Tooltip>
                         <Tooltip title='How-To Guides'>
                             <IconButton href='https://github.com/codalab/codalab-worksheets/wiki'>

--- a/frontend/src/components/NavBar.js
+++ b/frontend/src/components/NavBar.js
@@ -145,7 +145,7 @@ class NavBar extends React.Component<{
                         {!this.props.auth.isAuthenticated && (
                             <React.Fragment>
                                 <Link to='/account/signup'>
-                                    <Button color='inherit' href='/account/signup'>
+                                    <Button color='inherit'>
                                         Sign Up
                                     </Button>
                                 </Link>

--- a/frontend/src/components/PasswordReset.js
+++ b/frontend/src/components/PasswordReset.js
@@ -3,6 +3,7 @@ import SubHeader from './SubHeader';
 import ContentWrapper from './ContentWrapper';
 import Immutable from 'seamless-immutable';
 import queryString from 'query-string';
+import { NavLink } from 'react-router-dom';
 
 export const PasswordResetSent = (props) => {
     return (
@@ -26,7 +27,7 @@ export const PasswordResetComplete = (props) => {
                 <p>Your password has been updated.</p>
                 {!props.auth.isAuthenticated && (
                     <p>
-                        You may go ahead and <a href='/account/login'>log in</a> now.
+                        You may go ahead and <NavLink to='/account/login'>log in</NavLink> now.
                     </p>
                 )}
             </ContentWrapper>
@@ -130,7 +131,7 @@ export class PasswordResetVerified extends React.Component {
                             {
                                 'The password reset link was invalid, possibly because it has already been used. Please request a '
                             }
-                            <a href='/account/reset'>new password reset</a>.
+                            <NavLink to='/account/reset'>new password reset</NavLink>.
                         </p>
                     )}
                     <div class='row'>

--- a/frontend/src/components/SignUp.js
+++ b/frontend/src/components/SignUp.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import Immutable from 'seamless-immutable';
-import { Redirect } from 'react-router-dom';
+import { NavLink } from 'react-router-dom';
 import SubHeader from './SubHeader';
 import ContentWrapper from './ContentWrapper';
 import queryString from 'query-string';
@@ -50,7 +50,7 @@ export class SignUp extends React.Component {
                 <SubHeader title='Sign Up' />
                 <ContentWrapper>
                     <p>
-                        Already have an account? Then please <a href='/account/login'>sign in</a>.
+                        Already have an account? Then please <NavLink to='/account/login'>sign in</NavLink>.
                     </p>
                     <form
                         className='signup'

--- a/frontend/src/components/VerifySuccess.js
+++ b/frontend/src/components/VerifySuccess.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import SubHeader from './SubHeader';
 import ContentWrapper from './ContentWrapper';
+import { NavLink } from 'react-router-dom';
 
 const VerifySuccess = (props) => {
     return (
@@ -13,13 +14,12 @@ const VerifySuccess = (props) => {
                         {props.auth.isAuthenticated && (
                             <p className='user-authenticated'>
                                 Check out your{' '}
-                                <a
-                                    href='/rest/worksheets/?name=dashboard'
+                                <NavLink
+                                    href='/worksheets?name=dashboard'
                                     tabIndex={2}
-                                    target='_self'
                                 >
                                     dashboard
-                                </a>{' '}
+                                </NavLink>{' '}
                                 to get started.
                             </p>
                         )}

--- a/frontend/src/components/VerifySuccess.js
+++ b/frontend/src/components/VerifySuccess.js
@@ -15,7 +15,7 @@ const VerifySuccess = (props) => {
                             <p className='user-authenticated'>
                                 Check out your{' '}
                                 <NavLink
-                                    href='/worksheets?name=dashboard'
+                                    to='/worksheets?name=dashboard'
                                     tabIndex={2}
                                 >
                                     dashboard

--- a/frontend/src/components/worksheets/WorksheetNameSearch.js
+++ b/frontend/src/components/worksheets/WorksheetNameSearch.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import queryString from 'query-string';
+
+export default class extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            loading: true,
+            error: false
+        }
+    }
+    async componentDidMount() {
+        const { name } = queryString.parse(this.props.location.search);
+        try {
+            const response = await fetch(`/rest/worksheets?specs=${name}`).then(e => e.json());
+            const uuid = response.data[0].id;
+            this.props.history.push(`/worksheets/${uuid}/`);
+        }
+        catch (e) {
+            console.error(e);
+            this.setState({ error: true, loading: false });
+        }
+    }
+    render() {
+        const styles = {
+            position: "absolute",
+            top: "50%",
+            left: "50%",
+        }
+        return <div>
+            {this.state.loading && <div style={styles}><img src={`${process.env.PUBLIC_URL}/img/Preloader_Small.gif`} /></div>}
+            {this.state.error && <div>Error.</div>}
+        </div>
+    }
+}

--- a/frontend/src/components/worksheets/WorksheetNameSearch.js
+++ b/frontend/src/components/worksheets/WorksheetNameSearch.js
@@ -7,7 +7,7 @@ export default class extends React.Component {
         this.state = {
             loading: true,
             error: false
-        }
+        };
     }
     async componentDidMount() {
         const { name } = queryString.parse(this.props.location.search);

--- a/frontend/src/components/worksheets/WorksheetNameSearch.js
+++ b/frontend/src/components/worksheets/WorksheetNameSearch.js
@@ -15,8 +15,7 @@ export default class extends React.Component {
             const response = await fetch(`/rest/worksheets?specs=${name}`).then(e => e.json());
             const uuid = response.data[0].id;
             this.props.history.push(`/worksheets/${uuid}/`);
-        }
-        catch (e) {
+        } catch (e) {
             console.error(e);
             this.setState({ error: true, loading: false });
         }

--- a/frontend/src/routes/HomePage.js
+++ b/frontend/src/routes/HomePage.js
@@ -8,7 +8,7 @@ import Table from '@material-ui/core/Table';
 import TableCell from '@material-ui/core/TableCell';
 import TableRow from '@material-ui/core/TableRow';
 import ResponsiveEmbed from 'react-responsive-embed';
-
+import { Link } from 'react-router-dom';
 import UploadIcon from '@material-ui/icons/CloudUploadOutlined'; // insert_chart, cloud upload
 import ExperimentIcon from '@material-ui/icons/InsertChartOutlined'; // extension, barchart, score
 import PublishIcon from '@material-ui/icons/PublicOutlined'; // share, public
@@ -26,14 +26,15 @@ class HomePage extends React.Component<{
     renderButton(title, href) {
         const { classes } = this.props;
         return (
-            <Button
+            <Link to={href}>
+                <Button
                 variant='contained'
                 color='primary'
-                href={href}
                 classes={{ root: classes.buttonRoot, label: classes.buttonLabel }}
-            >
-                {title}
-            </Button>
+                >
+                    {title}
+                </Button>
+            </Link>
         );
     }
 

--- a/frontend/src/routes/HomePage.js
+++ b/frontend/src/routes/HomePage.js
@@ -23,6 +23,14 @@ class HomePage extends React.Component<{
         signout: () => void,
     },
 }> {
+    constructor(props) {
+        super(props);
+        const {auth, redirectAuthToDashboard} = this.props;
+        if (auth.isAuthenticated && redirectAuthToDashboard) {
+            this.props.history.push("/worksheets?name=dashboard");
+        }
+    }
+
     renderButton(title, href) {
         const { classes } = this.props;
         return (
@@ -53,7 +61,6 @@ class HomePage extends React.Component<{
 
     render() {
         const { classes, auth } = this.props;
-
         return (
             <Grid container>
                 {/** Splash w/ tagline, primary buttons, and video.*/}

--- a/frontend/src/routes/HomePage.js
+++ b/frontend/src/routes/HomePage.js
@@ -79,7 +79,7 @@ class HomePage extends React.Component<{
                                         </React.Fragment>
                                     }
                                     {auth.isAuthenticated &&
-                                        this.renderButton('Dashboard', '/rest/worksheets/?name=dashboard')
+                                        this.renderButton('Dashboard', '/worksheets?name=dashboard')
                                     }
                                 </div>
                             </Grid>


### PR DESCRIPTION
Fixes #1230.
- When the logged-in user goes to the home page at first, it redirects them to http://localhost/worksheets?name=dashboard. This page is represented by the `WorksheetNameSearch` component, which does a REST API call to get the right worksheet ID and then redirects the user to the dashboard.
- Redirects are all done JS-side with a loading animation to make the user experience fast and smooth. I've also changed the log in / sign up / home page links on the home page and navbar to use react-router's `Link` rather than an `<a>` tag -- this also speeds up navigation.
- When the user clicks on the "Codalab" logo on the navbar, it sends them to http://localhost/home which will show the home page regardless of whether the user is logged in or not.
- With these changes, we may no longer need the `/rest/worksheets/?name=dashboard` endpoint, and it was unusual anyway to have the user be directly sent to REST endpoint in the browser -- are you fine with removing it @percyliang ?