### PR TITLE
When a item is selected, the highlight color now occupies whole row

### DIFF
--- a/frontend/src/css/imports.css
+++ b/frontend/src/css/imports.css
@@ -7105,6 +7105,7 @@ fieldset[disabled] .worksheet_content .header-row .controls .edit-features .btn-
   background-color: #e2f0f5;
   border-left: #1d91c0 solid 3px;
   padding-left: 4px;
+  width:100%;
 }
 .worksheet_content.editable .ws-item {
   margin-left: 24px;

--- a/frontend/src/css/imports.css
+++ b/frontend/src/css/imports.css
@@ -7105,7 +7105,7 @@ fieldset[disabled] .worksheet_content .header-row .controls .edit-features .btn-
   background-color: #e2f0f5;
   border-left: #1d91c0 solid 3px;
   padding-left: 4px;
-  width:100%;
+  width: 100%;
 }
 .worksheet_content.editable .ws-item {
   margin-left: 24px;


### PR DESCRIPTION
Fix #1459 

To test: checkout to this branch and select any block

![highlight-example2](https://user-images.githubusercontent.com/23012631/66105075-4bf52b80-e56f-11e9-8cb0-ec46fc6325ce.png)
![hightlight-example](https://user-images.githubusercontent.com/23012631/66105076-4bf52b80-e56f-11e9-9074-39860bb8ef63.png)
