### PR TITLE
Handle File cancel properly

### DIFF
--- a/frontend/src/components/worksheets/NewUpload/NewUpload.jsx
+++ b/frontend/src/components/worksheets/NewUpload/NewUpload.jsx
@@ -173,7 +173,7 @@ class NewUpload extends React.Component<{
     }
 
     // Handling cancel
-    // When the user clicks, it focuses back on the window and triggers onClose 
+    // When the user cancels, will focus back on the window and triggers onClose()
     handleFocusBack=()=>{
         this.props.onClose();
         window.removeEventListener('focus', this.handleFocusBack);

--- a/frontend/src/components/worksheets/NewUpload/NewUpload.jsx
+++ b/frontend/src/components/worksheets/NewUpload/NewUpload.jsx
@@ -79,7 +79,8 @@ class NewUpload extends React.Component<{
         this.inputFile.click();
     }
 
-    setFile = (_) => {
+    setFile = () => {
+        window.removeEventListener('focus', this.handleFocusBack);
         const files = this.inputFile.files;
         if (!files.length) {
             this.props.onClose();
@@ -171,6 +172,18 @@ class NewUpload extends React.Component<{
         this.setState({ percentComplete: 0, uploading: false });
     }
 
+    // Handling cancelling
+    // Based on: https://stackoverflow.com/questions/49627109/reactjs-how-to-detect-when-cancel-is-clicked-on-file-input
+    handleFocusBack=()=>{
+        this.props.onClose();
+        window.removeEventListener('focus', this.handleFocusBack);
+    }
+
+    clickedFileInput=()=>{
+        window.addEventListener('focus', this.handleFocusBack);
+    }
+    
+
     render() {
         const { classes } = this.props;
         const { percentComplete, uploading } = this.state;
@@ -182,7 +195,7 @@ class NewUpload extends React.Component<{
                     style={ { visibility: 'hidden', position: 'absolute' } }
                     ref={ (ele) => { this.inputFile = ele; } }
                     onChange={ this.setFile }
-                    onClick={ this.props.onClose }
+                    onClick={ this.clickedFileInput }
                 />
                 { uploading && <CircularProgress
                         className={ classes.progress }

--- a/frontend/src/components/worksheets/NewUpload/NewUpload.jsx
+++ b/frontend/src/components/worksheets/NewUpload/NewUpload.jsx
@@ -172,8 +172,8 @@ class NewUpload extends React.Component<{
         this.setState({ percentComplete: 0, uploading: false });
     }
 
-    // Handling cancelling
-    // Based on: https://stackoverflow.com/questions/49627109/reactjs-how-to-detect-when-cancel-is-clicked-on-file-input
+    // Handling cancel
+    // When the user clicks, it focuses back on the window and triggers onClose 
     handleFocusBack=()=>{
         this.props.onClose();
         window.removeEventListener('focus', this.handleFocusBack);


### PR DESCRIPTION
The fix #1720 was not complete - it actually fails to upload things...
Found a solution here: https://stackoverflow.com/questions/49627109/reactjs-how-to-detect-when-cancel-is-clicked-on-file-input

Test:
1. upload-cancel-upload-cancel-upload sequence works fine, that is, the upload pops up every time
2. can actually upload things using the UI


In general the file input cancel event doesn't expose to browser, so needs the trick to properly handle this, hopefully material-ui will have their file upload component ready soon (it's in their road map)