### PR TITLE
separate init and update for DB migrations

### DIFF
--- a/codalab_service.py
+++ b/codalab_service.py
@@ -274,7 +274,7 @@ class CodalabArgs(argparse.Namespace):
             '-s',
             nargs='*',
             help='List of services to run',
-            choices=SERVICES + ['default', 'default-no-worker', 'init', 'test'],
+            choices=SERVICES + ['default', 'default-no-worker', 'init', 'update', 'test'],
             default=argparse.SUPPRESS,
         )
 
@@ -632,9 +632,11 @@ class CodalabServiceManager(object):
             )
 
             print_header('Initializing the database with alembic')
-            self.run_service_cmd(
-                "%salembic stamp head && alembic upgrade head" % cmd_prefix, root=True
-            )
+            self.run_service_cmd("%salembic stamp head" % cmd_prefix, root=True)
+
+        if should_run_service(self.args, 'update'):
+            print_header('Update the database with alembic (run migrations)')
+            self.run_service_cmd("%salembic upgrade head" % cmd_prefix, root=True)
 
         self.bring_up_service('rest-server')
 


### PR DESCRIPTION
DB migrations weren't working properly before because `init` would first do `alembic stamp` (which declares the current DB to be the head), so the subsequent `alembic upgrade` was a no-op.  On the other hand, `alembic stamp` is needed at initialization.  So, `init` is split up into `init`, which does `alembic stamp` and `update`, which does `alembic upgrade`.