### PR TITLE
Fix table item padding

### DIFF
--- a/frontend/src/components/worksheets/BundleDetail/BundleDetail.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/BundleDetail.jsx
@@ -203,8 +203,8 @@ class BundleDetail extends React.Component<
             stderr,
             fileContents } = this.state;
 
-        if (!bundleInfo) {
-            return null;
+        if (!bundleInfo || bundleInfo.bundle_type === 'private') {
+            return <div>Detail not available for this bundle</div>
         }
 
         return (

--- a/frontend/src/components/worksheets/items/TableItem/TableItem.js
+++ b/frontend/src/components/worksheets/items/TableItem/TableItem.js
@@ -146,7 +146,7 @@ class TableItem extends React.Component<{
                     onMouseLeave={(e) => this.setState({ hovered: false })}
                     component='th'
                     key={index}
-                    style={{ paddingLeft: 0 }}
+                    style={editPermission || index != 0? { paddingLeft: 0 } : { paddingLeft: 30 }}
                 >
                     {checkbox}
                     {item}

--- a/frontend/src/components/worksheets/items/TableItem/TableItem.js
+++ b/frontend/src/components/worksheets/items/TableItem/TableItem.js
@@ -146,7 +146,7 @@ class TableItem extends React.Component<{
                     onMouseLeave={(e) => this.setState({ hovered: false })}
                     component='th'
                     key={index}
-                    style={editPermission || index !== 0? { paddingLeft: 0 } : { paddingLeft: 30 }}
+                    style={editPermission || index !== 0 ? { paddingLeft: 0 } : { paddingLeft: 30 }}
                 >
                     {editPermission && checkbox}
                     {item}


### PR DESCRIPTION
#1791 Currently when you view a table of a non-editable worksheet, the header-value alignment is off, fixing that

To test: log in & log out, the table header-value alignment should both be nice