### PR TITLE
1883: Get rid of MySQL operational errors during worker checkin's

### DIFF
--- a/codalab/rest/workers.py
+++ b/codalab/rest/workers.py
@@ -23,8 +23,7 @@ def checkin(worker_id):
     """
     WAIT_TIME_SECS = 3.0
 
-    # Old workers might not have all the fields, so allow subsets to be
-    # missing.
+    # Old workers might not have all the fields, so allow subsets to be missing.
     socket_id = local.worker_model.worker_checkin(
         request.user.user_id,
         worker_id,
@@ -34,9 +33,8 @@ def checkin(worker_id):
         request.json.get("memory_bytes"),
         request.json.get("free_disk_bytes"),
         request.json["dependencies"],
-        request.json.get("shared_file_system"),
+        request.json.get("shared_file_system", False),
     )
-
     for run in request.json["runs"]:
         try:
             worker_run = BundleCheckinState.from_dict(run)

--- a/codalab/rest/workers.py
+++ b/codalab/rest/workers.py
@@ -35,6 +35,7 @@ def checkin(worker_id):
         request.json["dependencies"],
         request.json.get("shared_file_system", False),
     )
+
     for run in request.json["runs"]:
         try:
             worker_run = BundleCheckinState.from_dict(run)


### PR DESCRIPTION
Fixes #1883. 

`shared_file_system` is a relatively new field that old workers most likely do not specify. The errors happen when inserting null values for `shared_file_system`. This fix gets rid of these errors by using a default value of `False` if the value of the field is unspecified.