### PR TITLE
Remove the unused worker/update_bundle_metadata API endpoint and methods

### DIFF
--- a/codalab/rest/workers.py
+++ b/codalab/rest/workers.py
@@ -133,37 +133,6 @@ def start_bundle(worker_id, uuid):
     return json.dumps(False)
 
 
-@put(
-    "/workers/<worker_id>/update_bundle_metadata/<uuid:re:%s>" % spec_util.UUID_STR,
-    name="worker_update_bundle_metadata",
-    apply=AuthenticatedPlugin(),
-)
-def update_bundle_metadata(worker_id, uuid):
-    """
-    Updates metadata related to a running bundle.
-    """
-    bundle = local.model.get_bundle(uuid)
-    check_run_permission(bundle)
-    allowed_keys = set(
-        [
-            "run_status",
-            "time",
-            "time_user",
-            "time_system",
-            "memory",
-            "memory_max",
-            "data_size",
-            "last_updated",
-            "docker_image",
-        ]
-    )
-    metadata_update = {}
-    for key, value in request.json.items():
-        if key in allowed_keys:
-            metadata_update[key] = value
-    local.model.update_bundle(bundle, {"metadata": metadata_update})
-
-
 @get("/workers/info", name="workers_info", apply=AuthenticatedPlugin())
 def workers_info():
     if request.user.user_id != local.model.root_user_id:

--- a/docs/REST-API-Reference.md
+++ b/docs/REST-API-Reference.md
@@ -751,10 +751,6 @@ Checks whether the bundle is still assigned to run on the worker with the
 given worker_id. If so, reports that it's starting to run and returns True.
 Otherwise, returns False, meaning the worker shouldn't run the bundle.
 
-### `PUT /workers/<worker_id>/update_bundle_metadata/<uuid:re:0x[0-9a-f]{32}>`
-
-Updates metadata related to a running bundle.
-
 ### `GET /workers/info`
 
 &uarr; [Back to Top](#table-of-contents)


### PR DESCRIPTION
Part of the effort to break up #983 and get the good parts out.
This API endpoint is not used in our codebase at all, and would be good to get rid of while it is unused and there's no clear need for it.