### PR TITLE
Don't open uuid link in bundle row by pressing 'enter' 

### DIFF
--- a/frontend/src/components/worksheets/items/TableItem/BundleRow.js
+++ b/frontend/src/components/worksheets/items/TableItem/BundleRow.js
@@ -238,7 +238,7 @@ class BundleRow extends Component {
 
          // Keyboard opening/closing
          if (this.props.focused) {
-             //need the e.preventDefault to avoid openning selected link
+             // Use e.preventDefault to avoid openning selected link
              Mousetrap.bind(
                 ['enter'], 
                 (e) => {

--- a/frontend/src/components/worksheets/items/TableItem/BundleRow.js
+++ b/frontend/src/components/worksheets/items/TableItem/BundleRow.js
@@ -238,7 +238,14 @@ class BundleRow extends Component {
 
          // Keyboard opening/closing
          if (this.props.focused) {
-             Mousetrap.bind(['enter'], (e) => this.setState((state) => ({ showDetail: !state.showDetail })), 'keydown');
+             Mousetrap.bind(
+                ['enter'], 
+                (e) => {
+                    e.preventDefault();
+                    this.setState((state) => ({ showDetail: !state.showDetail }))
+                    }, 
+                'keydown'
+            );
              Mousetrap.bind(['escape'], (e) => this.setState({ showDetail: false }), 'keydown');
          }
 

--- a/frontend/src/components/worksheets/items/TableItem/BundleRow.js
+++ b/frontend/src/components/worksheets/items/TableItem/BundleRow.js
@@ -238,6 +238,7 @@ class BundleRow extends Component {
 
          // Keyboard opening/closing
          if (this.props.focused) {
+             //need the e.preventDefault to avoid openning selected link
              Mousetrap.bind(
                 ['enter'], 
                 (e) => {


### PR DESCRIPTION
Fix #1531 
After we click on a link, we 'selected' the link. The default behaviour of pressing 'enter' while a link is 'selected' is to open it, so we just need to prevent the default behavior from happening. Now it will only expand/collapse the bundle detail

To test:
1. checkout to the branch, open any worksheet with bundle tables
2. click on a bundle uuid, which should open bundle detail page on new tab
3. go back to the worksheet, press 'enter', it will only expand the bundle detail