### PR TITLE
Enable shared filesystem workers again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ jobs:
       install:
         - python3 codalab_service.py build services --version ${TRAVIS_BRANCH} --pull $([ -z "${CODALAB_DOCKER_USERNAME}" ] || echo "--push")
         - python3 codalab_service.py start --services default monitor --version ${TRAVIS_BRANCH}
-        - python3 codalab_service.py start --services default monitor --version ${TRAVIS_BRANCH}
       script:
         - python3 codalab_service.py test --version ${TRAVIS_BRANCH} default
         - docker stop codalab_worker_1

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,7 @@ jobs:
       services:
         - docker
       env:
-        - CODALAB_SHARED_FILESYTEM=false CODALAB_USERNAME=codalab CODALAB_PASSWORD=codalab CI=false
-        - CODALAB_SHARED_FILESYTEM=true CODALAB_USERNAME=codalab CODALAB_PASSWORD=codalab CI=false
-      python: 3.6
+        - CODALAB_USERNAME=codalab CODALAB_PASSWORD=codalab CI=false
       before_install:
         - sudo rm /usr/local/bin/docker-compose
         - curl -L https://github.com/docker/compose/releases/download/1.23.2/docker-compose-`uname -s`-`uname -m` > docker-compose
@@ -24,6 +22,8 @@ jobs:
         - python3 codalab_service.py build services --version ${TRAVIS_BRANCH} --pull $([ -z "${CODALAB_DOCKER_USERNAME}" ] || echo "--push")
       script:
         - python3 codalab_service.py start --services default monitor test --version ${TRAVIS_BRANCH}
+        - python3 codalab_service.py stop
+        - python3 codalab_service.py start --services default monitor test --version ${TRAVIS_BRANCH} --shared-file-system
     - stage: deploy
       script: echo "Deploying"
       language: python

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ jobs:
         - docker
       env:
         - CODALAB_USERNAME=codalab CODALAB_PASSWORD=codalab CI=false
+      python: 3.6
       before_install:
         - sudo rm /usr/local/bin/docker-compose
         - curl -L https://github.com/docker/compose/releases/download/1.23.2/docker-compose-`uname -s`-`uname -m` > docker-compose

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ jobs:
         - chmod +x docker-compose
         - sudo mv docker-compose /usr/local/bin
         - sudo service mysql stop
+        - pip install psutil
       install:
         - python3 codalab_service.py build services --version ${TRAVIS_BRANCH} --pull $([ -z "${CODALAB_DOCKER_USERNAME}" ] || echo "--push")
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ jobs:
       services:
         - docker
       env:
-        - CODALAB_USERNAME=codalab CODALAB_PASSWORD=codalab CI=false
+        - CODALAB_SHARED_FILESYTEM=false CODALAB_USERNAME=codalab CODALAB_PASSWORD=codalab CI=false
+        - CODALAB_SHARED_FILESYTEM=true CODALAB_USERNAME=codalab CODALAB_PASSWORD=codalab CI=false
       python: 3.6
       before_install:
         - sudo rm /usr/local/bin/docker-compose

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ jobs:
         - chmod +x docker-compose
         - sudo mv docker-compose /usr/local/bin
         - sudo service mysql stop
-        - pip install psutil
       install:
         - python3 codalab_service.py build services --version ${TRAVIS_BRANCH} --pull $([ -z "${CODALAB_DOCKER_USERNAME}" ] || echo "--push")
       script:

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -1043,6 +1043,7 @@ class BundleCLI(object):
             'last_checkin',
             'tag',
             'runs',
+            'shared_file_system',
         ]
 
         data = []
@@ -1060,6 +1061,7 @@ class BundleCLI(object):
                     ),
                     'tag': worker['tag'],
                     'runs': ",".join([uuid[0:8] for uuid in worker['run_uuids']]),
+                    'shared_file_system': worker['shared_file_system'],
                 }
             )
 

--- a/codalab/lib/codalab_manager.py
+++ b/codalab/lib/codalab_manager.py
@@ -348,11 +348,7 @@ class CodaLabManager(object):
 
     @cached
     def worker_model(self):
-        # Whether the file system is shared between the worker and the bundle
-        # service. Note, that the file system is considered to be shared only if
-        # the worker is running as the root user.
-        shared_file_system = self.config['workers'].get('shared_file_system', False)
-        return WorkerModel(self.model().engine, self.worker_socket_dir, shared_file_system)
+        return WorkerModel(self.model().engine, self.worker_socket_dir)
 
     @cached
     def upload_manager(self):

--- a/codalab/lib/download_manager.py
+++ b/codalab/lib/download_manager.py
@@ -72,7 +72,7 @@ class DownloadManager(object):
             # system since 1) due to NFS caching the worker has more up to date
             # information on directory contents, and 2) the logic of hiding
             # the dependency paths doesn't need to be re-implemented here.
-            worker = self._worker_model.get_bundle_worker(uuid)
+            worker = self._bundle_model.get_bundle_worker(uuid)
             response_socket_id = self._worker_model.allocate_socket(
                 worker['user_id'], worker['worker_id']
             )
@@ -104,7 +104,7 @@ class DownloadManager(object):
             directory_path = self._get_target_path(uuid, path)
             return file_util.tar_gzip_directory(directory_path)
         else:
-            worker = self._worker_model.get_bundle_worker(uuid)
+            worker = self._bundle_model.get_bundle_worker(uuid)
             response_socket_id = self._worker_model.allocate_socket(
                 worker['user_id'], worker['worker_id']
             )
@@ -130,7 +130,7 @@ class DownloadManager(object):
             else:
                 return open(file_path, 'rb')
         else:
-            worker = self._worker_model.get_bundle_worker(uuid)
+            worker = self._bundle_model.get_bundle_worker(uuid)
             response_socket_id = self._worker_model.allocate_socket(
                 worker['user_id'], worker['worker_id']
             )
@@ -158,7 +158,7 @@ class DownloadManager(object):
                 bytestring = file_util.gzip_bytestring(bytestring)
             return bytestring
         else:
-            worker = self._worker_model.get_bundle_worker(uuid)
+            worker = self._bundle_model.get_bundle_worker(uuid)
             response_socket_id = self._worker_model.allocate_socket(
                 worker['user_id'], worker['worker_id']
             )
@@ -195,7 +195,7 @@ class DownloadManager(object):
                 bytestring = file_util.gzip_bytestring(bytestring)
             return bytestring
         else:
-            worker = self._worker_model.get_bundle_worker(uuid)
+            worker = self._bundle_model.get_bundle_worker(uuid)
             response_socket_id = self._worker_model.allocate_socket(
                 worker['user_id'], worker['worker_id']
             )
@@ -221,7 +221,7 @@ class DownloadManager(object):
         """
         Sends a raw bytestring into the specified port of a running bundle, then return the response.
         """
-        worker = self._worker_model.get_bundle_worker(uuid)
+        worker = self._bundle_model.get_bundle_worker(uuid)
         response_socket_id = self._worker_model.allocate_socket(
             worker['user_id'], worker['worker_id']
         )
