### PR TITLE
Replace / with _ for codalab version

### DIFF
--- a/codalab_service.py
+++ b/codalab_service.py
@@ -94,7 +94,7 @@ def get_default_version():
     """Get the current git branch."""
     return subprocess.check_output(
         ['git', 'rev-parse', '--abbrev-ref', 'HEAD'], encoding='utf-8'
-    ).strip()
+    ).strip().replace("/", "_")
 
 
 def var_path(name):

--- a/codalab_service.py
+++ b/codalab_service.py
@@ -92,9 +92,11 @@ def main():
 
 def get_default_version():
     """Get the current git branch."""
-    return subprocess.check_output(
-        ['git', 'rev-parse', '--abbrev-ref', 'HEAD'], encoding='utf-8'
-    ).strip().replace("/", "_")
+    return (
+        subprocess.check_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD'], encoding='utf-8')
+        .strip()
+        .replace("/", "_")
+    )
 
 
 def var_path(name):

--- a/codalab_service.py
+++ b/codalab_service.py
@@ -94,7 +94,7 @@ def get_default_version():
     """Get the current git branch."""
     return subprocess.check_output(
         ['git', 'rev-parse', '--abbrev-ref', 'HEAD'], encoding='utf-8'
-    ).strip().replace("/", "_")
+    ).strip().replace("/", "_") # This is required so that branches with "/" in their name do not fail CI.
 
 
 def var_path(name):


### PR DESCRIPTION
This fixes #1369, so that branches with "/" in their name do not fail CI.