### PR TITLE
Add download to run bundles; show 'Contents' instead of 'Files' when bundle is not a directory; kill button only at proper state

### DIFF
--- a/frontend/src/components/worksheets/BundleDetail/BundleActions.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/BundleActions.jsx
@@ -51,6 +51,13 @@ class BundleActions extends React.Component<
 	            >
 	            	Kill
 	            </Button>
+				<Button
+					variant='contained'
+					color='primary'
+					onClick={ () => { window.location.href = bundleDownloadUrl; } }
+				>
+					Download
+				</Button>
 	            <Button variant='contained' color='primary'
 	            	onClick={ this.rerun }
 	            >

--- a/frontend/src/components/worksheets/BundleDetail/BundleActions.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/BundleActions.jsx
@@ -41,16 +41,23 @@ class BundleActions extends React.Component<
 	render() {
 		const { bundleInfo } = this.props;
 		const bundleDownloadUrl = '/rest/bundles/' + bundleInfo.uuid + '/contents/blob/';
-		const isRunBundle = bundleInfo.bundle_type === 'run';
-
+		const isRunBundle = bundleInfo.bundle_type === 'run' && bundleInfo.metadata;
+		const isKillableBundle = (bundleInfo.state === 'running' 
+								|| bundleInfo.state === 'preparing');
+		const isDownloadableRunBundle = bundleInfo.state !== 'preparing' 
+						&&  bundleInfo.state !== 'starting' 
+						&& 	bundleInfo.state !== 'created' 
+						&& bundleInfo.state !== 'staged';
 		return (
 			isRunBundle
 			? <div style={ { display: 'flex', flexDirection: 'row', alignItems: 'center' } }>
-	            <Button variant='text' color='primary'
+	            {isKillableBundle && 
+				<Button variant='text' color='primary'
 	            	onClick={ this.kill }
 	            >
 	            	Kill
-	            </Button>
+				</Button>}
+				{isDownloadableRunBundle &&
 				<Button
 					variant='contained'
 					color='primary'
@@ -58,6 +65,7 @@ class BundleActions extends React.Component<
 				>
 					Download
 				</Button>
+				}
 	            <Button variant='contained' color='primary'
 	            	onClick={ this.rerun }
 	            >

--- a/frontend/src/components/worksheets/BundleDetail/MainContent.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/MainContent.jsx
@@ -102,7 +102,7 @@ class MainContent extends React.Component<
                         color='inherit'
                         aria-label='Expand file viewer'
                         >
-                        {'Files'}
+                        {fileContents? 'Contents' : 'Files'}
                         {this.state.showFileBrowser 
                             ? <KeyboardArrowDownIcon />
                             : <ChevronRightIcon />}


### PR DESCRIPTION
fixes #1762, fixes #1763 , fixes #1772 
Test: 
1. can download a run bundle that has finished
2. can download a running bundle (while true; do date; done)

![Screenshot from 2019-11-29 17-53-52](https://user-images.githubusercontent.com/23012631/69894192-4b5be580-12d1-11ea-9d8f-3c15cdf4c8f0.png)


Contents:
![Screenshot from 2019-11-30 11-13-55](https://user-images.githubusercontent.com/23012631/69904960-9114be80-1362-11ea-9265-3d71434322f6.png)