@@ -235,7 +235,7 @@ class DownloadManager(object):
 
     def _is_available_locally(self, uuid):
         if self._bundle_model.get_bundle_state(uuid) in [State.RUNNING, State.PREPARING]:
-            return self._worker_model.get_bundle_worker(uuid)['shared_file_system']
+            return self._bundle_model.get_bundle_worker(uuid)['shared_file_system']
         return True
 
     def _get_target_path(self, uuid, path):

--- a/codalab/lib/download_manager.py
+++ b/codalab/lib/download_manager.py
@@ -234,14 +234,7 @@ class DownloadManager(object):
         return bytestring
 
     def _is_available_locally(self, uuid):
-        if self._bundle_model.get_bundle_state(uuid) in [State.RUNNING, State.PREPARING]:
-            if self._worker_model.shared_file_system:
-                worker = self._worker_model.get_bundle_worker(uuid)
-                return worker['user_id'] == self._bundle_model.root_user_id
-            else:
-                return False
-
-        return True
+        return self._worker_model.get_bundle_worker(uuid)['shared_file_system']
 
     def _get_target_path(self, uuid, path):
         bundle_path = self._bundle_store.get_bundle_location(uuid)

--- a/codalab/lib/download_manager.py
+++ b/codalab/lib/download_manager.py
@@ -234,7 +234,9 @@ class DownloadManager(object):
         return bytestring
 
     def _is_available_locally(self, uuid):
-        return self._worker_model.get_bundle_worker(uuid)['shared_file_system']
+        if self._bundle_model.get_bundle_state(uuid) in [State.RUNNING, State.PREPARING]:
+            return self._worker_model.get_bundle_worker(uuid)['shared_file_system']
+        return True
 
     def _get_target_path(self, uuid, path):
         bundle_path = self._bundle_store.get_bundle_location(uuid)

--- a/codalab/lib/download_manager.py
+++ b/codalab/lib/download_manager.py
@@ -100,22 +100,18 @@ class DownloadManager(object):
         Returns a file-like object containing a tarred and gzipped archive
         of the given directory.
         """
-        if self._is_available_locally(uuid):
-            directory_path = self._get_target_path(uuid, path)
-            return file_util.tar_gzip_directory(directory_path)
-        else:
-            worker = self._bundle_model.get_bundle_worker(uuid)
-            response_socket_id = self._worker_model.allocate_socket(
-                worker['user_id'], worker['worker_id']
-            )
-            try:
-                read_args = {'type': 'stream_directory'}
-                self._send_read_message(worker, response_socket_id, uuid, path, read_args)
-                fileobj = self._get_read_response_stream(response_socket_id)
-                return Deallocating(fileobj, self._worker_model, response_socket_id)
-            except Exception:
-                self._worker_model.deallocate_socket(response_socket_id)
-                raise
+        worker = self._bundle_model.get_bundle_worker(uuid)
+        response_socket_id = self._worker_model.allocate_socket(
+            worker['user_id'], worker['worker_id']
+        )
+        try:
+            read_args = {'type': 'stream_directory'}
+            self._send_read_message(worker, response_socket_id, uuid, path, read_args)
+            fileobj = self._get_read_response_stream(response_socket_id)
+            return Deallocating(fileobj, self._worker_model, response_socket_id)
+        except Exception:
+            self._worker_model.deallocate_socket(response_socket_id)
+            raise
 
     @retry_if_no_longer_running
     def stream_file(self, uuid, path, gzipped):

--- a/codalab/lib/upload_manager.py
+++ b/codalab/lib/upload_manager.py
@@ -176,36 +176,6 @@ class UploadManager(object):
         path_util.rename(child_path, path)
         path_util.remove(temp_path)
 
-    def update_metadata_and_save(self, bundle, enforce_disk_quota=False):
-        """
-        Updates the metadata about the contents of the bundle, including
-        data_size as well as the total amount of disk used by the user.
-
-        If |new_bundle| is True, saves the bundle as a new bundle. Otherwise,
-        updates it.
-        """
-        bundle_path = self._bundle_store.get_bundle_location(bundle.uuid)
-
-        dirs_and_files = None
-        if os.path.isdir(bundle_path):
-            dirs_and_files = path_util.recursive_ls(bundle_path)
-        else:
-            dirs_and_files = [], [bundle_path]
-
-        data_hash = '0x%s' % (path_util.hash_directory(bundle_path, dirs_and_files))
-        data_size = path_util.get_size(bundle_path, dirs_and_files)
-        if enforce_disk_quota:
-            disk_left = self._bundle_model.get_user_disk_quota_left(bundle.owner_id)
-            if data_size > disk_left:
-                raise UsageError(
-                    "Can't save bundle, bundle size %s greater than user's disk quota left: %s"
-                    % (data_size, disk_left)
-                )
-
-        bundle_update = {'data_hash': data_hash, 'metadata': {'data_size': data_size}}
-        self._bundle_model.update_bundle(bundle, bundle_update)
-        self._bundle_model.update_user_disk_used(bundle.owner_id)
-
     def has_contents(self, bundle):
         return os.path.exists(self._bundle_store.get_bundle_location(bundle.uuid))
 

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -7,7 +7,6 @@ import datetime
 import os
 import re
 import time
-import threading
 from uuid import uuid4
 
 from sqlalchemy import and_, or_, not_, select, union, desc, func
@@ -833,7 +832,6 @@ class BundleModel(object):
             If the user running the bundle was the CodaLab root user,
             increments the time used by the bundle owner.
         """
-
         failure_message, exitcode = worker_run.failure_message, worker_run.exitcode
         if failure_message is None and exitcode is not None and exitcode != 0:
             failure_message = 'Exit code %d' % exitcode

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -868,7 +868,7 @@ class BundleModel(object):
 
         worker = self.get_bundle_worker(bundle.uuid)
         if worker['shared_file_system']:
-            self.update_metadata_and_save(bundle, bundle_location)
+            self.update_disk_metadata(bundle, bundle_location)
 
         metadata = {'run_status': 'Finished', 'last_updated': int(time.time())}
 
@@ -882,7 +882,7 @@ class BundleModel(object):
     # Bundle state machine helper functions
     # ==========================================================================
 
-    def update_metadata_and_save(self, bundle, bundle_location, enforce_disk_quota=False):
+    def update_disk_metadata(self, bundle, bundle_location, enforce_disk_quota=False):
         dirs_and_files = None
         if os.path.isdir(bundle_location):
             dirs_and_files = path_util.recursive_ls(bundle_location)

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -924,9 +924,7 @@ class BundleModel(object):
                 self.transition_bundle_running(
                     bundle, worker_run, row, user_id, worker_id, connection
                 )
