### PR TITLE
Disable all worksheet edit related buttons when loading

### DIFF
--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -597,7 +597,7 @@ class Worksheet extends React.Component {
             return;
         }
 
-        if (!this.state.ws.info){
+        if (!this.state.ws.info) {
             // disable all keyboard shortcuts when loading worksheet
             return;
         }

--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -1256,6 +1256,7 @@ class Worksheet extends React.Component {
                     size='small'
                     color='inherit'
                     aria-label='Edit Source'
+                    disabled={!info}
                 >
                     <EditIcon className={classes.buttonIcon} />
                     {sourceStr}
@@ -1266,6 +1267,7 @@ class Worksheet extends React.Component {
                     color='inherit'
                     aria-label='Expand CLI'
                     id='terminal-button'
+                    disabled={!info}
                 >
                     {this.state.showActionBar ? (
                         <ContractIcon className={classes.buttonIcon} />
@@ -1279,6 +1281,7 @@ class Worksheet extends React.Component {
                     size='small'
                     color='inherit'
                     aria-label='Delete Worksheet'
+                    disabled={!info}
                 >
                     <Tooltip
                         disableFocusListener

--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -597,6 +597,11 @@ class Worksheet extends React.Component {
             return;
         }
 
+        if (!this.state.ws.info){
+            // disable all keyboard shortcuts when loading worksheet
+            return;
+        }
+
         if (
             !(
                 this.state.openDelete ||

--- a/frontend/src/components/worksheets/Worksheet/WorksheetHeader.js
+++ b/frontend/src/components/worksheets/Worksheet/WorksheetHeader.js
@@ -122,6 +122,7 @@ export default ({
                     >
                         <Grid item>
                             <ActionButtons
+                                info={info}
                                 onShowNewUpload={onShowNewUpload}
                                 onShowNewRun={onShowNewRun}
                                 onShowNewText={onShowNewText}

--- a/frontend/src/components/worksheets/items/ActionButtons.js
+++ b/frontend/src/components/worksheets/items/ActionButtons.js
@@ -22,6 +22,7 @@ class ActionButtons extends React.Component<{
             handleSelectedBundleCommand,
             showBundleOperationButtons,
             togglePopup,
+            info,
         } = this.props;
         return (
             <div
@@ -36,6 +37,7 @@ class ActionButtons extends React.Component<{
                         color='inherit'
                         aria-label='Add Text'
                         onClick={onShowNewText}
+                        disabled={!info}
                     >
                         <AddIcon className={classes.buttonIcon} />
                         Text
@@ -47,6 +49,7 @@ class ActionButtons extends React.Component<{
                         color='inherit'
                         aria-label='Add New Upload'
                         onClick={onShowNewUpload}
+                        disabled={!info}
                     >
                         <UploadIcon className={classes.buttonIcon} />
                         Upload
@@ -58,6 +61,7 @@ class ActionButtons extends React.Component<{
                         color='inherit'
                         aria-label='Add New Run'
                         onClick={onShowNewRun}
+                        disabled={!info}
                     >
                         <RunIcon className={classes.buttonIcon} />
                         Run


### PR DESCRIPTION
Fix #1774, very bad bug, disabling all keyboard shortcuts & buttons that can be used to edit worksheet when worksheet is loading

Verify: button & shortcuts are disabled when worksheet is loading; can use them after loaded