### PR TITLE
Re-add travis-deploy.sh

### DIFF
--- a/scripts/travis-deploy.sh
+++ b/scripts/travis-deploy.sh
@@ -9,8 +9,8 @@
 
 tag=$1
 
-python3.6 codalab_service.py build --version $tag --pull --push
+python3 codalab_service.py build --version $tag --pull --push
 if [ "$tag" != "master" ]; then
-  python3.6 codalab_service.py build --version latest --pull --push
+  python3 codalab_service.py build --version latest --pull --push
   ./scripts/upload-to-pypi.sh $tag
 fi

--- a/scripts/travis-deploy.sh
+++ b/scripts/travis-deploy.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Called by Travis CI at the end of a successful build to do necessary
+# deployment actions like building and pushing docker images and PyPI
+# packages.  The two possibilities are:
+#
+#   travis-deploy.sh master
+#   travis-deploy.sh 0.3.3   (for releases)
+
+tag=$1
+
+python3.6 codalab_service.py build --version $tag --pull --push
+if [ "$tag" != "master" ]; then
+  python3.6 codalab_service.py build --version latest --pull --push
+  ./scripts/upload-to-pypi.sh $tag
+fi


### PR DESCRIPTION
Somehow it was removed in #1014; that's probably why 0.4.1 wasn't
automatically deployed to pypi.