### PR TITLE
Name bundle containers by the UUIDs

### DIFF
--- a/codalab/worker/docker_utils.py
+++ b/codalab/worker/docker_utils.py
@@ -141,9 +141,11 @@ def start_bundle_container(
         # nvidia-docker runtime uses this env variable to allocate GPUs
         environment['NVIDIA_VISIBLE_DEVICES'] = ','.join(gpuset) if gpuset else 'all'
 
+    # Name the container same as the UUID to avoid network name clashes
     container = client.containers.run(
         image=docker_image,
         command=docker_command,
+        name=uuid,
         network=network,
         mem_limit=memory_bytes,
         cpuset_cpus=cpuset_str,

--- a/codalab/worker/docker_utils.py
+++ b/codalab/worker/docker_utils.py
@@ -141,11 +141,12 @@ def start_bundle_container(
         # nvidia-docker runtime uses this env variable to allocate GPUs
         environment['NVIDIA_VISIBLE_DEVICES'] = ','.join(gpuset) if gpuset else 'all'
 
-    # Name the container same as the UUID to avoid network name clashes
+    # Name the container with the UUID for readability
+    container_name = 'codalab_run_%s' % uuid
     container = client.containers.run(
         image=docker_image,
         command=docker_command,
-        name=uuid,
+        name=container_name,
         network=network,
         mem_limit=memory_bytes,
         cpuset_cpus=cpuset_str,


### PR DESCRIPTION
This hopefully helps avoid name clashes and will help us better debug
the issue that sometimes happens on the workers. Also good for general
transparency