### PR TITLE
Combine format and functionality stages into one, so they run in parallel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,16 @@
 jobs:
   include:
-    - stage: style-backend
+    - stage: check
       language: python
       python: 3.6
       install: pip install --upgrade black==18.9b0
       script: black . --check --diff
-    - stage: style-frontend
+    - stage: check
       language: javascript
       install: cd frontend && npm install
       script:
         - npm run check-ci
-    - stage: functionality
+    - stage: check
       language: python
       sudo: required
       services:


### PR DESCRIPTION
Currently, we have to wait until the format jobs finish until the functionality jobs can run.

This change will speed up builds by ~2 minutes, and also allow a functionality build to be run even if the format fails (so the format can be fixed later without being a bottleneck).