### PR TITLE
Update DockerImageManager cleanup function

### DIFF
--- a/codalab/worker/docker_utils.py
+++ b/codalab/worker/docker_utils.py
@@ -30,7 +30,11 @@ def wrap_exception(message):
                 return f(*args, **kwargs)
             except DockerException as e:
                 raise DockerException(message + ': ' + str(e))
-            except (docker.errors.APIError, docker.errors.ImageNotFound) as e:
+            except (
+                docker.errors.APIError,
+                docker.errors.ImageNotFound,
+                docker.errors.NotFound,
+            ) as e:
                 raise DockerException(message + ': ' + str(e))
 
         return wrapper


### PR DESCRIPTION
Fixed #1030 . 
Based on the new get function(which is in the reviewing stage and hasn't been merged to master yet), since we always want to pull the image when it's requested, I feel the `image_cache` and `LRU` algorithm in `cleanup()` function could be simplified. `image_cache` could still be used to decide when to prune the system.   
**Question is that I am not sure if we want to only remove the image that is downloaded from `DockerImageManager`, as docker image prune will remove any image that's unused.** 