### PR TITLE
mapping port to 80 in nginx service

### DIFF
--- a/docker/compose_files/docker-compose.yml
+++ b/docker/compose_files/docker-compose.yml
@@ -72,7 +72,7 @@ services:
     <<: *codalab-base
     <<: *codalab-root
     ports:
-      - ${CODALAB_HTTP_PORT}:${CODALAB_HTTP_PORT}
+      - ${CODALAB_HTTP_PORT}:80
     volumes:
       - ./files/nginx.conf:/etc/nginx/nginx.conf:ro
 


### PR DESCRIPTION
In nginx service, `CODALAB_HTTP_PORT` is mapped to `CODALAB_HTTP_PORT`. However, nginx always listens to port 80 according to [nginx.conf](https://github.com/codalab/codalab-worksheets/blob/master/docker/compose_files/files/nginx.conf#L74). This will be a problem when `CODALAB_HTTP_PORT` is not set to 80.