### PR TITLE
Add deleting foreign key uuid in worker_run table before dropping the…

### DIFF
--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -981,6 +981,8 @@ class BundleModel(object):
             connection.execute(
                 cl_bundle_dependency.delete().where(cl_bundle_dependency.c.child_uuid.in_(uuids))
             )
+            # In case something goes wrong, delete bundles that are currently running on workers.
+            connection.execute(cl_worker_run.delete().where(cl_worker_run.c.run_uuid.in_(uuids)))
             connection.execute(cl_bundle.delete().where(cl_bundle.c.uuid.in_(uuids)))
 
     def remove_data_hash_references(self, uuids):


### PR DESCRIPTION
Fixed #1550.
`worker_run.run_uuid` is referenced as foreign key to `bundle.uuid`:
https://github.com/codalab/codalab-worksheets/blob/master/codalab/model/tables.py#L336