### PR TITLE
Fill owner column with real value

### DIFF
--- a/codalab/rest/interpret.py
+++ b/codalab/rest/interpret.py
@@ -188,7 +188,9 @@ def fetch_interpreted_worksheet(uuid):
     # Go and fetch more information about the worksheet contents by
     # resolving the interpreted items.
     try:
-        interpreted_blocks = interpret_items(get_default_schemas(), worksheet_info['items'])
+        interpreted_blocks = interpret_items(
+            get_default_schemas(), worksheet_info['items'], db_model=local.model
+        )
     except UsageError as e:
         interpreted_blocks = {'blocks': []}
         worksheet_info['error'] = str(e)


### PR DESCRIPTION
Fixed #1344. Currently `owner_name` doesn't exist in `bundle_info` dictionary. If we want to have a real name return back, I'll find a way to transfer `owner_id` to `owner_name` by populating a new field directory to `bundle_info`.
