### PR TITLE
Do not fail jobs without enough resources

### DIFF
--- a/codalab/server/bundle_manager.py
+++ b/codalab/server/bundle_manager.py
@@ -320,9 +320,13 @@ class BundleManager(object):
             reverse=True,
         )
 
-        # Get bundles in RUNNING state from the bundle table
-        running_bundles = self._model.batch_get_bundles(state=State.RUNNING)
-        # Build a dictionary which maps from uuid to bundle
+        # Get all the run_uuids from workers
+        run_uuids = []
+        for worker in workers.workers():
+            run_uuids.extend(worker["run_uuids"])
+        # Get the running bundles that exist in the bundle table
+        running_bundles = self._model.batch_get_bundles(uuid=run_uuids)
+        # Build a dictionary which maps from uuid to running bundle
         uuid_to_running_bundles = {bundle.uuid: bundle for bundle in running_bundles}
 
         # Dispatch bundles

--- a/codalab/worker/worker_run_state.py
+++ b/codalab/worker/worker_run_state.py
@@ -270,7 +270,7 @@ class RunStateMachine(StateTransitioner):
             message = "Cannot assign enough resources: %s" % str(e)
             logger.error(message)
             logger.error(traceback.format_exc())
-            return run_state._replace(stage=RunStage.CLEANING_UP, failure_message=message)
+            return run_state._replace(run_status=message)
 
         # 4) Start container
         try:


### PR DESCRIPTION
Fixed #1841 
I tested the functionality by setting the requested_cpu larger than the total available number of cpus. Bundle will stay in `PREPARING` state if not enough computing resources can be assigned with. `run_status` will be updated with a message similar as `Cannot assign enough resources: Requested more CPUs (5) than available (4 currently out of 4 on the machine)`
Not sure if we want to put the bundle back to `STAGED` state, I searched through our code base, didn't find a state that can be set back to `STAGED` in worker side. If I missed anything, @bkgoksel please do let me know.