### PR TITLE
Update time_used logic to consider time overlap between bundles

### DIFF
--- a/alembic/versions/2019110622_add_last_bundle_finished_time__dc6d60726d9a.py
+++ b/alembic/versions/2019110622_add_last_bundle_finished_time__dc6d60726d9a.py
@@ -1,0 +1,22 @@
+"""add last bundle finished time to user table
+
+Revision ID: dc6d60726d9a
+Revises: 75d4288ae265
+Create Date: 2019-11-06 22:39:59.913605
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'dc6d60726d9a'
+down_revision = '75d4288ae265'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('user', sa.Column('last_bundle_finished_time', sa.DateTime(), nullable=False))
+
+
+def downgrade():
+    op.drop_column('user', 'last_bundle_finished_time')

--- a/codalab/model/tables.py
+++ b/codalab/model/tables.py
@@ -204,6 +204,9 @@ user = Table(
     # Additional information
     Column('affiliation', String(255, convert_unicode=True), nullable=True),
     Column('url', String(255, convert_unicode=True), nullable=True),
+    Column(
+        'last_bundle_finished_time', DateTime, nullable=False
+    ),  # Time when this user's last bundle was finished
     # Quotas
     Column('time_quota', Float, nullable=False),  # Number of seconds allowed
     Column('parallel_run_quota', Integer, nullable=False),  # Number of parallel jobs allowed

--- a/codalab/objects/user.py
+++ b/codalab/objects/user.py
@@ -2,6 +2,7 @@
 User objects representing rows from the user table
 """
 import base64
+import time
 
 from codalab.common import UsageError
 from codalab.lib import formatting
@@ -31,6 +32,7 @@ class User(ORMObject):
         'disk_used',
         'affiliation',
         'url',
+        'last_bundle_finished_time',
     )
 
     PASSWORD_MIN_LENGTH = 8
@@ -146,5 +148,6 @@ PUBLIC_USER = User(
         "disk_used": 0,
         "affiliation": None,
         "url": None,
+        "last_bundle_finished_time": time.time(),
     }
 )

--- a/tests/objects/user_test.py
+++ b/tests/objects/user_test.py
@@ -25,6 +25,7 @@ user = User(
         "disk_used": 0,
         "affiliation": None,
         "url": None,
+        "last_bundle_finished_time": "2019-11-06 03:40:38"
     }
 )
 


### PR DESCRIPTION
Fixed #1533 .
In this PR, I am trying to fix the unusual time quota increasing problem. 

- Current logic: 
For each bundle, when it starts to finalize, we update the `user['time_used']` by directly adding the amount of wall clock running time from `bundle.metadata` to `time_used`. This logic doesn't consider the overlapping time windows that could be generated from other bundles owned by this user. So those certain users who created a large number of bundles in a short time window will get their time quota reached very quickly.

- New logic:
In this PR, I added a new column that tracks the timestamp of the last bundle from each user to `user` table, named with `last_bundle_finished_time`. During the time that we update `user['time_used']`, we compare if the start time of the current bundle is earlier the `last_bundle_finished_time`. If yes, then there is an overlapping period which we shouldn't add to the final result. If no, we can use the bundle start time as the left boundary of the current time window to calculate the amount of time to be added to `user['time_used']`.
