### PR TITLE
Do not depend on the mysql service in Docker compose

### DIFF
--- a/docker/compose_files/docker-compose.yml
+++ b/docker/compose_files/docker-compose.yml
@@ -75,16 +75,12 @@ services:
     command: cl-server
     <<: *codalab-base
     <<: *codalab-server
-    depends_on:
-      - mysql
 
   bundle-manager:
     image: codalab/server:${CODALAB_VERSION}
     command: cl-bundle-manager
     <<: *codalab-base
     <<: *codalab-server
-    depends_on:
-      - mysql
 
   worker-manager-cpu:
     image: codalab/server:${CODALAB_VERSION}


### PR DESCRIPTION
Using depends_on to make other services depend on mysql doesn't make
sense if we want to allow remote mysql hosts since docker compose
wouldn't know about them. Additionally, we don't really make use of the
depends_on statements given the way we use docker compose (ie by
bringing up services one by one using an external management script)