### PR TITLE
Fix size parameters for display image

### DIFF
--- a/frontend/src/components/worksheets/items/ImageItem.js
+++ b/frontend/src/components/worksheets/items/ImageItem.js
@@ -22,12 +22,11 @@ class ImageItem extends React.Component {
         var src = 'data:image/png;base64,' + this.props.item.image_data;
         var styles = {};
         if (this.props.item.hasOwnProperty('height')) {
-            styles['height'] = this.props.item.height + 'px;';
+            styles['height'] = this.props.item.height + 'px';
         }
         if (this.props.item.hasOwnProperty('width')) {
-            styles['width'] = this.props.item.width + 'px;';
+            styles['width'] = this.props.item.width + 'px';
         }
-
         return (
             <div className='ws-item' onClick={this.handleClick}>
                 <div className={className} ref={this.props.item.ref}>

--- a/frontend/src/components/worksheets/items/ImageItem.js
+++ b/frontend/src/components/worksheets/items/ImageItem.js
@@ -27,6 +27,7 @@ class ImageItem extends React.Component {
         if (this.props.item.hasOwnProperty('width')) {
             styles['width'] = this.props.item.width + 'px';
         }
+        
         return (
             <div className='ws-item' onClick={this.handleClick}>
                 <div className={className} ref={this.props.item.ref}>


### PR DESCRIPTION
Fixing #1342 When passing a dictionary for the styles, the character ; is not needed like in hard coding strings. Changing the height and width parameters now work
![display-200-200-cmd](https://user-images.githubusercontent.com/23012631/65932395-63db7c80-e3c2-11e9-9ed8-48f285897de9.png)
![display-200-200-image](https://user-images.githubusercontent.com/23012631/65932397-63db7c80-e3c2-11e9-8fe2-abce4b1687a3.png)
![display-400-400-cmd](https://user-images.githubusercontent.com/23012631/65932399-64741300-e3c2-11e9-8614-ff75b218a4ca.png)
![display-400-400-image](https://user-images.githubusercontent.com/23012631/65932400-64741300-e3c2-11e9-9ffc-96fb14849014.png)

