### PR TITLE
Don't use subprocess for cli tests

### DIFF
--- a/codalab/bin/cl.py
+++ b/codalab/bin/cl.py
@@ -4,14 +4,16 @@ from codalab.lib.bundle_cli import BundleCLI
 from codalab.lib.codalab_manager import CodaLabManager
 
 
-def main():
+def run_cli_command(argv):
     cli = BundleCLI(CodaLabManager())
     try:
-        cli.do_command(sys.argv[1:])
+        cli.do_command(argv)
     except KeyboardInterrupt:
         print('Terminated by Ctrl-C')
         sys.exit(130)
 
+def main():
+    run_cli_command(sys.argv[1:])
 
 if __name__ == '__main__':
     main()

--- a/codalab/bin/cl.py
+++ b/codalab/bin/cl.py
@@ -4,16 +4,14 @@ from codalab.lib.bundle_cli import BundleCLI
 from codalab.lib.codalab_manager import CodaLabManager
 
 
-def run_cli_command(argv):
+def main():
     cli = BundleCLI(CodaLabManager())
     try:
-        cli.do_command(argv)
+        cli.do_command(sys.argv[1:])
     except KeyboardInterrupt:
         print('Terminated by Ctrl-C')
         sys.exit(130)
 
-def main():
-    run_cli_command(sys.argv[1:])
 
 if __name__ == '__main__':
     main()