-                return self.transition_bundle_finalizing(
-                    bundle, user_id, worker_run, connection
-                )
+                return self.transition_bundle_finalizing(bundle, user_id, worker_run, connection)
 
             if worker_run.state in [State.PREPARING, State.RUNNING]:
                 return self.transition_bundle_running(

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -883,6 +883,10 @@ class BundleModel(object):
     # ==========================================================================
 
     def update_disk_metadata(self, bundle, bundle_location, enforce_disk_quota=False):
+        """
+        Computes the disk use and data hash of the given bundle.
+        Updates the database rows for the bundle and user with the new disk use
+        """
         dirs_and_files = None
         if os.path.isdir(bundle_location):
             dirs_and_files = path_util.recursive_ls(bundle_location)

--- a/codalab/model/tables.py
+++ b/codalab/model/tables.py
@@ -313,6 +313,9 @@ worker = Table(
         'checkin_time', DateTime, nullable=False
     ),  # When the worker last checked in with the bundle service.
     Column('socket_id', Integer, nullable=False),  # Socket ID worker listens for messages on.
+    Column(
+        'shared_file_system', Boolean, nullable=False
+    ),  # Whether the worker is on a shared FS with server.
 )
 
 # Store information about all sockets currently allocated to each worker.

--- a/codalab/model/tables.py
+++ b/codalab/model/tables.py
@@ -315,7 +315,7 @@ worker = Table(
     Column('socket_id', Integer, nullable=False),  # Socket ID worker listens for messages on.
     Column(
         'shared_file_system', Boolean, nullable=False
-    ),  # Whether the worker is on a shared FS with server.
+    ),  # Whether the worker and the server have a shared filesystem.
 )
 
 # Store information about all sockets currently allocated to each worker.

--- a/codalab/model/worker_model.py
+++ b/codalab/model/worker_model.py
@@ -32,13 +32,21 @@ class WorkerModel(object):
        listen on these sockets for messages and send messages to these sockets.
     """
 
-    def __init__(self, engine, socket_dir, shared_file_system):
+    def __init__(self, engine, socket_dir):
         self._engine = engine
         self._socket_dir = socket_dir
-        self.shared_file_system = shared_file_system
 
     def worker_checkin(
-        self, user_id, worker_id, tag, cpus, gpus, memory_bytes, free_disk_bytes, dependencies
+        self,
+        user_id,
+        worker_id,
+        tag,
+        cpus,
+        gpus,
+        memory_bytes,
+        free_disk_bytes,
+        dependencies,
+        shared_file_system,
     ):
         """
         Adds the worker to the database, if not yet there. Returns the socket ID
@@ -52,6 +60,7 @@ class WorkerModel(object):
                 'memory_bytes': memory_bytes,
                 'free_disk_bytes': free_disk_bytes,
                 'checkin_time': datetime.datetime.now(),
+                'shared_file_system': shared_file_system,
             }
             existing_row = conn.execute(
                 cl_worker.select().where(
@@ -172,6 +181,7 @@ class WorkerModel(object):
                 'run_uuids': [],
                 'dependencies': row.dependencies
                 and self._deserialize_dependencies(row.dependencies),
+                'shared_file_system': row.shared_file_system,
             }
             for row in worker_rows
         }
@@ -197,6 +207,7 @@ class WorkerModel(object):
             return {
                 'user_id': worker_row.user_id,
                 'worker_id': worker_row.worker_id,
+                'shared_file_system': worker_row.shared_file_system,
                 'socket_id': worker_row.socket_id,
             }
 

--- a/codalab/model/worker_model.py
+++ b/codalab/model/worker_model.py
@@ -189,28 +189,6 @@ class WorkerModel(object):
             worker_dict[(row.user_id, row.worker_id)]['run_uuids'].append(row.run_uuid)
         return list(worker_dict.values())
 
-    def get_bundle_worker(self, uuid):
-        """
-        Returns information about the worker that the given bundle is running
-        on. This method should be called only for bundles that are running.
-        """
-        with self._engine.begin() as conn:
-            row = conn.execute(
-                cl_worker_run.select().where(cl_worker_run.c.run_uuid == uuid)
-            ).fetchone()
-            precondition(row, 'Trying to find worker for bundle that is not running.')
-            worker_row = conn.execute(
-                cl_worker.select().where(
-                    and_(cl_worker.c.user_id == row.user_id, cl_worker.c.worker_id == row.worker_id)
-                )
-            ).fetchone()
-            return {
-                'user_id': worker_row.user_id,
-                'worker_id': worker_row.worker_id,
-                'shared_file_system': worker_row.shared_file_system,
-                'socket_id': worker_row.socket_id,
-            }
-
     def allocate_socket(self, user_id, worker_id, conn=None):
         """
         Allocates a unique socket ID.

--- a/codalab/rest/bundle_actions.py
+++ b/codalab/rest/bundle_actions.py
@@ -23,7 +23,7 @@ def create_bundle_actions():
         if bundle.state not in [State.RUNNING, State.PREPARING]:
             raise UsageError('Cannot execute this action on a bundle that is not running.')
 
-        worker = local.worker_model.get_bundle_worker(action['uuid'])
+        worker = local.model.get_bundle_worker(action['uuid'])
         precondition(
             local.worker_model.send_json_message(worker['socket_id'], action, 60),
             'Unable to reach worker.',

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -677,7 +677,8 @@ def _update_bundle_contents_blob(uuid):
             simplify_archives=query_get_bool('simplify', default=True),
         )  # See UploadManager for full explanation of 'simplify'
 
-        local.upload_manager.update_metadata_and_save(bundle, enforce_disk_quota=True)
+        bundle_location = local.bundle_store.get_bundle_location(uuid)
+        local.model.update_metadata_and_save(bundle, bundle_location, enforce_disk_quota=True)
 
     except UsageError as err:
         # This is a user error (most likely disk quota overuser) so raise a client HTTP error

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -678,7 +678,7 @@ def _update_bundle_contents_blob(uuid):
         )  # See UploadManager for full explanation of 'simplify'
 
         bundle_location = local.bundle_store.get_bundle_location(uuid)
-        local.model.update_metadata_and_save(bundle, bundle_location, enforce_disk_quota=True)
+        local.model.update_disk_metadata(bundle, bundle_location, enforce_disk_quota=True)
 
     except UsageError as err:
         # This is a user error (most likely disk quota overuser) so raise a client HTTP error

--- a/codalab/rest/workers.py
+++ b/codalab/rest/workers.py
@@ -4,8 +4,6 @@ from __future__ import (
 from contextlib import closing
 import http.client
 import json
-import os
-import subprocess
 from datetime import datetime
 
 from bottle import abort, get, local, post, put, request, response
@@ -43,10 +41,7 @@ def checkin(worker_id):
         try:
             worker_run = WorkerRun.from_dict(run)
             bundle = local.model.get_bundle(worker_run.uuid)
-            bundle_location = local.bundle_store.get_bundle_location(worker_run.uuid)
-            local.model.bundle_checkin(
-                bundle, worker_run, request.user.user_id, worker_id, bundle_location
-            )
+            local.model.bundle_checkin(bundle, worker_run, request.user.user_id, worker_id)
         except Exception:
             pass
 

--- a/codalab/rest/workers.py
+++ b/codalab/rest/workers.py
@@ -36,6 +36,7 @@ def checkin(worker_id):
         request.json.get("memory_bytes"),
         request.json.get("free_disk_bytes"),
         request.json["dependencies"],
+        request.json.get("shared_file_system"),
     )
 
     for run in request.json["runs"]:

--- a/codalab/rest/workers.py
+++ b/codalab/rest/workers.py
@@ -43,7 +43,10 @@ def checkin(worker_id):
         try:
             worker_run = WorkerRun.from_dict(run)
             bundle = local.model.get_bundle(worker_run.uuid)
-            local.model.bundle_checkin(bundle, worker_run, request.user.user_id, worker_id)
+            bundle_location = local.bundle_store.get_bundle_location(worker_run.uuid)
+            local.model.bundle_checkin(
+                bundle, worker_run, request.user.user_id, worker_id, bundle_location
+            )
         except Exception:
             pass
 

--- a/codalab/server/bundle_manager.py
+++ b/codalab/server/bundle_manager.py
@@ -272,7 +272,8 @@ class BundleManager(object):
                 worker['socket_id'], {'type': 'mark_finalized', 'uuid': bundle.uuid}, 0.2
             ):
                 logger.info('Acknowledged finalization of run bundle %s', bundle.uuid)
-                self._model.transition_bundle_finished(bundle)
+                bundle_location = self._bundle_store.get_bundle_location(bundle.uuid)
+                self._model.transition_bundle_finished(bundle, bundle_location)
 
     def _bring_offline_stuck_running_bundles(self, workers):
         """

