### PR TITLE
Re-add install_requires to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,17 @@ if int(setuptools.__version__.split('.')[0]) < 25:
         "Recommended command: `pip3 install -U setuptools`"
     )
 
+
+def get_requirements(*requirements_file_paths):
+    requirements = []
+    for requirements_file_path in requirements_file_paths:
+        with open(requirements_file_path) as requirements_file:
+            for line in requirements_file:
+                if line[0:2] != '-r' and line.find('git') == -1:
+                    requirements.append(line.strip())
+    return requirements
+
+
 setup(
     name='codalab',
     version=CODALAB_VERSION,
@@ -31,6 +42,7 @@ setup(
     ],
     python_requires='~=3.6',
     include_package_data=True,
+    install_requires=get_requirements('requirements.txt'),
     entry_points={
         'console_scripts': [
             'cl=codalab.bin.cl:main',


### PR DESCRIPTION
Looks like https://github.com/codalab/codalab-worksheets/commit/ce7a845567055f0f5ac262fe1498c4ac5cdc79be#diff-2eeaed663bd0d25b7e608891384b7298 inadvertently removed the `install_requires` from `setup.py`. As a result, dependencies aren't being installed when you `pip install codalab`.

To reproduce (in a fresh environment):

```
$ pip install codalab==0.4.2
Collecting codalab==0.4.2
Installing collected packages: codalab
Successfully installed codalab-0.4.2

$ cl --version
Traceback (most recent call last):
  File "/u/scr/nfliu/miniconda3/envs/cl/bin/cl", line 6, in <module>
    from codalab.bin.cl import main
  File "/u/scr/nfliu/miniconda3/envs/cl/lib/python3.6/site-packages/codalab/bin/cl.py", line 8, in <module>
    from watchdog.observers import Observer
ModuleNotFoundError: No module named 'watchdog'
```

versus:

```
$ pip install codalab==0.4.0
Collecting codalab==0.4.0
  Using cached https://files.pythonhosted.org/packages/c4/e2/87ce7c3ba7658cb3413883410b002b90c1de0cee61a0e6c496a192fa3497/codalab-0.4.0.tar.gz
Collecting codalabworker>=0.4.0 (from codalab==0.4.0)
Collecting bottle==0.12.9 (from codalab==0.4.0)
Collecting docker==3.7.0 (from codalab==0.4.0)
  Using cached https://files.pythonhosted.org/packages/7e/3c/b610f22b170b0f8fe4d8f78974878e116562389f666f99e6549567eb9d87/docker-3.7.0-py2.py3-none-any.whl
Collecting marshmallow-jsonapi==0.15.1 (from codalab==0.4.0)
Collecting marshmallow==2.6.1 (from codalab==0.4.0)
[...etc...]

$ cl --version
CodaLab CLI version 0.4.0
```

Unsure how unit tests work, but maybe you could guard against this in the future by installing with `pip install -e .` versus `pip install -r requirements.txt`?