### PR TITLE
cache building default-[cg]pu images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ jobs:
         # Otherwise if we're on master or staging build named images
         - provider: script
           # Remove first char of tag (v) to get version number from tag
-          script: ./scripts/travis-deploy.sh ${TRAVIS_TAG#?} release
+          script: ./scripts/travis-deploy.sh ${TRAVIS_TAG#?}
           on:
             # only build on valid semver tags
             tags: true

--- a/scripts/travis-deploy.sh
+++ b/scripts/travis-deploy.sh
@@ -1,20 +1,16 @@
 #!/bin/bash
-# travis-deploy.sh
+
 # Called by Travis CI at the end of a successful build to do necessary
 # deployment actions like building and pushing docker images and PyPI
-# packages
+# packages.  The two possibilities are:
+#
+#   travis-deploy.sh master
+#   travis-deploy.sh 0.3.3   (for releases)
 
-TAG=$1
-RELEASE=0
-if [ "$2" = "release" ]; then
-  RELEASE=1
+tag=$1
+
+./codalab_service.py build all --version $tag --pull --push
+if [ "$tag" != "master" ]; then
+  ./codalab_service.py build all --version latest --pull --push
+  ./scripts/upload-to-pypi.sh $tag
 fi
-
-if [ "$RELEASE" = "1" ]; then
-  ./codalab_service.py build all -v $TAG --push
-  ./codalab_service.py build all -v latest --push
-  ./scripts/upload-to-pypi.sh $TAG
-else
-  ./codalab_service.py build all -v $TAG --push
-fi
-


### PR DESCRIPTION
Add `--pull` to the `build` commands to make things go faster.  Also simplify the `travis-deploy.sh` interface.

Need to merge into `master` to really test this.