--- a/codalab/server/bundle_manager.py
+++ b/codalab/server/bundle_manager.py
@@ -262,7 +262,7 @@ class BundleManager(object):
         Acknowledge recently finished bundles to workers so they can discard run information.
         """
         for bundle in self._model.batch_get_bundles(state=State.FINALIZING, bundle_type='run'):
-            worker = workers.get_bundle_worker(bundle.uuid)
+            worker = self._model.get_bundle_worker(bundle.uuid)
             if worker is None:
                 logger.info(
                     'Bringing bundle offline %s: %s', bundle.uuid, 'No worker claims bundle'

--- a/codalab/server/bundle_manager.py
+++ b/codalab/server/bundle_manager.py
@@ -389,7 +389,7 @@ class BundleManager(object):
 
         def get_sort_key(worker):
             if worker['shared_file_system']:
-                num_available_deps = len(neded_deps)
+                num_available_deps = len(needed_deps)
             else:
                 deps = set(worker['dependencies'])
                 num_available_deps = len(needed_deps & deps)

--- a/codalab/server/bundle_manager.py
+++ b/codalab/server/bundle_manager.py
@@ -388,12 +388,16 @@ class BundleManager(object):
         needed_deps = set([(dep.parent_uuid, dep.parent_path) for dep in bundle.dependencies])
 
         def get_sort_key(worker):
-            deps = set(worker['dependencies'])
+            if worker['shared_file_system']:
+                num_available_deps = len(neded_deps)
+            else:
+                deps = set(worker['dependencies'])
+                num_available_deps = len(needed_deps & deps)
             worker_id = worker['worker_id']
 
             # if the bundle doesn't request GPUs (only request CPUs), prioritize workers that don't have GPUs
             gpu_priority = bundle_resources.gpus or not has_gpu[worker_id]
-            return (gpu_priority, len(needed_deps & deps), worker['cpus'], random.random())
+            return (gpu_priority, num_available_deps, worker['cpus'], random.random())
 
         workers_list.sort(key=get_sort_key, reverse=True)
 

--- a/codalab/server/bundle_manager.py
+++ b/codalab/server/bundle_manager.py
@@ -214,7 +214,7 @@ class BundleManager(object):
                 for dependency_path, child_path in deps:
                     path_util.copy(dependency_path, child_path, follow_symlinks=False)
 
-            self._model.update_metadata_and_save(bundle, bundle_location, enforce_disk_quota=True)
+            self._model.update_disk_metadata(bundle, bundle_location, enforce_disk_quota=True)
             logger.info('Finished making bundle %s', bundle.uuid)
             self._model.update_bundle(bundle, {'state': State.READY})
         except Exception as e:

--- a/codalab/server/bundle_manager.py
+++ b/codalab/server/bundle_manager.py
@@ -406,10 +406,7 @@ class BundleManager(object):
         """
         if self._model.transition_bundle_starting(bundle, worker['user_id'], worker['worker_id']):
             workers.set_starting(bundle.uuid, worker)
-            if (
-                self._worker_model.shared_file_system
-                and worker['user_id'] == self._model.root_user_id
-            ):
+            if worker['shared_file_system']:
                 # On a shared file system we create the path here to avoid NFS
                 # directory cache issues.
                 path = self._bundle_store.get_bundle_location(bundle.uuid)
@@ -509,7 +506,7 @@ class BundleManager(object):
         message = {}
         message['type'] = 'run'
         message['bundle'] = bundle_util.bundle_to_bundle_info(self._model, bundle)
