### PR TITLE
Fix unicode

### DIFF
--- a/codalab/client/json_api_client.py
+++ b/codalab/client/json_api_client.py
@@ -442,7 +442,7 @@ class JsonApiClient(RestClient):
         :return: the response
         """
         request_path = '/bundles/%s/netcat/%s/' % (bundle_id, port)
-        return self._make_request('PUT', request_path, data=data)
+        return self._make_request('PUT', request_path, data=data, return_response=True)
 
     @wrap_exception('Unable to create {1}')
     def create(self, resource_type, data, params=None):

--- a/codalab/client/json_api_client.py
+++ b/codalab/client/json_api_client.py
@@ -674,7 +674,7 @@ class JsonApiClient(RestClient):
             method='POST',
             path='/worksheets/%s/raw' % worksheet_id,
             headers={'Content-Type': 'text/plain'},
-            data='\n'.join(lines).encode(),
+            data='\n'.join(lines),
         )
 
     @wrap_exception('Unable to fetch worker information')

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -2222,8 +2222,10 @@ class BundleCLI(object):
         client, worksheet_uuid, bundle_uuid, subpath = self.resolve_target(
             client, worksheet_uuid, args.bundle_spec
         )
-        info = client.netcat(bundle_uuid, port=args.port, data={"message": args.message})
-        print(info['data'], file=self.stdout)
+        contents = client.netcat(bundle_uuid, port=args.port, data={"message": args.message})
+        with closing(contents):
+            shutil.copyfileobj(contents, self.stdout.buffer)
+
 
     @Commands.command(
         'cat',

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -2226,7 +2226,6 @@ class BundleCLI(object):
         with closing(contents):
             shutil.copyfileobj(contents, self.stdout.buffer)
 
-
     @Commands.command(
         'cat',
         help=[

--- a/codalab/lib/download_manager.py
+++ b/codalab/lib/download_manager.py
@@ -288,6 +288,7 @@ class DownloadManager(object):
 
     def _get_read_response_string(self, response_socket_id):
         with closing(self._get_read_response_stream(response_socket_id)) as fileobj:
+            # This function returns a binary string, as the file could be gzipped.
             return fileobj.read()
 
 

--- a/codalab/lib/download_manager.py
+++ b/codalab/lib/download_manager.py
@@ -224,11 +224,11 @@ class DownloadManager(object):
         )
         try:
             self._send_netcat_message(worker, response_socket_id, uuid, port, message)
-            bytestring = self._get_read_response(response_socket_id)
+            string = self._get_read_response(response_socket_id)
         finally:
             self._worker_model.deallocate_socket(response_socket_id)
 
-        return bytestring
+        return string
 
     def _is_available_locally(self, uuid):
         if self._bundle_model.get_bundle_state(uuid) in [State.RUNNING, State.PREPARING]:

--- a/codalab/lib/download_manager.py
+++ b/codalab/lib/download_manager.py
@@ -224,11 +224,11 @@ class DownloadManager(object):
         )
         try:
             self._send_netcat_message(worker, response_socket_id, uuid, port, message)
-            string = self._get_read_response(response_socket_id)
+            bytestring = self._get_read_response(response_socket_id)
         finally:
             self._worker_model.deallocate_socket(response_socket_id)
 
-        return string
+        return bytestring
 
     def _is_available_locally(self, uuid):
         if self._bundle_model.get_bundle_state(uuid) in [State.RUNNING, State.PREPARING]:

--- a/codalab/lib/download_manager.py
+++ b/codalab/lib/download_manager.py
@@ -288,7 +288,7 @@ class DownloadManager(object):
 
     def _get_read_response_string(self, response_socket_id):
         with closing(self._get_read_response_stream(response_socket_id)) as fileobj:
-            return fileobj.read().decode()
+            return fileobj.read()
 
 
 class Deallocating(object):

--- a/codalab/lib/download_manager.py
+++ b/codalab/lib/download_manager.py
@@ -165,7 +165,7 @@ class DownloadManager(object):
             try:
                 read_args = {'type': 'read_file_section', 'offset': offset, 'length': length}
                 self._send_read_message(worker, response_socket_id, uuid, path, read_args)
-                string = self._get_read_response_string(response_socket_id)
+                string = self._get_read_response(response_socket_id)
             finally:
                 self._worker_model.deallocate_socket(response_socket_id)
 
@@ -206,7 +206,7 @@ class DownloadManager(object):
                     'truncation_text': truncation_text,
                 }
                 self._send_read_message(worker, response_socket_id, uuid, path, read_args)
-                string = self._get_read_response_string(response_socket_id)
+                string = self._get_read_response(response_socket_id)
             finally:
                 self._worker_model.deallocate_socket(response_socket_id)
 
@@ -224,7 +224,7 @@ class DownloadManager(object):
         )
         try:
             self._send_netcat_message(worker, response_socket_id, uuid, port, message)
-            string = self._get_read_response_string(response_socket_id)
+            string = self._get_read_response(response_socket_id)
         finally:
             self._worker_model.deallocate_socket(response_socket_id)
 
@@ -286,7 +286,7 @@ class DownloadManager(object):
             precondition(fileobj is not None, 'Unable to reach worker')
             return fileobj
 
-    def _get_read_response_string(self, response_socket_id):
+    def _get_read_response(self, response_socket_id):
         with closing(self._get_read_response_stream(response_socket_id)) as fileobj:
             # This function returns a binary string, as the file could be gzipped.
             return fileobj.read()

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -409,9 +409,8 @@ def _netcat_bundle(uuid, port):
     Send a raw bytestring into the specified port of the running bundle with uuid.
     Return the response from this bundle.
     """
