### PR TITLE
Make deployment easier

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,9 @@ jobs:
         - sudo mv docker-compose /usr/local/bin
         - sudo service mysql stop
       install:
-        - ./codalab_service.py build services -v ${TRAVIS_BRANCH} --push
+        - ./codalab_service.py build services --version ${TRAVIS_BRANCH} --push
       script:
-        - ./codalab_service.py start -s default test --mysql-port 3306 --version ${TRAVIS_BRANCH}
+        - ./codalab_service.py start --services default test --version ${TRAVIS_BRANCH}
     - stage: deploy
       script: echo "Deploying"
       language: python

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,13 +20,6 @@ jobs:
         - sudo mv docker-compose /usr/local/bin
         - sudo service mysql stop
       install:
-        - echo ${TRAVIS_BRANCH}
-        - git branch
-        - docker pull codalab/frontend:${TRAVIS_BRANCH} || true
-        - docker pull codalab/server:${TRAVIS_BRANCH} || true
-        - docker pull codalab/worker:${TRAVIS_BRANCH} || true
-        - docker images -a
-        - docker build --cache-from codalab/server:master --cache-from codalab/server:faster-travis -t codalab/server:faster-travis -f docker/dockerfiles/Dockerfile.server .
         - ./codalab_service.py build services --version ${TRAVIS_BRANCH} --push
       script:
         - ./codalab_service.py start --services default test --version ${TRAVIS_BRANCH}

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ jobs:
         - sudo mv docker-compose /usr/local/bin
         - sudo service mysql stop
       install:
+        - docker images -a
+        - docker ps -a
         - ./codalab_service.py build services --version ${TRAVIS_BRANCH} --push
       script:
         - ./codalab_service.py start --services default test --version ${TRAVIS_BRANCH}

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,13 @@ jobs:
         - sudo mv docker-compose /usr/local/bin
         - sudo service mysql stop
       install:
+        - echo ${TRAVIS_BRANCH}
+        - git branch
         - docker pull codalab/frontend:${TRAVIS_BRANCH} || true
         - docker pull codalab/server:${TRAVIS_BRANCH} || true
         - docker pull codalab/worker:${TRAVIS_BRANCH} || true
+        - docker images -a
+        - docker build --cache-from codalab/server:master --cache-from codalab/server:faster-travis -t codalab/server:faster-travis -f docker/dockerfiles/Dockerfile.server .
         - ./codalab_service.py build services --version ${TRAVIS_BRANCH} --push
       script:
         - ./codalab_service.py start --services default test --version ${TRAVIS_BRANCH}

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,9 @@ jobs:
         - sudo mv docker-compose /usr/local/bin
         - sudo service mysql stop
       install:
-        - docker images -a
-        - docker ps -a
+        - docker pull codalab/frontend:${TRAVIS_BRANCH} || true
+        - docker pull codalab/server:${TRAVIS_BRANCH} || true
+        - docker pull codalab/worker:${TRAVIS_BRANCH} || true
         - ./codalab_service.py build services --version ${TRAVIS_BRANCH} --push
       script:
         - ./codalab_service.py start --services default test --version ${TRAVIS_BRANCH}

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ jobs:
         - sudo mv docker-compose /usr/local/bin
         - sudo service mysql stop
       install:
-        - ./codalab_service.py build services --version ${TRAVIS_BRANCH} --push
+        - ./codalab_service.py build services --version ${TRAVIS_BRANCH} --pull --push
       script:
         - ./codalab_service.py start --services default test --version ${TRAVIS_BRANCH}
     - stage: deploy

--- a/codalab_service.py
+++ b/codalab_service.py
@@ -38,7 +38,7 @@ def should_run_service(args, service):
 
 
 def need_image_for_service(args, image):
-    """Does `image` support a service we want to run."""
+    """Does `image` support a service we want to run?"""
     for service, service_image in SERVICE_TO_IMAGE.items():
         if should_run_service(args, service) and image == service_image:
             return True

--- a/codalab_service.py
+++ b/codalab_service.py
@@ -587,7 +587,7 @@ class CodalabServiceManager(object):
             try:
                 subprocess.check_call(command_string, shell=True, cwd=self.root_dir)
                 success = True
