### PR TITLE
Respect minimum number of workers on worker manager

### DIFF
--- a/codalab/worker_manager/main.py
+++ b/codalab/worker_manager/main.py
@@ -52,12 +52,14 @@ def main():
         logging.basicConfig(format='%(asctime)s %(message)s', level=logging.DEBUG)
     else:
         logging.basicConfig(format='%(asctime)s %(message)s', level=logging.INFO)
+    if args.max_workers < args.min_workers:
+        raise ValueError('Minimum # of workers (%d) greater than maximum # of workers (%d)' % (args.min_workers, args.max_workers))
 
     # Choose the worker manager type.
     if args.worker_manager_type == 'aws-batch':
         manager = AWSBatchWorkerManager(args)
     else:
-        raise Exception('Invalid worker manager type: {}'.format(args.worker_manager_type))
+        raise ValueError('Invalid worker manager type: {}'.format(args.worker_manager_type))
 
     # Go!
     manager.run_loop()

--- a/codalab/worker_manager/main.py
+++ b/codalab/worker_manager/main.py
@@ -53,7 +53,10 @@ def main():
     else:
         logging.basicConfig(format='%(asctime)s %(message)s', level=logging.INFO)
     if args.max_workers < args.min_workers:
-        raise ValueError('Minimum # of workers (%d) greater than maximum # of workers (%d)' % (args.min_workers, args.max_workers))
+        raise ValueError(
+            'Minimum # of workers (%d) greater than maximum # of workers (%d)'
+            % (args.min_workers, args.max_workers)
+        )
 
     # Choose the worker manager type.
     if args.worker_manager_type == 'aws-batch':

--- a/codalab/worker_manager/worker_manager.py
+++ b/codalab/worker_manager/worker_manager.py
@@ -133,7 +133,6 @@ class WorkerManager(object):
 
             # Make sure we don't queue up more workers than staged UUIDs if there are
             # more workers still booting up than staged bundles
-            # However override this if we have less than minimum number of workers
             if len(pending_worker_jobs) >= len(self.staged_uuids):
                 logger.info(
                     'Don\'t launch because still more pending workers than staged bundles ({} >= {})'.format(

--- a/docs/CLI-Reference.md
+++ b/docs/CLI-Reference.md
@@ -123,33 +123,33 @@ This file is auto-generated from the output of `cl help -v` and provides the lis
 
       search (s):
         Search for bundles on a CodaLab instance (returns 10 results by default).
-          search <keyword> ... <keyword>         : Name or uuid contains each <keyword>.',
-          search name=<value>                    : Name is <value>, where `name` can be any metadata field (e.g., description).',
-          search type=<type>                     : Bundle type is <type> (`run` or `dataset`).',
-          search id=<id>                         : Has <id> (integer used for sorting, strictly increasing over time).',
-          search uuid=<uuid>                     : UUID is <uuid> (e.g., 0x...).',
-          search state=<state>                   : State is <state> (e.g., staged, running, ready, failed).',
-          search command=<command>               : Command to run is <command>.',
-          search dependency=<uuid>               : Has a dependency with <uuid>.',
-          search dependency/<name>=<uuid>        : Has a dependency <name>:<uuid>.',
-          ,
-          search owner=<owner>                   : Owned by <owner> (e.g., `pliang`).',
-          search .mine                           : Owned by me.',
-          search group=<group>                   : Shared with <group>.',
-          search .shared                         : Shared with any of the groups I\'m in.',
-          ,
-          search host_worksheet=<worksheet>      : On <worksheet>.',
-          search .floating                       : Not on any worksheet.',
-          ,
-          search .limit=<limit>                  : Limit the number of results to the top <limit> (e.g., 50).',
-          search .offset=<offset>                : Return results starting at <offset>.',
-          ,
-          search size=.sort                      : Sort by a particular field (where `size` can be any metadata field).',
-          search size=.sort-                     : Sort by a particular field in reverse (e.g., `size`).',
-          search .last                           : Sort in reverse chronological order (equivalent to id=.sort-).',
-          search .count                          : Count the number of matching bundles.',
-          search size=.sum                       : Compute total of a particular field (e.g., `size`).',
-          search .format=<format>                : Apply <format> function (see worksheet markdown).',
+          search <keyword> ... <keyword>         : Name or uuid contains each <keyword>.
+          search name=<value>                    : Name is <value>, where `name` can be any metadata field (e.g., description).
+          search type=<type>                     : Bundle type is <type> (`run` or `dataset`).
+          search id=<id>                         : Has <id> (integer used for sorting, strictly increasing over time).
+          search uuid=<uuid>                     : UUID is <uuid> (e.g., 0x...).
+          search state=<state>                   : State is <state> (e.g., staged, running, ready, failed).
+          search command=<command>               : Command to run is <command>.
+          search dependency=<uuid>               : Has a dependency with <uuid>.
+          search dependency/<name>=<uuid>        : Has a dependency <name>:<uuid>.
+        
+          search owner=<owner>                   : Owned by <owner> (e.g., `pliang`).
+          search .mine                           : Owned by me.
+          search group=<group>                   : Shared with <group>.
+          search .shared                         : Shared with any of the groups I'm in.
+        
+          search host_worksheet=<worksheet>      : On <worksheet>.
+          search .floating                       : Not on any worksheet.
+        
+          search .limit=<limit>                  : Limit the number of results to the top <limit> (e.g., 50).
+          search .offset=<offset>                : Return results starting at <offset>.
+        
+          search size=.sort                      : Sort by a particular field (where `size` can be any metadata field).
+          search size=.sort-                     : Sort by a particular field in reverse (e.g., `size`).
+          search .last                           : Sort in reverse chronological order (equivalent to id=.sort-).
+          search .count                          : Count the number of matching bundles.
+          search size=.sum                       : Compute total of a particular field (e.g., `size`).
+          search .format=<format>                : Apply <format> function (see worksheet markdown).
         Arguments:
           keywords              Keywords to search for.
           -a, --append          Append these bundles to the current worksheet.


### PR DESCRIPTION
An earlier change made it such that we would never launch a worker if
there were no staged bundles. This updates the logic slightly so we
still launch workers to reach the minimum worker count even when there
are no bundles waiting.