-    check_bundles_have_read_permission(local.model, request.user, [uuid])
+    check_bundles_have_all_permission(local.model, request.user, [uuid])
     bundle = local.model.get_bundle(uuid)
-    print(bundle.state)
     if bundle.state != State.RUNNING:
         abort(http.client.FORBIDDEN, 'Cannot netcat bundle, bundle not running.')
     info = local.download_manager.netcat(uuid, port, request.json['message'])

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -413,8 +413,7 @@ def _netcat_bundle(uuid, port):
     bundle = local.model.get_bundle(uuid)
     if bundle.state != State.RUNNING:
         abort(http.client.FORBIDDEN, 'Cannot netcat bundle, bundle not running.')
-    info = local.download_manager.netcat(uuid, port, request.json['message'])
-    return {'data': info}
+    return local.download_manager.netcat(uuid, port, request.json['message'])
 
 
 @post(
@@ -458,14 +457,14 @@ def _netcurl_bundle(uuid, port, path=''):
         message += "\r\n"
         message += request.body.read()
 
-        info = local.download_manager.netcat(uuid, port, message)
+        bytestring = local.download_manager.netcat(uuid, port, message)
     except Exception:
         print("{}".format(request.environ), file=sys.stderr)
         raise
     finally:
         request.path_shift(-4)  # restore the URL
 
-    return info
+    return bytestring
 
 
 @get('/bundles/<uuid:re:%s>/contents/blob/' % spec_util.UUID_STR, name='fetch_bundle_contents_blob')

--- a/test_cli.py
+++ b/test_cli.py
@@ -116,9 +116,7 @@ def sanitize(string, max_chars=256):
 def run_command(
     args, expected_exit_code=0, max_output_chars=256, env=None, include_stderr=False, binary=False
 ):
-    print(
-        ">>", *[a.encode('ascii', errors='replace') if type(a) is str else a for a in args], sep=" "
-    )
+    print(">>", *map(str, args), sep=" ")
     sys.stdout.flush()
 
     try:

--- a/test_cli.py
+++ b/test_cli.py
@@ -1023,7 +1023,7 @@ def test(ctx):
     # test download stdout
     path = temp_path('')
     run_command([cl, 'download', uuid + '/stdout', '-o', path])
-    check_equals('hello', path_contents(path + '/stdout'))
+    check_equals('hello', path_contents(path))
     # get info
     check_equals('ready', run_command([cl, 'info', '-f', 'state', uuid]))
     check_contains(['run "echo hello"'], run_command([cl, 'info', '-f', 'args', uuid]))

--- a/test_cli.py
+++ b/test_cli.py
@@ -116,6 +116,8 @@ def sanitize(string, max_chars=256):
 def run_command(
     args, expected_exit_code=0, max_output_chars=256, env=None, include_stderr=False, binary=False
 ):
+    """If we don't care about the exit code, set `expected_exit_code` to None.
+    """
     print(">>", *map(str, args), sep=" ")
     sys.stdout.flush()
 
@@ -135,7 +137,7 @@ def run_command(
     except Exception as e:
         output = traceback.format_exc()
         exitcode = 'test-cli exception'
-    if exitcode != expected_exit_code:
+    if expected_exit_code is not None and exitcode != expected_exit_code:
         colorize = Colorizer.red
         extra = ' BAD'
     else:
@@ -377,7 +379,7 @@ class ModuleContext(object):
                 try:
                     if run_command([cl, 'info', '-f', 'state', bundle]) not in ('ready', 'failed'):
                         run_command([cl, 'kill', bundle])
-                        run_command([cl, 'wait', bundle])
+                        run_command([cl, 'wait', bundle], expected_exit_code=1)
                 except AssertionError:
                     print('CAUGHT')
                     pass

--- a/test_cli.py
+++ b/test_cli.py
@@ -1021,8 +1021,9 @@ def test(ctx):
     check_equals(uuid, run_command([cl, 'search', name, '-u']))
     run_command([cl, 'search', name, '--append'])
     # test download stdout
-    run_command([cl, 'download', uuid + '/stdout'])
-    check_equals('hello', path_contents('stdout'))
+    path = temp_path('')
+    run_command([cl, 'download', uuid + '/stdout', '-o', path])
+    check_equals('hello', path_contents(path + '/stdout'))
     # get info
     check_equals('ready', run_command([cl, 'info', '-f', 'state', uuid]))
     check_contains(['run "echo hello"'], run_command([cl, 'info', '-f', 'args', uuid]))

--- a/test_cli.py
+++ b/test_cli.py
@@ -1020,6 +1020,9 @@ def test(ctx):
     check_contains(name, run_command([cl, 'search', name]))
     check_equals(uuid, run_command([cl, 'search', name, '-u']))
     run_command([cl, 'search', name, '--append'])
+    # test download stdout
+    run_command([cl, 'download', uuid + '/stdout'])
+    check_equals('hello', path_contents('stdout'))
     # get info
     check_equals('ready', run_command([cl, 'info', '-f', 'state', uuid]))
     check_contains(['run "echo hello"'], run_command([cl, 'info', '-f', 'args', uuid]))

--- a/tests/files/netcat-test.py
+++ b/tests/files/netcat-test.py
@@ -1,8 +1,7 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import socket
 import time
-
 
 TCP_IP = '0.0.0.0'
 TCP_PORT = 5005
@@ -11,20 +10,18 @@ BUFFER_SIZE = 1024
 s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 s.bind((TCP_IP, TCP_PORT))
 s.listen(1)
-while 1:
-    # print "polling data"
+
+while True:
     conn, addr = s.accept()
-    # print 'Connection address:', addr
     data = conn.recv(BUFFER_SIZE)
     if not data:
         conn.close()
         continue
-    # print "received data:", data
-    if data != "yo dawg!":
-        conn.send("No, this is dawg")  # echo
+    if data == b'yo dawg!':
+        conn.send(b'Hi this is dawg')
     else:
-        conn.send("Hi this is dawg")
+        conn.send(b'No, this is dawg')
     conn.close()
     break
-    time.sleep(1)
+
 s.close()

--- a/worker/codalabworker/bundle_service_client.py
+++ b/worker/codalabworker/bundle_service_client.py
@@ -136,14 +136,16 @@ class BundleServiceClient(RestClient):
         )
 
     @wrap_exception('Unable to reply to message from bundle service')
-    def reply_data(self, worker_id, socket_id, header_message, fileobj_or_string):
+    def reply_data(self, worker_id, socket_id, header_message, fileobj_or_bytestring):
         method = 'POST'
         url = self._worker_url_prefix(worker_id) + '/reply_data/' + str(socket_id)
         query_params = {'header_message': json.dumps(header_message)}
-        if isinstance(fileobj_or_string, str):
-            self._make_request(method, url, query_params, headers={}, data=fileobj_or_string)
+        if isinstance(fileobj_or_bytestring, bytes):
+            self._make_request(method, url, query_params, headers={}, data=fileobj_or_bytestring)
+        elif isinstance(fileobj_or_bytestring, str):
+            raise Exception('Expected bytes, got string')
         else:
-            self._upload_with_chunked_encoding(method, url, query_params, fileobj_or_string)
+            self._upload_with_chunked_encoding(method, url, query_params, fileobj_or_bytestring)
 
     @wrap_exception('Unable to start bundle in bundle service')
     def start_bundle(self, worker_id, uuid, request_data):

--- a/worker/codalabworker/docker_utils.py
+++ b/worker/codalabworker/docker_utils.py
@@ -216,6 +216,8 @@ def get_container_stats(container):
 def check_finished(container):
     # Unfortunately docker SDK doesn't update the status of Container objects
     # so we re-fetch them from the API again to get the most recent state
+    if container is None:
+        return (True, None, 'Docker container not found')
     container = client.containers.get(container.id)
     if container.status != 'running':
         # If the logs are nonempty, then something might have gone
@@ -223,6 +225,7 @@ def check_finished(container):
         # such as bash or cd.
         stderr = container.logs(stderr=True, stdout=False)
         # Strip non-ASCII chars since failure_message is not Unicode
+        # TODO: don't need to strip since we can support unicode?
         if len(stderr) > 0:
             failure_msg = stderr.decode('ascii', errors='ignore')
         else:

--- a/worker/codalabworker/file_util.py
+++ b/worker/codalabworker/file_util.py
@@ -181,7 +181,7 @@ def summarize_file(file_path, num_head_lines, num_tail_lines, max_line_length, t
     Summarizes the file at the given path, returning a string containing the
     given numbers of lines from beginning and end of the file. If the file needs
     to be truncated, places truncation_text at the truncation point.
-    Unlike other methods, this method treats everything as Unicodes string.
+    Unlike other methods, this method treats everything as a Unicode string.
     """
     assert num_head_lines > 0 or num_tail_lines > 0
 

--- a/worker/codalabworker/file_util.py
+++ b/worker/codalabworker/file_util.py
@@ -144,7 +144,7 @@ def un_gzip_stream(fileobj):
 
 def gzip_string(string):
     """
-    Gzips the given string.
+    Gzips the given string.  Return bytes.
     """
     with closing(BytesIO()) as output_fileobj:
         with gzip.GzipFile(None, 'wb', 6, output_fileobj) as fileobj:
@@ -154,7 +154,7 @@ def gzip_string(string):
 
 def un_gzip_string(bytestring):
     """
-    Gunzips the given bytestring.
+    Gunzips the given bytestring.  Return string.
 
     Raises an IOError if the archive is not valid.
     """
@@ -166,11 +166,12 @@ def un_gzip_string(bytestring):
 def read_file_section(file_path, offset, length):
     """
     Reads length bytes of the given file from the given offset.
+    Return bytes.
     """
     file_size = os.stat(file_path).st_size
     if offset >= file_size:
-        return ''
-    with open(file_path) as fileobj:
+        return b''
+    with open(file_path, 'rb') as fileobj:
         fileobj.seek(offset, os.SEEK_SET)
         return fileobj.read(length)
 
@@ -180,6 +181,7 @@ def summarize_file(file_path, num_head_lines, num_tail_lines, max_line_length, t
     Summarizes the file at the given path, returning a string containing the
     given numbers of lines from beginning and end of the file. If the file needs
     to be truncated, places truncation_text at the truncation point.
+    Unlike other methods, this method treats everything as Unicodes string.
     """
     assert num_head_lines > 0 or num_tail_lines > 0
 

--- a/worker/codalabworker/local_run/local_reader.py
+++ b/worker/codalabworker/local_run/local_reader.py
@@ -98,12 +98,12 @@ class LocalReader(Reader):
     def read_file_section(self, run_state, path, dep_paths, args, reply_fn):
         """
         Read the section of file at path of length args['length'] starting at
-        args['offset'] using a separate thread
+        args['offset'] (bytes) using a separate thread
         """
 
         def read_file_section_thread(final_path):
-            string = gzip_string(read_file_section(final_path, args['offset'], args['length']))
-            reply_fn(None, {}, string)
+            bytestring = gzip_string(read_file_section(final_path, args['offset'], args['length']))
+            reply_fn(None, {}, bytestring)
 
         self._threaded_read(run_state, path, read_file_section_thread, reply_fn)
 
@@ -115,7 +115,7 @@ class LocalReader(Reader):
         """
 
         def summarize_file_thread(final_path):
-            string = gzip_string(
+            bytestring = gzip_string(
                 summarize_file(
                     final_path,
                     args['num_head_lines'],
@@ -124,6 +124,6 @@ class LocalReader(Reader):
                     args['truncation_text'],
                 )
             )
-            reply_fn(None, {}, string)
+            reply_fn(None, {}, bytestring)
 
         self._threaded_read(run_state, path, summarize_file_thread, reply_fn)

--- a/worker/codalabworker/local_run/local_run_manager.py
+++ b/worker/codalabworker/local_run/local_run_manager.py
@@ -290,7 +290,7 @@ class LocalRunManager(BaseRunManager):
         )
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         s.connect((container_ip, port))
-        s.sendall(message)
+        s.sendall(message.encode())
 
         total_data = []
         while True:

--- a/worker/codalabworker/local_run/local_run_manager.py
+++ b/worker/codalabworker/local_run/local_run_manager.py
@@ -273,7 +273,7 @@ class LocalRunManager(BaseRunManager):
 
     def write(self, run_state, path, dep_paths, string):
         """
-        Write string to path in bundle with uuid
+        Write `string` (string) to path in bundle with uuid.
         """
         if os.path.normpath(path) in dep_paths:
             return
@@ -282,8 +282,8 @@ class LocalRunManager(BaseRunManager):
 
     def netcat(self, run_state, port, message, reply):
         """
-        Write message to port of bundle with uuid and read the response.
-        Returns a stream with the response contents
+        Write `message` (string) to port of bundle with uuid and read the response.
+        Returns a stream with the response contents (bytes).
         """
         container_ip = docker_utils.get_container_ip(
             self.worker_docker_network.name, run_state.container
@@ -299,7 +299,7 @@ class LocalRunManager(BaseRunManager):
                 break
             total_data.append(data)
         s.close()
-        reply(None, {}, b''.join(total_data).decode())
+        reply(None, {}, b''.join(total_data))
 
     def kill(self, run_state):
         """

--- a/worker/codalabworker/rest_client.py
+++ b/worker/codalabworker/rest_client.py
@@ -45,7 +45,7 @@ class RestClient(object):
         path,
         query_params=None,
         headers=None,
-        data=None,
+        data=None,  # Can be str or bytes
         return_response=False,
         authorized=True,
     ):

--- a/worker/codalabworker/rest_client.py
+++ b/worker/codalabworker/rest_client.py
@@ -45,33 +45,42 @@ class RestClient(object):
         path,
         query_params=None,
         headers=None,
-        data=None,  # Can be str or bytes
+        data=None,
         return_response=False,
         authorized=True,
     ):
