### PR TITLE
Fix undefined element error

### DIFF
--- a/frontend/src/components/NavBar.js
+++ b/frontend/src/components/NavBar.js
@@ -281,7 +281,7 @@ class NavBar extends React.Component<{
                         })}
                         message={
                             <span className={classes.snackbarMessage}>
-                                <SnackbarIcon className={classes.snackbarIcon}/>
+                                {SnackbarIcon && <SnackbarIcon className={classes.snackbarIcon}/>}
                                 {this.state.snackbarMessage}
                             </span>
                         }


### PR DESCRIPTION
Fix error:

"Warning: React.createElement: type is invalid -- expected a string (for built-in components) or a class/function (for composite components) but got: undefined."