### PR TITLE
Add libssl-dev for mysqlclient

### DIFF
--- a/docker/dockerfiles/Dockerfile.server
+++ b/docker/dockerfiles/Dockerfile.server
@@ -12,6 +12,7 @@ RUN apt-get update; apt-get install -y \
     libfuse-dev \
     libjpeg-dev \
     libmysqlclient-dev \
+    libssl-dev \
     mysql-client \
     python3.6 \
     python3.6-dev \


### PR DESCRIPTION
Fixed #1737 .

It appears that `libssl-dev` is a requirement for installing `mysqlclient`. Please check this [mysqlclient-python-issue](https://github.com/PyMySQL/mysqlclient-python/issues/341) out.