### PR TITLE
Reorder code line to make it more intuitive

### DIFF
--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -1327,9 +1327,9 @@ class BundleModel(object):
         for row in rows:
             row = str_key_dict(row)
             row['group_permissions'] = uuid_group_permissions[row['uuid']]
-            row_dicts.append(row)
             if row['title']:
                 row['title'] = self.decode_str(row['title'])
+            row_dicts.append(row)
         return row_dicts
 
     def new_worksheet(self, worksheet):


### PR DESCRIPTION
This works in python because what row_dicts append is a reference of row, so modifying row later than the append still modifies the same object, but it's better to have it in the desired happen order. This will be consistent with frontend-branch
Works correctly after order change:
![Screenshot from 2019-11-11 17-30-32](https://user-images.githubusercontent.com/23012631/68634043-fdf61080-04a8-11ea-8953-03ffaf915753.png)
