### PR TITLE
fix-stucked-bundle-in-uploading-state

### DIFF
--- a/codalab/client/json_api_client.py
+++ b/codalab/client/json_api_client.py
@@ -15,7 +15,7 @@ def wrap_exception(message):
                 return f(*args, **kwargs)
             except urllib.error.HTTPError as e:
                 # Translate known errors to the standard CodaLab errors
-                error_body = e.read().decode()
+                error_body = e.read()
                 exc = http_error_to_exception(e.code, error_body)
                 # All standard CodaLab errors are subclasses of UsageError
                 if isinstance(exc, UsageError):

--- a/codalab/worker/bundle_service_client.py
+++ b/codalab/worker/bundle_service_client.py
@@ -22,27 +22,18 @@ def wrap_exception(message):
                 raise BundleServiceException(message + ': ' + str(e), e.client_error)
             except urllib.error.HTTPError as e:
                 try:
-                    client_error = json.loads(e.read().decode())
-
-                    if client_error['error'] == 'invalid_grant':
+                    client_error = e.read()
+                    if e.reason == 'invalid_grant':
                         raise BundleAuthException(
-                            message
-                            + ': '
-                            + http.client.responses[e.code]
-                            + ' - '
-                            + json.dumps(client_error),
+                            message + ': ' + http.client.responses[e.code] + ' - ' + client_error,
                             True,
                         )
                     else:
                         raise BundleServiceException(
-                            message
-                            + ': '
-                            + http.client.responses[e.code]
-                            + ' - '
-                            + json.dumps(client_error),
+                            message + ': ' + http.client.responses[e.code] + ' - ' + client_error,
                             e.code >= 400 and e.code < 500,
                         )
-                except json.decoder.JSONDecodeError:
+                except json.decoder.JSONDecodeError as e:
                     raise BundleServiceException(message + ': ' + str(e), False)
             except (urllib.error.URLError, http.client.HTTPException, socket.error) as e:
                 raise BundleServiceException(message + ': ' + str(e), False)

--- a/codalab/worker/worker.py
+++ b/codalab/worker/worker.py
@@ -31,8 +31,9 @@ but they expect the platform specific RunManagers they use to implement a common
 
 
 class Worker:
-    # Number of seconds to retry a bundle service client command
-    COMMAND_RETRY_SECONDS = 60 * 12
+    # Number of retries when a bundle service client command failed to execute. Defining a large number here
+    # would allow offline workers to patiently wait until connection to server is re-established.
+    COMMAND_RETRY_ATTEMPTS = 720
     # Network buffer size to use while proxying with netcat
     NETCAT_BUFFER_SIZE = 4096
     # Number of seconds to wait for bundle kills to propagate before forcing kill
@@ -524,7 +525,7 @@ class Worker:
 
     @staticmethod
     def execute_bundle_service_command_with_retry(cmd):
-        retries_left = Worker.COMMAND_RETRY_SECONDS
+        retries_left = Worker.COMMAND_RETRY_ATTEMPTS
         while True:
             try:
                 retries_left -= 1


### PR DESCRIPTION
Fixed #1875 and #1829 
During investigating on #1875, there are two issues were discovered:
1. `AttributeError: 'str' object has no attribute 'decode'`: might be related to #1853 
```
Traceback (most recent call last):
  File "/usr/local/bin/cl", line 11, in <module>
    load_entry_point('codalab', 'console_scripts', 'cl')()
  File "/opt/codalab-worksheets/codalab/bin/cl.py", line 10, in main
    cli.do_command(sys.argv[1:])
  File "/opt/codalab-worksheets/codalab/lib/bundle_cli.py", line 839, in do_command
    structured_result = command_fn()
  File "/opt/codalab-worksheets/codalab/lib/bundle_cli.py", line 833, in <lambda>
    command_fn = lambda: args.function(self, args)
  File "/opt/codalab-worksheets/codalab/lib/bundle_cli.py", line 1229, in do_upload_command
    progress_callback=progress.update,
  File "/opt/codalab-worksheets/codalab/client/json_api_client.py", line 18, in wrapper
    error_body = e.read().decode()
AttributeError: 'str' object has no attribute 'decode'
```
2. Bundle failed to move to `failed` state for a very long time. It kept moving from `failed` --> `running` --> `failed` and caused the situation described in #1875. This is due to a very large retry number defined at [COMMAND_RETRY_SECONDS](https://github.com/codalab/codalab-worksheets/blob/master/codalab/worker/worker.py#L35). When the current bundle failed from uploading, it keeps retrying until the number of retries becomes a negative value, see logic here [execute_bundle_service_command_with_retry](https://github.com/codalab/codalab-worksheets/blob/master/codalab/worker/worker.py#L530). Hence, the bundle got stuck in uploading state will eventually move to a permanent `failed` state. However, this will take a very long time. 
**We need to decide how many times of retries should be used for function** `execute_bundle_service_command_with_retry` **as the existing value seems to be quite big.**