### PR TITLE
Set maximum docker image size before pulling from docker hub

### DIFF
--- a/codalab/worker/main.py
+++ b/codalab/worker/main.py
@@ -79,6 +79,16 @@ def parse_args():
         'is not specified.',
     )
     parser.add_argument(
+        '--max-image-size',
+        type=str,
+        metavar='SIZE',
+        default='10g',
+        help='Limit the size of Docker images to download from the Docker Hub'
+        '(e.g. 3, 3k, 3m, 3g, 3t). If the limit is exceeded, '
+        'the requested image will not be downloaded. '
+        'The bundle depends on this image will fail accordingly.',
+    )
+    parser.add_argument(
         '--password-file',
         help='Path to the file containing the username and '
         'password for logging into the bundle service, '
@@ -156,6 +166,7 @@ def main():
     max_image_cache_size_bytes = (
         parse_size(args.max_image_cache_size) if args.max_image_cache_size else None
     )
+    max_image_size_bytes = parse_size(args.max_image_size)
 
     if not os.path.exists(args.work_dir):
         logging.debug('Work dir %s doesn\'t exist, creating.', args.work_dir)
@@ -173,7 +184,9 @@ def main():
     )
 
     image_manager = DockerImageManager(
-        os.path.join(args.work_dir, 'images-state.json'), max_image_cache_size_bytes
+        os.path.join(args.work_dir, 'images-state.json'),
+        max_image_cache_size_bytes,
+        max_image_size_bytes,
     )
 
     worker = Worker(


### PR DESCRIPTION
Fixed #1894.
Final failure message will be showing as follows:
<img width="1227" alt="Screen Shot 2020-01-13 at 12 25 56 PM" src="https://user-images.githubusercontent.com/1483372/72289898-efd78400-3600-11ea-9a5d-ce6b96d9f315.png">

Issues:
Tried using [docker-py](https://docker-py.readthedocs.io/en/stable/images.html#registrydata-objects) at the beginning as I want to reuse the existing libraries instead of introducing a new one. However, by examining the results return from `RegistryData` object as following:
```
>>> import docker
>>> client = docker.from_env()
>>> r = client.images.get_registry_data("codalab/default-cpu")
>>> r.attrs
{'Descriptor': {'mediaType': 'application/vnd.docker.distribution.manifest.v2+json', 'digest': 'sha256:ff7de716ac5f94d9b4ff8d6341d60166ed5b0163cc05d8d51da9418511caf5e1', 'size': 4544}, 'Platforms': [{'architecture': 'amd64', 'os': 'linux'}]}
```
The returned `size` element is quite different than its actual value [(5G in docker hub)](https://hub.docker.com/layers/codalab/default-cpu/latest/images/sha256-ff7de716ac5f94d9b4ff8d6341d60166ed5b0163cc05d8d51da9418511caf5e1). 
I also tried to find any documentation about the `size` returned from `RegistryData.attrs` and correlation between the size return by `RegistryData.attrs` and the actual value. Nothing helpful has been discovered. (**If anyone has suggestions of this, please feel free to let me know.**)
Then, I decided to move to Docker HTTP API V2 to query the size information of an image before pulling from docker hub. 