--- a/test_cli.py
+++ b/test_cli.py
@@ -149,8 +149,8 @@ def run_command(
             # than opening a new subprocess to do so.
             stderr = io.StringIO()  # Not used; we just don't want to redirect stderr to f.
             f = FakeStdout()
+            cli = BundleCLI(CodaLabManager(), stdout=f, stderr=stderr)
             try:
-                cli = BundleCLI(CodaLabManager(), stdout=f, stderr=stderr)
                 cli.do_command(args[1:])
                 exitcode = 0
             except SystemExit as e:

--- a/test_cli.py
+++ b/test_cli.py
@@ -144,7 +144,7 @@ def run_command(
             kwargs = dict(kwargs, encoding="utf-8")
         if include_stderr:
             kwargs = dict(kwargs, stderr=subprocess.STDOUT)
-        if isinstance(args, list) and args[0] == "cl":
+        if isinstance(args, list) and args[0] == cl:
             # In this case, run the codalab CLI directly, which is much faster
             # than opening a new subprocess to do so.
             stderr = io.StringIO()  # Not used; we just don't want to redirect stderr to f.

--- a/test_cli.py
+++ b/test_cli.py
@@ -31,8 +31,6 @@ import sys
 import time
 import traceback
 from unittest.mock import patch
-from codalab.lib.bundle_cli import BundleCLI
-from codalab.lib.codalab_manager import CodaLabManager
 
 
 global cl
@@ -133,6 +131,12 @@ class FakeStdout(io.StringIO):
 def run_command(
     args, expected_exit_code=0, max_output_chars=1024, env=None, include_stderr=False, binary=False
 ):
+    # We import the following imports here because codalab_service.py imports TestModule from
+    # this file. If we kept the imports at the top, then anyone who ran codalab_service.py
+    # would also have to install all the dependencies that BundleCLI and CodaLabManager use.
+    from codalab.lib.bundle_cli import BundleCLI
+    from codalab.lib.codalab_manager import CodaLabManager
+
     """If we don't care about the exit code, set `expected_exit_code` to None.
     """
     print(">>", *map(str, args), sep=" ")

--- a/test_cli.py
+++ b/test_cli.py
@@ -125,7 +125,15 @@ class FakeStdout(io.StringIO):
         self.buffer = io.BytesIO()
 
     def getvalue(self):
-        return super().getvalue() + self.buffer.getvalue().decode()
+        """If self.buffer has a non-unicode value, return that value.
+        Otherwise, decode the self.buffer value and append it
+        to self.getvalue().
+        """
+        try:
+            buffer_value = self.buffer.getvalue().decode()
+        except UnicodeDecodeError:
+            return self.buffer.getvalue()
+        return super().getvalue() + buffer_value
 
 
 def run_command(

--- a/test_cli.py
+++ b/test_cli.py
@@ -177,9 +177,7 @@ def run_command(
                 exitcode = e.code
             output = stdout.getvalue()
         else:
-            output = subprocess.check_output(
-                [a.encode() for a in args], **kwargs
-            )
+            output = subprocess.check_output([a.encode() for a in args], **kwargs)
             exitcode = 0
     except subprocess.CalledProcessError as e:
         output = e.output

--- a/test_cli.py
+++ b/test_cli.py
@@ -125,9 +125,21 @@ class FakeStdout(io.StringIO):
         self.buffer = io.BytesIO()
 
     def getvalue(self):
-        """If self.buffer has a non-unicode value, return that value.
+        """
+        If self.buffer has a non-unicode value, return that value.
         Otherwise, decode the self.buffer value and append it
         to self.getvalue().
+
+        This is because this function is mimicking the behavior of `sys.stdout`.
+        `sys.stdout` can be read as either a string or bytes.
+
+        When a string is written to `sys.stdout`, it returns a string when doing `getvalue()`.
+
+        When bytes are written to `sys.stdout` (by writing to `sys.stdout.buffer`),
+        it returns bytes when doing `getvalue()`. The reason we need to account for this
+        case is that there are tests in which a binary file is uploaded, then it is
+        printed out (by writing to `sys.stdout.buffer`), and then the test reads what's
+        printed out and makes sure it matches the original file.
         """
         try:
             buffer_value = self.buffer.getvalue().decode()

--- a/test_cli.py
+++ b/test_cli.py
@@ -159,9 +159,9 @@ def run_command(
         if isinstance(args, list) and args[0] == cl:
             # In this case, run the codalab CLI directly, which is much faster
             # than opening a new subprocess to do so.
-            stderr = io.StringIO()  # Not used; we just don't want to redirect stderr to f.
+            _ = io.StringIO()  # Not used; we just don't want to redirect cli.stderr to f.
             f = FakeStdout()
-            cli = BundleCLI(CodaLabManager(), stdout=f, stderr=stderr)
+            cli = BundleCLI(CodaLabManager(), stdout=f, stderr=_)
             try:
                 cli.do_command(args[1:])
                 exitcode = 0

--- a/test_cli.py
+++ b/test_cli.py
@@ -109,8 +109,8 @@ def sanitize(string, max_chars=256):
     """
     if isinstance(string, bytes):
         string = '<binary>'
-    # if len(string) > max_chars:
-    #     string = string[:max_chars] + ' (...more...)'
+    if len(string) > max_chars:
+        string = string[:max_chars] + ' (...more...)'
     return string
 
 

--- a/test_cli.py
+++ b/test_cli.py
@@ -162,23 +162,23 @@ def run_command(
             kwargs = dict(kwargs, encoding="utf-8")
         if include_stderr:
             kwargs = dict(kwargs, stderr=subprocess.STDOUT)
-        if not force_subprocess and isinstance(args, list) and args[0] == cl:
+        if not force_subprocess and args[0] == cl:
             # In this case, run the codalab CLI directly, which is much faster
             # than opening a new subprocess to do so.
             # We skip doing this if force_subprocess is set to true (which forces
             # us to use subprocess even for cl commands.)
-            _ = io.StringIO()  # Not used; we just don't want to redirect cli.stderr to f.
-            f = FakeStdout()
-            cli = BundleCLI(CodaLabManager(), stdout=f, stderr=_)
+            stderr = io.StringIO()  # Not used; we just don't want to redirect cli.stderr to stdout.
+            stdout = FakeStdout()
+            cli = BundleCLI(CodaLabManager(), stdout=stdout, stderr=stderr)
             try:
                 cli.do_command(args[1:])
                 exitcode = 0
             except SystemExit as e:
                 exitcode = e.code
-            output = f.getvalue()
+            output = stdout.getvalue()
         else:
             output = subprocess.check_output(
-                [a.encode() if isinstance(a, str) else a for a in args], **kwargs
+                [a.encode() for a in args], **kwargs
             )
             exitcode = 0
     except subprocess.CalledProcessError as e:

--- a/test_cli.py
+++ b/test_cli.py
@@ -137,7 +137,13 @@ class FakeStdout(io.StringIO):
 
 
 def run_command(
-    args, expected_exit_code=0, max_output_chars=1024, env=None, include_stderr=False, binary=False, force_subprocess=False
+    args,
+    expected_exit_code=0,
+    max_output_chars=1024,
+    env=None,
+    include_stderr=False,
+    binary=False,
+    force_subprocess=False,
 ):
     # We import the following imports here because codalab_service.py imports TestModule from
     # this file. If we kept the imports at the top, then anyone who ran codalab_service.py
@@ -969,7 +975,9 @@ def test(ctx):
     # Modify to non-ascii tags
     # TODO: enable with Unicode support.
     non_ascii_tags = ['你好世界😊', 'fáncy ünicode']
-    run_command([cl, 'wedit', wname, '--tags'] + non_ascii_tags, 1, force_subprocess=True) # TODO: find a way to make this work without force_subprocess
+    run_command(
+        [cl, 'wedit', wname, '--tags'] + non_ascii_tags, 1, force_subprocess=True
+    )  # TODO: find a way to make this work without force_subprocess
     # check_contains(non_ascii_tags, run_command([cl, 'ls', '-w', wuuid]))
     # Delete tags
     run_command([cl, 'wedit', wname, '--tags'])

--- a/test_cli.py
+++ b/test_cli.py
@@ -145,6 +145,8 @@ def run_command(
         if include_stderr:
             kwargs = dict(kwargs, stderr=subprocess.STDOUT)
         if isinstance(args, list) and args[0] == "cl":
+            # In this case, run the codalab CLI directly, which is much faster
+            # than opening a new subprocess to do so.
             stderr = io.StringIO()  # Not used; we just don't want to redirect stderr to f.
             f = FakeStdout()
             try:


### PR DESCRIPTION
This will greatly speed up functionality tests (45 minutes -> 27 minutes)