### PR TITLE
Make contiguous blocks of text appear on different lines

### DIFF
--- a/frontend/src/components/worksheets/items/TextEditorItem/TextEditorItem.js
+++ b/frontend/src/components/worksheets/items/TextEditorItem/TextEditorItem.js
@@ -84,14 +84,11 @@ class TextEditorItem extends React.Component<{
 
         let url = `/rest/worksheets/${worksheetUUID}/add-items`;
         const items = this.text.split(/[\n]/);
-        // Interleave items with empty lines, so they can be rendered as separate blocks
-        // const items = [];
-        // raw_items.forEach((item, idx) => {
-        //     items.push(item);
-        //     if (idx < raw_items.length - 1) {
-        //         items.push('');
-        //     }
-        // });
+        if (mode === 'create') {
+            // Add an extra line to the beginning of new text items,
+            // so they are separate from previous items.
+            items.unshift('');
+        }
 
         const data = { items };
 


### PR DESCRIPTION
Fixes #1268 by adding a newline to the beginning of new text
items, so that they stay separate from the previous item.