### PR TITLE
Position delete buttom better

### DIFF
--- a/frontend/src/components/worksheets/items/TableItem/BundleRow.js
+++ b/frontend/src/components/worksheets/items/TableItem/BundleRow.js
@@ -503,6 +503,7 @@ const styles = (theme) => ({
     },
     iconButtonRoot: {
         backgroundColor: theme.color.grey.lighter,
+        marginBottom: 6,
     },
     buttonRoot: {
         width: 120,

--- a/frontend/src/components/worksheets/items/TableItem/BundleRow.js
+++ b/frontend/src/components/worksheets/items/TableItem/BundleRow.js
@@ -503,7 +503,9 @@ const styles = (theme) => ({
     },
     iconButtonRoot: {
         backgroundColor: theme.color.grey.lighter,
-        marginBottom: 6,
+        padding: "1px 2px",
+        marginBottom: 3,
+        marginRight: 1,
     },
     buttonRoot: {
         width: 120,


### PR DESCRIPTION
Adding a buttom margin to vertically center the delete button in bundle rows #1519, this change is based on the bundle row height change in #1540 and will be merged there before getting into frontend branch
![Screenshot from 2019-10-19 14-00-56](https://user-images.githubusercontent.com/23012631/67151292-f9a75080-f278-11e9-9da8-9c5ad7bbe5cd.png)
