### PR TITLE
Remove the unused waiting_for_worker_startup state

### DIFF
--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -643,26 +643,6 @@ class BundleModel(object):
         ]
         return bundles
 
-    def set_waiting_for_worker_startup_bundle(self, bundle, job_handle):
-        """
-        Sets the bundle to WAITING_FOR_WORKER_STARTUP, updating the job_handle
-        and last_updated metadata.
-        """
-        with self.engine.begin() as connection:
-            # Check that it still exists.
-            row = connection.execute(
-                cl_bundle.select().where(cl_bundle.c.id == bundle.id)
-            ).fetchone()
-            if not row:
-                # The user deleted the bundle.
-                return
-
-            bundle_update = {
-                'state': State.WAITING_FOR_WORKER_STARTUP,
-                'metadata': {'job_handle': job_handle, 'last_updated': int(time.time())},
-            }
-            self.update_bundle(bundle, bundle_update, connection)
-
     def set_starting_bundle(self, bundle, user_id, worker_id):
         """
         Sets the bundle to STARTING, updating the last_updated metadata. Adds

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -746,9 +746,9 @@ class BundleModel(object):
         return True
 
     def bundle_checkin(self, bundle, bundle_update, user_id, worker_id):
-        '''
+        """
         Updates the database tables with the most recent bundle information from worker
-        '''
+        """
         state = bundle_update['state']
         with self.engine.begin() as connection:
             # If bundle isn't in db anymore the user deleted it so cancel
@@ -777,9 +777,9 @@ class BundleModel(object):
                 return False
 
     def resume_bundle(self, bundle, bundle_update, row, user_id, worker_id, connection):
-        '''
+        """
         Marks the bundle as running. If bundle was WORKER_OFFLINE, also inserts a row into worker_run.
-        '''
+        """
         if row.state == State.WORKER_OFFLINE:
             run_row = connection.execute(
                 cl_worker_run.select().where(cl_worker_run.c.run_uuid == bundle.uuid)
@@ -840,10 +840,10 @@ class BundleModel(object):
         return True
 
     def finish_bundle(self, bundle):
-        '''
+        """
         Updates the given FINALIZING bundle to FINISHED state so the server stops
         telling the worker it is finalized
-        '''
+        """
         metadata = bundle.metadata.to_dict()
         failure_message = metadata.get('failure_message', None)
         exitcode = metadata.get('exitcode', 0)
@@ -1959,13 +1959,13 @@ class BundleModel(object):
         return user_id, verification_key
 
     def delete_user(self, user_id=None):
-        '''
+        """
         Delete the user with the given uuid.
         Delete all items in the database with a
         foreign key that references the user.
 
         :param user_id: id of user to delete
-        '''
+        """
         with self.engine.begin() as connection:
 
             # User verification

--- a/codalab/objects/home.ws
+++ b/codalab/objects/home.ws
@@ -3,7 +3,7 @@ bundles and worksheets in the system.
 
 ## **Pending bundles**
 % display table run owner:owner_name
-% search state=created,staged,making,waiting_for_worker_startup,starting,running id=.sort- .limit=10000
+% search state=created,staged,making,starting,running id=.sort- .limit=10000
 % search id=.sort- .limit=10
 
 ## **Recent bundles**

--- a/codalab/worker/bundle_state.py
+++ b/codalab/worker/bundle_state.py
@@ -28,16 +28,6 @@ class State(object):
     # Assigned worker has gone offline
     WORKER_OFFLINE = 'worker_offline'
 
-    OPTIONS = {
-        CREATED,
-        STAGED,
-        MAKING,
-        STARTING,
-        RUNNING,
-        READY,
-        FAILED,
-        PREPARING,
-        FINALIZING,
-    }
+    OPTIONS = {CREATED, STAGED, MAKING, STARTING, RUNNING, READY, FAILED, PREPARING, FINALIZING}
     ACTIVE_STATES = {MAKING, STARTING, RUNNING, FINALIZING, PREPARING}
     FINAL_STATES = {READY, FAILED, KILLED}

--- a/codalab/worker/bundle_state.py
+++ b/codalab/worker/bundle_state.py
@@ -11,8 +11,6 @@ class State(object):
     STAGED = 'staged'
     # Creating a make bundle.
     MAKING = 'making'
-    # Waiting for the worker to start up.
-    WAITING_FOR_WORKER_STARTUP = 'waiting_for_worker_startup'
     # Wait for the worker to start running the bundle.
     STARTING = 'starting'
     # Wait for worker to download dependencies and docker images
@@ -34,7 +32,6 @@ class State(object):
         CREATED,
         STAGED,
         MAKING,
-        WAITING_FOR_WORKER_STARTUP,
         STARTING,
         RUNNING,
         READY,
@@ -42,5 +39,5 @@ class State(object):
         PREPARING,
         FINALIZING,
     }
-    ACTIVE_STATES = {MAKING, WAITING_FOR_WORKER_STARTUP, STARTING, RUNNING, FINALIZING, PREPARING}
+    ACTIVE_STATES = {MAKING, STARTING, RUNNING, FINALIZING, PREPARING}
     FINAL_STATES = {READY, FAILED, KILLED}


### PR DESCRIPTION
This is a bundle state that exists in the codebase, but is not ever
used. In fact the method that sets the budle to be in that state is not
even called once in our codebase, so we can safely remove it for a bit
of simplification. This is part of my effort to break up and extract the
good parts of #983