-            except OSError as e:
+            except subprocess.CalledProcessError as e:
                 success = False
                 if not allow_fail:
                     raise e

--- a/codalab_service.py
+++ b/codalab_service.py
@@ -555,9 +555,10 @@ class CodalabServiceManager(object):
 
     def build_image(self, image):
         print_header('Building {} image'.format(image))
+        docker_image = 'codalab/{}:{}'.format(image, self.args.version)
         self._run_docker_cmd(
-            'build -t codalab/%s:%s -f docker/dockerfiles/Dockerfile.%s .'
-            % (image, self.args.version, image)
+            'build --cache-from %s -t %s -f docker/dockerfiles/Dockerfile.%s .'
+            % (docker_image, docker_image, image)
         )
 
     def push_image(self, image):

--- a/codalab_service.py
+++ b/codalab_service.py
@@ -28,7 +28,7 @@ def print_header(description):
 
 def should_run_service(args, service):
     # `default` is generally used to bring up everything for local dev or quick testing.
-    # `default-but-worker` is generally used for real deployment since we don't
+    # `default-no-worker` is generally used for real deployment since we don't
     # want a worker running on the same machine.
     return (
         service in args.services
@@ -36,6 +36,12 @@ def should_run_service(args, service):
         or (service != 'test' and service != 'worker' and 'default-no-worker' in args.services)
     )
 
+def need_image_for_service(args, image):
+    """Does `image` support a service we want to run."""
+    for service, service_image in SERVICE_TO_IMAGE.items():
+        if should_run_service(args, service) and image == service_image:
+            return True
+    return False
 
 def should_build_image(args, image):
     if image in args.images:
@@ -43,10 +49,7 @@ def should_build_image(args, image):
     if 'all' in args.images:
         return True
     if 'services' in args.images:
-        # Build all images that are correspond to the services we're running
-        for service, service_image in SERVICE_TO_IMAGE.items():
-            if should_run_service(args, service) and image == service_image:
-                return True
+        return need_image_for_service(args, image)
     return False
 
 
@@ -133,13 +136,13 @@ class CodalabArgs(argparse.Namespace):
 
         start_cmd = subparsers.add_parser('start', help='Start a CodaLab service instance')
         logs_cmd = subparsers.add_parser('logs', help='View logs for existing CodaLab instance')
+        pull_cmd = subparsers.add_parser('pull', help='Pull images from Docker Hub')
         build_cmd = subparsers.add_parser(
             'build', help='Build CodaLab docker images using the local codebase'
         )
         run_cmd = subparsers.add_parser('run', help='Run a command inside a service container')
-
         stop_cmd = subparsers.add_parser('stop', help='Stop any existing CodaLab service instances')
-        down_cmd = subparsers.add_parser(
+        delete_cmd = subparsers.add_parser(
             'delete',
             help='Bring down any existing CodaLab service instances (and delete all non-external data!)',
         )
@@ -148,7 +151,7 @@ class CodalabArgs(argparse.Namespace):
         )
 
         #  CLIENT SETTINGS
-        for cmd in [start_cmd, logs_cmd, build_cmd, run_cmd, stop_cmd, down_cmd, restart_cmd]:
+        for cmd in [start_cmd, logs_cmd, pull_cmd, build_cmd, run_cmd, stop_cmd, delete_cmd, restart_cmd]:
             cmd.add_argument(
                 '--dry-run',
                 action='store_true',
@@ -254,7 +257,7 @@ class CodalabArgs(argparse.Namespace):
         )
 
         #  DEPLOYMENT SETTINGS
-        for cmd in [start_cmd, stop_cmd, restart_cmd, down_cmd, logs_cmd]:
+        for cmd in [start_cmd, stop_cmd, restart_cmd, delete_cmd, logs_cmd]:
             cmd.add_argument(
                 '--instance-name',
                 type=str,
@@ -543,6 +546,8 @@ class CodalabServiceManager(object):
     def execute(self):
         if self.command == 'build':
             self.build_images()
+        elif self.command == 'pull':
+            self.pull_images()
         elif self.command == 'start':
             if self.args.build_images:
                 self.build_images()
@@ -589,6 +594,8 @@ class CodalabServiceManager(object):
 
     def push_image(self, image):
         self._run_docker_cmd('push codalab/%s:%s' % (image, self.args.version))
+    def pull_image(self, image):
+        self._run_docker_cmd('pull codalab/%s:%s' % (image, self.args.version))
 
     def _run_docker_cmd(self, cmd, allow_fail=False):
         """Return whether the command succeeded."""
@@ -699,11 +706,8 @@ class CodalabServiceManager(object):
             )
 
             print_header('Initializing the database with alembic')
