### PR TITLE
Fix 'enter' event after multiple clicks on worksheet row

### DIFF
--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -338,9 +338,9 @@ class Worksheet extends React.Component {
 // BULK OPERATION RELATED CODE ABOVE======================================
 
     setFocus = (index, subIndex, shouldScroll = true) => {
-        if (index === this.state.focusIndex && subIndex === this.state.subFocusIndex){
-            return;
-        }
+        // if (index === this.state.focusIndex && subIndex === this.state.subFocusIndex){
+        //     return;
+        // }
         var info = this.state.ws.info;
         // resolve to the last item that contains bundle(s)
         if (index === 'end') {

--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -338,6 +338,9 @@ class Worksheet extends React.Component {
 // BULK OPERATION RELATED CODE ABOVE======================================
 
     setFocus = (index, subIndex, shouldScroll = true) => {
+        if (index === this.state.focusIndex && subIndex === this.state.subFocusIndex){
+            return;
+        }
         var info = this.state.ws.info;
         // resolve to the last item that contains bundle(s)
         if (index === 'end') {

--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -670,18 +670,6 @@ class Worksheet extends React.Component {
             },
         );
         
-<<<<<<< HEAD
-        // Confirm operation
-        Mousetrap.bind(['enter'], function(e) {
-            if (this.state.openDelete){
-                this.executeBundleCommandNoEvent('rm');
-            }else if (this.state.openKill){
-                this.executeBundleCommandNoEvent('kill');
-            }else if (this.state.openDetach){
-                this.executeBundleCommandNoEvent('detach');
-            }
-        }.bind(this));
-=======
         if (this.state.showBundleOperationButtons && (this.state.openDelete||this.state.openKill||this.state.openDetach)){
             // Confirm operation
             Mousetrap.bind(['enter'], function(e) {
@@ -694,7 +682,6 @@ class Worksheet extends React.Component {
                 }
             }.bind(this));
         }
->>>>>>> e81e329b... fix typo delete->detach
 
         // Select/Deselect to force delete during deletion dialog
         Mousetrap.bind(['f'], function() {

--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -670,6 +670,7 @@ class Worksheet extends React.Component {
             },
         );
         
+<<<<<<< HEAD
         // Confirm operation
         Mousetrap.bind(['enter'], function(e) {
             if (this.state.openDelete){
@@ -680,6 +681,20 @@ class Worksheet extends React.Component {
                 this.executeBundleCommandNoEvent('detach');
             }
         }.bind(this));
+=======
+        if (this.state.showBundleOperationButtons && (this.state.openDelete||this.state.openKill||this.state.openDetach)){
+            // Confirm operation
+            Mousetrap.bind(['enter'], function(e) {
+                if (this.state.openDelete){
+                    this.executeBundleCommandNoEvent('rm');
+                }else if (this.state.openKill){
+                    this.executeBundleCommandNoEvent('kill');
+                }else if (this.state.openDetach){
+                    this.executeBundleCommandNoEvent('detach');
+                }
+            }.bind(this));
+        }
+>>>>>>> e81e329b... fix typo delete->detach
 
         // Select/Deselect to force delete during deletion dialog
         Mousetrap.bind(['f'], function() {


### PR DESCRIPTION
Fixing #1643

Not entirely sure what's going on, but I think the setState even when index, subIndex didn't change will cause the focus of a click change. Adding the check solves this problem and - it's good practice to return early anyway

Also a nit change to scope 'enter' binding