### PR TITLE
Python3 byte string error

### DIFF
--- a/worker/codalabworker/docker_utils.py
+++ b/worker/codalabworker/docker_utils.py
@@ -80,7 +80,7 @@ def get_nvidia_devices():
         cuda_image, nvidia_command, runtime=NVIDIA_RUNTIME, detach=False, stdout=True, remove=True
     )
     # Get newline delimited gpu-index, gpu-uuid list
-    output = output.decode('utf-8')
+    output = output.decode()
     print(output.split('\n')[:-1])
     return {gpu.split(',')[0].strip(): gpu.split(',')[1].strip() for gpu in output.split('\n')[:-1]}
 

--- a/worker/codalabworker/docker_utils.py
+++ b/worker/codalabworker/docker_utils.py
@@ -80,6 +80,7 @@ def get_nvidia_devices():
         cuda_image, nvidia_command, runtime=NVIDIA_RUNTIME, detach=False, stdout=True, remove=True
     )
     # Get newline delimited gpu-index, gpu-uuid list
+    output = output.decode('utf-8')
     print(output.split('\n')[:-1])
     return {gpu.split(',')[0].strip(): gpu.split(',')[1].strip() for gpu in output.split('\n')[:-1]}
 


### PR DESCRIPTION
Failing to start worker service in newest docker image with the following error:

> worker_1          | Traceback (most recent call last):
> worker_1          |   File "/usr/local/bin/cl-worker", line 11, in <module>
> worker_1          |     load_entry_point('codalabworker', 'console_scripts', 'cl-worker')()
> worker_1          |   File "/opt/worker/codalabworker/main.py", line 199, in main
> worker_1          |     bundle_service,
> worker_1          |   File "/opt/worker/codalabworker/worker.py", line 45, in __init__
> worker_1          |     self._run_manager = create_run_manager(self)
> worker_1          |   File "/opt/worker/codalabworker/main.py", line 165, in create_local_run_manager
> worker_1          |     docker_runtime = docker_utils.get_available_runtime()
> worker_1          |   File "/opt/worker/codalabworker/docker_utils.py", line 30, in wrapper
> worker_1          |     return f(*args, **kwargs)
> worker_1          |   File "/opt/worker/codalabworker/docker_utils.py", line 59, in get_available_runtime
> worker_1          |     nvidia_devices = get_nvidia_devices()
> worker_1          |   File "/opt/worker/codalabworker/docker_utils.py", line 30, in wrapper
> worker_1          |     return f(*args, **kwargs)
> worker_1          |   File "/opt/worker/codalabworker/docker_utils.py", line 84, in get_nvidia_devices
> worker_1          |     print(output.split('\n')[:-1])
> worker_1          | TypeError: a bytes-like object is required, not 'str'
> codalab_worker_1 exited with code 1

Seems to be a common error when migrating to python3. It starts correctly after applying this change.