### PR TITLE
Not to raise exception when bundle is not found on target worker when…

### DIFF
--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -7,6 +7,8 @@ import datetime
 import os
 import re
 import time
+import logging
+
 from uuid import uuid4
 
 from sqlalchemy import and_, or_, not_, select, union, desc, func
@@ -48,6 +50,8 @@ from codalab.objects.user import User
 from codalab.rest.util import get_group_info
 from codalab.worker.bundle_state import State
 
+
+logger = logging.getLogger(__name__)
 
 SEARCH_KEYWORD_REGEX = re.compile('^([\.\w/]*)=(.*)$')
 
@@ -221,9 +225,11 @@ class BundleModel(object):
             row = conn.execute(
                 cl_worker_run.select().where(cl_worker_run.c.run_uuid == uuid)
             ).fetchone()
-            precondition(
-                row, 'Trying to find worker for bundle {} that is not running.'.format(uuid)
-            )
+
+            if not row:
+                logger.info('Trying to find worker for bundle {} that is not running.'.format(uuid))
+                return None
+
             worker_row = conn.execute(
                 cl_worker.select().where(
                     and_(cl_worker.c.user_id == row.user_id, cl_worker.c.worker_id == row.worker_id)


### PR DESCRIPTION
Fixed #1485 . 
When we tried to acknowledge recently finished bundles, we always try to get a list of bundles that are in `finalizing` state and loop through each of them to see if we can find the current bundle is running on a worker by scanning the `worker_run` table. When we cannot find the current bundle running on any workers (this could be due to a worker lost connection to our server or any other possible reasons), we send this bundle to go through a `precondition` check, which will then raise a `PreconditionViolation` error. This raised error will block the rest of the bundles that were trying to get acknowledged. I update the precondition check here to be non-blocking for the rest of the bundles that were in `finalizing` state.
