### PR TITLE
support unicode in current frontend

### DIFF
--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -1099,6 +1099,8 @@ class BundleModel(object):
         # Set tags
         for value in worksheet_values.values():
             value['tags'] = []
+            if value['title']:
+                value['title'] = self.decode_str(value['title'])
         for row in tag_rows:
             worksheet_values[row.worksheet_uuid]['tags'].append(row.tag)
         if fetch_items:
@@ -1318,7 +1320,8 @@ class BundleModel(object):
             row = str_key_dict(row)
             row['group_permissions'] = uuid_group_permissions[row['uuid']]
             row_dicts.append(row)
-
+            if row['title']:
+                row['title'] = self.decode_str(row['title'])
         return row_dicts
 
     def new_worksheet(self, worksheet):
@@ -1433,6 +1436,8 @@ class BundleModel(object):
             worksheet.frozen = info['frozen']
         if 'owner_id' in info:
             worksheet.owner_id = info['owner_id']
+        if 'title' in info:
+            info['title'] = self.encode_str(info['title'])
         worksheet.validate()
         with self.engine.begin() as connection:
             if 'tags' in info:

--- a/codalab/model/mysql_model.py
+++ b/codalab/model/mysql_model.py
@@ -59,6 +59,12 @@ class MySQLModel(BundleModel):
     # TODO: Remove these methods below when all appropriate table columns have
     # been converted to the appropriate types that perform automatic encoding.
     # (See tables.py for more details.)
+    # These two methods are currently used for: worksheet title, body
+    # Please update the line above if more fields are using this encoding hack
+    # These two methods are needed right now for unicode support because the
+    # database configuration doesn't support storing unicode directly.
+    # To correctly use it, we should find all codes on the backend side that
+    # actually stores/gets the encoded field
 
     def encode_str(self, value):
         return value.encode()

--- a/codalab/rest/schemas.py
+++ b/codalab/rest/schemas.py
@@ -112,7 +112,7 @@ class WorksheetSchema(Schema):
     uuid = fields.String(attribute='uuid')  # for backwards compatibility
     name = fields.String(validate=validate_name)
     owner = fields.Relationship(include_resource_linkage=True, type_='users', attribute='owner_id')
-    title = fields.String(validate=validate_ascii)
+    title = fields.String()
     frozen = fields.DateTime(allow_none=True)
     is_anonymous = fields.Bool()
     tags = fields.List(fields.String(validate=validate_ascii))

--- a/frontend/src/components/EditableField.js
+++ b/frontend/src/components/EditableField.js
@@ -86,8 +86,14 @@ export class EditableField extends React.Component<{
         }
     };
 
-    handleChange = (event) => {
+    handleAsciiChange = (event) => {
+        // only ascii
         this.setState({ value: event.target.value, isValid: isAscii(event.target.value) });
+    };
+
+    handleFreeChange = (event) => {
+        // allows non-ascii
+        this.setState({ value: event.target.value });
     };
 
     shouldComponentUpdate(nextProps, nextState) {
@@ -113,7 +119,7 @@ export class EditableField extends React.Component<{
                         autoFocus
                         value={this.state.value}
                         onBlur={this.onBlur}
-                        onChange={this.handleChange}
+                        onChange={this.props.allowASCII ? this.handleFreeChange : this.handleAsciiChange}
                         onKeyDown={this.handleKeyPress}
                     />
                     {!this.state.isValid && (
@@ -153,6 +159,10 @@ export class WorksheetEditableField extends React.Component<{
             />
         );
     }
+}
+
+WorksheetEditableField.defaultProps = {
+    allowASCII: false,
 }
 
 export class BundleEditableField extends React.Component<{

--- a/frontend/src/components/worksheets/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet.js
@@ -875,6 +875,7 @@ class Worksheet extends React.Component {
                                                             value={info && info.title || '(untitled)'}
                                                             uuid={info && info.uuid}
                                                             onChange={() => this.reloadWorksheet()}
+                                                            allowASCII={true}
                                                         />
                                                     </h4>
                                                 </div>

--- a/test_cli.py
+++ b/test_cli.py
@@ -1666,9 +1666,9 @@ def test(ctx):
     run_command([cl, 'wedit', wuuid, '--title', 'nonunicode'])
     check_contains('nonunicode', run_command([cl, 'print', wuuid]))
 
-    # TODO: enable with Unicode support.
-    run_command([cl, 'wedit', wuuid, '--title', 'fáncy ünicode 你好世界😊'], 1)
-    # check_contains('fáncy ünicode 你好世界😊', run_command([cl, 'print']))
+    # unicode in worksheet title
+    run_command([cl, 'wedit', wuuid, '--title', 'fáncy ünicode 你好世界😊'], 0)
+    check_contains('fáncy ünicode 你好世界😊', run_command([cl, 'print', wuuid]))
 
     # Non-unicode in file contents
     uuid = run_command([cl, 'upload', '--contents', 'nounicode'])


### PR DESCRIPTION
Allow unicode in worksheet title, name is still restricted
![Screenshot from 2019-10-23 19-13-58](https://user-images.githubusercontent.com/23012631/67447712-96475680-f5c9-11e9-94b0-f49de3079904.png)
Persists (actually saves)
![Screenshot from 2019-10-23 19-14-08](https://user-images.githubusercontent.com/23012631/67447718-99424700-f5c9-11e9-914d-e8d173bd9b68.png)

Changes identical to #1511 