+        """
+        `data` can be one of the following:
+        - bytes
+        - string (text/plain)
+        - dict (application/json)
+        """
+        # Set headers
         if headers is None:
             headers = {}
-
+        headers['X-Requested-With'] = 'XMLHttpRequest'
         access_token = self._get_access_token()
         if authorized and access_token:
             headers['Authorization'] = 'Bearer ' + self._get_access_token()
 
-        if data is not None and isinstance(data, dict):
+        if isinstance(data, dict):
             headers['Content-Type'] = 'application/json'
-            data = json.dumps(data)
-        headers['X-Requested-With'] = 'XMLHttpRequest'
-        if query_params is not None:
-            path = path + '?' + urllib.parse.urlencode(query_params)
-
-        # Everything needs to be utf-8 encoded or else urllib will complain
-        if 'Content-Type' in headers:
-            headers['Content-Type'] += '; charset=utf-8'
+            data = json.dumps(data)  # Turn dict into string
         if isinstance(data, str):
-            data = data.encode()
-        request_url = self._base_url + path
+            data = data.encode()  # Turn string into bytes
+
+        # Emphasize utf-8 for non-bytes data.
+        if headers.get('Content-Type') in ('text/plain', 'application/json'):
+            headers['Content-Type'] += '; charset=utf-8'
 
         headers.update(self._extra_headers)
 