-        if self._worker_model.shared_file_system and worker['user_id'] == self._model.root_user_id:
+        if worker['shared_file_system']:
             message['bundle']['location'] = self._bundle_store.get_bundle_location(bundle.uuid)
             for dependency in message['bundle']['dependencies']:
                 dependency['location'] = self._bundle_store.get_bundle_location(

--- a/codalab/server/bundle_manager.py
+++ b/codalab/server/bundle_manager.py
@@ -180,7 +180,8 @@ class BundleManager(object):
 
     def _make_bundle(self, bundle):
         try:
-            path = os.path.normpath(self._bundle_store.get_bundle_location(bundle.uuid))
+            bundle_location = self._bundle_store.get_bundle_location(bundle.uuid)
+            path = os.path.normpath(bundle_location)
 
             deps = []
             for dep in bundle.dependencies:
@@ -213,7 +214,7 @@ class BundleManager(object):
                 for dependency_path, child_path in deps:
                     path_util.copy(dependency_path, child_path, follow_symlinks=False)
 
-            self._upload_manager.update_metadata_and_save(bundle, enforce_disk_quota=True)
+            self._model.update_metadata_and_save(bundle, bundle_location, enforce_disk_quota=True)
             logger.info('Finished making bundle %s', bundle.uuid)
             self._model.update_bundle(bundle, {'state': State.READY})
         except Exception as e:

--- a/codalab/server/worker_info_accessor.py
+++ b/codalab/server/worker_info_accessor.py
@@ -45,6 +45,3 @@ class WorkerInfoAccessor(object):
             worker = self._uuid_to_worker[uuid]
             worker['run_uuids'].remove(uuid)
             del self._uuid_to_worker[uuid]
-
-    def get_bundle_worker(self, uuid):
-        return self._uuid_to_worker.get(uuid, None)

--- a/codalab/worker/local_run/local_reader.py
+++ b/codalab/worker/local_run/local_reader.py
@@ -43,11 +43,12 @@ class LocalReader(Reader):
         read_thread.start()
         self.read_threads.append(read_thread)
 
-    def get_target_info(self, run_state, path, dep_paths, args, reply_fn):
+    def get_target_info(self, run_state, path, args, reply_fn):
         """
         Return target_info of path in bundle as a message on the reply_fn
         """
         target_info = None
+        dep_paths = set([dep.child_path for dep in run_state.bundle.dependencies])
 
         # if path is a dependency raise an error
         if path and os.path.normpath(path) in dep_paths:
@@ -74,10 +75,11 @@ class LocalReader(Reader):
 
         reply_fn(None, {'target_info': target_info}, None)
 
-    def stream_directory(self, run_state, path, dep_paths, args, reply_fn):
+    def stream_directory(self, run_state, path, args, reply_fn):
         """
         Stream the directory at path using a separate thread
         """
+        dep_paths = set([dep.child_path for dep in run_state.bundle.dependencies])
         exclude_names = [] if path else dep_paths
 
         def stream_thread(final_path):
@@ -86,7 +88,7 @@ class LocalReader(Reader):
 
         self._threaded_read(run_state, path, stream_thread, reply_fn)
 
-    def stream_file(self, run_state, path, dep_paths, args, reply_fn):
+    def stream_file(self, run_state, path, args, reply_fn):
         """
         Stream the file  at path using a separate thread
         """
@@ -97,7 +99,7 @@ class LocalReader(Reader):
 
         self._threaded_read(run_state, path, stream_file, reply_fn)
 
-    def read_file_section(self, run_state, path, dep_paths, args, reply_fn):
+    def read_file_section(self, run_state, path, args, reply_fn):
         """
         Read the section of file at path of length args['length'] starting at
         args['offset'] (bytes) using a separate thread
@@ -111,7 +113,7 @@ class LocalReader(Reader):
 
         self._threaded_read(run_state, path, read_file_section_thread, reply_fn)
 
-    def summarize_file(self, run_state, path, dep_paths, args, reply_fn):
+    def summarize_file(self, run_state, path, args, reply_fn):
         """
         Summarize the file including args['num_head_lines'] and
         args['num_tail_lines'] but limited with args['max_line_length'] using

--- a/codalab/worker/local_run/local_reader.py
+++ b/codalab/worker/local_run/local_reader.py
@@ -48,7 +48,7 @@ class LocalReader(Reader):
         Return target_info of path in bundle as a message on the reply_fn
         """
         target_info = None
-        dep_paths = set([dep.child_path for dep in run_state.bundle.dependencies])
+        dep_paths = set([dep.child_path for dep in run_state.bundle.dependencies.values()])
 
         # if path is a dependency raise an error
         if path and os.path.normpath(path) in dep_paths:
@@ -79,7 +79,7 @@ class LocalReader(Reader):
         """
         Stream the directory at path using a separate thread
         """
-        dep_paths = set([dep.child_path for dep in run_state.bundle.dependencies])
+        dep_paths = set([dep.child_path for dep in run_state.bundle.dependencies.values()])
         exclude_names = [] if path else dep_paths
 
         def stream_thread(final_path):

--- a/codalab/worker/local_run/local_run_manager.py
+++ b/codalab/worker/local_run/local_run_manager.py
@@ -31,6 +31,8 @@ class LocalRunManager(BaseRunManager):
     KILL_TIMEOUT = 100
     # Directory name to store running bundles in worker filesystem
     BUNDLES_DIR_NAME = 'runs'
+    # Number of loops to check for bundle directory creation by server on shared FS workers
+    BUNDLE_DIR_WAIT_NUM_TRIES = 120
 
     def __init__(
         self,
@@ -220,6 +222,7 @@ class LocalRunManager(BaseRunManager):
             run_status='',
             bundle=bundle,
             bundle_path=os.path.realpath(bundle_path),
+            bundle_dir_wait_num_tries=LocalRunManager.BUNDLE_DIR_WAIT_NUM_TRIES,
             resources=resources,
             bundle_start_time=now,
             container_start_time=None,

--- a/codalab/worker/local_run/local_run_manager.py
+++ b/codalab/worker/local_run/local_run_manager.py
@@ -299,17 +299,17 @@ class LocalRunManager(BaseRunManager):
             with self._lock:
                 self._runs[uuid] = self._runs[uuid]._replace(finalized=True)
 
-    def read(self, run_state, path, dep_paths, args, reply):
+    def read(self, run_state, path, args, reply):
         """
         Use your Reader helper to invoke the given read command
         """
-        self._reader.read(run_state, path, dep_paths, args, reply)
+        self._reader.read(run_state, path, args, reply)
 
-    def write(self, run_state, path, dep_paths, string):
+    def write(self, run_state, path, string):
         """
         Write `string` (string) to path in bundle with uuid.
         """
-        if os.path.normpath(path) in dep_paths:
+        if os.path.normpath(path) in set(dep.child_path for dep in run_state.bundle.dependencies):
             return
         with open(os.path.join(run_state.bundle_path, path), 'w') as f:
             f.write(string)

--- a/codalab/worker/local_run/local_run_manager.py
+++ b/codalab/worker/local_run/local_run_manager.py
@@ -372,6 +372,9 @@ class LocalRunManager(BaseRunManager):
     def all_dependencies(self):
         """
         Returns a list of all dependencies available in this RunManager
+        If on a shared filesystem, reports nothing since all bundles are on the
+        same filesystem and the concept of caching dependencies doesn't apply
+        to this worker.
         """
         if self._shared_file_system:
             return []

--- a/codalab/worker/local_run/local_run_state.py
+++ b/codalab/worker/local_run/local_run_state.py
@@ -214,7 +214,7 @@ class LocalRunStateMachine(StateTransitioner):
         # 1) Set up a directory to store the bundle.
         if self.shared_file_system:
             try:
-                self._wait_for_bundle_folder(run_state.bundle_path)
+                self._wait_for_bundle_folder(run_state)
             except self.NoBundleFolderException as ex:
                 message = 'Bundle folder unavailable: %s' % str(ex)
                 logger.error(message)

--- a/codalab/worker/local_run/local_run_state.py
+++ b/codalab/worker/local_run/local_run_state.py
@@ -243,9 +243,7 @@ class LocalRunStateMachine(StateTransitioner):
             docker_dependency_path = os.path.join(docker_dependencies_path, dep.child_path)
             if self.shared_file_system:
                 # On a shared FS, we know where the dep is stored and can get the contents directly
-                dependency_path = os.path.realpath(
-                    os.path.join(dep.location, dep.parent_path)
-                )
+                dependency_path = os.path.realpath(os.path.join(dep.location, dep.parent_path))
             else:
                 # On a dependency_manager setup ask the manager where the dependency is
                 dependency_path = os.path.join(

--- a/codalab/worker/local_run/local_run_state.py
+++ b/codalab/worker/local_run/local_run_state.py
@@ -225,7 +225,7 @@ class LocalRunStateMachine(StateTransitioner):
 
         # 2) Set up symlinks
         docker_dependencies = []
-        docker_dependencies_path = '/' + run_state.bundle.uuid + '_dependencies'
+        docker_dependencies_path = '/' + run_state.bundle.uuid + ('_dependencies' if not self.shared_file_system else '')
         for dep_key, dep in run_state.bundle.dependencies.items():
             full_child_path = os.path.normpath(os.path.join(run_state.bundle_path, dep.child_path))
             if not full_child_path.startswith(run_state.bundle_path):

--- a/codalab/worker/local_run/local_run_state.py
+++ b/codalab/worker/local_run/local_run_state.py
@@ -225,7 +225,9 @@ class LocalRunStateMachine(StateTransitioner):
 
         # 2) Set up symlinks
         docker_dependencies = []
-        docker_dependencies_path = '/' + run_state.bundle.uuid + ('_dependencies' if not self.shared_file_system else '')
+        docker_dependencies_path = (
+            '/' + run_state.bundle.uuid + ('_dependencies' if not self.shared_file_system else '')
+        )
         for dep_key, dep in run_state.bundle.dependencies.items():
             full_child_path = os.path.normpath(os.path.join(run_state.bundle_path, dep.child_path))
             if not full_child_path.startswith(run_state.bundle_path):

--- a/codalab/worker/local_run/local_run_state.py
+++ b/codalab/worker/local_run/local_run_state.py
@@ -215,7 +215,7 @@ class LocalRunStateMachine(StateTransitioner):
         if self.shared_file_system:
             try:
                 self._wait_for_bundle_directory(run_state)
-            except self.NoBundleFolderException as ex:
+            except self.NoBundleDirectoryException as ex:
                 message = (
                     'Bundle directory unavailable. Please make sure the bundle store is properly mounted'
                     ' on your worker host machine or contact your Codalab administrators: %s'
@@ -244,7 +244,7 @@ class LocalRunStateMachine(StateTransitioner):
             if self.shared_file_system:
                 # On a shared FS, we know where the dep is stored and can get the contents directly
                 dependency_path = os.path.realpath(
-                    os.path.join(os.path.realpath(dep.location), dep.parent_path)
+                    os.path.join(dep.location, dep.parent_path)
                 )
             else:
                 # On a dependency_manager setup ask the manager where the dependency is
@@ -306,7 +306,7 @@ class LocalRunStateMachine(StateTransitioner):
             gpuset=gpuset,
         )
 
-    class NoBundleFolderException(Exception):
+    class NoBundleDirectoryException(Exception):
         pass
 
     def _wait_for_bundle_directory(self, run_state):
@@ -320,7 +320,7 @@ class LocalRunStateMachine(StateTransitioner):
             retries_left -= 1
             time.sleep(0.5)
         if not retries_left:
-            raise self.NoBundleFolderException(
+            raise self.NoBundleDirectoryException(
                 "Bundle location {} not found".format(run_state.bundle_path)
             )
 

--- a/codalab/worker/local_run/local_run_state.py
+++ b/codalab/worker/local_run/local_run_state.py
@@ -540,14 +540,14 @@ class LocalRunStateMachine(StateTransitioner):
             run_state = run_state._replace(failure_message=run_state.kill_message)
         return run_state._replace(stage=LocalRunStage.FINALIZING, run_status="Finalizing bundle")
 
-    @staticmethod
-    def _transition_from_FINALIZING(run_state):
+    def _transition_from_FINALIZING(self, run_state):
         """
         If a full worker cycle has passed since we got into FINALIZING we already reported to
         server so can move on to FINISHED. Can also remove bundle_path now
         """
         if run_state.finalized:
-            remove_path(run_state.bundle_path)
+            if not self.shared_file_system:
+                remove_path(run_state.bundle_path)  # don't remove bundle if shared FS
             return run_state._replace(stage=LocalRunStage.FINISHED, run_status='Finished')
         else:
             return run_state

--- a/codalab/worker/main.py
+++ b/codalab/worker/main.py
@@ -108,9 +108,7 @@ def main():
     parser.add_argument(
         '--shared-file-system',
         action='store_true',
-        help='Internal use: Whether the file system containing '
-        'bundle data is shared between the bundle service '
-        'and the worker.',
+        help='Internal use: If specified, the worker expects to find bundles mounted on its filesystem.',
     )
     args = parser.parse_args()
 
@@ -191,6 +189,7 @@ chmod 600 %s"""
             cpuset,
             gpuset,
             args.work_dir,
+            args.shared_file_system,
             docker_runtime=docker_runtime,
             docker_network_prefix=args.network_prefix,
         )

