### PR TITLE
Rename LocalFileSystemDependencyManager to DependencyManager

### DIFF
--- a/codalab/worker/local_run/local_dependency_manager.py
+++ b/codalab/worker/local_run/local_dependency_manager.py
@@ -32,7 +32,7 @@ class DownloadAbortedException(Exception):
         super(DownloadAbortedException, self).__init__(message)
 
 
-class LocalFileSystemDependencyManager(StateTransitioner, BaseDependencyManager):
+class DependencyManager(StateTransitioner, BaseDependencyManager):
     """
     This dependency manager downloads dependency bundles from Codalab server
     to the local filesystem. It caches all downloaded dependencies but cleans up the
@@ -51,7 +51,7 @@ class LocalFileSystemDependencyManager(StateTransitioner, BaseDependencyManager)
     MAX_SERIALIZED_LEN = 60000
 
     def __init__(self, commit_file, bundle_service, worker_dir, max_cache_size_bytes):
-        super(LocalFileSystemDependencyManager, self).__init__()
+        super(DependencyManager, self).__init__()
         self.add_transition(DependencyStage.DOWNLOADING, self._transition_from_DOWNLOADING)
         self.add_terminal(DependencyStage.READY)
         self.add_terminal(DependencyStage.FAILED)
@@ -59,9 +59,7 @@ class LocalFileSystemDependencyManager(StateTransitioner, BaseDependencyManager)
         self._state_committer = JsonStateCommitter(commit_file)
         self._bundle_service = bundle_service
         self._max_cache_size_bytes = max_cache_size_bytes
-        self.dependencies_dir = os.path.join(
-            worker_dir, LocalFileSystemDependencyManager.DEPENDENCIES_DIR_NAME
-        )
+        self.dependencies_dir = os.path.join(worker_dir, DependencyManager.DEPENDENCIES_DIR_NAME)
         if not os.path.exists(self.dependencies_dir):
             logger.info('{} doesn\'t exist, creating.'.format(self.dependencies_dir))
             os.makedirs(self.dependencies_dir, 0o770)
@@ -202,7 +200,7 @@ class LocalFileSystemDependencyManager(StateTransitioner, BaseDependencyManager)
                 for dep_key, dep_state in self._dependencies.items()
                 if dep_state.stage == DependencyStage.FAILED
                 and time.time() - dep_state.last_used
-                > LocalFileSystemDependencyManager.DEPENDENCY_FAILURE_COOLDOWN
+                > DependencyManager.DEPENDENCY_FAILURE_COOLDOWN
             }
             for dep_key, dep_state in failed_deps.items():
                 self._delete_dependency(dep_key)
@@ -224,7 +222,7 @@ class LocalFileSystemDependencyManager(StateTransitioner, BaseDependencyManager)
                 serialized_length = len(codalab.worker.pyjson.dumps(self._dependencies))
                 if (
                     bytes_used > self._max_cache_size_bytes
-                    or serialized_length > LocalFileSystemDependencyManager.MAX_SERIALIZED_LEN
+                    or serialized_length > DependencyManager.MAX_SERIALIZED_LEN
                 ):
                     logger.debug(
                         '%d dependencies in cache, disk usage: %s (max %s), serialized size: %s (max %s)',
@@ -232,7 +230,7 @@ class LocalFileSystemDependencyManager(StateTransitioner, BaseDependencyManager)
                         size_str(bytes_used),
                         size_str(self._max_cache_size_bytes),
                         size_str(serialized_length),
-                        LocalFileSystemDependencyManager.MAX_SERIALIZED_LEN,
+                        DependencyManager.MAX_SERIALIZED_LEN,
                     )
                     ready_deps = {
                         dep_key: dep_state

--- a/codalab/worker/local_run/local_run_manager.py
+++ b/codalab/worker/local_run/local_run_manager.py
@@ -38,7 +38,7 @@ class LocalRunManager(BaseRunManager):
         self,
         worker,  # type: Worker
         image_manager,  # type: DockerImageManager
-        dependency_manager,  # type: LocalFileSystemDependencyManager
+        dependency_manager,  # type: DependencyManager
         commit_file,  # type: str
         cpuset,  # type: Set[str]
         gpuset,  # type: Set[str]

--- a/codalab/worker/main.py
+++ b/codalab/worker/main.py
@@ -18,7 +18,7 @@ from codalab.lib.formatting import parse_size
 from .bundle_service_client import BundleServiceClient, BundleAuthException
 from . import docker_utils
 from .worker import Worker
-from .local_run.local_dependency_manager import LocalFileSystemDependencyManager
+from .local_run.local_dependency_manager import DependencyManager
 from .local_run.docker_image_manager import DockerImageManager
 from .local_run.local_run_manager import LocalRunManager
 
@@ -170,7 +170,7 @@ chmod 600 %s"""
         cpuset = parse_cpuset_args(args.cpuset)
         gpuset = parse_gpuset_args(args.gpuset)
 
-        dependency_manager = LocalFileSystemDependencyManager(
+        dependency_manager = DependencyManager(
             os.path.join(args.work_dir, 'dependencies-state.json'),
             bundle_service,
             args.work_dir,

--- a/docs/CLI-Reference.md
+++ b/docs/CLI-Reference.md
@@ -21,6 +21,7 @@ This file is auto-generated from the output of `cl help -v` and provides the lis
           -p, --pack               If path is an archive file (e.g., zip, tar.gz), keep it packed.
           -z, --force-compression  Always use compression (this may speed up single-file uploads over a slow network).
           -w, --worksheet-spec     Upload to this worksheet ([(<alias>|<address>)::](<uuid>|<name>)).
+          -i, --ignore             Name of file containing patterns matching files and directories to exclude from upload. This option is currently only supported with the GNU tar library.
           -n, --name               Short variable name (not necessarily unique); must conform to ^[a-zA-Z_][a-zA-Z0-9_\.\-]*$.
           -d, --description        Full description of the bundle.
           --tags                   Space-separated list of tags used for search (e.g., machine-learning).
@@ -47,6 +48,7 @@ This file is auto-generated from the output of `cl help -v` and provides the lis
           target_spec                  [<key>]:[[(<alias>|<address>)::](<uuid>|<name>)//](<uuid>|<name>|^<index>)[/<subpath within bundle>]
           command                      Arbitrary Linux command to execute.
           -w, --worksheet-spec         Operate on this worksheet ([(<alias>|<address>)::](<uuid>|<name>)).
+          -a, --after_sort_key         Insert after this sort_key
           -n, --name                   Short variable name (not necessarily unique); must conform to ^[a-zA-Z_][a-zA-Z0-9_\.\-]*$.
           -d, --description            Full description of the bundle.
           --tags                       Space-separated list of tags used for search (e.g., machine-learning).

--- a/docs/REST-API-Reference.md
+++ b/docs/REST-API-Reference.md
@@ -906,6 +906,11 @@ If |recursive|, add all bundles downstream too.
 If |data-only|, only remove from the bundle store, not the bundle metadata.
 If |dry-run|, just return list of bundles that would be deleted, but do not actually delete.
 
+### `POST /worksheets/<worksheet_uuid:re:0x[0-9a-f]{32}>/add-items`
+
+Replace worksheet items with 'ids' with new 'items'.
+The new items will be inserted after the after_sort_key
+
 ### `GET /worksheets/sample/`
 
 Get worksheets to display on the front page.


### PR DESCRIPTION
We don't really need this naming scheme anymore because local runs are the canonical main form of runs now. Part of my larger worker simplification