### PR TITLE
Change display of run time for bundles

### DIFF
--- a/frontend/src/components/worksheets/BundleDetail/MainContent.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/MainContent.jsx
@@ -7,6 +7,7 @@ import Grid from '@material-ui/core/Grid';
 import { withStyles } from '@material-ui/core/styles';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
 import AccessTimeIcon from '@material-ui/icons/AccessTime';
+import {renderDuration} from '../../../util/worksheet_utils';
 
 import { FileBrowserLite } from '../../FileBrowser';
 
@@ -37,17 +38,8 @@ class MainContent extends React.Component<
             //undefined
             bundleRunTime = '-- --';
         }
-        else if (bundleInfo.metadata.time > 1){
-            //more than a second display in hh:mm:ss
-            let date = new Date(null);
-            date.setSeconds(bundleInfo.metadata.time);
-            bundleRunTime = date.toISOString().substr(11, 8);
-        }
-        else{
-            //less than a second display
-            bundleRunTime = bundleInfo.metadata.time < 0.00001 
-                            ? '< 0.00001s' 
-                            : bundleInfo.metadata.time.toFix(5) + 's'; 
+        else {
+            bundleRunTime = renderDuration(bundleInfo.metadata.time);
         }
 
 		return (

--- a/frontend/src/components/worksheets/BundleDetail/MainContent.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/MainContent.jsx
@@ -32,15 +32,11 @@ class MainContent extends React.Component<
 		const stateSpecClass = bundleInfo.state === 'failed'
             ? 'failedState'
             : (bundleInfo.state === 'ready' ? 'readyState' : 'otherState');
+        
         //Get the correct run time display
-        let bundleRunTime;
-        if (!bundleInfo.metadata.time){
-            //undefined
-            bundleRunTime = '-- --';
-        }
-        else {
-            bundleRunTime = renderDuration(bundleInfo.metadata.time);
-        }
+        const bundleRunTime = bundleInfo.metadata.time
+                                ? renderDuration(bundleInfo.metadata.time)
+                                : "-- --";
 
 		return (
             <div className={ classes.outter }>

--- a/frontend/src/components/worksheets/BundleDetail/MainContent.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/MainContent.jsx
@@ -32,7 +32,7 @@ class MainContent extends React.Component<
 		const stateSpecClass = bundleInfo.state === 'failed'
             ? 'failedState'
             : (bundleInfo.state === 'ready' ? 'readyState' : 'otherState');
-        //Get the correct run time display, truncate to 5 decimals
+        //Get the correct run time display
         let bundleRunTime;
         if (!bundleInfo.metadata.time){
             //undefined

--- a/frontend/src/components/worksheets/BundleDetail/MainContent.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/MainContent.jsx
@@ -6,6 +6,7 @@ import Tooltip from '@material-ui/core/Tooltip';
 import Grid from '@material-ui/core/Grid';
 import { withStyles } from '@material-ui/core/styles';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
+import AccessTimeIcon from '@material-ui/icons/AccessTime';
 
 import { FileBrowserLite } from '../../FileBrowser';
 
@@ -30,7 +31,15 @@ class MainContent extends React.Component<
 		const stateSpecClass = bundleInfo.state === 'failed'
             ? 'failedState'
             : (bundleInfo.state === 'ready' ? 'readyState' : 'otherState');
-		
+        //Get the correct run time display, truncate to 5 decimals
+        let bundleRunTime;
+        if (bundleInfo.metadata.time){
+            bundleRunTime = bundleInfo.metadata.time < 0.00001? '< 0.00001s' : bundleInfo.metadata.time.toFixed(5) + 's';
+        }
+        else{
+            bundleRunTime = '-- --';
+        }
+
 		return (
             <div className={ classes.outter }>
                 <div className={ `${ classes.stateBox } ${ classes[stateSpecClass] }`}>
@@ -38,13 +47,6 @@ class MainContent extends React.Component<
                 </div>
     			<Grid container classes={ { container: classes.container } } spacing={16}>
                     { /** Run bundle specific components =========================================================== */}
-                    { isRunBundle &&
-                        <Grid item xs={12} md="auto">
-                            <Typography variant="body1">
-                                run time: { bundleInfo.metadata.time || '-- --' }
-                            </Typography>
-                        </Grid>
-                    }
                     { isRunBundle &&
                         <Grid item xs={12}>  
                             <CopyToClipboard
@@ -61,6 +63,18 @@ class MainContent extends React.Component<
                                     </Tooltip>
                                 </div>
                             </CopyToClipboard>
+                        </Grid>
+                    }
+                    { isRunBundle &&
+                        <Grid container xs={12} md="auto" direction="row" justify='flex-end' style={{marginRight: 10}}>
+                            <Grid item style={{ marginRight: 2 }}>
+                                <AccessTimeIcon/>
+                            </Grid>
+                            <Grid item>
+                                <Typography variant="body1">
+                                    run time: { bundleRunTime }
+                                </Typography>
+                            </Grid>
                         </Grid>
                     }
                     { /** Stdout/stderr components ================================================================= */}

--- a/frontend/src/components/worksheets/BundleDetail/MainContent.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/MainContent.jsx
@@ -33,11 +33,21 @@ class MainContent extends React.Component<
             : (bundleInfo.state === 'ready' ? 'readyState' : 'otherState');
         //Get the correct run time display, truncate to 5 decimals
         let bundleRunTime;
-        if (bundleInfo.metadata.time){
-            bundleRunTime = bundleInfo.metadata.time < 0.00001? '< 0.00001s' : bundleInfo.metadata.time.toFixed(5) + 's';
+        if (!bundleInfo.metadata.time){
+            //undefined
+            bundleRunTime = '-- --';
+        }
+        else if (bundleInfo.metadata.time > 1){
+            //more than a second display in hh:mm:ss
+            let date = new Date(null);
+            date.setSeconds(bundleInfo.metadata.time);
+            bundleRunTime = date.toISOString().substr(11, 8);
         }
         else{
-            bundleRunTime = '-- --';
+            //less than a second display
+            bundleRunTime = bundleInfo.metadata.time < 0.00001 
+                            ? '< 0.00001s' 
+                            : bundleInfo.metadata.time.toFix(5) + 's'; 
         }
 
 		return (

--- a/frontend/src/components/worksheets/BundleDetail/MainContent.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/MainContent.jsx
@@ -35,8 +35,8 @@ class MainContent extends React.Component<
         
         //Get the correct run time display
         const bundleRunTime = bundleInfo.metadata.time
-                                ? renderDuration(bundleInfo.metadata.time)
-                                : "-- --";
+            ? renderDuration(bundleInfo.metadata.time)
+            : "-- --";
 
 		return (
             <div className={ classes.outter }>

--- a/frontend/src/components/worksheets/items/TableItem/BundleRow.js
+++ b/frontend/src/components/worksheets/items/TableItem/BundleRow.js
@@ -11,6 +11,8 @@ import Paper from '@material-ui/core/Paper';
 import Typography from '@material-ui/core/Typography';
 
 import DeleteIcon from '@material-ui/icons/Delete';
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import ExpandLessIcon from '@material-ui/icons/ExpandLess';
 import UploadIcon from '@material-ui/icons/CloudUpload';
 import AddIcon from '@material-ui/icons/PlayCircleFilled';
 
@@ -87,13 +89,16 @@ class BundleRow extends Component {
         this.setState({ bundleInfoUpdates });
     };
 
-    handleClick = () => {
-        this.props.updateRowIndex(this.props.rowIndex);
+    handleDetailClick = () => {
         const { showDetail } = this.state;
         this.setState({
             showDetail: !showDetail,
         });
     };
+
+    handleSelectRowClick = () => {
+        this.props.updateRowIndex(this.props.rowIndex);
+    }
 
     showNewUpload = (val) => () => {
         this.setState({ showNewUpload: val });
@@ -185,13 +190,20 @@ class BundleRow extends Component {
         var baseUrl = this.props.url;
         var uuid = this.props.uuid;
         var columnWithHyperlinks = this.props.columnWithHyperlinks;
-        var rowCells = this.props.headerItems.map(function(headerKey, col) {
+        var rowCells = this.props.headerItems.map((headerKey, col) => {
             var rowContent = rowItems[headerKey];
 
             // See if there's a link
             var url;
+            var showDetailButton;
             if (col === 0) {
                 url = baseUrl;
+                showDetailButton = 
+                        <IconButton onClick={this.handleDetailClick}>
+                            {this.state.showDetail?
+                            <ExpandLessIcon/>:
+                            <ExpandMoreIcon/>}
+                        </IconButton>;
             } else if (columnWithHyperlinks.indexOf(headerKey) !== -1) {
                 url = '/rest/bundles/' + uuid + '/contents/blob' + rowContent['path'];
                 if ('text' in rowContent) {
@@ -204,7 +216,7 @@ class BundleRow extends Component {
             }
             if (url)
                 rowContent = (
-                    <a href={url} className='bundle-link' target='_blank'>
+                    <a href={url} className='bundle-link' target='_blank' style={{ display: 'inline-block', width: 60 }}>
                         {rowContent}
                     </a>
                 );
@@ -217,6 +229,7 @@ class BundleRow extends Component {
                         root: classes.root,
                     }}
                 >
+                    {showDetailButton}
                     {rowContent}
                 </TableCell>
             );
@@ -300,7 +313,7 @@ class BundleRow extends Component {
                   */}
                 <TableRow
                     hover
-                    onClick={this.handleClick}
+                    onClick={this.handleSelectRowClick}
                     onContextMenu={this.props.handleContextMenu.bind(
                         null,
                         bundleInfo.uuid,

--- a/frontend/src/components/worksheets/items/TableItem/TableItem.js
+++ b/frontend/src/components/worksheets/items/TableItem/TableItem.js
@@ -49,8 +49,9 @@ class TableItem extends React.Component<{
         var bundleInfos = item.bundles_spec.bundle_infos;
         var headerItems = item.header;
         var headerHtml = headerItems.map(function(item, index) {
+            let styleDict = index == 0 ?  {paddingLeft: 42} : {};
             return (
-                <TableCell component='th' key={index}>
+                <TableCell component='th' key={index} style={ styleDict }>
                     {item}
                 </TableCell>
             );


### PR DESCRIPTION
Addressing #1199 
1. Changed to display run time below the command and positioned to right so it won't be the first information that comes to eye
2. Formatted to hh:mm:ss for run time > 1s, display 0.xxxxxs for run time less than 1 second
2. Truncate the time to show at most 5 decimals, run time smaller than 0.00001s will just show '< 0.00001s' instead
3. Added a clock icon

![Screenshot from 2019-10-05 14-24-56](https://user-images.githubusercontent.com/23012631/66261103-82ec5c80-e77c-11e9-8cd2-85d1697fda1f.png)
![Screenshot from 2019-10-05 14-51-36](https://user-images.githubusercontent.com/23012631/66261306-b41a5c00-e77f-11e9-9d64-3905f041e166.png)

