### PR TITLE
Add monitor script to codalab service script

### DIFF
--- a/codalab_service.py
+++ b/codalab_service.py
@@ -685,7 +685,6 @@ class CodalabServiceManager(object):
                 root=(not self.args.codalab_home),
             )
 
-
     def build_images(self):
         images_to_build = [
             image for image in self.ALL_IMAGES if should_build_image(self.args, image)

--- a/codalab_service.py
+++ b/codalab_service.py
@@ -274,7 +274,8 @@ class CodalabArgs(argparse.Namespace):
             '-s',
             nargs='*',
             help='List of services to run',
-            choices=SERVICES + ['default', 'default-no-worker', 'init', 'update', 'test', 'monitor'],
+            choices=SERVICES 
+            + ['default', 'default-no-worker', 'init', 'update', 'test', 'monitor'],
             default=argparse.SUPPRESS,
         )
 

--- a/codalab_service.py
+++ b/codalab_service.py
@@ -274,7 +274,7 @@ class CodalabArgs(argparse.Namespace):
             '-s',
             nargs='*',
             help='List of services to run',
-            choices=SERVICES 
+            choices=SERVICES
             + ['default', 'default-no-worker', 'init', 'update', 'test', 'monitor'],
             default=argparse.SUPPRESS,
         )

--- a/monitor.py
+++ b/monitor.py
@@ -158,6 +158,7 @@ def error_logs(error_type, s):
 
 durations = defaultdict(list)  # Command => durations for that command
 
+
 def run_command(args, soft_time_limit=15, hard_time_limit=60, include_output=True):
     # We cap the running time to hard_time_limit, but print out an error if we exceed soft_time_limit.
     start_time = time.time()
@@ -261,6 +262,7 @@ def check_disk_space(paths):
             'low disk space',
             'Only %s MB of disk space left on %s!' % (total / 1024, ' '.join(paths)),
         )
+
 
 # Make sure we can connect (might prompt for username/password)
 if subprocess.call(['cl', 'work']) != 0:

--- a/monitor.py
+++ b/monitor.py
@@ -158,7 +158,6 @@ def error_logs(error_type, s):
 
 durations = defaultdict(list)  # Command => durations for that command
 
-
 def run_command(args, soft_time_limit=15, hard_time_limit=60, include_output=True):
     # We cap the running time to hard_time_limit, but print out an error if we exceed soft_time_limit.
     start_time = time.time()
@@ -263,9 +262,8 @@ def check_disk_space(paths):
             'Only %s MB of disk space left on %s!' % (total / 1024, ' '.join(paths)),
         )
 
-
 # Make sure we can connect (might prompt for username/password)
-if subprocess.call(['cl', 'work', 'localhost::']) != 0:
+if subprocess.call(['cl', 'work']) != 0:
     sys.exit(1)
 
 # Begin monitoring loop
@@ -289,7 +287,7 @@ while True:
         # Get statistics on bundles
         if ping_time():
             # Simple things
-            run_command(['cl', 'work', 'localhost::'])
+            run_command(['cl', 'work'])
             run_command(['cl', 'search', '.count'])
         if run_time():
             # More intense


### PR DESCRIPTION
Link to #1280.
Removed 'localhost::' to avoid `codalab.client.json_api_client.JsonApiException: Unable to fetch worksheets: <urlopen error [Errno 99] Cannot assign requested address>` exception.