### PR TITLE
fix-time-quota-miscalculation

### DIFF
--- a/codalab/worker/docker_utils.py
+++ b/codalab/worker/docker_utils.py
@@ -9,7 +9,8 @@ created if not.
 import logging
 import os
 import docker
-
+from dateutil import parser, tz
+import datetime
 from codalab.lib.formatting import parse_size
 
 
@@ -256,3 +257,25 @@ def check_finished(container):
             failure_msg = 'Memory limit exceeded.'
         return (True, exitcode, failure_msg)
     return (False, None, None)
+
+
+@wrap_exception('Unable to check Docker container running time')
+def get_container_running_time(container):
+    # Get the current container
+    container = client.containers.get(container.id)
+    # Load this container from the server again and update attributes with the new data.
+    container.reload()
+    # Calculate the start_time of the current container
+    start_time = container.attrs['State']['StartedAt']
+    # Calculate the end_time of the current container. If 'Status' of the current container is not 'exited',
+    # then using the current time as end_time
+    end_time = (
+        container.attrs['State']['FinishedAt']
+        if container.attrs['State']['Status'] == 'exited'
+        else str(datetime.datetime.now().replace(tzinfo=tz.tzutc()))
+    )
+    # Docker reports both the start_time and the end_time in ISO format. We currently use dateutil.parser.isoparse to
+    # parse them. In Python3.7 or above, the built-in function datetime.fromisoformat() can be used to parse ISO
+    # formatted datetime string directly.
+    container_running_time = parser.isoparse(end_time) - parser.isoparse(start_time)
+    return container_running_time.total_seconds()

--- a/codalab/worker/local_run/local_run_state.py
+++ b/codalab/worker/local_run/local_run_state.py
@@ -339,7 +339,7 @@ class LocalRunStateMachine(StateTransitioner):
                 disk_utilization=self.disk_utilization[run_state.bundle.uuid]['disk_utilization']
             )
 
-            container_time_total = time.time() - run_state.container_start_time
+            container_time_total = docker_utils.get_container_running_time(run_state.container)
             run_state = run_state._replace(
                 container_time_total=container_time_total,
                 container_time_user=run_stats.get(

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ six==1.11.0
 SQLAlchemy==1.0.8
 watchdog==0.8.3
 fusepy==2.0.4
+python-dateutil


### PR DESCRIPTION
**Note that I haven't been able to test this PR locally yet due to both of the laptops I have are not working functionally in different ways.** 
Since I don't want to block the issue gets fixed, I read through the code and did some investigation on the docker api and those users who experienced unusual time quota increases, then I came up with this PR. 
Basically, I did a bunch of checks on those finished containers and got an impression that the stats returning from `docker inspect` is more reliable than manually calculating the time. There are some open questions we still need to decide:
1. Should we keep updating the `container_time_total` when the container is still `running`? The current logic (before this PR) seems to do so. 
2. This question is related to 1st, if we do want to keep updating the `container_time_total` even if the container is still `running`, then when we inspect the docker container, should we calculate the difference between now and start time? Or give it a default value?   