### PR TITLE
Make bundle height similar to current version

### DIFF
--- a/frontend/src/components/worksheets/items/TableItem/BundleRow.js
+++ b/frontend/src/components/worksheets/items/TableItem/BundleRow.js
@@ -121,7 +121,7 @@ class BundleRow extends Component {
             if (col === 0) {
                 url = baseUrl;
                 showDetailButton = 
-                        <IconButton onClick={this.handleDetailClick}>
+                        <IconButton onClick={this.handleDetailClick} style={{ padding: 2 }}>
                             {this.state.showDetail?
                             <ExpandLessIcon/>:
                             <ExpandMoreIcon/>}
@@ -148,7 +148,7 @@ class BundleRow extends Component {
                 <TableCell
                     key={col}
                     classes={{
-                        root: classes.root,
+                        root: classes.rootNoPad,
                     }}
                 >
                     {showDetailButton}
@@ -319,8 +319,9 @@ const styles = (theme) => ({
         marginRight: theme.spacing.large,
     },
     contentRow: {
-        height: 36,
+        height: 26,
         borderBottom: '2px solid #ddd',
+        padding: 0,
     },
     highlight: {
         backgroundColor: `${theme.color.primary.lightest} !important`,

--- a/frontend/src/components/worksheets/items/TableItem/BundleRow.js
+++ b/frontend/src/components/worksheets/items/TableItem/BundleRow.js
@@ -200,7 +200,7 @@ class BundleRow extends Component {
             if (col === 0) {
                 url = baseUrl;
                 showDetailButton = 
-                        <IconButton onClick={this.handleDetailClick}>
+                        <IconButton onClick={this.handleDetailClick} style={{ padding: 2 }}>
                             {this.state.showDetail?
                             <ExpandLessIcon/>:
                             <ExpandMoreIcon/>}
@@ -227,7 +227,7 @@ class BundleRow extends Component {
                 <TableCell
                     key={col}
                     classes={{
-                        root: classes.root,
+                        root: classes.rootNoPad,
                     }}
                 >
                     {showDetailButton}
@@ -517,8 +517,9 @@ const styles = (theme) => ({
         marginRight: theme.spacing.large,
     },
     contentRow: {
-        height: 36,
+        height: 26,
         borderBottom: '2px solid #ddd',
+        padding: 0,
     },
     highlight: {
         backgroundColor: `${theme.color.primary.lightest} !important`,

--- a/frontend/src/components/worksheets/items/TableItem/BundleRow.js
+++ b/frontend/src/components/worksheets/items/TableItem/BundleRow.js
@@ -503,6 +503,9 @@ const styles = (theme) => ({
     },
     iconButtonRoot: {
         backgroundColor: theme.color.grey.lighter,
+        padding: "1px 2px",
+        marginBottom: 3,
+        marginRight: 1,
     },
     buttonRoot: {
         width: 120,

--- a/frontend/src/components/worksheets/items/TableItem/BundleRow.js
+++ b/frontend/src/components/worksheets/items/TableItem/BundleRow.js
@@ -305,6 +305,9 @@ const styles = (theme) => ({
     },
     iconButtonRoot: {
         backgroundColor: theme.color.grey.lighter,
+        padding: "1px 2px",
+        marginBottom: 3,
+        marginRight: 1,
     },
     buttonRoot: {
         width: 120,

--- a/frontend/src/components/worksheets/items/TableItem/BundleRow.js
+++ b/frontend/src/components/worksheets/items/TableItem/BundleRow.js
@@ -223,8 +223,8 @@ class BundleRow extends Component {
                                     </Button>
                                 </DialogActions>
                             </Dialog>
-
-                        </div>
+                            
+                            </div>
                     </TableCell>
                 </TableRow>
                 {/** ---------------------------------------------------------------------------------------------------
@@ -293,11 +293,15 @@ const styles = (theme) => ({
     root: {
         verticalAlign: 'middle !important',
         border: 'none !important',
+        wordWrap: 'break-word',
+        maxWidth: 100,
     },
     rootNoPad: {
         verticalAlign: 'middle !important',
         border: 'none !important',
         padding: '0px !important',
+        wordWrap: 'break-word',
+        maxWidth: 100,
     },
     bundleDetail: {
         paddingLeft: `${theme.spacing.largest}px !important`,

--- a/frontend/src/components/worksheets/items/TableItem/TableItem.js
+++ b/frontend/src/components/worksheets/items/TableItem/TableItem.js
@@ -49,7 +49,7 @@ class TableItem extends React.Component<{
         var bundleInfos = item.bundles_spec.bundle_infos;
         var headerItems = item.header;
         var headerHtml = headerItems.map(function(item, index) {
-            let styleDict = index == 0 ?  {paddingLeft: 42} : {};
+            let styleDict = index == 0 ?  { paddingLeft: 28 } : { paddingLeft: 0 };
             return (
                 <TableCell component='th' key={index} style={ styleDict }>
                     {item}


### PR DESCRIPTION
Addressing #1523 
After [one row takes up ~29px]:
![Screenshot from 2019-10-19 13-42-38](https://user-images.githubusercontent.com/23012631/67151160-6b31cf80-f276-11e9-8dcb-91a4a32d33da.png)


Before [one row takes up ~41px]:
![Screenshot from 2019-10-19 13-43-48](https://user-images.githubusercontent.com/23012631/67151175-a2a07c00-f276-11e9-9bff-9ee61115ca9d.png)

