### PR TITLE
Add a test command to be able to run particular tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ jobs:
         - sudo mv docker-compose /usr/local/bin
         - sudo service mysql stop
       install:
-        - python3 codalab_service.py build services --version ${TRAVIS_BRANCH} --pull $([ -z "${CODALAB_DOCKER_USERNAME}" ] || echo "--push")
+        - python3 codalab_service.py build --images services --version ${TRAVIS_BRANCH} --pull $([ -z "${CODALAB_DOCKER_USERNAME}" ] || echo "--push")
       script:
         - python3 codalab_service.py start --services default monitor test --version ${TRAVIS_BRANCH}
     - stage: deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ jobs:
         - chmod +x docker-compose
         - sudo mv docker-compose /usr/local/bin
         - sudo service mysql stop
-        - pip3 install psutil
       install:
         - python3 codalab_service.py build services --version ${TRAVIS_BRANCH} --pull $([ -z "${CODALAB_DOCKER_USERNAME}" ] || echo "--push")
         - python3 codalab_service.py start --services default monitor --version ${TRAVIS_BRANCH}

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ jobs:
         - chmod +x docker-compose
         - sudo mv docker-compose /usr/local/bin
         - sudo service mysql stop
+        - pip3 install psutil
       install:
         - python3 codalab_service.py build services --version ${TRAVIS_BRANCH} --pull $([ -z "${CODALAB_DOCKER_USERNAME}" ] || echo "--push")
         - python3 codalab_service.py start --services default monitor --version ${TRAVIS_BRANCH}

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,10 @@ jobs:
         - sudo mv docker-compose /usr/local/bin
         - sudo service mysql stop
       install:
-        - python3 codalab_service.py build --images services --version ${TRAVIS_BRANCH} --pull $([ -z "${CODALAB_DOCKER_USERNAME}" ] || echo "--push")
+        - python3 codalab_service.py build services --version ${TRAVIS_BRANCH} --pull $([ -z "${CODALAB_DOCKER_USERNAME}" ] || echo "--push")
+        - python3 codalab_service.py start --services default monitor --version ${TRAVIS_BRANCH}
       script:
-        - python3 codalab_service.py start --services default monitor test --version ${TRAVIS_BRANCH}
+        - python3 codalab_service.py test default --version ${TRAVIS_BRANCH}
     - stage: deploy
       script: echo "Deploying"
       language: python

--- a/test_cli.py
+++ b/test_cli.py
@@ -30,7 +30,6 @@ import sys
 import time
 import traceback
 
-from codalab.lib.codalab_manager import CodaLabManager
 
 global cl
 # Directory where this script lives.
@@ -335,6 +334,7 @@ class ModuleContext(object):
         self.error = None
 
         # Allow for making REST calls
+        from codalab.lib.codalab_manager import CodaLabManager
         manager = CodaLabManager()
         self.client = manager.current_client()
 

--- a/test_cli.py
+++ b/test_cli.py
@@ -335,6 +335,7 @@ class ModuleContext(object):
 
         # Allow for making REST calls
         from codalab.lib.codalab_manager import CodaLabManager
+
         manager = CodaLabManager()
         self.client = manager.current_client()
 


### PR DESCRIPTION
This is mainly so that we can test shared filesystem workers on Travis without running all the tests from scratch. Also helpful for locally developing backend features as it makes it possible to only rerun failing tests.
