### PR TITLE
Set CODALAB_PUBLIC_WORKERS in codalab_service.py

### DIFF
--- a/codalab_service.py
+++ b/codalab_service.py
@@ -266,6 +266,8 @@ CODALAB_ARGUMENTS = [
         default=2048,
         help='Default memory (in MB) for each worker in the AWS Batch Worker Manager',
     ),
+    ### Public workers
+    CodalabArg(name='public_workers', help='Comma-separated list of worker ids to monitor'),
 ]
 
 for worker_manager_type in ['cpu', 'gpu']:
@@ -696,6 +698,7 @@ class CodalabServiceManager(object):
                         'server/default_user_info/parallel_run_quota',
                         self.args.user_parallel_run_quota,
                     ),
+                    ('server/public_workers', self.args.public_workers),
                     ('email/host', self.args.email_host),
                     ('email/username', self.args.email_username),
                     ('email/password', self.args.email_password),


### PR DESCRIPTION
This PR will set the value of `CODALAB_PUBLIC_WORKERS` in Docker container from `codalab_service.py` during deployment. 
Note that **master** has more commits than the **staging** branch. I'll sync them once the PR is approved to make sure those changes are in the right order. 