### PR TITLE
Flush username prompt when authenticating

### DIFF
--- a/codalab/lib/codalab_manager.py
+++ b/codalab/lib/codalab_manager.py
@@ -491,6 +491,7 @@ class CodaLabManager(object):
             print('Requesting access at %s' % cache_key)
         if username is None:
             sys.stdout.write('Username: ')  # Use write to avoid extra space
+            sys.stdout.flush()
             username = sys.stdin.readline().rstrip()
         if password is None:
             password = getpass.getpass()


### PR DESCRIPTION
On my machine, when I run `cl work`, I see:

```
$ cl work
Requesting access at https://worksheets.codalab.org

```

Note that the "username" prompt that usually appears is not there.

After hitting ctrl-c, it shows up.

```
$ cl work
Requesting access at https://worksheets.codalab.org
^CUsername: Terminated by Ctrl-C
```

(I can still authenticate by typing my username into the void)

Seems like its reading the username properly, the text just isn't being immediately flushed because of `sys.stdout.write`'s buffering.