### PR TITLE
Fixes ctrl+enter to save bundle

### DIFF
--- a/frontend/src/components/worksheets/ConfigPanel/ConfigCodeInput.jsx
+++ b/frontend/src/components/worksheets/ConfigPanel/ConfigCodeInput.jsx
@@ -15,7 +15,7 @@ class ConfigCodeInput extends React.Component<{
     autoFocus?: boolean,
 }> {
     render() {
-        const { classes, placeholder, multiline, maxRows, value, onValueChange, autoFocus } = this.props;
+        const { classes, placeholder, multiline, maxRows, value, onValueChange, onKeyDown, autoFocus } = this.props;
         return (
             <TextField
                 value={value}
@@ -23,6 +23,7 @@ class ConfigCodeInput extends React.Component<{
                 placeholder={placeholder}
                 multiline={multiline}
                 autoFocus={autoFocus}
+                onKeyDown={onKeyDown}
                 margin="dense"
                 variant="filled"
                 fullWidth

--- a/frontend/src/components/worksheets/NewRun/NewRun.jsx
+++ b/frontend/src/components/worksheets/NewRun/NewRun.jsx
@@ -491,7 +491,7 @@ class NewRun extends React.Component<{
                     placeholder="python train.py --data mydataset.txt"
                     maxRows={4}
                     onKeyDown={(e) => {
-                         if(e.keyCode == 18 && (e.ctrlKey || e.shiftKey || e.metaKey)) {
+                         if(e.keyCode === 13 && (e.ctrlKey || e.shiftKey || e.metaKey)) {
                             // Press control enter
                             e.preventDefault();
                             this.runCommand();


### PR DESCRIPTION
Fixes #1521. This error happens on the bundle run
screen. The fix makes sure that the `onKeyPress`
prop is passed on and uses the right key code
(13) for enter.