### PR TITLE
1838: Fix the typo in the error message

### DIFF
--- a/codalab/server/bundle_manager.py
+++ b/codalab/server/bundle_manager.py
@@ -145,7 +145,7 @@ class BundleManager(object):
                 if killed_uuids:
                     failure_message += ' Parent bundles were killed: %s' % ', '.join(killed_uuids)
                 if failure_message:
-                    failure_message += ' (Please use the --allow-failed-dependencies flag to depend on results fo failed or killed bundles)'
+                    failure_message += ' (Please use the --allow-failed-dependencies flag to depend on results of failed or killed bundles)'
                     bundles_to_fail.append((bundle, failure_message))
                     continue
 


### PR DESCRIPTION
Fixes #1838 

Change "fo" to "of" in the error message.