### PR TITLE
Remove unreachable logic

### DIFF
--- a/codalab/server/bundle_manager.py
+++ b/codalab/server/bundle_manager.py
@@ -76,9 +76,6 @@ class BundleManager(object):
 
             time.sleep(sleep_time)
 
-        while self._is_making_bundles():
-            time.sleep(sleep_time)
-
     def signal(self):
         with self._exiting_lock:
             self._exiting = True


### PR DESCRIPTION
Fixed #1836 .

This [logic]( https://github.com/codalab/codalab-worksheets/blob/master/codalab/server/bundle_manager.py#L79-L80) seems to be not reachable during the iteration. The option is to either move it inside [while loop](https://github.com/codalab/codalab-worksheets/blob/master/codalab/server/bundle_manager.py#L71) or completely remove it. Based on the situation in production, I remove that piece of unreachable logic for now. Open to discuss this.