### PR TITLE
Update MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-include worker/requirements.txt
+include requirements.txt
 include rc


### PR DESCRIPTION
From https://pypi.org/project/codalab/#history, download any 0.3.x / 0.4.x and late 0.2.X release, the requirements.txt is missing in the package

worker/requirements.txt is a legacy file which was removed in some 0.2.x version, the current requirements.txt is in the top folder and needs to be included in MANIFEST.in for installing dependencies after the install_require fix in #1477 .

This fix is following this answer https://stackoverflow.com/questions/43748284/requirements-txt-file-for-my-package-missing-from-pypi-install-and-tarball