### PR TITLE
1813: get rid of the default for cl upload --ignore

### DIFF
--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -1111,7 +1111,7 @@ class BundleCLI(object):
                 '-i',
                 '--ignore',
                 help='Name of file containing patterns matching files and directories to exclude from upload. '
-                'This option is currently only supported with GNU tar library.',
+                'This option is currently only supported with the GNU tar library.',
             ),
         )
         + Commands.metadata_arguments([UploadedBundle])

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -1110,8 +1110,8 @@ class BundleCLI(object):
             Commands.Argument(
                 '-i',
                 '--ignore',
-                help='Name of file containing patterns matching files and directories to exclude from upload.',
-                default='.gitignore',
+                help='Name of file containing patterns matching files and directories to exclude from upload. '
+                'This option is currently only supported with GNU tar library.',
             ),
         )
         + Commands.metadata_arguments([UploadedBundle])


### PR DESCRIPTION
Fixes #1813 

Currently, `cl upload` can't be run on Macs since `--exclude-ignore` is only supported by GNU tar library and not BSD tar library. The quick and safest fix for now will be to just get rid of the default value of `--ignore` for `cl upload`.

I will create another issue to figure how we can specify ignore files for BSD tar library.