-            self.run_service_cmd("%salembic stamp head" % cmd_prefix, root=True)
-
-        if should_run_service(self.args, 'update'):
-            print_header('Update the database with alembic (run migrations)')
             self.run_service_cmd("%salembic upgrade head" % cmd_prefix, root=True)
+            self.run_service_cmd("%salembic stamp head" % cmd_prefix, root=True)
 
         self.bring_up_service('rest-server')
 
@@ -725,6 +729,10 @@ class CodalabServiceManager(object):
                 "/opt/wait-for-it.sh rest-server:2900 -- python test_cli.py --instance http://rest-server:2900 default",
                 root=(not self.args.codalab_home),
             )
+
+    def pull_images(self):
+        for image in self.SERVICE_IMAGES:
+            self.pull_image(image)
 
     def build_images(self):
         images_to_build = [

--- a/codalab_service.py
+++ b/codalab_service.py
@@ -489,6 +489,8 @@ class CodalabServiceManager(object):
         if args.mysql_port:
             environment['CODALAB_MYSQL_PORT'] = args.mysql_port
         if args.use_ssl:
+            assert args.ssl_cert_file
+            assert args.ssl_key_file
             environment['CODALAB_SSL_CERT_FILE'] = args.ssl_cert_file
             environment['CODALAB_SSL_KEY_FILE'] = args.ssl_key_file
         if 'DOCKER_HOST' in os.environ:

--- a/codalab_service.py
+++ b/codalab_service.py
@@ -615,9 +615,13 @@ class CodalabServiceManager(object):
                     env=self.compose_env,
                     shell=True,
                     stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
                 )
-                for stdout_line in popen.stdout:
+                # Note: don't do `for stdout_line in popen.stdout` because that buffers.
+                while True:
+                    stdout_line = popen.stdout.readline()
+                    if not stdout_line:
+                        break;
                     print(
                         "process: " + stdout_line.decode('utf-8').encode('ascii', errors='replace'),
                         end="",

--- a/codalab_service.py
+++ b/codalab_service.py
@@ -638,7 +638,7 @@ class CodalabServiceManager(object):
                         end="",
                     )
                 popen.wait()
-                success = (popen.returncode == 0)
+                success = popen.returncode == 0
                 if not success:
                     raise Exception('Command exited with code {}'.format(popen.returncode))
             except subprocess.CalledProcessError as e:

--- a/codalab_service.py
+++ b/codalab_service.py
@@ -468,7 +468,7 @@ class CodalabServiceManager(object):
             'CODALAB_HTTP_PORT': args.http_port,
             'CODALAB_VERSION': args.version,
             'CODALAB_WORKER_NETWORK_NAME': '%s-worker-network' % args.instance_name,
-            #'PATH': os.environ['PATH'],
+            'PATH': os.environ['PATH'],
         }
         if args.uid:
             environment['CODALAB_UID'] = args.uid

--- a/codalab_service.py
+++ b/codalab_service.py
@@ -55,9 +55,11 @@ def main():
     service_manager = CodalabServiceManager(args)
     service_manager.execute()
 
+
 def get_default_version():
     """Get the current git branch."""
     return subprocess.check_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD']).strip()
