### PR TITLE
Update sql outerjoin query

### DIFF
--- a/codalab/model/worker_model.py
+++ b/codalab/model/worker_model.py
@@ -152,7 +152,10 @@ class WorkerModel(object):
         with self._engine.begin() as conn:
             worker_rows = conn.execute(
                 select([cl_worker, cl_worker_dependency.c.dependencies]).select_from(
-                    cl_worker.outerjoin(cl_worker_dependency)
+                    cl_worker.outerjoin(
+                        cl_worker_dependency,
+                        cl_worker.c.worker_id == cl_worker_dependency.c.worker_id,
+                    )
                 )
             ).fetchall()
             worker_run_rows = conn.execute(cl_worker_run.select()).fetchall()


### PR DESCRIPTION
This will fix slow transition from `staged` to `preparing` in  #1254 . 
This sql query change resolved the slow transition issue from `staged` to `preparing` on my local machine. The original outerjoin(no join key specified) somehow doesn't return any valid worker even if there is a valid one. I waited for 45 minutes to get a simple `cl run date` running. Once I added the join key, it ran immediately.