### PR TITLE
Fix failures due to duplicate container names

### DIFF
--- a/codalab/worker/docker_utils.py
+++ b/codalab/worker/docker_utils.py
@@ -144,7 +144,6 @@ def start_bundle_container(
     container_name = 'codalab_run_%s' % uuid
 
     if container_exists(container_name):
-        client.containers.remove(container_name)
         return client.get(container_name)
 
     container = client.containers.run(

--- a/codalab/worker/docker_utils.py
+++ b/codalab/worker/docker_utils.py
@@ -142,6 +142,11 @@ def start_bundle_container(
 
     # Name the container with the UUID for readability
     container_name = 'codalab_run_%s' % uuid
+
+    if container_exists(container_name):
+        client.containers.remove(container_name)
+        return client.get(container_name)
+
     container = client.containers.run(
         image=docker_image,
         command=docker_command,


### PR DESCRIPTION
Fixed #1704.

There are two temporary options to fix this problem when we discovered that there is an existing container with the same container name as the new one:
1. Delete the old container and return the new container.
2. Return the old container without trying to starting a new container.