### PR TITLE
1831: fix footer link

### DIFF
--- a/frontend/src/components/Footer.js
+++ b/frontend/src/components/Footer.js
@@ -33,7 +33,7 @@ class Footer extends React.Component {
                         </li>
                         <li>
                             <a
-                                href='https://codalab-worksheets.readthedocs.io/en/latest/Latest-Features'
+                                href='https://github.com/codalab/codalab-worksheets/releases'
                                 target='_blank'
                             >
                                 v{CODALAB_VERSION}


### PR DESCRIPTION
Fixes #1831 

I noticed the versions link at the footer led to a broken page. Is our Github releases page a good replacement?

https://github.com/codalab/codalab-worksheets/releases