### PR TITLE
Display detail unavailable message for invalid/private bundles

### DIFF
--- a/frontend/src/components/worksheets/BundleDetail/BundleDetail.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/BundleDetail.jsx
@@ -203,8 +203,8 @@ class BundleDetail extends React.Component<
             stderr,
             fileContents } = this.state;
 
-        if (!bundleInfo) {
-            return null;
+        if (!bundleInfo || bundleInfo.bundle_type === 'private') {
+            return <div>Detail not available for this bundle</div>
         }
 
         return (


### PR DESCRIPTION
Currently crashes when we try to open detail for a private bundle
#1786 