### PR TITLE
Remove context menu for bundle rows

### DIFF
--- a/frontend/src/components/worksheets/items/TableItem/BundleRow.js
+++ b/frontend/src/components/worksheets/items/TableItem/BundleRow.js
@@ -243,13 +243,6 @@ class BundleRow extends Component {
                  */}
                 <TableRow
                     onClick={this.handleSelectRowClick}
-                    onContextMenu={this.props.handleContextMenu.bind(
-                        null,
-                        bundleInfo.uuid,
-                        this.props.focusIndex,
-                        this.props.rowIndex,
-                        bundleInfo.bundle_type === 'run',
-                    )}
                     className={classNames({
                         [classes.contentRow]: true,
                         [classes.highlight]: this.props.focused,

--- a/frontend/src/components/worksheets/items/TableItem/TableItem.js
+++ b/frontend/src/components/worksheets/items/TableItem/TableItem.js
@@ -15,7 +15,6 @@ import CheckBoxIcon from '@material-ui/icons/CheckBox';
 class TableItem extends React.Component<{
     worksheetUUID: string,
     item: {},
-    handleContextMenu: () => any,
     reloadWorksheet: () => any,
 }> {
     /** Constructor. */
@@ -195,7 +194,6 @@ class TableItem extends React.Component<{
                     canEdit={canEdit}
                     updateRowIndex={this.updateRowIndex}
                     columnWithHyperlinks={columnWithHyperlinks}
-                    handleContextMenu={this.props.handleContextMenu}
                     reloadWorksheet={this.props.reloadWorksheet}
                     ws={this.props.ws}
                     checkStatus={this.state.childrenCheckState[rowIndex]}


### PR DESCRIPTION
Not sure about other use case, but moving to use the bulk operations for bundle rows