### PR TITLE
Use placeholder for empty worksheet titles

### DIFF
--- a/frontend/src/components/EditableField.js
+++ b/frontend/src/components/EditableField.js
@@ -111,7 +111,7 @@ class EditableFieldBase extends React.Component<{
                     onClick={this.onClick}
                     style={{ color: '#225ea8' }}
                 >
-                    {this.state.value === '' ? '<none>' : this.state.value}
+                    {!this.state.value ? '<none>' : this.state.value}
                 </span>
             );
         } else {

--- a/frontend/src/components/EditableField.js
+++ b/frontend/src/components/EditableField.js
@@ -111,7 +111,7 @@ class EditableFieldBase extends React.Component<{
                     onClick={this.onClick}
                     style={{ color: '#225ea8' }}
                 >
-                    {!this.state.value ? '<none>' : this.state.value}
+                    {this.state.value || '<none>'}
                 </span>
             );
         } else {


### PR DESCRIPTION
fix #1721 , test by adding a new worksheet, verify that the title shows <none> instead of not having the component