### PR TITLE
Fix syntax error in read_json_or_die

### DIFF
--- a/codalab/lib/codalab_manager.py
+++ b/codalab/lib/codalab_manager.py
@@ -69,9 +69,10 @@ def write_pretty_json(data, path):
 
 
 def read_json_or_die(path):
+    with open(path, 'r') as f:
+        string = f.read()
     try:
-        with open(path, 'r') as f:
-            return json.loads(f.read())
+        return json.loads(string)
     except ValueError as e:
         print("Invalid JSON in %s:\n%s" % (path, string))
         print(e)


### PR DESCRIPTION
Otherwise, when this function catches the
exception, it gives an error that `string`
was not defined. This error was introduced
in the Python 2 -> 3 migration.