--- a/codalab/worker/main.py
+++ b/codalab/worker/main.py
@@ -108,7 +108,7 @@ def main():
     parser.add_argument(
         '--shared-file-system',
         action='store_true',
-        help='Internal use: If specified, the worker expects to find bundles mounted on its filesystem.',
+        help='To be used when the server and the worker share the bundle store on their filesystems.',
     )
     args = parser.parse_args()
 

--- a/codalab/worker/main.py
+++ b/codalab/worker/main.py
@@ -203,6 +203,7 @@ chmod 600 %s"""
         args.exit_when_idle,
         args.idle_seconds,
         bundle_service,
+        args.shared_file_system,
     )
 
     # Register a signal handler to ensure safe shutdown.

--- a/codalab/worker/run_manager.py
+++ b/codalab/worker/run_manager.py
@@ -127,18 +127,17 @@ class Reader(object):
             'summarize_file': self.summarize_file,
         }
 
-    def read(self, run_state, path, dep_paths, read_args, reply):
-        dep_paths = set([dep.child_path for dep in run_state.bundle.dependencies.values()])
+    def read(self, run_state, path, read_args, reply):
         read_type = read_args['type']
         handler = self.read_handlers.get(read_type, None)
         if handler:
-            handler(run_state, path, dep_paths, read_args, reply)
+            handler(run_state, path, read_args, reply)
         else:
             err = (http.client.BAD_REQUEST, "Unsupported read_type for read: %s" % read_type)
             reply(err)
 
     @abstractmethod
-    def get_target_info(self, run_state, path, dep_paths, args, reply_fn):
+    def get_target_info(self, run_state, path, args, reply_fn):
         """
         Calls reply_fn(err, msg, data) with the target_info of the path
         in the msg field, or with err if there is an error
@@ -146,7 +145,7 @@ class Reader(object):
         raise NotImplementedError
 
     @abstractmethod
-    def stream_directory(self, run_state, path, dep_paths, args, reply_fn):
+    def stream_directory(self, run_state, path, args, reply_fn):
         """
         Calls reply_fn(err, msg, data) with the dir contents of the path
         in the data field, or with err if there is an error
@@ -154,7 +153,7 @@ class Reader(object):
         raise NotImplementedError
 
     @abstractmethod
-    def stream_file(self, run_state, path, dep_paths, args, reply_fn):
+    def stream_file(self, run_state, path, args, reply_fn):
         """
         Calls reply_fn(err, msg, data) with the file contents of the path
         in the data field, or with err if there is an error
@@ -162,7 +161,7 @@ class Reader(object):
         raise NotImplementedError
 
     @abstractmethod
