### PR TITLE
gzip should support taking bytes, not string; rename things

### DIFF
--- a/codalab/rest/interpret.py
+++ b/codalab/rest/interpret.py
@@ -265,7 +265,7 @@ def cat_target(target):
 MAX_BYTES_PER_LINE = 1024
 
 
-def head_target(target, max_num_lines, replace_non_unicode=False):
+def head_target(target, max_num_lines):
     """
     Return the first max_num_lines of target as a list of strings.
 
@@ -273,15 +273,12 @@ def head_target(target, max_num_lines, replace_non_unicode=False):
 
     :param target: (bundle_uuid, subpath)
     :param max_num_lines: max number of lines to fetch
-    :param replace_non_unicode: replace non-unicode characters with something printable
     """
     rest_util.check_target_has_read_permission(target)
+    # Note: summarize_file returns bytes, but should be decodable to a string.
     lines = local.download_manager.summarize_file(
         target[0], target[1], max_num_lines, 0, MAX_BYTES_PER_LINE, None, gzipped=False
-    ).splitlines(True)
-
-    if replace_non_unicode:
-        lines = list(map(formatting.verbose_contents_str, lines))
+    ).decode().splitlines(True)
 
     return lines
 
@@ -338,7 +335,6 @@ def resolve_interpreted_blocks(interpreted_blocks):
                                     block['target_genpath'],
                                 ),
                                 block['max_lines'],
-                                replace_non_unicode=True,
                             )
                         elif mode == BlockModes.image_block:
                             block['status']['code'] = FetchStatusCodes.ready
@@ -375,7 +371,7 @@ def resolve_interpreted_blocks(interpreted_blocks):
                     except NotFoundError as e:
                         continue
                     if target_info['type'] == 'file':
-                        contents = head_target(target, block['max_lines'], replace_non_unicode=True)
+                        contents = head_target(target, block['max_lines'])
                         # Assume TSV file without header for now, just return each line as a row
                         info['points'] = points = []
                         for line in contents:

--- a/codalab/rest/interpret.py
+++ b/codalab/rest/interpret.py
@@ -276,9 +276,13 @@ def head_target(target, max_num_lines):
     """
     rest_util.check_target_has_read_permission(target)
     # Note: summarize_file returns bytes, but should be decodable to a string.
-    lines = local.download_manager.summarize_file(
-        target[0], target[1], max_num_lines, 0, MAX_BYTES_PER_LINE, None, gzipped=False
-    ).decode().splitlines(True)
+    lines = (
+        local.download_manager.summarize_file(
+            target[0], target[1], max_num_lines, 0, MAX_BYTES_PER_LINE, None, gzipped=False
+        )
+        .decode()
+        .splitlines(True)
+    )
 
     return lines
 

--- a/tests/lib/upload_manager_test.py
+++ b/tests/lib/upload_manager_test.py
@@ -4,7 +4,7 @@ import tempfile
 import unittest
 
 from codalab.lib.upload_manager import UploadManager
-from codalabworker.file_util import gzip_string, remove_path, tar_gzip_directory
+from codalabworker.file_util import gzip_bytestring, remove_path, tar_gzip_directory
 
 
 class UploadManagerTest(unittest.TestCase):
@@ -69,7 +69,7 @@ class UploadManagerTest(unittest.TestCase):
 
     def test_single_local_gzip_path(self):
         source = os.path.join(self.temp_dir, 'filename.gz')
-        self.write_bytes_to_file(gzip_string('testing'), source)
+        self.write_bytes_to_file(gzip_bytestring(b'testing'), source)
         self.do_upload([source], unpack=True)
         self.assertTrue(os.path.exists(source))
         self.check_file_contains_string(self.bundle_location, 'testing')
@@ -93,7 +93,7 @@ class UploadManagerTest(unittest.TestCase):
 
     def test_single_local_gzip_path_remove_sources(self):
         source = os.path.join(self.temp_dir, 'filename.gz')
-        self.write_bytes_to_file(gzip_string('testing'), source)
+        self.write_bytes_to_file(gzip_bytestring(b'testing'), source)
         self.do_upload([source], remove_sources=True)
         self.assertFalse(os.path.exists(source))
 

--- a/tests/worker/file_util_test.py
+++ b/tests/worker/file_util_test.py
@@ -5,12 +5,12 @@ import bz2
 
 from codalabworker.file_util import (
     gzip_file,
-    gzip_string,
+    gzip_bytestring,
     remove_path,
     tar_gzip_directory,
     un_gzip_stream,
     un_bz2_file,
-    un_gzip_string,
+    un_gzip_bytestring,
     un_tar_directory,
 )
 
@@ -63,5 +63,5 @@ class FileUtilTest(unittest.TestCase):
         source_read.close()
         destination.close()
 
-    def test_gzip_string(self):
-        self.assertEqual(un_gzip_string(gzip_string('contents')), 'contents')
+    def test_gzip_bytestring(self):
+        self.assertEqual(un_gzip_bytestring(gzip_bytestring(b'contents')), b'contents')

--- a/worker/codalabworker/file_util.py
+++ b/worker/codalabworker/file_util.py
@@ -144,25 +144,24 @@ def un_gzip_stream(fileobj):
     return UnGzipStream(fileobj)
 
 
-def gzip_string(string):
+def gzip_bytestring(bytestring):
     """
