### PR TITLE
Fix problem in cl detaching last item

### DIFF
--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -1354,6 +1354,7 @@ class BundleCLI(object):
                         'worksheet': JsonApiRelationship('worksheets', dest_worksheet_uuid),
                         'bundle': JsonApiRelationship('bundles', source_bundle_uuid),
                     },
+                    params={'uuid': dest_worksheet_uuid},
                 )
             return
 
@@ -1755,7 +1756,9 @@ class BundleCLI(object):
             if not detach:
                 new_items.append(item)
 
-        client.create('worksheet-items', data=new_items, params={'replace': True})
+        client.create(
+            'worksheet-items', data=new_items, params={'replace': True, 'uuid': worksheet_uuid}
+        )
 
     @Commands.command(
         'rm',
@@ -1902,6 +1905,7 @@ class BundleCLI(object):
                     }
                     for bundle in bundles
                 ],
+                params={'uuid': worksheet_uuid},
             )
             worksheet_info = client.fetch('worksheets', worksheet_uuid)
             print(
@@ -2755,6 +2759,7 @@ class BundleCLI(object):
                             'worksheet': JsonApiRelationship('worksheets', dest_worksheet_uuid),
                             'value': item_spec[1:].strip(),
                         },
+                        params={'uuid': dest_worksheet_uuid},
                     )
                 else:
                     dest_client.create(
@@ -2764,6 +2769,7 @@ class BundleCLI(object):
                             'worksheet': JsonApiRelationship('worksheets', dest_worksheet_uuid),
                             'value': item_spec,
                         },
+                        params={'uuid': dest_worksheet_uuid},
                     )
 
         elif args.item_type == 'bundle':
@@ -2804,6 +2810,7 @@ class BundleCLI(object):
                         'worksheet': JsonApiRelationship('worksheets', dest_worksheet_uuid),
                         'subworksheet': JsonApiRelationship('worksheets', subworksheet_uuid),
                     },
+                    params={'uuid': dest_worksheet_uuid},
                 )
 
     @Commands.command(
@@ -3203,7 +3210,11 @@ class BundleCLI(object):
         # Save all items to the destination worksheet
         for item in source_items:
             item['worksheet'] = JsonApiRelationship('worksheets', dest_worksheet_uuid)
-        dest_client.create('worksheet-items', source_items, params={'replace': args.replace})
+        dest_client.create(
+            'worksheet-items',
+            source_items,
+            params={'replace': args.replace, 'uuid': dest_worksheet_uuid},
+        )
 
         # Copy over the bundles
         for item in source_items:

--- a/codalab/lib/bundle_util.py
+++ b/codalab/lib/bundle_util.py
@@ -277,7 +277,11 @@ def mimic_bundles(
                                     item2['worksheet'] = JsonApiRelationship(
                                         'worksheets', worksheet_uuid
                                     )
-                                    client.create('worksheet-items', data=item2)
+                                    client.create(
+                                        'worksheet-items',
+                                        data=item2,
+                                        params={'uuid': worksheet_uuid},
+                                    )
 
                             # Add the bundle item
                             client.create(
@@ -287,6 +291,7 @@ def mimic_bundles(
                                     'worksheet': JsonApiRelationship('worksheets', worksheet_uuid),
                                     'bundle': JsonApiRelationship('bundles', new_bundle_uuid),
                                 },
+                                params={'uuid': worksheet_uuid},
                             )
                             new_bundle_uuids_added.add(new_bundle_uuid)
                             just_added = True
@@ -310,6 +315,7 @@ def mimic_bundles(
                         'worksheet': JsonApiRelationship('worksheets', worksheet_uuid),
                         'bundle': JsonApiRelationship('bundles', new_bundle_uuid),
                     },
+                    params={'uuid': worksheet_uuid},
                 )
 
     return plan

--- a/codalab/rest/worksheets.py
+++ b/codalab/rest/worksheets.py
@@ -13,6 +13,7 @@ from codalab.lib.server_util import (
     decoded_body,
     json_api_include,
     query_get_bool,
+    query_get_type,
     query_get_json_api_include_set,
     query_get_list,
 )
@@ -229,12 +230,16 @@ def create_worksheet_items():
     |replace| - Replace existing items in host worksheets. Default is False.
     """
     replace = query_get_bool('replace', False)
-
+    # Get the uuid of the current worksheet
+    worksheet_uuid = query_get_type(str, 'uuid')
     new_items = WorksheetItemSchema(strict=True, many=True).load(request.json).data
 
+    # Map of worksheet_uuid to list of items that exist in this worksheet
     worksheet_to_items = {}
+    worksheet_to_items.setdefault(worksheet_uuid, [])
+
     for item in new_items:
-        worksheet_to_items.setdefault(item['worksheet_uuid'], []).append(item)
+        worksheet_to_items[worksheet_uuid].append(item)
 
     for worksheet_uuid, items in worksheet_to_items.items():
         worksheet_info = get_worksheet_info(worksheet_uuid, fetch_items=True)

--- a/test_cli.py
+++ b/test_cli.py
@@ -1025,11 +1025,14 @@ def test(ctx):
     ctx.collect_bundle(uuid2)
     # State after the above: 1 2 1 2
     run_command([cl, 'detach', uuid1], 1)  # multiple indices
-    run_command([cl, 'detach', uuid1, '-n', '3'], 1)  # indes out of range
+    run_command([cl, 'detach', uuid1, '-n', '3'], 1)  # index out of range
     run_command([cl, 'detach', uuid2, '-n', '2'])  # State: 1 1 2
     check_equals(get_info('^', 'uuid'), uuid2)
     run_command([cl, 'detach', uuid2])  # State: 1 1
     check_equals(get_info('^', 'uuid'), uuid1)
+    run_command([cl, 'detach', uuid1, '-n', '2'])  # State: 1
+    run_command([cl, 'detach', uuid1])  # Worksheet becomes empty
+    check_equals('', run_command([cl, 'ls', '-u']))  # Return string from `cl ls -u` should be empty
 
 
 @TestModule.register('perm')


### PR DESCRIPTION
Fixed  #1467.
After investigating on the issue #1467, we found out that the reason why the very last item in a worksheet cannot be detached is due to the for-loop logic, which will never be executed when there are no elements in `new_items` in function `create_worksheet_items()`. 