### PR TITLE
filter out unqualified bundles and update run_status to inform user i…

### DIFF
--- a/codalab/bundles/run_bundle.py
+++ b/codalab/bundles/run_bundle.py
@@ -44,6 +44,8 @@ class RunBundle(DerivedBundle):
     METADATA_SPECS.append(MetadataSpec('started', int, 'Time when this bundle started executing.', generated=True, formatting='date'))
     METADATA_SPECS.append(MetadataSpec('last_updated', int, 'Time when information about this bundle was last updated.', generated=True, formatting='date'))
     METADATA_SPECS.append(MetadataSpec('run_status', str, 'Execution status of the bundle.', generated=True))
+    METADATA_SPECS.append(MetadataSpec('staged_status', str, 'Information about the status of the staged bundle.', generated=True))
+
 
     # Information about running
     METADATA_SPECS.append(MetadataSpec('docker_image', str, 'Which docker image was used to run the process.', generated=True, hide_when_anonymous=True))

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -1003,6 +1003,7 @@ class BundleModel(object):
         # Apply the column and metadata updates in memory and validate the result.
         metadata_update = update.pop('metadata', {})
         bundle.update_in_memory(update)
+
         # Currently we only allow deleting fields in metadata dict.
         # When delete = True, delete the keys from bundle.metadata dict
         # When delete = False, update the key, value pair in bundle.metadata dict

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -895,7 +895,6 @@ class BundleModel(object):
             was recorded during finalization of the bundle.
         """
         metadata = bundle.metadata.to_dict()
-        logger.info("**** transition_bundle_finished, metadata = {}".format(metadata))
         failure_message = metadata.get('failure_message', None)
         exitcode = metadata.get('exitcode', 0)
         state = State.FAILED if failure_message or exitcode else State.READY

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -895,6 +895,7 @@ class BundleModel(object):
             was recorded during finalization of the bundle.
         """
         metadata = bundle.metadata.to_dict()
+        logger.info("**** transition_bundle_finished, metadata = {}".format(metadata))
         failure_message = metadata.get('failure_message', None)
         exitcode = metadata.get('exitcode', 0)
         state = State.FAILED if failure_message or exitcode else State.READY
@@ -1002,6 +1003,7 @@ class BundleModel(object):
         # Apply the column and metadata updates in memory and validate the result.
         metadata_update = update.pop('metadata', {})
         bundle.update_in_memory(update)
+<<<<<<< HEAD
 
         # Currently we only allow deleting fields in metadata dict.
         # When delete = True, delete the keys from bundle.metadata dict

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -1003,8 +1003,6 @@ class BundleModel(object):
         # Apply the column and metadata updates in memory and validate the result.
         metadata_update = update.pop('metadata', {})
         bundle.update_in_memory(update)
-<<<<<<< HEAD
-
         # Currently we only allow deleting fields in metadata dict.
         # When delete = True, delete the keys from bundle.metadata dict
         # When delete = False, update the key, value pair in bundle.metadata dict

--- a/codalab/objects/metadata.py
+++ b/codalab/objects/metadata.py
@@ -56,6 +56,10 @@ class Metadata(object):
         self._metadata_keys.add(key)
         setattr(self, key, value)
 
+    def remove_metadata_key(self, key):
+        if key in self._metadata_keys:
+            self._metadata_keys.remove(key)
+
     @classmethod
     def collapse_dicts(cls, metadata_specs, rows):
         '''

--- a/codalab/server/bundle_manager.py
+++ b/codalab/server/bundle_manager.py
@@ -769,7 +769,6 @@ class BundleManager(object):
                 # Remove the uuid from self._bundles_without_matched_workers if a matched
                 # private worker is found in the system and update bundle's metadata
                 if bundle.uuid in self._bundles_without_matched_workers:
-                    # bundle.metadata.remove_metadata_key('staged_status')
                     self._model.update_bundle(
                         bundle, {'metadata': {'staged_status': ''}}, delete=True
                     )

--- a/tests/server/bundle_manager_test.py
+++ b/tests/server/bundle_manager_test.py
@@ -5,9 +5,24 @@ from codalab.objects.metadata_spec import MetadataSpec
 from codalab.server.bundle_manager import BundleManager
 from codalab.worker.bundle_state import RunResources
 from codalab.bundles import RunBundle
+from codalab.lib.codalab_manager import CodaLabManager
 
 
 class BundleManagerTest(unittest.TestCase):
+    def setUp(self):
+        self.codalab_manager = Mock(CodaLabManager)
+        self.codalab_manager.config = {
+            "workers": {
+                'default_cpu_image': 'codalab/default-cpu:latest',
+                'default_gpu_image': 'codalab/default-gpu:latest',
+            }
+        }
+        self.bundle_manager = BundleManager(self.codalab_manager)
+
+    def tearDown(self):
+        del self.bundle_manager
+        del self.codalab_manager
+
     def get_sample_workers_list(self):
         workers_list = [
             {
@@ -52,7 +67,7 @@ class BundleManagerTest(unittest.TestCase):
         )
 
         # gpu worker should be last in the filtered and sorted list
-        sorted_workers_list = BundleManager._filter_and_sort_workers(
+        sorted_workers_list = self.bundle_manager._filter_and_sort_workers(
             self.get_sample_workers_list(), bundle, bundle_resources
         )
         self.assertEqual(len(sorted_workers_list), 3)
@@ -62,7 +77,7 @@ class BundleManagerTest(unittest.TestCase):
 
         # gpu worker should be the only worker in the filtered and sorted list
         bundle_resources.gpus = 1
-        sorted_workers_list = BundleManager._filter_and_sort_workers(
+        sorted_workers_list = self.bundle_manager._filter_and_sort_workers(
             self.get_sample_workers_list(), bundle, bundle_resources
         )
         self.assertEqual(len(sorted_workers_list), 1)


### PR DESCRIPTION

Fixed #1800 
Added a new metadata field called `staged_status` (open to discuss of renaming or reusing `run_status`). 
This ticket will filter out staged bundles that are requested to run on the personal worker which hasn't been connected to CodaLab server yet.
 New frontend will look like this:
<img width="1152" alt="Screen Shot 2019-12-02 at 12 53 20 PM" src="https://user-images.githubusercontent.com/1483372/69994441-bfc99b00-1502-11ea-8bc2-1f70be4fe67e.png">
