### PR TITLE
Don't decode return value from download_manager._get_read_response_string()

### DIFF
--- a/codalab/lib/download_manager.py
+++ b/codalab/lib/download_manager.py
@@ -288,6 +288,7 @@ class DownloadManager(object):
 
     def _get_read_response_string(self, response_socket_id):
         with closing(self._get_read_response_stream(response_socket_id)) as fileobj:
+            # This function returns a binary string, as the file could be gzipped.
             return fileobj.read()
 
 

--- a/codalab/lib/download_manager.py
+++ b/codalab/lib/download_manager.py
@@ -288,7 +288,7 @@ class DownloadManager(object):
 
     def _get_read_response_string(self, response_socket_id):
         with closing(self._get_read_response_stream(response_socket_id)) as fileobj:
-            return fileobj.read().decode()
+            return fileobj.read()
 
 
 class Deallocating(object):

--- a/codalab/lib/download_manager.py
+++ b/codalab/lib/download_manager.py
@@ -165,7 +165,7 @@ class DownloadManager(object):
             try:
                 read_args = {'type': 'read_file_section', 'offset': offset, 'length': length}
                 self._send_read_message(worker, response_socket_id, uuid, path, read_args)
-                string = self._get_read_response_string(response_socket_id)
+                string = self._get_read_response(response_socket_id)
             finally:
                 self._worker_model.deallocate_socket(response_socket_id)
 
@@ -206,7 +206,7 @@ class DownloadManager(object):
                     'truncation_text': truncation_text,
                 }
                 self._send_read_message(worker, response_socket_id, uuid, path, read_args)
-                string = self._get_read_response_string(response_socket_id)
+                string = self._get_read_response(response_socket_id)
             finally:
                 self._worker_model.deallocate_socket(response_socket_id)
 
@@ -224,7 +224,7 @@ class DownloadManager(object):
         )
         try:
             self._send_netcat_message(worker, response_socket_id, uuid, port, message)
-            string = self._get_read_response_string(response_socket_id)
+            string = self._get_read_response(response_socket_id)
         finally:
             self._worker_model.deallocate_socket(response_socket_id)
 
@@ -286,7 +286,7 @@ class DownloadManager(object):
             precondition(fileobj is not None, 'Unable to reach worker')
             return fileobj
 
-    def _get_read_response_string(self, response_socket_id):
+    def _get_read_response(self, response_socket_id):
         with closing(self._get_read_response_stream(response_socket_id)) as fileobj:
             # This function returns a binary string, as the file could be gzipped.
             return fileobj.read()

--- a/test_cli.py
+++ b/test_cli.py
@@ -1021,8 +1021,9 @@ def test(ctx):
     check_equals(uuid, run_command([cl, 'search', name, '-u']))
     run_command([cl, 'search', name, '--append'])
     # test download stdout
-    run_command([cl, 'download', uuid + '/stdout'])
-    check_equals('hello', path_contents('stdout'))
+    path = temp_path('')
+    run_command([cl, 'download', uuid + '/stdout', '-o', path])
+    check_equals('hello', path_contents(path + '/stdout'))
     # get info
     check_equals('ready', run_command([cl, 'info', '-f', 'state', uuid]))
     check_contains(['run "echo hello"'], run_command([cl, 'info', '-f', 'args', uuid]))

--- a/test_cli.py
+++ b/test_cli.py
@@ -1020,6 +1020,9 @@ def test(ctx):
     check_contains(name, run_command([cl, 'search', name]))
     check_equals(uuid, run_command([cl, 'search', name, '-u']))
     run_command([cl, 'search', name, '--append'])
+    # test download stdout
+    run_command([cl, 'download', uuid + '/stdout'])
+    check_equals('hello', path_contents('stdout'))
     # get info
     check_equals('ready', run_command([cl, 'info', '-f', 'state', uuid]))
     check_contains(['run "echo hello"'], run_command([cl, 'info', '-f', 'args', uuid]))


### PR DESCRIPTION
Fixes #1387, in which the `/rest/bundles/{bundleId}/contents/blob/stdout` and `/rest/bundles/{bundleId}/contents/blob/sterr` endpoints were returning 500 errors (I've deployed this branch to dev for now to confirm that the error is gone).

Note that the test I added doesn't actually cover this use case of the response being gzipped; but the test I did add is a good test to have anyway, so I just kept it. Any pointers on how we could write a test that might cover the functionality that broke in #1387?

Some context from my comment in that issue:

> The issue is this line of code: https://github.com/codalab/codalab-worksheets/blob/5b9390b5ecdead2ef736c4e43dc94037f2aeb161/codalab/lib/download_manager.py#L291
> 
> (In python 2, we didn't decode the data).
> 
> From [this link](https://stackoverflow.com/questions/44659851/unicodedecodeerror-utf-8-codec-cant-decode-byte-0x8b-in-position-1-invalid/44660123), it looks like "0x8b" byte is indicative of a gzipped file. We probably shouldn't be decoding the file here. I must have assumed that `_get_read_response_string` returns a string, so it must have `.decode()` in it; that assumption was wrong.

_Originally posted by @epicfaace in https://github.com/codalab/codalab-worksheets/issues/1387#issuecomment-530216143_