+        # Set path
+        if query_params is not None:
+            path = path + '?' + urllib.parse.urlencode(query_params)
+        request_url = self._base_url + path
+
+        # Make the actual request
         request = urllib.request.Request(request_url, data=data, headers=headers)
         request.get_method = lambda: method
         if return_response:

--- a/worker/codalabworker/worker.py
+++ b/worker/codalabworker/worker.py
@@ -105,9 +105,7 @@ class Worker(object):
             elif action_type == 'read':
                 self._read(socket_id, response['uuid'], response['path'], response['read_args'])
             elif action_type == 'netcat':
-                self._netcat(
-                    socket_id, response['uuid'], response['port'], response['message']
-                )
+                self._netcat(socket_id, response['uuid'], response['port'], response['message'])
             elif action_type == 'write':
                 self._write(response['uuid'], response['subpath'], response['string'])
             elif action_type == 'kill':

--- a/worker/codalabworker/worker.py
+++ b/worker/codalabworker/worker.py
@@ -106,7 +106,7 @@ class Worker(object):
                 self._read(socket_id, response['uuid'], response['path'], response['read_args'])
             elif action_type == 'netcat':
                 self._netcat(
-                    socket_id, response['uuid'], response['port'], response['message'].encode()
+                    socket_id, response['uuid'], response['port'], response['message']
                 )
             elif action_type == 'write':
                 self._write(response['uuid'], response['subpath'], response['string'])


### PR DESCRIPTION
There were more inconsistencies around reading files from the worker.  With the exception of summarize_file, everything returned should be in terms of bytes (since we can have binary files).

The inputs to netcat/write are string's, which is not fully general, but good enough for now.