### PR TITLE
Show lines between table rows

### DIFF
--- a/frontend/public/css/imports.css
+++ b/frontend/public/css/imports.css
@@ -2072,9 +2072,6 @@ th {
 .table > thead:first-child > tr:first-child > td {
   border-top: 0;
 }
-.table > tbody + tbody {
-  border-top: 2px solid #ddd;
-}
 .table .table {
   background-color: #f7f7f7;
 }

--- a/frontend/src/components/worksheets/items/TableItem/BundleRow.js
+++ b/frontend/src/components/worksheets/items/TableItem/BundleRow.js
@@ -444,7 +444,6 @@ const styles = (theme) => ({
     panelContainer: {
         display: 'block',
         height: '0px !important',
-        border: 'none !important',
         overflow: 'visible',
     },
     panelCellContainer: {
@@ -508,6 +507,7 @@ const styles = (theme) => ({
     },
     contentRow: {
         height: 36,
+        borderBottom: '2px solid #ddd',
     },
     modal: {
         position: 'absolute',


### PR DESCRIPTION
Fixes #1221.

Looks like this now:

![image](https://user-images.githubusercontent.com/1689183/60402353-3b35b380-9b43-11e9-9e38-6bbc632750c9.png)
