### PR TITLE
Don't push docker images on PR builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,9 @@ jobs:
         - sudo mv docker-compose /usr/local/bin
         - sudo service mysql stop
       install:
-        - python3 codalab_service.py build services --version ${TRAVIS_BRANCH} --pull $([ -z "${CODALAB_DOCKER_USERNAME}" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ] || echo "--push")
+        - echo "TRAVIS_PULL_REQUEST_BRANCH is:"
+        - echo $TRAVIS_PULL_REQUEST_BRANCH
+        - python3 codalab_service.py build services --version ${TRAVIS_BRANCH} --pull $([ -z "${CODALAB_DOCKER_USERNAME}" ] && [ "$TRAVIS_PULL_REQUEST_BRANCH" = "" ] || echo "--push")
         - python3 codalab_service.py start --services default monitor --version ${TRAVIS_BRANCH}
       script:
         - python3 codalab_service.py test --version ${TRAVIS_BRANCH} default

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ jobs:
         - sudo mv docker-compose /usr/local/bin
         - sudo service mysql stop
       install:
-        - python3 codalab_service.py build services --version ${TRAVIS_BRANCH} --pull $([ -z "${CODALAB_DOCKER_USERNAME}" ] || echo "--push")
+        - python3 codalab_service.py build services --version ${TRAVIS_BRANCH} --pull $([ -z "${CODALAB_DOCKER_USERNAME}" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ] || echo "--push")
         - python3 codalab_service.py start --services default monitor --version ${TRAVIS_BRANCH}
       script:
         - python3 codalab_service.py test --version ${TRAVIS_BRANCH} default

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ jobs:
         - sudo mv docker-compose /usr/local/bin
         - sudo service mysql stop
       install:
-        - python3 codalab_service.py build services --version ${TRAVIS_BRANCH} --pull $([ -z "${CODALAB_DOCKER_USERNAME}" ] && [ -z "${TRAVIS_PULL_REQUEST_BRANCH}" ] || echo "--push")
+        - python3 codalab_service.py build services --version ${TRAVIS_BRANCH} --pull $([ -z "${CODALAB_DOCKER_USERNAME}" ] || [ -z "${TRAVIS_PULL_REQUEST_BRANCH}" ] || echo "--push")
         - python3 codalab_service.py start --services default monitor --version ${TRAVIS_BRANCH}
       script:
         - python3 codalab_service.py test --version ${TRAVIS_BRANCH} default

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ jobs:
         - sudo mv docker-compose /usr/local/bin
         - sudo service mysql stop
       install:
-        - python3 codalab_service.py build services --version ${TRAVIS_BRANCH} --pull $([ -z "${CODALAB_DOCKER_USERNAME}" ] || [ -z "${TRAVIS_PULL_REQUEST_BRANCH}" ] || echo "--push")
+        - python3 codalab_service.py build services --version ${TRAVIS_BRANCH} --pull $([ -z "${CODALAB_DOCKER_USERNAME}" ] || [ "$TRAVIS_PULL_REQUEST_BRANCH" != "" ] || echo "--push")
         - python3 codalab_service.py start --services default monitor --version ${TRAVIS_BRANCH}
       script:
         - python3 codalab_service.py test --version ${TRAVIS_BRANCH} default

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,7 @@ jobs:
         - sudo mv docker-compose /usr/local/bin
         - sudo service mysql stop
       install:
-        - echo "TRAVIS_PULL_REQUEST_BRANCH is:"
-        - echo $TRAVIS_PULL_REQUEST_BRANCH
-        - python3 codalab_service.py build services --version ${TRAVIS_BRANCH} --pull $([ -z "${CODALAB_DOCKER_USERNAME}" ] && [ "$TRAVIS_PULL_REQUEST_BRANCH" = "" ] || echo "--push")
+        - python3 codalab_service.py build services --version ${TRAVIS_BRANCH} --pull $([ -z "${CODALAB_DOCKER_USERNAME}" ] && [ -z "${TRAVIS_PULL_REQUEST_BRANCH}" ] || echo "--push")
         - python3 codalab_service.py start --services default monitor --version ${TRAVIS_BRANCH}
       script:
         - python3 codalab_service.py test --version ${TRAVIS_BRANCH} default


### PR DESCRIPTION
This fixes #1581. Each time a PR is sent, it creates a PR build and a push build. This PR makes it so that the PR build will not push docker images, but only the push build will do so.