### PR TITLE
Properly redirect http to https

### DIFF
--- a/docker/compose_files/files/nginx.conf.ssl
+++ b/docker/compose_files/files/nginx.conf.ssl
@@ -70,10 +70,9 @@ http {
 
   # Redirects all http traffic to https.
   server {	
-    listen 80;	
-    server_name 127.0.0.1 localhost;	
+    listen 80;		
     location / {	
-      rewrite ^ https://$server_name$request_uri permanent;	
+      rewrite ^ https://$host$request_uri permanent;	
     }	
   }
 


### PR DESCRIPTION
Fixes #1366.

Can't use $server_name because it ends up redirecting to 127.0.0.1. Instead, using $host will redirect the site to the appropriate host.