### PR TITLE
Don't do a production build in dev mode

### DIFF
--- a/docker/compose_files/docker-compose.yml
+++ b/docker/compose_files/docker-compose.yml
@@ -88,7 +88,7 @@ services:
 
   frontend:
     image: codalab/frontend:${CODALAB_VERSION}
-    command: serve -s build -l ${CODALAB_FRONTEND_PORT}
+    command: npm run build --production && serve -s build -l ${CODALAB_FRONTEND_PORT}
     <<: *codalab-base
     <<: *codalab-root
     depends_on:

--- a/docker/dockerfiles/Dockerfile.frontend
+++ b/docker/dockerfiles/Dockerfile.frontend
@@ -14,7 +14,4 @@ RUN npm install
 # Overridden in dev mode
 COPY frontend .
 
-# Build static files
-RUN npm run build --production
-
 EXPOSE 2700


### PR DESCRIPTION
The problem was that whenever you started up a codalab instance
in dev mode, you would have to wait for the files to build in
production mode, which takes a long time. This is partly why
it takes so long to set up our demos. Additionally, when you
switch between branches that have different node_modules installed,
when you do `npm install` it resets your node_modules directory,
so essentially you have to wait for a full production build each
time you switch between branches (whereas if you could just reuse
the same node_modules folder, you wouldn't have to do that).

This change changes that by making sure that the production build
happens only in production mode, and that dev mode only spins up
the dev server.