### PR TITLE
[Frontend] Disable edit related bttons according to permission 

### DIFF
--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -1288,7 +1288,7 @@ class Worksheet extends React.Component {
                     size='small'
                     color='inherit'
                     aria-label='Delete Worksheet'
-                    disabled={!info}
+                    disabled={!editPermission}
                 >
                     <Tooltip
                         disableFocusListener

--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -586,7 +586,7 @@ class Worksheet extends React.Component {
     setupEventHandlers() {
         var self = this;
         // Load worksheet from history when back/forward buttons are used.
-        let editPermission = info && info.edit_permission;
+        let editPermission = this.state.ws.info && this.state.ws.info.edit_permission;
 
         window.onpopstate = function(event) {
             if (event.state === null) return;

--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -586,6 +586,8 @@ class Worksheet extends React.Component {
     setupEventHandlers() {
         var self = this;
         // Load worksheet from history when back/forward buttons are used.
+        let editPermission = info && info.edit_permission;
+
         window.onpopstate = function(event) {
             if (event.state === null) return;
             this.setState({ ws: new WorksheetContent(event.state.uuid) });
@@ -705,7 +707,7 @@ class Worksheet extends React.Component {
                     }
                 }.bind(this),
             );
-            if (!this.state.showBundleOperationButtons) {
+            if (!this.state.showBundleOperationButtons && editPermission) {
                 // insert text after current cell
                 Mousetrap.bind(
                     ['a t'],

--- a/frontend/src/components/worksheets/WorksheetItemList.js
+++ b/frontend/src/components/worksheets/WorksheetItemList.js
@@ -243,6 +243,7 @@ class WorksheetItemList extends React.Component {
                         handleCheckBundle: this.props.handleCheckBundle,
                         confirmBundleRowAction: this.props.confirmBundleRowAction,
                         setDeleteItemCallback: this.props.setDeleteItemCallback,
+                        editPermission: info && info.edit_permission,
                     };
                     addWorksheetItems(
                         props,

--- a/frontend/src/components/worksheets/items/ActionButtons.js
+++ b/frontend/src/components/worksheets/items/ActionButtons.js
@@ -24,6 +24,8 @@ class ActionButtons extends React.Component<{
             togglePopup,
             info,
         } = this.props;
+        let editPermission = info && info.edit_permission;
+
         return (
             <div
                 onMouseMove={(ev) => {
@@ -37,7 +39,7 @@ class ActionButtons extends React.Component<{
                         color='inherit'
                         aria-label='Add Text'
                         onClick={onShowNewText}
-                        disabled={!info}
+                        disabled={!editPermission}
                     >
                         <AddIcon className={classes.buttonIcon} />
                         Text
@@ -49,7 +51,7 @@ class ActionButtons extends React.Component<{
                         color='inherit'
                         aria-label='Add New Upload'
                         onClick={onShowNewUpload}
-                        disabled={!info}
+                        disabled={!editPermission}
                     >
                         <UploadIcon className={classes.buttonIcon} />
                         Upload
@@ -61,7 +63,7 @@ class ActionButtons extends React.Component<{
                         color='inherit'
                         aria-label='Add New Run'
                         onClick={onShowNewRun}
-                        disabled={!info}
+                        disabled={!editPermission}
                     >
                         <RunIcon className={classes.buttonIcon} />
                         Run

--- a/frontend/src/components/worksheets/items/MarkdownItem.js
+++ b/frontend/src/components/worksheets/items/MarkdownItem.js
@@ -58,13 +58,14 @@ class MarkdownItem extends React.Component {
         this.setState({ showEdit: !this.state.showEdit });
     };
 
-    capture_keys() {
+    capture_keys = () => {
         // Edit the markdown
+        const { editPermission } = this.props;
         Mousetrap.bind(
             ['enter'],
             function(ev) {
                 ev.preventDefault();
-                if(editPermission){
+                if (editPermission) {
                     this.toggleEdit();
                 }
             }.bind(this),
@@ -76,13 +77,13 @@ class MarkdownItem extends React.Component {
             function(ev) {
                 ev.preventDefault();
                 if (this.props.focused) {
-                    if(editPermission){
+                    if (editPermission) {
                         this.props.setDeleteItemCallback(this.deleteItem);
                     }
                 }
             }.bind(this),
         );
-    }
+    };
 
     handleDeleteClick = () => {
         this.props.setDeleteItemCallback(this.deleteItem);

--- a/frontend/src/components/worksheets/items/MarkdownItem.js
+++ b/frontend/src/components/worksheets/items/MarkdownItem.js
@@ -64,7 +64,9 @@ class MarkdownItem extends React.Component {
             ['enter'],
             function(ev) {
                 ev.preventDefault();
-                this.toggleEdit();
+                if(editPermission){
+                    this.toggleEdit();
+                }
             }.bind(this),
         );
 
@@ -74,8 +76,9 @@ class MarkdownItem extends React.Component {
             function(ev) {
                 ev.preventDefault();
                 if (this.props.focused) {
-                    console.log('focuseeeeeeeeeeeeeeeeed on markdown item');
-                    this.props.setDeleteItemCallback(this.deleteItem);
+                    if(editPermission){
+                        this.props.setDeleteItemCallback(this.deleteItem);
+                    }
                 }
             }.bind(this),
         );
@@ -108,7 +111,7 @@ class MarkdownItem extends React.Component {
     };
 
     render() {
-        const { classes, item } = this.props;
+        const { classes, item, editPermission } = this.props;
         var { showEdit } = this.state;
         var contents = item.text;
         // Order is important!
@@ -153,25 +156,27 @@ class MarkdownItem extends React.Component {
                     className={`${className} ${classes.textRender}`}
                     dangerouslySetInnerHTML={{ __html: contents }}
                 />
-                <div className={classes.buttonsPanel}>
-                    <Tooltip title='Edit'>
-                        <IconButton
-                            onClick={this.toggleEdit}
-                            classes={{ root: classes.iconButtonRoot }}
-                        >
-                            <EditIcon />
-                        </IconButton>
-                    </Tooltip>
-                    &nbsp;&nbsp;
-                    <Tooltip title='Delete'>
-                        <IconButton
-                            onClick={this.handleDeleteClick}
-                            classes={{ root: classes.iconButtonRoot }}
-                        >
-                            <DeleteIcon />
-                        </IconButton>
-                    </Tooltip>
-                </div>
+                {editPermission && (
+                    <div className={classes.buttonsPanel}>
+                        <Tooltip title='Edit'>
+                            <IconButton
+                                onClick={this.toggleEdit}
+                                classes={{ root: classes.iconButtonRoot }}
+                            >
+                                <EditIcon />
+                            </IconButton>
+                        </Tooltip>
+                        &nbsp;&nbsp;
+                        <Tooltip title='Delete'>
+                            <IconButton
+                                onClick={this.handleDeleteClick}
+                                classes={{ root: classes.iconButtonRoot }}
+                            >
+                                <DeleteIcon />
+                            </IconButton>
+                        </Tooltip>
+                    </div>
+                )}
             </div>
         );
     }

--- a/frontend/src/components/worksheets/items/TableItem/BundleRow.js
+++ b/frontend/src/components/worksheets/items/TableItem/BundleRow.js
@@ -122,6 +122,7 @@ class BundleRow extends Component {
             reloadWorksheet,
             isLast,
             checkStatus,
+            editPermission,
         } = this.props;
         const rowItems = { ...item, ...bundleInfoUpdates };
         var baseUrl = this.props.url;
@@ -193,7 +194,7 @@ class BundleRow extends Component {
                     onMouseEnter={(e) => this.setState({ hovered: true })}
                     onMouseLeave={(e) => this.setState({ hovered: false })}
                 >
-                    {checkBox}
+                    {editPermission && checkBox}
                     {showDetailButton}
                     {rowContent}
                 </TableCell>
@@ -225,6 +226,9 @@ class BundleRow extends Component {
             Mousetrap.bind(
                 ['x'],
                 (e) => {
+                    if (!editPermission) {
+                        return;
+                    }
                     if (!this.props.confirmBundleRowAction(e.code)) {
                         this.props.handleCheckBundle(
                             uuid,

--- a/frontend/src/components/worksheets/items/TableItem/TableItem.js
+++ b/frontend/src/components/worksheets/items/TableItem/TableItem.js
@@ -102,7 +102,7 @@ class TableItem extends React.Component<{
     };
 
     render() {
-        const { worksheetUUID, setFocus, prevItem } = this.props;
+        const { worksheetUUID, setFocus, prevItem, editPermission } = this.props;
 
         let prevItemProcessed = null;
         if (prevItem) {
@@ -146,9 +146,9 @@ class TableItem extends React.Component<{
                     onMouseLeave={(e) => this.setState({ hovered: false })}
                     component='th'
                     key={index}
-                    style={{ paddingLeft: 0 }}
+                    style={editPermission ? { paddingLeft: 0 } : { paddingLeft: 30 }}
                 >
-                    {checkbox}
+                    {editPermission && checkbox}
                     {item}
                 </TableCell>
             );
@@ -197,6 +197,7 @@ class TableItem extends React.Component<{
                     refreshCheckBox={this.refreshCheckBox}
                     worksheetName={worksheetName}
                     worksheetUrl={worksheetUrl}
+                    editPermission={editPermission}
                 />
             );
         });


### PR DESCRIPTION
 If user doesn't have edit permission on worksheet, disable +text, upload, run, markdown item edit/delete buttons & shortcuts. 
Also don't show checkbox/disable 'x' when no edit worksheet permission. 
Disabling worksheet deletion as well.

<s>Bundle operations are trickier in this case, because not having permission to edit worksheet doesn't mean the user can't have permission to the bundles in the worksheet, thoughts? Currently the execution respects the bundle permission on backend side</s>

After thinking a bit, we should just respect 'view' mode should only view, not edit. We don't have bulk attach operation for now, so the selection is mostly useless to view mode users

#1780 