### PR TITLE
Frontend - fix crashing when selecting rows

### DIFF
--- a/frontend/src/components/worksheets/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet.js
@@ -196,7 +196,6 @@ class Worksheet extends React.Component {
                 pos = -1000000; // Scroll all the way to the top
             } else {
                 var item = this.refs.list.refs['item' + index];
-                if (this._numTableRows(item.props.item) !== null) item = item.refs['row' + subIndex]; // Specifically, the row
                 var node = ReactDOM.findDOMNode(item);
                 pos = node.getBoundingClientRect().top;
             }

--- a/frontend/src/components/worksheets/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet.js
@@ -196,6 +196,9 @@ class Worksheet extends React.Component {
                 pos = -1000000; // Scroll all the way to the top
             } else {
                 var item = this.refs.list.refs['item' + index];
+                if (this._numTableRows(item.props.item)) {
+                    item = item.refs['row' + subIndex]; // Specifically, the row
+                }
                 var node = ReactDOM.findDOMNode(item);
                 pos = node.getBoundingClientRect().top;
             }


### PR DESCRIPTION
The issue was that the condition used to say `this._numTableRows(item.props.item) != null`, but I changed it to `this._numTableRows(item.props.item) !== null` to fix lint issues.

However, this meant that when `this._numTableRows(item.props.item)` is equal to undefined, it would end up evaluating the if statement when it wasn't actually supposed to.