### PR TITLE
Fix default cpu docker file

### DIFF
--- a/docker/dockerfiles/Dockerfile.default-cpu
+++ b/docker/dockerfiles/Dockerfile.default-cpu
@@ -1,8 +1,6 @@
 FROM ubuntu:xenial
 MAINTAINER CodaLab Team "codalab.worksheets@gmail.com"
 
-RUN add-apt-repository ppa:deadsnakes/ppa 
-
 ############################################################
 # Common steps (must be the same in the CPU and GPU images)
 


### PR DESCRIPTION
The dockerfile wasn't able to build because `add-apt-repository ppa:deadsnakes/ppa` needs to run after `apt-get install python-software-properties`.