### PR TITLE
Prevent page crashing when referencing a worksheet uuid as bundle uuid

### DIFF
--- a/codalab/rest/util.py
+++ b/codalab/rest/util.py
@@ -129,6 +129,8 @@ def get_bundle_infos(
         worksheet_names = _get_readable_worksheet_names(model, worksheet_uuids)
 
         for bundle_uuid, host_uuids in host_worksheets.items():
+            if bundle_uuid not in bundle_infos:
+                continue
             for host_uuid in host_uuids:
                 if host_uuid in worksheet_names:
                     bundle_infos[bundle_uuid]['host_worksheet'] = {

--- a/codalab/rest/util.py
+++ b/codalab/rest/util.py
@@ -148,6 +148,8 @@ def get_bundle_infos(
 
         # Fill the info
         for bundle_uuid, host_uuids in host_worksheets.items():
+            if bundle_uuid not in bundle_infos:
+                continue
             bundle_infos[bundle_uuid]['host_worksheets'] = [
                 {'uuid': host_uuid, 'name': worksheet_names[host_uuid]}
                 for host_uuid in host_uuids


### PR DESCRIPTION
Address #1756 

Not the cleanest, but it works, we should find ways to handle error better, easier to debug

When we pass in worksheet_uuid as a bundle uuid into get_bundle_infos, bundles (constructed on line 71) will filter out invalid ones, but the newly added get_host_worksheet_uuids function doesn't filter invalid ones out, so there will be a key error thrown on line 136 because bundle_infos doesn't contain the invalid worksheet uuid key, but host_worksheets does.

Line HERE 1: printed uuids before line 71
HERE 2: printed bundles right after line 71
HERE 3: printed (host_uuid, worksheet_names, bundle_uuid, bundles_info) 

![Screenshot from 2019-11-30 01-08-30](https://user-images.githubusercontent.com/23012631/69898486-39993300-130f-11ea-9aac-cfb45a443dd0.png)

Not entirely sure if 151-152 needs it too, but from the way host_worksheets is constructed, we should just add it to make sure


To test:
1. stop local service, checkout to `master`, restart, create a worksheet, edit source, add a line []{worksheet_uuid} (use any valid worksheet uuid), the page will crash and return worksheet not found
2. checkout to this branch, restart (it's a backend change so should restart backend to see difference), the page should show again

Ideally we should show it's tell not a valid bundle uuid, but not now