### PR TITLE
Cleaning up the hovering insert panels

### DIFF
--- a/frontend/src/components/worksheets/items/TableItem/BundleRow.js
+++ b/frontend/src/components/worksheets/items/TableItem/BundleRow.js
@@ -14,13 +14,9 @@ import DialogTitle from '@material-ui/core/DialogTitle';
 import DeleteIcon from '@material-ui/icons/Delete';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import ExpandLessIcon from '@material-ui/icons/ExpandLess';
-import UploadIcon from '@material-ui/icons/CloudUpload';
-import AddIcon from '@material-ui/icons/PlayCircleFilled';
 
 import * as Mousetrap from '../../../../util/ws_mousetrap_fork';
 import BundleDetail from '../../BundleDetail';
-import NewRun from '../../NewRun';
-import NewUpload from '../../NewUpload';
 import { buildTerminalCommand } from '../../../../util/worksheet_utils';
 import { executeCommand } from '../../../../util/cli_utils';
 
@@ -28,55 +24,11 @@ import { executeCommand } from '../../../../util/cli_utils';
 // We need the various columns to be aligned for all `BundleRow` within a `Table`, therefore using `div` is not an
 // option. Instead, we must make use of zero-height rows.
 
-class InsertButtons extends Component<{
-    classes: {},
-    showNewUpload: () => void,
-    showNewRun: () => void,
-}> {
-    render() {
-        const { classes, showNewUpload, showNewRun } = this.props;
-        return (
-            <div
-                onMouseMove={(ev) => {
-                    ev.stopPropagation();
-                }}
-                className={classes.buttonsPanel}
-            >
-                <Button
-                    key='upload'
-                    variant='outlined'
-                    size='small'
-                    color='primary'
-                    aria-label='New Upload'
-                    onClick={() => showNewUpload()}
-                    classes={{ root: classes.buttonRoot }}
-                >
-                    <UploadIcon className={classes.buttonIcon} />
-                    Upload
-                </Button>
-                <Button
-                    key='run'
-                    variant='outlined'
-                    size='small'
-                    color='primary'
-                    aria-label='New Run'
-                    onClick={() => showNewRun()}
-                    classes={{ root: classes.buttonRoot }}
-                >
-                    <AddIcon className={classes.buttonIcon} />
-                    Run
-                </Button>
-            </div>
-        );
-    }
-}
-
 class BundleRow extends Component {
     state = {
         showDetail: false,
         showNewUpload: 0,
         showNewRun: 0,
-        showInsertButtons: 0,
         bundleInfoUpdates: {},
         showDetail: false,
         openDelete: false,
@@ -109,36 +61,6 @@ class BundleRow extends Component {
         this.setState({ showNewRun: val });
     };
 
-    /**
-     * Mouse listener triggered when hovering a row. It decides whether to show the buttons above or below the row,
-     * based on the vertical position of where the user hovered.
-     */
-    showButtons = (ev) => {
-        const { bundleInfo = {} } = this.props;
-        const { sort_key, id } = bundleInfo;
-        // If this bundle has no id nor sort_key, then it's not really a worksheet_item.
-        // Don't show the insert buttons.
-        if (sort_key === undefined && id === undefined) {
-            return;
-        }
-
-        const row = ev.currentTarget;
-        const { top, height } = row.getBoundingClientRect();
-        const { clientY } = ev;
-        const onTop = clientY >= top && clientY <= top + 0.25 * height;
-        const onBotttom = clientY >= top + 0.75 * height && clientY <= top + height;
-        if (onTop) {
-            this.setState({
-                showInsertButtons: -1,
-            });
-        }
-        if (onBotttom) {
-            this.setState({
-                showInsertButtons: 1,
-            });
-        }
-    };
-
     deleteItem = (ev) => {
         const { setFocus } = this.props;
         ev.stopPropagation();
@@ -169,7 +91,6 @@ class BundleRow extends Component {
 
     render() {
         const {
-            showInsertButtons,
             showDetail,
             showNewUpload,
             showNewRun,
@@ -246,69 +167,7 @@ class BundleRow extends Component {
         return (
             <TableBody
                 classes={{ root: classes.tableBody }}
-                onMouseMove={this.showButtons}
-                onMouseLeave={() => {
-                    this.setState({
-                        showInsertButtons: 0,
-                    });
-                }}
             >
-                {/** ---------------------------------------------------------------------------------------------------
-                  *  Insert Buttons (above)
-                  */}
-                <TableRow classes={{ root: classes.panelContainer }}>
-                    <TableCell colSpan='100%' classes={{ root: classes.panelCellContainer }}>
-                        {showInsertButtons < 0 && (
-                            <InsertButtons
-                                classes={classes}
-                                showNewUpload={this.showNewUpload(-1)}
-                                showNewRun={this.showNewRun(-1)}
-                            />
-                        )}
-                    </TableCell>
-                </TableRow>
-                {/** ---------------------------------------------------------------------------------------------------
-                  *  New Upload (above)
-                  */}
-                {showNewUpload === -1 && (
-                    <TableRow classes={{ root: classes.panelContainer }}>
-                        <TableCell colSpan='100%' classes={{ root: classes.panelCellContainer }}>
-                            <NewUpload
-                                after_sort_key={
-                                    prevBundleInfo
-                                        ? prevBundleInfo.sort_key
-                                        : bundleInfo.sort_key - 10
-                                }
-                                worksheetUUID={worksheetUUID}
-                                reloadWorksheet={reloadWorksheet}
-                                onClose={() => {
-                                    this.setState({ showNewUpload: 0 });
-                                }}
-                            />
-                        </TableCell>
-                    </TableRow>
-                )}
-                {/** ---------------------------------------------------------------------------------------------------
-                  *  New Run (above)
-                  */}
-                {showNewRun === -1 && (
-                    <TableRow>
-                        <TableCell colSpan='100%' classes={{ root: classes.insertPanel }}>
-                            <div className={classes.insertBox}>
-                                <NewRun
-                                    ws={this.props.ws}
-                                    onSubmit={() => this.setState({ showNewRun: 0 })}
-                                    after_sort_key={
-                                        prevBundleInfo
-                                            ? prevBundleInfo.sort_key
-                                            : bundleInfo.sort_key - 10
-                                    }
-                                    reloadWorksheet={reloadWorksheet}
-                                />
-                            </div>
-                        </TableCell>
-                    </TableRow>
-                )}
                 {/** ---------------------------------------------------------------------------------------------------
                   *  Main Content
                   */}
@@ -394,53 +253,6 @@ class BundleRow extends Component {
                         </TableCell>
                     </TableRow>
                 )}
-                {/** ---------------------------------------------------------------------------------------------------
-                  *  New Upload (below)
-                  */}
-                {showNewUpload === 1 && (
-                    <TableRow classes={{ root: classes.panelContainer }}>
-                        <TableCell colSpan='100%' classes={{ root: classes.panelCellContainer }}>
-                            <NewUpload
-                                after_sort_key={bundleInfo.sort_key}
-                                worksheetUUID={worksheetUUID}
-                                reloadWorksheet={reloadWorksheet}
-                                onClose={() => this.setState({ showNewUpload: 0 })}
-                            />
-                        </TableCell>
-                    </TableRow>
-                )}
-                {/** ---------------------------------------------------------------------------------------------------
-                  *  New Run (below)
-                  */}
-                {showNewRun === 1 && (
-                    <TableRow>
-                        <TableCell colSpan='100%' classes={{ root: classes.insertPanel }}>
-                            <div className={classes.insertBox}>
-                                <NewRun
-                                    ws={this.props.ws}
-                                    onSubmit={() => this.setState({ showNewRun: 0 })}
-                                    after_sort_key={bundleInfo.sort_key}
-                                    reloadWorksheet={reloadWorksheet}
-                                    defaultRun={ runProp }
-                                />
-                            </div>
-                        </TableCell>
-                    </TableRow>
-                )}
-                {/** ---------------------------------------------------------------------------------------------------
-                  *  Insert Buttons (below)
-                  */}
-                <TableRow classes={{ root: classes.panelContainer }}>
-                    <TableCell colSpan='100%' classes={{ root: classes.panelCellContainer }}>
-                        {(showInsertButtons > 0 && !isLast) && (
-                            <InsertButtons
-                                classes={classes}
-                                showNewUpload={this.showNewUpload(1)}
-                                showNewRun={this.showNewRun(1)}
-                            />
-                        )}
-                    </TableCell>
-                </TableRow>
             </TableBody>
         );
     }
@@ -486,16 +298,6 @@ const styles = (theme) => ({
         verticalAlign: 'middle !important',
         border: 'none !important',
         padding: '0px !important',
-    },
-    insertPanel: {
-        verticalAlign: 'middle !important',
-        padding: '32px 64px !important',
-        backgroundColor: 'white',
-        borderLeft: '4px solid white !important',  // Erase highlight border.
-        borderRight: '4px solid white !important',  // Erase highlight border.
-    },
-    insertBox: {
-        border: `2px solid ${theme.color.primary.base}`,
     },
     bundleDetail: {
         paddingLeft: `${theme.spacing.largest}px !important`,


### PR DESCRIPTION
Fixing #1518 
The upload & run button the nav bar already works when a there's a selected bundle, just need some code cleaned up in bundle row.

Test: checkout & hover to bundle rows, should no longer appear the insert panel on any bundle table

p.s: the feeling of just deleting, wow...