+
 
 class CodalabArgs(argparse.Namespace):
     DEFAULT_ARGS = {

--- a/codalab_service.py
+++ b/codalab_service.py
@@ -55,10 +55,13 @@ def main():
     service_manager = CodalabServiceManager(args)
     service_manager.execute()
 
+def get_default_version():
+    """Get the current git branch."""
+    return subprocess.check_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD']).strip()
 
 class CodalabArgs(argparse.Namespace):
     DEFAULT_ARGS = {
-        'version': 'latest',
+        'version': get_default_version(),
         'dev': False,
         'push': False,
         'docker_user': None,
@@ -555,10 +558,11 @@ class CodalabServiceManager(object):
 
     def build_image(self, image):
         print_header('Building {} image'.format(image))
+        master_docker_image = 'codalab/{}:{}'.format(image, 'master')
         docker_image = 'codalab/{}:{}'.format(image, self.args.version)
         self._run_docker_cmd(
-            'build --cache-from %s -t %s -f docker/dockerfiles/Dockerfile.%s .'
-            % (docker_image, docker_image, image)
+            'build --cache-from %s --cache-from %s -t %s -f docker/dockerfiles/Dockerfile.%s .'
+            % (master_docker_image, docker_image, docker_image, image)
         )
 
     def push_image(self, image):

--- a/codalab_service.py
+++ b/codalab_service.py
@@ -222,7 +222,7 @@ class CodalabArgs(argparse.Namespace):
             cmd.add_argument(
                 '--pull',
                 action='store_true',
-                help='If specified, pull images to Docker Hub (for caching)',
+                help='If specified, pull images from Docker Hub (for caching)',
                 default=argparse.SUPPRESS,
             )
             cmd.add_argument(

--- a/codalab_service.py
+++ b/codalab_service.py
@@ -572,12 +572,18 @@ class CodalabServiceManager(object):
 
         # Pull the previous image on this version (branch) if we have it.  Otherwise, use master.
         if self.args.pull:
-            if not self._run_docker_cmd('pull {}'.format(docker_image), allow_fail=True):
+            if self._run_docker_cmd('pull {}'.format(docker_image), allow_fail=True):
+                cache_image = docker_image
+            else:
                 self._run_docker_cmd('pull {}'.format(master_docker_image))
+                cache_image = master_docker_image
+            cache_args = ' --cache-from {}'.format(cache_image)
+        else:
+            cache_args = ''
 
         # Build the image using the cache
         self._run_docker_cmd(
-            'build -t %s -f docker/dockerfiles/Dockerfile.%s .' % (docker_image, image)
+            'build%s -t %s -f docker/dockerfiles/Dockerfile.%s .' % (cache_args, docker_image, image)
         )
 
     def push_image(self, image):

--- a/codalab_service.py
+++ b/codalab_service.py
@@ -621,7 +621,7 @@ class CodalabServiceManager(object):
                 while True:
                     stdout_line = popen.stdout.readline()
                     if not stdout_line:
-                        break;
+                        break
                     print(
                         "process: " + stdout_line.decode('utf-8').encode('ascii', errors='replace'),
                         end="",

--- a/codalab_service.py
+++ b/codalab_service.py
@@ -65,6 +65,7 @@ class CodalabArgs(argparse.Namespace):
     DEFAULT_ARGS = {
         'version': get_default_version(),
         'dev': False,
+        'pull': False,
         'push': False,
         'docker_user': None,
         'docker_password': None,
@@ -576,8 +577,7 @@ class CodalabServiceManager(object):
 
         # Build the image using the cache
         self._run_docker_cmd(
-            'build -t %s -f docker/dockerfiles/Dockerfile.%s .'
-            % (docker_image, image)
+            'build -t %s -f docker/dockerfiles/Dockerfile.%s .' % (docker_image, image)
         )
 
     def push_image(self, image):

--- a/codalab_service.py
+++ b/codalab_service.py
@@ -209,7 +209,7 @@ class CodalabArgs(argparse.Namespace):
                 '--version',
                 '-v',
                 type=str,
-                help='CodaLab version to use for building and deployment (should be branch name)',
+                help='CodaLab version to use for building and deployment (defaults to branch name, set only for Travis CI)',
                 default=argparse.SUPPRESS,
             )
             cmd.add_argument(

--- a/codalab_service.py
+++ b/codalab_service.py
@@ -705,7 +705,7 @@ class CodalabServiceManager(object):
                 root=True,
             )
 
-            print_header('Initializing the database with alembic')
+            print_header('Initializing and migrating the database with alembic')
             self.run_service_cmd("%salembic upgrade head" % cmd_prefix, root=True)
             self.run_service_cmd("%salembic stamp head" % cmd_prefix, root=True)
 

--- a/codalab_service.py
+++ b/codalab_service.py
@@ -583,7 +583,8 @@ class CodalabServiceManager(object):
 
         # Build the image using the cache
         self._run_docker_cmd(
-            'build%s -t %s -f docker/dockerfiles/Dockerfile.%s .' % (cache_args, docker_image, image)
+            'build%s -t %s -f docker/dockerfiles/Dockerfile.%s .'
+            % (cache_args, docker_image, image)
         )
 
     def push_image(self, image):

--- a/docs/Server-Setup.md
+++ b/docs/Server-Setup.md
@@ -60,6 +60,11 @@ There are two use cases going forward: (i) development (you're trying to modify
 CodaLab) and (ii) productionization (you want to deploy this as a system that
 people will use).  Each will build on this basic framework in a different way.
 
+If you want to update CodaLab (and run any database migrations), run the following commands:
+
+    ./codalab_service.py pull
+    ./codalab_service.py start
+
 # Development
 
 If you're actively developing and want to test your changes, add the following two flags:
@@ -164,9 +169,8 @@ You can execute commands in the Docker images to see what's going on, for exampl
 
 ## Database migrations
 
-If you just want to update your database, run the following command (which includes something to update the database schema via `alembic`):
-
-    ./codalab_service.py start -bd -s update
+Note: database migrations are run automatically when you start the CodaLab
+services.
 
 If you want to modify the database schema, use `alembic` to create a migration.  Note that everything must be run in Docker, but your modifications are outside in your local codebase.
 

--- a/docs/Server-Setup.md
+++ b/docs/Server-Setup.md
@@ -60,10 +60,14 @@ There are two use cases going forward: (i) development (you're trying to modify
 CodaLab) and (ii) productionization (you want to deploy this as a system that
 people will use).  Each will build on this basic framework in a different way.
 
-If you want to update CodaLab (and run any database migrations), run the following commands:
+If you want to update CodaLab, run the following commands:
 
+    git pull
     ./codalab_service.py pull
     ./codalab_service.py start
+
+This will grab the latest Docker images, migrate the database, and start or
+restart all the CodaLab services.  Any ongoing runs should not be affected.
 
 # Development
 

--- a/docs/Server-Setup.md
+++ b/docs/Server-Setup.md
@@ -69,19 +69,17 @@ If you're actively developing and want to test your changes, add the following t
   [DockerHub](https://hub.docker.com/u/codalab) will be used.
 - `-d` (`--dev`): runs the development version of the frontend so that your
   changes will be propagated instantly rather than having to rebuild any docker images.
-- `-v <name>` (optional): tag the Docker images so that you can play with
-  different versions of CodaLab.
 
 Start the CodaLab service as follows:
 
-    ./codalab_service.py start -bdvlocal
+    ./codalab_service.py start -bd
 
 If you modify the frontend, you can do so without restarting.  If you would
 like to modify the rest server, bundle manager, or worker, then you can edit
 the code and then start only that single Docker container.  For example, for
 the worker, the command would be:
 
-    ./codalab_service.py start -bdvlocal -s worker
+    ./codalab_service.py start -bd -s worker
 
 To stop all the Docker containers associated with the CodaLab service (but preserve all the data):
 
@@ -95,7 +93,7 @@ If you want to delete all the data associated with this, then do:
 
 If you just want to build the Docker images without starting the CodaLab service:
 
-    ./codalab_service.py build -v local
+    ./codalab_service.py build
 
 We provide two default Docker images that bundles are run in if no Docker image
 is specified, one for GPU jobs and one for non-GPU jobs:
@@ -106,17 +104,17 @@ is specified, one for GPU jobs and one for non-GPU jobs:
 If you would like to build these as well (note that this might take up to an
 hour because lots of packages have to be installed):
 
-    ./codalab_service.py build all -v local
+    ./codalab_service.py build all
 
 ## Testing
 
 Since tests run against an existing instance, make sure you update your instance first.
 
-    ./codalab_service.py start -bdvlocal -s rest-server
+    ./codalab_service.py start -bd -s rest-server
 
 To run the tests against an instance that you've already set up:
 
-    ./codalab_service.py start -bdvlocal -s test
+    ./codalab_service.py start -bd -s test
 
 Or to run a specific test (e.g., basic):
 
@@ -124,7 +122,7 @@ Or to run a specific test (e.g., basic):
 
 You can also start an instance and run tests on it:
 
-    ./codalab_service.py start -bdvlocal -s default test
+    ./codalab_service.py start -bd -s default test
 
 To fix any style issues for the Python code:
 
@@ -168,7 +166,7 @@ You can execute commands in the Docker images to see what's going on, for exampl
 
 If you just want to update your database, run the following command (which includes something to update the database schema via `alembic`):
 
-    ./codalab_service.py start -bdvlocal -s update
+    ./codalab_service.py start -bd -s update
 
 If you want to modify the database schema, use `alembic` to create a migration.  Note that everything must be run in Docker, but your modifications are outside in your local codebase.
 
@@ -176,7 +174,7 @@ If you want to modify the database schema, use `alembic` to create a migration. 
 
 1. Rebuild the Docker image for the rest server:
 
-        ./codalab_service.py start -bdvlocal -s rest-server
+        ./codalab_service.py start -bd -s rest-server
 
 1. Auto-generate the migration script:
 
@@ -190,7 +188,7 @@ If you want to modify the database schema, use `alembic` to create a migration. 
 
 1. Rebuild the Docker image:
 
-        ./codalab_service.py start -bdvlocal -s rest-server
+        ./codalab_service.py start -bd -s rest-server
 
 1. Apply the migration to change the actual database:
 

--- a/test_cli.py
+++ b/test_cli.py
@@ -115,6 +115,7 @@ def run_command(args, expected_exit_code=0, max_output_chars=256, env=None, incl
         assert isinstance(a, str)
     # Travis only prints ASCII
     print('>> %s' % " ".join([a.decode("utf-8").encode("ascii", errors='replace') for a in args]))
+    sys.stdout.flush()
 
     try:
         if include_stderr:
@@ -133,7 +134,9 @@ def run_command(args, expected_exit_code=0, max_output_chars=256, env=None, incl
     else:
         colorize = Colorizer.cyan
     print(colorize(" (exit code %s, expected %s)" % (exitcode, expected_exit_code)))
+    sys.stdout.flush()
     print(sanitize(output, max_output_chars))
+    sys.stdout.flush()
     assert expected_exit_code == exitcode, 'Exit codes don\'t match'
     return output.rstrip()
 

--- a/test_cli.py
+++ b/test_cli.py
@@ -326,7 +326,7 @@ class ModuleContext(object):
 
     def __enter__(self):
         """Prepares clean environment for test module."""
-        print(Colorizer.yellow("[*][*] SWITCHING TO TEMPORARY WORKSHEET"))
+        print("[*][*] SWITCHING TO TEMPORARY WORKSHEET")
 
         self.original_environ = os.environ.copy()
         self.original_worksheet = run_command([cl, 'work', '-u'])
@@ -334,7 +334,7 @@ class ModuleContext(object):
         self.worksheets.append(temp_worksheet)
         run_command([cl, 'work', temp_worksheet])
 
-        print(Colorizer.yellow("[*][*] BEGIN TEST"))
+        print("[*][*] BEGIN TEST")
 
         return self
 
@@ -346,7 +346,7 @@ class ModuleContext(object):
             if exc_type is AssertionError:
                 print(Colorizer.red("[!] ERROR: %s" % exc_value.message))
             elif exc_type is KeyboardInterrupt:
-                print(Colorizer.yellow("[!] Caught interrupt! Quitting after cleanup."))
+                print(Colorizer.red("[!] Caught interrupt! Quitting after cleanup."))
             else:
                 print(Colorizer.red("[!] ERROR: Test raised an exception!"))
                 traceback.print_exception(exc_type, exc_value, tb)
@@ -463,8 +463,8 @@ class TestModule(object):
             elif name in cls.modules:
                 modules_to_run.append(cls.modules[name])
             else:
-                print(Colorizer.yellow("[!] Could not find module %s" % name))
-                print(Colorizer.yellow("[*] Modules: all %s" % " ".join(cls.modules.keys())))
+                print(Colorizer.red("[!] Could not find module %s" % name))
+                print(Colorizer.red("[*] Modules: all %s" % " ".join(cls.modules.keys())))
                 sys.exit(1)
 
         print(


### PR DESCRIPTION
Two main changes:
- `./codalab-service.py pull` grabs the images.
- `./codalab-service.py start` does migrations for you so you don't have to do an `update` explicitly, which was error prone before (if you forget).

Also, some drive-by improvements.