### PR TITLE
Create cProfile decorator

### DIFF
--- a/codalab/lib/profiling_util.py
+++ b/codalab/lib/profiling_util.py
@@ -1,0 +1,53 @@
+import cProfile
+import pstats
+
+
+def cprofile(sort_args=['cumulative'], print_args=[10]):
+    """
+    Decorator to profile a callable object using cProfile. Stats will be output to log file, e.g. docker logs
+    Usage:
+    1. import profiling_util from codalab.lib
+    2. decorate your function as following:
+        @profiling_util.cprofile(print_args=[20])
+        def function_to_test():
+            ...
+
+    View the result:
+    1. figure out which container your decorated function goes to, e.g. codalab_bundle-manager_1
+    2. check the result by
+        docker logs codalab_bundle-manager_1
+
+    Example result:
+    Fri Jan 10 00:39:01 2020    _stage_bundles.profile
+
+         1081 function calls (1056 primitive calls) in 0.024 seconds
+
+        Ordered by: cumulative time
+        List reduced from 255 to 20 due to restriction <20>
+
+        ncalls  tottime  percall  cumtime  percall filename:lineno(function)
+             1    0.000    0.000    0.024    0.024 /opt/codalab-worksheets/codalab/server/bundle_manager.py:96(_stage_bundles)
+             2    0.000    0.000    0.024    0.012 /opt/codalab-worksheets/codalab/model/bundle_model.py:677(batch_get_bundles)
+             2    0.000    0.000    0.013    0.006 /usr/local/lib/python3.6/dist-packages/sqlalchemy/engine/base.py:1974(execute)
+             2    0.000    0.000    0.012    0.006 /usr/local/lib/python3.6/dist-packages/sqlalchemy/engine/base.py:846(execute)
+             2    0.000    0.000    0.012    0.006 /usr/local/lib/python3.6/dist-packages/sqlalchemy/sql/elements.py:322(_execute_on_connection)
+             ...
+    :param sort_args: a list of string that is used to sort the output, e.g. 'cumulative', 'pcalls', 'totime'
+    :param print_args: a list of arguments (mixed type, e.g. string, integer, decimal fraction) used to
+                       limit the output down to the significant entries.
+    :return: the decorator function that contain calls to the original function "f".
+    """
+
+    def decorator(f):
+        def wrapper(*args, **kwargs):
+            output_file = f.__name__ + ".profile"
+            profiler = cProfile.Profile()
+            result = profiler.runcall(f, *args, **kwargs)
+            profiler.dump_stats(output_file)
+            stats = pstats.Stats(output_file)
+            stats.sort_stats(*sort_args).print_stats(*print_args)
+            return result
+
+        return wrapper
+
+    return decorator


### PR DESCRIPTION
Adding cProfile decorator as a util to codalab.lib for future usage. 
#### Usage:
1. import `profiling_util` from `codalab.lib`
2. decorate your function as following:
```
@profiling_util.cprofile(print_args=[20])
def function_to_test():
    ....
```
#### View the result:
1. figure out which container has the function you just decorated
2. fill the following docker command with the container found in step 1.
```
docker logs <container_name>
```
#### Example result:
```
Fri Jan 10 00:17:39 2020    _schedule_run_bundles_on_workers.profile

         12656 function calls (12252 primitive calls) in 0.213 seconds

   Ordered by: cumulative time
   List reduced from 297 to 20 due to restriction <20>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000    0.214    0.214 /opt/codalab-worksheets/codalab/server/bundle_manager.py:312(_schedule_run_bundles_on_workers)
        8    0.002    0.000    0.204    0.025 /opt/codalab-worksheets/codalab/model/bundle_model.py:2334(get_user_parallel_run_quota_left)
       17    0.000    0.000    0.128    0.008 /usr/local/lib/python3.6/dist-packages/sqlalchemy/engine/base.py:1974(execute)
       17    0.000    0.000    0.127    0.007 /usr/local/lib/python3.6/dist-packages/sqlalchemy/engine/base.py:846(execute)
       17    0.000    0.000    0.127    0.007 /usr/local/lib/python3.6/dist-packages/sqlalchemy/sql/elements.py:322(_execute_on_connection)
       17    0.001    0.000    0.126    0.007 /usr/local/lib/python3.6/dist-packages/sqlalchemy/engine/base.py:975(_execute_clauseelement)
        8    0.001    0.000    0.108    0.014 /opt/codalab-worksheets/codalab/model/bundle_model.py:2283(get_user_info)
       17    0.000    0.000    0.090    0.005 /usr/local/lib/python3.6/dist-packages/sqlalchemy/sql/elements.py:431(compile)
       17    0.000    0.000    0.089    0.005 /usr/local/lib/python3.6/dist-packages/sqlalchemy/sql/elements.py:496(_compiler)
       17    0.001    0.000    0.089    0.005 /usr/local/lib/python3.6/dist-packages/sqlalchemy/sql/compiler.py:329(__init__)
       17    0.000    0.000    0.088    0.005 /usr/local/lib/python3.6/dist-packages/sqlalchemy/sql/compiler.py:167(__init__)
    18/17    0.000    0.000    0.088    0.005 /usr/local/lib/python3.6/dist-packages/sqlalchemy/sql/compiler.py:212(process)
   340/17    0.005    0.000    0.088    0.005 /usr/local/lib/python3.6/dist-packages/sqlalchemy/sql/visitors.py:75(_compiler_dispatch)
    25/17    0.002    0.000    0.087    0.005 /usr/local/lib/python3.6/dist-packages/sqlalchemy/sql/compiler.py:1503(visit_select)
       25    0.002    0.000    0.050    0.002 /usr/local/lib/python3.6/dist-packages/sqlalchemy/sql/compiler.py:1573(<listcomp>)
      184    0.011    0.000    0.049    0.000 /usr/local/lib/python3.6/dist-packages/sqlalchemy/sql/compiler.py:1275(_label_select_column)
       17    0.001    0.000    0.035    0.002 /usr/local/lib/python3.6/dist-packages/sqlalchemy/engine/base.py:1061(_execute_context)
      216    0.012    0.000    0.030    0.000 /usr/local/lib/python3.6/dist-packages/sqlalchemy/sql/compiler.py:620(visit_column)
    25/17    0.001    0.000    0.025    0.001 /usr/local/lib/python3.6/dist-packages/sqlalchemy/sql/compiler.py:1679(_compose_select_body)
    32/24    0.001    0.000    0.020    0.001 /usr/local/lib/python3.6/dist-packages/sqlalchemy/sql/compiler.py:904(visit_binary)


Fri Jan 10 00:17:39 2020    _fail_unresponsive_bundles.profile

         5632 function calls (5548 primitive calls) in 0.092 seconds
```