### PR TITLE
Install AWS Elastic Container Registry Login helper on Worker image

### DIFF
--- a/docker/dockerfiles/Dockerfile.worker
+++ b/docker/dockerfiles/Dockerfile.worker
@@ -1,3 +1,12 @@
+FROM golang as ecr-login-installation
+# Install the Amazon ECR Docker Credential Helper
+# Use Docker multi-stage builds to get rid of intermediate layers related to installation
+
+ENV GOPATH /root/go
+RUN go get -u github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login
+WORKDIR /root/go/src/github.com/awslabs/amazon-ecr-credential-helper
+RUN make
+
 FROM ubuntu:16.04
 MAINTAINER CodaLab Worksheets <codalab.worksheets@gmail.com>
 
@@ -12,6 +21,8 @@ RUN apt-get update; apt-get install -y \
 
 # Set Python3.6 as the default python3 version
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 1
+
+COPY --from=ecr-login-installation /root/go/src/github.com/awslabs/amazon-ecr-credential-helper/bin/local /usr/local/bin
 
 WORKDIR /opt
 RUN mkdir ${WORKDIR}/codalab

--- a/docker/dockerfiles/Dockerfile.worker
+++ b/docker/dockerfiles/Dockerfile.worker
@@ -23,6 +23,8 @@ RUN apt-get update; apt-get install -y \
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 1
 
 COPY --from=ecr-login-installation /root/go/src/github.com/awslabs/amazon-ecr-credential-helper/bin/local /usr/local/bin
+RUN mkdir $HOME/.docker
+RUN echo "{\"credsStore\": \"ecr-login\"}" >> ~/.docker/config.json
 
 WORKDIR /opt
 RUN mkdir ${WORKDIR}/codalab


### PR DESCRIPTION
This is a package that allows the Docker client of the worker to use
private AWS Docker image repositories via setting simple environment
variables.

Preinstalling this on our image means any downstream user of Codalab can
launch a worker that can use their private registries without having to
do any modifications beforehands beyond setting environment variables at
 runtime.