### PR TITLE
Fix slow transition issue due to doublecounting the resource of run_uuid

### DIFF
--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -293,7 +293,7 @@ class BundleModel(object):
 
     def search_bundles(self, user_id, keywords):
         """
-        Returns a  bundle search result dict where:
+        Returns a bundle search result dict where:
             result: list of bundle uuids matching search criteria in order
                           specified for bundle searches
                     single number value for aggregate searches(.count, .sum)

--- a/codalab/server/worker_info_accessor.py
+++ b/codalab/server/worker_info_accessor.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+import copy
 
 
 class WorkerInfoAccessor(object):
@@ -25,7 +26,11 @@ class WorkerInfoAccessor(object):
         return None
 
     def user_owned_workers(self, user_id):
-        return list(self._user_id_to_workers[user_id])
+        # A deep copy is necessary here due to the following facts:
+        # 1. assignment statements in Python do not copy objects, meaning it generates a shallow copy
+        # 2. deep copy is only necessary for compound objects which contains other objects, like lists or class instances
+        # 3. a deep copy will guarantee that one can change one copy without changing the other
+        return list(copy.deepcopy(worker) for worker in self._user_id_to_workers[user_id])
 
     def remove(self, worker):
         self._workers.remove(worker)


### PR DESCRIPTION
The issue in logic here https://github.com/codalab/codalab-worksheets/blob/codalab/server/bundle_manager.py#L335-L344 is: 
double-counting the cpu/gpu/memory resources => negative values of resources on available workers => no available workers => jobs stuck in staged state. 
Here is the logging messages that shows the transition of `cpu` and `memory_bytes`:
The value of `cpu` is substracted 1 a time. 
The value of `memory_bytes` is substracted `2g` a time. 
```
########################################Current bundle uuid = 0x56105637af6c4d8c8c20198bfdd5f884
2019-10-26 23:33:43,758 get_user_parallel_run_quota_left takes time = 0.007198333740234375
2019-10-26 23:33:43,758 ORG_workers_list = [{'user_id': '0', 'worker_id': 'Stanfords-MacBook-Pro.local(31814)', 'tag': 'mojolady', 'cpus': 8, 'gpus': 0, 'memory_bytes': 17179869184}
2019-10-26 23:33:43,779 [_deduct_worker_resources] uuid = 0x12895b688fce44e7b7dc669a818d304c, bundle_resources cpu = 1, memory = 0
2019-10-26 23:33:43,779 [_deduct_worker_resources] worker = {'user_id': '0', 'worker_id': 'Stanfords-MacBook-Pro.local(31814)', 'tag': 'mojolady', 'cpus': 8, 'gpus': 0, 'memory_bytes': 17179869184}
2019-10-26 23:33:43,800 [_deduct_worker_resources] uuid = 0x04f18d7b5e3140a5be2aa95db3d563d0, bundle_resources cpu = 1, memory = 0
2019-10-26 23:33:43,800 [_deduct_worker_resources] worker = {'user_id': '0', 'worker_id': 'Stanfords-MacBook-Pro.local(31814)', 'tag': 'mojolady', 'cpus': 7, 'gpus': 0, 'memory_bytes': 15032385536}
2019-10-26 23:33:43,821 [_deduct_worker_resources] uuid = 0x9fa54604662c41ecbc72aa38b112ea9b, bundle_resources cpu = 1, memory = 0
2019-10-26 23:33:43,821 [_deduct_worker_resources] worker = {'user_id': '0', 'worker_id': 'Stanfords-MacBook-Pro.local(31814)', 'tag': 'mojolady', 'cpus': 6, 'gpus': 0, 'memory_bytes': 12884901888}
...
2019-10-26 23:33:43,843 [_deduct_worker_resources] uuid = 0xbb03d8ed12504591a19b95d050278a72, bundle_resources cpu = 1, memory = 0
2019-10-26 23:33:43,935 [_deduct_worker_resources] worker = {'user_id': '0', 'worker_id': 'Stanfords-MacBook-Pro.local(31814)', 'tag': 'mojolady', 'cpus': 1, 'gpus': 0, 'memory_bytes': 2147483648}
2019-10-26 23:33:43,958 [_deduct_worker_resources] uuid = 0xd757daa59b18418da11b71cb1e41a90a, bundle_resources cpu = 1, memory = 0
2019-10-26 23:33:43,958 [_deduct_worker_resources] worker = {'user_id': '0', 'worker_id': 'Stanfords-MacBook-Pro.local(31814)', 'tag': 'mojolady', 'cpus': 0, 'gpus': 0, 'memory_bytes': 0}
2019-10-26 23:33:43,980 [_deduct_worker_resources] uuid = 0x6ea7d0acdc994a1c9e22aa1e2fe691f6, bundle_resources cpu = 1, memory = 0
2019-10-26 23:33:43,980 [_deduct_worker_resources] worker = {'user_id': '0', 'worker_id': 'Stanfords-MacBook-Pro.local(31814)', 'tag': 'mojolady', 'cpus': -1, 'gpus': 0, 'memory_bytes': -2147483648}
2019-10-26 23:33:43,980 deduct_worker_resources Workers_list = [{'user_id': '0', 'worker_id': 'Stanfords-MacBook-Pro.local(31814)', 'tag': 'mojolady', 'cpus': -2, 'gpus': 0, 'memory_bytes': -4294967296}
2019-10-26 23:33:43,996 Bundle_resources memory = 2147483648, cpu = 1, disk = 0
2019-10-26 23:33:43,997 [server/bundle_manager.py] _filter_and_sort_workers Check filter out MEMORY = [{'user_id': '0', 'worker_id': 'Stanfords-MacBook-Pro.local(31814)', 'tag': 'mojolady', 'cpus': -2, 'gpus': 0, 'memory_bytes': -4294967296}
2019-10-26 23:33:43,997 [server/bundle_manager.py]  Caution: this is a special queue request tag = <_sre.SRE_Match object; span=(0, 13), match='tag=mojolady2'>
```
I added a variable to track those `run_uuids`, so that each of them will be calculated once. Then there will be no double-counting and no negative values generated from `def _deduct_worker_resources()` function.