### PR TITLE
Add expand button to control bundle row detail showing

### DIFF
--- a/frontend/src/components/worksheets/items/TableItem/BundleRow.js
+++ b/frontend/src/components/worksheets/items/TableItem/BundleRow.js
@@ -216,9 +216,9 @@ class BundleRow extends Component {
             }
             if (url)
                 rowContent = (
-                        <a href={url} className='bundle-link' target='_blank' style={{ display: 'inline-block', width: 60 }}>
-                            {rowContent}
-                        </a>
+                    <a href={url} className='bundle-link' target='_blank' style={{ display: 'inline-block', width: 60 }}>
+                        {rowContent}
+                    </a>
                 );
             // else rowContent = rowContent + '';
 

--- a/frontend/src/components/worksheets/items/TableItem/BundleRow.js
+++ b/frontend/src/components/worksheets/items/TableItem/BundleRow.js
@@ -228,7 +228,7 @@ class BundleRow extends Component {
                     classes={{
                         root: classes.root,
                     }}
-                >                       
+                >
                     {rowContent}
                     {showDetailButton}
                 </TableCell>

--- a/frontend/src/components/worksheets/items/TableItem/BundleRow.js
+++ b/frontend/src/components/worksheets/items/TableItem/BundleRow.js
@@ -11,6 +11,7 @@ import Paper from '@material-ui/core/Paper';
 import Typography from '@material-ui/core/Typography';
 
 import DeleteIcon from '@material-ui/icons/Delete';
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import UploadIcon from '@material-ui/icons/CloudUpload';
 import AddIcon from '@material-ui/icons/PlayCircleFilled';
 
@@ -87,13 +88,16 @@ class BundleRow extends Component {
         this.setState({ bundleInfoUpdates });
     };
 
-    handleClick = () => {
-        this.props.updateRowIndex(this.props.rowIndex);
+    handleDetailClick = () => {
         const { showDetail } = this.state;
         this.setState({
             showDetail: !showDetail,
         });
     };
+
+    handleSelectRowClick = () => {
+        this.props.updateRowIndex(this.props.rowIndex);
+    }
 
     showNewUpload = (val) => () => {
         this.setState({ showNewUpload: val });
@@ -300,7 +304,7 @@ class BundleRow extends Component {
                   */}
                 <TableRow
                     hover
-                    onClick={this.handleClick}
+                    onClick={this.handleSelectRowClick}
                     onContextMenu={this.props.handleContextMenu.bind(
                         null,
                         bundleInfo.uuid,
@@ -315,6 +319,9 @@ class BundleRow extends Component {
                         [classes.lowlight]: !this.props.focused && this.state.showDetail,
                     })}
                 >
+                    <IconButton onClick={this.handleDetailClick}>                    
+                        <ExpandMoreIcon />
+                    </IconButton>
                     {rowCells}
                 </TableRow>
                 {/** ---------------------------------------------------------------------------------------------------

--- a/frontend/src/components/worksheets/items/TableItem/BundleRow.js
+++ b/frontend/src/components/worksheets/items/TableItem/BundleRow.js
@@ -12,6 +12,7 @@ import Typography from '@material-ui/core/Typography';
 
 import DeleteIcon from '@material-ui/icons/Delete';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import ExpandLessIcon from '@material-ui/icons/ExpandLess';
 import UploadIcon from '@material-ui/icons/CloudUpload';
 import AddIcon from '@material-ui/icons/PlayCircleFilled';
 
@@ -189,13 +190,20 @@ class BundleRow extends Component {
         var baseUrl = this.props.url;
         var uuid = this.props.uuid;
         var columnWithHyperlinks = this.props.columnWithHyperlinks;
-        var rowCells = this.props.headerItems.map(function(headerKey, col) {
+        var rowCells = this.props.headerItems.map((headerKey, col) => {
             var rowContent = rowItems[headerKey];
 
             // See if there's a link
             var url;
+            var showDetailButton;
             if (col === 0) {
                 url = baseUrl;
+                showDetailButton = 
+                        <IconButton onClick={this.handleDetailClick}>
+                            {this.state.showDetail?
+                            <ExpandLessIcon/>:
+                            <ExpandMoreIcon/>}
+                        </IconButton>;
             } else if (columnWithHyperlinks.indexOf(headerKey) !== -1) {
                 url = '/rest/bundles/' + uuid + '/contents/blob' + rowContent['path'];
                 if ('text' in rowContent) {
@@ -208,9 +216,9 @@ class BundleRow extends Component {
             }
             if (url)
                 rowContent = (
-                    <a href={url} className='bundle-link' target='_blank'>
-                        {rowContent}
-                    </a>
+                        <a href={url} className='bundle-link' target='_blank' style={{ display: 'inline-block', width: 60 }}>
+                            {rowContent}
+                        </a>
                 );
             // else rowContent = rowContent + '';
 
@@ -220,8 +228,9 @@ class BundleRow extends Component {
                     classes={{
                         root: classes.root,
                     }}
-                >
+                >                       
                     {rowContent}
+                    {showDetailButton}
                 </TableCell>
             );
         });
@@ -319,9 +328,6 @@ class BundleRow extends Component {
                         [classes.lowlight]: !this.props.focused && this.state.showDetail,
                     })}
                 >
-                    <IconButton onClick={this.handleDetailClick}>                    
-                        <ExpandMoreIcon />
-                    </IconButton>
                     {rowCells}
                 </TableRow>
                 {/** ---------------------------------------------------------------------------------------------------

--- a/frontend/src/components/worksheets/items/TableItem/BundleRow.js
+++ b/frontend/src/components/worksheets/items/TableItem/BundleRow.js
@@ -229,8 +229,8 @@ class BundleRow extends Component {
                         root: classes.root,
                     }}
                 >
-                    {rowContent}
                     {showDetailButton}
+                    {rowContent}
                 </TableCell>
             );
         });

--- a/frontend/src/components/worksheets/items/TableItem/TableItem.js
+++ b/frontend/src/components/worksheets/items/TableItem/TableItem.js
@@ -49,8 +49,13 @@ class TableItem extends React.Component<{
         var bundleInfos = item.bundles_spec.bundle_infos;
         var headerItems = item.header;
         var headerHtml = headerItems.map(function(item, index) {
+            let styleDict;
+            console.log('index', index)
+            if (index == 0){
+                styleDict = {paddingLeft: 42}; 
+            }
             return (
-                <TableCell component='th' key={index}>
+                <TableCell component='th' key={index} style={ styleDict }>
                     {item}
                 </TableCell>
             );

--- a/frontend/src/components/worksheets/items/TableItem/TableItem.js
+++ b/frontend/src/components/worksheets/items/TableItem/TableItem.js
@@ -50,7 +50,6 @@ class TableItem extends React.Component<{
         var headerItems = item.header;
         var headerHtml = headerItems.map(function(item, index) {
             let styleDict;
-            console.log('index', index)
             if (index == 0){
                 styleDict = {paddingLeft: 42}; 
             }

--- a/frontend/src/components/worksheets/items/TableItem/TableItem.js
+++ b/frontend/src/components/worksheets/items/TableItem/TableItem.js
@@ -49,10 +49,7 @@ class TableItem extends React.Component<{
         var bundleInfos = item.bundles_spec.bundle_infos;
         var headerItems = item.header;
         var headerHtml = headerItems.map(function(item, index) {
-            let styleDict;
-            if (index == 0){
-                styleDict = {paddingLeft: 42}; 
-            }
+            let styleDict = index == 0 ?  {paddingLeft: 42} : {};
             return (
                 <TableCell component='th' key={index} style={ styleDict }>
                     {item}


### PR DESCRIPTION
Implementing #1272 
1. Clicking on a bundle row highlights the row but doesn't expand automatically
2. Clicking on the expand button highlights the row and expands the detail
3. Icon switches between expand more & expand less
![Screenshot from 2019-10-05 02-23-47](https://user-images.githubusercontent.com/23012631/66253018-36bb0100-e717-11e9-8edc-99ef4aec54e8.png)
![Screenshot from 2019-10-05 02-23-51](https://user-images.githubusercontent.com/23012631/66253020-37539780-e717-11e9-9a19-4dcfad77ab91.png)
![Screenshot from 2019-10-05 02-23-54](https://user-images.githubusercontent.com/23012631/66253021-37539780-e717-11e9-8fd7-15506a0a00ae.png)

Should use () => {} than function(){} for class methods, the later doesn't bind this to the class