-    def read_file_section(self, run_state, path, dep_paths, args, reply_fn):
+    def read_file_section(self, run_state, path, args, reply_fn):
         """
         Calls reply_fn(err, msg, data) with the file section contents of the path
         in the data field, or with err if there is an error
@@ -170,7 +169,7 @@ class Reader(object):
         raise NotImplementedError
 
     @abstractmethod
-    def summarize_file(self, run_state, path, dep_paths, args, reply_fn):
+    def summarize_file(self, run_state, path, args, reply_fn):
         """
         Calls reply_fn(err, msg, data) with the file summary of the path
         in the data field, or with err if there is an error

--- a/codalab/worker/run_manager.py
+++ b/codalab/worker/run_manager.py
@@ -44,10 +44,10 @@ class BaseRunManager(object, metaclass=ABCMeta):
         raise NotImplementedError
 
     @abstractmethod
-    def get_run(self, uuid):
+    def has_run(self, uuid):
         """
-        Returns the state of the run with the given UUID if it is managed
-        by this RunManager, returns None otherwise
+        Returns True if the run with the given UUID is managed
+        by this RunManager, False otherwise
         """
         raise NotImplementedError
 

--- a/codalab/worker/worker.py
+++ b/codalab/worker/worker.py
@@ -111,8 +111,8 @@ class Worker(object):
             action_type = response['type']
             logger.debug('Received %s message: %s', action_type, response)
             if action_type in ['read', 'netcat']:
+                socket_id = response['socket_id']
                 if not self._run_manager.has_run(response['uuid']):
-                    socket_id = response['socket_id']
                     self.read_run_missing(socket_id)
                     return
             if action_type == 'run':

--- a/codalab/worker/worker.py
+++ b/codalab/worker/worker.py
@@ -33,6 +33,7 @@ class Worker(object):
         exit_when_idle,  # type: str
         idle_seconds,  # type: int
         bundle_service,  # type: BundleServiceClient
+        shared_file_system,  # type: bool
     ):
         self.id = worker_id
         self._state_committer = JsonStateCommitter(commit_file)
@@ -44,6 +45,7 @@ class Worker(object):
         self._stop = False
         self._last_checkin_successful = False
         self._run_manager = create_run_manager(self)
+        self._shared_file_system = shared_file_system
 
     def start(self):
         """Return whether we ran anything."""
@@ -102,6 +104,7 @@ class Worker(object):
             ],
             'hostname': socket.gethostname(),
             'runs': [run.to_dict() for run in self._run_manager.all_runs],
+            'shared_file_system': self._shared_file_system,
         }
         response = self._bundle_service.checkin(self.id, request)
         if response:

--- a/codalab/worker/worker.py
+++ b/codalab/worker/worker.py
@@ -154,8 +154,7 @@ class Worker(object):
 
         try:
             run_state = self._run_manager.get_run(uuid)
-            dep_paths = set([dep.child_path for dep in run_state.bundle.dependencies.values()])
-            self._run_manager.read(run_state, path, dep_paths, read_args, reply)
+            self._run_manager.read(run_state, path, read_args, reply)
         except BundleServiceException:
             traceback.print_exc()
         except Exception as e:
@@ -179,8 +178,7 @@ class Worker(object):
 
     def _write(self, uuid, subpath, string):
         run_state = self._run_manager.get_run(uuid)
-        dep_paths = set([dep.child_path for dep in run_state.bundle.dependencies.values()])
-        self._run_manager.write(run_state, subpath, dep_paths, string)
+        self._run_manager.write(run_state, subpath, string)
 
     def _kill(self, uuid):
         run_state = self._run_manager.get_run(uuid)

--- a/codalab/worker/worker.py
+++ b/codalab/worker/worker.py
@@ -111,9 +111,8 @@ class Worker(object):
             action_type = response['type']
             logger.debug('Received %s message: %s', action_type, response)
             if action_type in ['read', 'netcat']:
-                run_state = self._run_manager.get_run(response['uuid'])
-                socket_id = response['socket_id']
-                if run_state is None:
+                if not self._run_manager.has_run(response['uuid']):
+                    socket_id = response['socket_id']
                     self.read_run_missing(socket_id)
                     return
             if action_type == 'run':
@@ -153,8 +152,7 @@ class Worker(object):
             self._bundle_service_reply(socket_id, err, message, data)
 
         try:
-            run_state = self._run_manager.get_run(uuid)
-            self._run_manager.read(run_state, path, read_args, reply)
+            self._run_manager.read(uuid, path, read_args, reply)
         except BundleServiceException:
             traceback.print_exc()
         except Exception as e:
@@ -167,8 +165,7 @@ class Worker(object):
             self._bundle_service_reply(socket_id, err, message, data)
 
         try:
-            run_state = self._run_manager.get_run(uuid)
-            self._run_manager.netcat(run_state, port, message, reply)
+            self._run_manager.netcat(uuid, port, message, reply)
         except BundleServiceException:
             traceback.print_exc()
         except Exception as e:
@@ -177,12 +174,10 @@ class Worker(object):
             reply(err)
 
     def _write(self, uuid, subpath, string):
-        run_state = self._run_manager.get_run(uuid)
-        self._run_manager.write(run_state, subpath, string)
+        self._run_manager.write(uuid, subpath, string)
 
     def _kill(self, uuid):
-        run_state = self._run_manager.get_run(uuid)
-        self._run_manager.kill(run_state)
+        self._run_manager.kill(uuid)
 
     def _mark_finalized(self, uuid):
         self._run_manager.mark_finalized(uuid)

--- a/codalab_service.py
+++ b/codalab_service.py
@@ -66,8 +66,8 @@ def should_run_service(args, service):
     services = [] if args.services is None else args.services
     if 'default' in args.services:
         services.extend(DEFAULT_SERVICES)
-    # 'shared-filesystem-worker` is just `worker` but with a different argument, so they're equivalent for us
-    if service == 'shared-filesystem-worker':
+    # 'worker-shared-file-system` is just `worker` but with a different argument, so they're equivalent for us
+    if service == 'worker-shared-file-system':
         service = 'worker'
     return (service in services) and ('no-' + service not in services)
 
@@ -697,7 +697,7 @@ class CodalabServiceManager(object):
         self.bring_up_service('frontend')
         self.bring_up_service('nginx')
         if self.args.shared_file_system:
-            self.bring_up_service('shared-filesystem-worker')
+            self.bring_up_service('worker-shared-file-system')
         else:
             self.bring_up_service('worker')
 

--- a/codalab_service.py
+++ b/codalab_service.py
@@ -624,7 +624,6 @@ class CodalabServiceManager(object):
                         'server/default_user_info/parallel_run_quota',
                         self.args.user_parallel_run_quota,
                     ),
-                    ('workers/shared_file_system', self.args.shared_file_system),
                     ('email/host', self.args.email_host),
                     ('email/username', self.args.email_username),
                     ('email/password', self.args.email_password),

--- a/codalab_service.py
+++ b/codalab_service.py
@@ -370,7 +370,7 @@ class CodalabArgs(object):
             choices=ALL_SERVICES,
             help='Service container to run command on',
         )
