### PR TITLE
Make all mail parameters configurable

### DIFF
--- a/codalab/lib/codalab_manager.py
+++ b/codalab/lib/codalab_manager.py
@@ -395,9 +395,10 @@ class CodaLabManager(object):
                 host=self.config['email']['host'],
                 user=self.config['email'].get('user', 'noreply@codalab.org'),
                 password=self.config['email'].get('password', None),
-                use_tls=True,
-                default_sender='CodaLab <noreply@codalab.org>',
-                server_email='noreply@codalab.org',
+                use_tls=self.config['email'].get('use_tls',True),
+                port=self.config['email'].get('port', 587),
+                default_sender=self.config['email'].get('default_sender','CodaLab <noreply@codalab.org>'),
+                server_email=self.config['email'].get('server_email','noreply@codalab.org'),
             )
         else:
             return ConsoleEmailer()

--- a/codalab/lib/codalab_manager.py
+++ b/codalab/lib/codalab_manager.py
@@ -397,8 +397,8 @@ class CodaLabManager(object):
                 password=self.config['email'].get('password', None),
                 use_tls=self.config['email'].get('use_tls',True),
                 port=self.config['email'].get('port', 587),
-                default_sender=self.config['email'].get('default_sender','CodaLab <noreply@codalab.org>'),
-                server_email=self.config['email'].get('server_email','noreply@codalab.org'),
+                default_sender=self.config['email'].get('sender_from','CodaLab <noreply@codalab.org>'),
+                server_email=self.config['email'].get('sender_email','noreply@codalab.org'),
             )
         else:
             return ConsoleEmailer()


### PR DESCRIPTION
It is now possible to change the port and sender configurations for all instances, with still having reasonable defaults.