### PR TITLE
Allow adding items to empty worksheets

### DIFF
--- a/frontend/src/components/worksheets/WorksheetItemList.js
+++ b/frontend/src/components/worksheets/WorksheetItemList.js
@@ -208,7 +208,9 @@ class WorksheetItemList extends React.Component {
             var worksheet_items = [];
             info.items.forEach(
                 function(item, index) {
-                    var focused = index === this.props.focusIndex;
+                    var focused = (index === this.props.focusIndex) ||
+                        // If nothing is focused, append to the end by default.
+                        (this.props.focusIndex === -1 && index === info.items.length - 1);
                     var props = {
                         worksheetUUID: info.uuid,
                         item: item,

--- a/frontend/src/components/worksheets/WorksheetItemList.js
+++ b/frontend/src/components/worksheets/WorksheetItemList.js
@@ -211,7 +211,7 @@ class WorksheetItemList extends React.Component {
             var worksheet_items = [];
             info.items.forEach(
                 function(item, index) {
-                    var focused = (index === this.props.focusIndex) ||
+                    const focused = (index === this.props.focusIndex) ||
                         // If nothing is focused, append to the end by default.
                         (this.props.focusIndex === -1 && index === info.items.length - 1);
                     var props = {

--- a/frontend/src/components/worksheets/WorksheetItemList.js
+++ b/frontend/src/components/worksheets/WorksheetItemList.js
@@ -205,7 +205,20 @@ class WorksheetItemList extends React.Component {
         var items_display;
         var info = this.props.ws.info;
         if (info && info.items.length === 0) { // Create a "dummy" item at the beginning so that only empty text can be added.
-            info.items = [{"isDummyItem": true, "text":"","mode":"markup_block","sort_keys":[-1],"ids":[null],"is_refined":true}];
+            info.items = [
+                {
+                    "isDummyItem": true,
+                    "text": "",
+                    "mode": "markup_block",
+                    "sort_keys": [
+                        -1
+                    ],
+                    "ids": [
+                        null
+                    ],
+                    "is_refined": true
+                }
+            ];
         }
         if (info && info.items.length > 0) {
             var worksheet_items = [];

--- a/frontend/src/components/worksheets/WorksheetItemList.js
+++ b/frontend/src/components/worksheets/WorksheetItemList.js
@@ -204,6 +204,9 @@ class WorksheetItemList extends React.Component {
         // Create items
         var items_display;
         var info = this.props.ws.info;
+        if (info && info.items.length === 0) { // Create a "dummy" item at the beginning so that only empty text can be added.
+            info.items = [{"isDummyItem": true, "text":"","mode":"markup_block","sort_keys":[-1],"ids":[null],"is_refined":true}];
+        }
         if (info && info.items.length > 0) {
             var worksheet_items = [];
             info.items.forEach(

--- a/frontend/src/components/worksheets/items/ItemWrapper.js
+++ b/frontend/src/components/worksheets/items/ItemWrapper.js
@@ -59,11 +59,15 @@ class ItemWrapper extends React.Component {
             isWorkSheetItem = false;
         }
 
+        const {isDummyItem} = item;
+
         return (
             <div
-                className={classes.container}
+                className={isDummyItem ? "": classes.container}
             >
-                <div className={classes.main}>{children}</div>
+                {!isDummyItem && 
+                    <div className={classes.main}>{children}</div>
+                }
                 {showNewUpload && (
                     <NewUpload
                         after_sort_key={itemKeys.maxKey}

--- a/frontend/src/components/worksheets/items/TextEditorItem/TextEditorItem.js
+++ b/frontend/src/components/worksheets/items/TextEditorItem/TextEditorItem.js
@@ -58,6 +58,9 @@ class TextEditorItem extends React.Component<{
             /* Pressed ctrl+enter or ctrl+s */
             this.saveText();
         }
+        if (pressed.includes('27')) { // Close editor upon pressing Escape
+            this.props.closeEditor();
+        }
     };
 
     updateText = (ev) => {


### PR DESCRIPTION
Fixes #1480.

This is done by rendering an item on the frontend
with the `isDummyItem` attribute equal to true.

This PR also:
- Hides the text editor upon pressing the "Escape" key
- Adds an item to the end of the worksheet if no item is selected


![image](https://user-images.githubusercontent.com/1689183/66876949-79c37280-ef68-11e9-8217-9463ac60455a.png)