-    Gzips the given string.  Return bytes.
+    Gzips the given bytestring.  Return bytes.
     """
     with closing(BytesIO()) as output_fileobj:
         with gzip.GzipFile(None, 'wb', 6, output_fileobj) as fileobj:
-            fileobj.write(string.encode())
+            fileobj.write(bytestring)
         return output_fileobj.getvalue()
 
 
-def un_gzip_string(bytestring):
+def un_gzip_bytestring(bytestring):
     """
-    Gunzips the given bytestring.  Return string.
-
+    Gunzips the given bytestring.  Return bytes.
     Raises an IOError if the archive is not valid.
     """
     with closing(BytesIO(bytestring)) as input_fileobj:
         with gzip.GzipFile(None, 'rb', fileobj=input_fileobj) as fileobj:
-            return fileobj.read().decode()
+            return fileobj.read()
 
 
 def read_file_section(file_path, offset, length):
@@ -183,7 +182,7 @@ def summarize_file(file_path, num_head_lines, num_tail_lines, max_line_length, t
     Summarizes the file at the given path, returning a string containing the
     given numbers of lines from beginning and end of the file. If the file needs
     to be truncated, places truncation_text at the truncation point.
-    Unlike other methods, this method treats everything as a Unicode string.
+    Unlike other methods, which traffic bytes, this method returns a string.
     """
     assert num_head_lines > 0 or num_tail_lines > 0
 

--- a/worker/codalabworker/local_run/local_reader.py
+++ b/worker/codalabworker/local_run/local_reader.py
@@ -124,7 +124,7 @@ class LocalReader(Reader):
                     args['num_tail_lines'],
                     args['max_line_length'],
                     args['truncation_text'],
-                )
+                ).encode()
             )
             reply_fn(None, {}, bytestring)
 

--- a/worker/codalabworker/local_run/local_reader.py
+++ b/worker/codalabworker/local_run/local_reader.py
@@ -8,7 +8,7 @@ import codalabworker.download_util as download_util
 from codalabworker.download_util import get_target_path, PathException
 from codalabworker.file_util import (
     gzip_file,
-    gzip_string,
+    gzip_bytestring,
     read_file_section,
     summarize_file,
     tar_gzip_directory,
@@ -102,7 +102,7 @@ class LocalReader(Reader):
         """
 
         def read_file_section_thread(final_path):
-            bytestring = gzip_string(read_file_section(final_path, args['offset'], args['length']))
+            bytestring = gzip_bytestring(read_file_section(final_path, args['offset'], args['length']))
             reply_fn(None, {}, bytestring)
 
         self._threaded_read(run_state, path, read_file_section_thread, reply_fn)
@@ -115,7 +115,7 @@ class LocalReader(Reader):
         """
 
         def summarize_file_thread(final_path):
-            bytestring = gzip_string(
+            bytestring = gzip_bytestring(
                 summarize_file(
                     final_path,
                     args['num_head_lines'],

--- a/worker/codalabworker/local_run/local_reader.py
+++ b/worker/codalabworker/local_run/local_reader.py
@@ -102,7 +102,9 @@ class LocalReader(Reader):
         """
 
         def read_file_section_thread(final_path):
-            bytestring = gzip_bytestring(read_file_section(final_path, args['offset'], args['length']))
+            bytestring = gzip_bytestring(
+                read_file_section(final_path, args['offset'], args['length'])
+            )
             reply_fn(None, {}, bytestring)
 
         self._threaded_read(run_state, path, read_file_section_thread, reply_fn)


### PR DESCRIPTION
Don't assume input to gzip is a string.  Should be bytestring.  Also, rename from `string` to `bytestring` in a lot of places to avoid confusion.