### PR TITLE
Allow branches with -'s in their name to pass CI

### DIFF
--- a/codalab_service.py
+++ b/codalab_service.py
@@ -102,12 +102,8 @@ def get_default_version():
         subprocess.check_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD'], encoding='utf-8')
         .strip()
         # This is required so that branches with special names do not fail CI.
-        .replace(
-            "/", "_"
-        )
-        .replace(
-            "-", "_"
-        )
+        .replace("/", "_")
+        .replace("-", "_")
     )
 
 

--- a/codalab_service.py
+++ b/codalab_service.py
@@ -101,9 +101,13 @@ def get_default_version():
     return (
         subprocess.check_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD'], encoding='utf-8')
         .strip()
+        # This is required so that branches with special names do not fail CI.
         .replace(
             "/", "_"
-        )  # This is required so that branches with "/" in their name do not fail CI.
+        )
+        .replace(
+            "-", "_"
+        )
     )
 
 


### PR DESCRIPTION
Fixes #1600 by replacing all -'s with a _.