### PR TITLE
Re-fix open detail

### DIFF
--- a/frontend/src/components/worksheets/items/TableItem/BundleRow.js
+++ b/frontend/src/components/worksheets/items/TableItem/BundleRow.js
@@ -138,7 +138,8 @@ class BundleRow extends Component {
             }
             if (url)
                 rowContent = (
-                    <a href={url} className='bundle-link' target='_blank' style={{ display: 'inline-block', width: 60 }}>
+                    <a href={url} className='bundle-link' target='_blank' style={{ display: 'inline-block', width: 60 }}
+                        onMouseDown={(e)=>{e.preventDefault(); window.open(e.target.href, '_blank')}}>
                         {rowContent}
                     </a>
                 );


### PR DESCRIPTION
Follow up fix for #1531 . It seems like my previous PR #1541 only fixed the issue before moving the floating buttons #1538 . I did some testing and after I removed the floating buttons, the issue comes back. 
Here is what I observed, after clicking on the bundle link and returning to the worksheet, the 'enter' fired for WorksheetItemList.js. I suspect it still relates to the link is 'focused'(selected) after the click and we need to remove this focus on this element. Previously when the floating button code was still there, the enter event still contained in bundle row, which is why #1541 worked.

This PR uses onMouseDown attribute to prevent focus on the link, see https://github.com/gpbl/react-day-picker/issues/16 for more info. 