-        run_cmd.add_argument('command', metavar='CMD', type=str, help='Command to run')
+        run_cmd.add_argument('service_command', metavar='CMD', type=str, help='Command to run')
 
         return parser
 
@@ -463,7 +463,7 @@ class CodalabServiceManager(object):
                 self.build_images()
             self.start_services()
         elif command == 'run':
-            self.run_service_cmd(self.args.command, service=self.args.service)
+            self.run_service_cmd(self.args.service_command, service=self.args.service)
         elif command == 'logs':
             cmd_str = 'logs'
             if self.args.tail is not None:

--- a/codalab_service.py
+++ b/codalab_service.py
@@ -64,7 +64,9 @@ def should_run_service(args, service):
     services = [] if args.services is None else args.services
     if 'default' in args.services:
         services.extend(DEFAULT_SERVICES)
-
+    # 'shared-filesystem-worker` is just `worker` but with a different argument, so they're equivalent for us
+    if service == 'shared-filesystem-worker':
+        service = 'worker'
     return (service in services) and ('no-' + service not in services)
 
 
@@ -665,7 +667,10 @@ class CodalabServiceManager(object):
         self.bring_up_service('worker-manager-gpu')
         self.bring_up_service('frontend')
         self.bring_up_service('nginx')
-        self.bring_up_service('worker')
+        if self.args.shared_file_system:
+            self.bring_up_service('shared-filesystem-worker')
+        else:
+            self.bring_up_service('worker')
 
         if should_run_service(self.args, 'test'):
             print_header('Running tests')

--- a/docker/compose_files/docker-compose.yml
+++ b/docker/compose_files/docker-compose.yml
@@ -133,7 +133,7 @@ services:
       - service
       - worker
 
-  shared-filesystem-worker:
+  worker-shared-file-system:
     image: codalab/worker:${CODALAB_VERSION}
     command: cl-worker --server http://rest-server:${CODALAB_REST_PORT} --verbose --work-dir ${CODALAB_WORKER_DIR} --network-prefix ${CODALAB_WORKER_NETWORK_PREFIX} --id ${HOSTNAME} --shared-file-system
     <<: *codalab-base

--- a/docker/compose_files/docker-compose.yml
+++ b/docker/compose_files/docker-compose.yml
@@ -143,6 +143,8 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ${CODALAB_WORKER_DIR}:${CODALAB_WORKER_DIR}
+      - ${CODALAB_HOME}:${CODALAB_HOME}
+      - ${CODALAB_BUNDLE_MOUNT}:${CODALAB_BUNDLE_MOUNT}
     networks:
       - service
       - worker

--- a/docker/compose_files/docker-compose.yml
+++ b/docker/compose_files/docker-compose.yml
@@ -133,6 +133,20 @@ services:
       - service
       - worker
 
+  shared-filesystem-worker:
+    image: codalab/worker:${CODALAB_VERSION}
+    command: cl-worker --server http://rest-server:${CODALAB_REST_PORT} --verbose --work-dir ${CODALAB_WORKER_DIR} --network-prefix ${CODALAB_WORKER_NETWORK_PREFIX} --id ${HOSTNAME} --shared-file-system
+    <<: *codalab-base
+    <<: *codalab-root  # Not ideal since worker files saved as root, but without it, can't use docker
+    depends_on:
+      - rest-server
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ${CODALAB_WORKER_DIR}:${CODALAB_WORKER_DIR}
+    networks:
+      - service
+      - worker
+
   monitor:
     image: codalab/server:${CODALAB_VERSION}
     command: python3.6 monitor.py --log-path ${CODALAB_MONITOR_DIR}/monitor.log --backup-path ${CODALAB_MONITOR_DIR}

--- a/test_cli.py
+++ b/test_cli.py
@@ -1704,7 +1704,18 @@ def test(ctx):
     # Check header which includes 8 columns in total from output.
     header = lines[0]
     check_contains(
-        ['worker_id', 'cpus', 'gpus', 'memory', 'free_disk', 'last_checkin', 'tag', 'runs', 'shared_file_system'], header
+        [
+            'worker_id',
+            'cpus',
+            'gpus',
+            'memory',
+            'free_disk',
+            'last_checkin',
+            'tag',
+            'runs',
+            'shared_file_system',
+        ],
+        header,
     )
 
     # Check number of not null values. First 7 columns should be not null. Column "tag" and "runs" could be empty.

--- a/test_cli.py
+++ b/test_cli.py
@@ -1146,8 +1146,12 @@ def test(ctx):
         # Download the whole bundle.
         path = temp_path('')
         run_command([cl, 'download', uuid, '-o', path])
-        assert not os.path.exists(os.path.join(path, 'dir')), '"dir" should not be in downloaded bundle'
-        assert not os.path.exists(os.path.join(path, 'file')), '"file" should not be in downloaded bundle'
+        assert not os.path.exists(
+            os.path.join(path, 'dir')
+        ), '"dir" should not be in downloaded bundle'
+        assert not os.path.exists(
+            os.path.join(path, 'file')
+        ), '"file" should not be in downloaded bundle'
         with open(os.path.join(path, 'stdout')) as fileobj:
             check_contains('5\n6\n7', fileobj.read())
         shutil.rmtree(path)

--- a/test_cli.py
+++ b/test_cli.py
@@ -1146,8 +1146,8 @@ def test(ctx):
         # Download the whole bundle.
         path = temp_path('')
         run_command([cl, 'download', uuid, '-o', path])
-        assert not os.path.exists(os.path.join(path, 'dir')), '"dir" should not be in bundle'
-        assert not os.path.exists(os.path.join(path, 'file')), '"file" should not be in bundle'
+        assert not os.path.exists(os.path.join(path, 'dir')), '"dir" should not be in downloaded bundle'
+        assert not os.path.exists(os.path.join(path, 'file')), '"file" should not be in downloaded bundle'
         with open(os.path.join(path, 'stdout')) as fileobj:
             check_contains('5\n6\n7', fileobj.read())
         shutil.rmtree(path)

--- a/tests/server/bundle_manager_test.py
+++ b/tests/server/bundle_manager_test.py
@@ -18,6 +18,7 @@ class BundleManagerTest(unittest.TestCase):
                 'tag': None,
                 'run_uuids': [],
                 'dependencies': [],
+                'shared_file_system': False,
             },
             {
                 'worker_id': 2,
@@ -27,6 +28,7 @@ class BundleManagerTest(unittest.TestCase):
                 'tag': None,
                 'run_uuids': [],
                 'dependencies': [],
+                'shared_file_system': False,
             },
             {
                 'worker_id': 3,
@@ -36,6 +38,7 @@ class BundleManagerTest(unittest.TestCase):
                 'tag': None,
                 'run_uuids': [],
                 'dependencies': [],
+                'shared_file_system': False,
             },
         ]
         return workers_list


### PR DESCRIPTION
After the worker rewrite, workers had no longer support for shared filesystem deployment even though server-side support was there.
This PR adds that mode back on.