### PR TITLE
Improve checking resource failure function

### DIFF
--- a/codalab/server/bundle_manager.py
+++ b/codalab/server/bundle_manager.py
@@ -631,27 +631,31 @@ class BundleManager(object):
         for bundle in self._model.batch_get_bundles(state=State.STAGED, bundle_type='run'):
             bundle_resources = self._compute_bundle_resources(bundle)
 
-            failure_message = self._check_resource_failure(
+            failure_message = (
+                self._check_resource_failure(
                     bundle_resources.disk,
                     user_fail_string='Requested more disk (%s) than user disk quota left (%s)',
                     user_max=self._model.get_user_disk_quota_left(bundle.owner_id),
                     global_fail_string='Maximum job disk size (%s) exceeded (%s)',
                     global_max=self._max_request_disk,
                     pretty_print=formatting.size_str,
-                ) or self._check_resource_failure(
+                )
+                or self._check_resource_failure(
                     bundle_resources.time,
                     user_fail_string='Requested more time (%s) than user time quota left (%s)',
                     user_max=self._model.get_user_time_quota_left(bundle.owner_id),
                     global_fail_string='Maximum job time (%s) exceeded (%s)',
                     global_max=self._max_request_time,
                     pretty_print=formatting.duration_str,
-                ) or self._check_resource_failure(
+                )
+                or self._check_resource_failure(
                     bundle_resources.memory,
                     global_fail_string='Requested more memory (%s) than maximum limit (%s)',
                     global_max=self._max_request_memory,
                     pretty_print=formatting.size_str,
                 )
-                
+            )
+
             if failure_message:
                 logger.info('Failing %s: %s', bundle.uuid, failure_message)
 
@@ -659,4 +663,3 @@ class BundleManager(object):
                     bundle,
                     {'state': State.FAILED, 'metadata': {'failure_message': failure_message}},
                 )
-                


### PR DESCRIPTION
Fixed #1706 .
This PR is to make the function `_fail_on_too_many_resources()` in the bundle manager run a bit faster.
The original logic tries to check for three conditions (memory, disk quota, and time quota) for each bundle to see if it was requested more resources than the system currently has. The logic could be changed to as long as one check failed, we fail the bundle right away, which can improve the performance a bit. It might be helpful to understand which resource check fails more frequently than others. Then we could reorder those checks to make it run faster.