### PR TITLE
Replace new line with space for worksheet bundle lines

### DIFF
--- a/codalab/lib/worksheet_util.py
+++ b/codalab/lib/worksheet_util.py
@@ -168,6 +168,7 @@ def get_worksheet_lines(worksheet_info):
                     description += ' -- ' + deps
                 command = bundle_info.get('command')
                 if command:
+                    command = command.replace('\n',' ')
                     description += ' : ' + command
             lines.append(bundle_line(description, bundle_info['uuid']))
         elif item_type == TYPE_WORKSHEET:

--- a/codalab/lib/worksheet_util.py
+++ b/codalab/lib/worksheet_util.py
@@ -168,7 +168,7 @@ def get_worksheet_lines(worksheet_info):
                     description += ' -- ' + deps
                 command = bundle_info.get('command')
                 if command:
-                    command = command.replace('\n',' ')
+                    command = command.replace('\n', ' ')
                     description += ' : ' + command
             lines.append(bundle_line(description, bundle_info['uuid']))
         elif item_type == TYPE_WORKSHEET:


### PR DESCRIPTION
Address #1879 

To test:
Issue a new run with a long command like:
`'export PYTHONPATH=".";
python3 experiments/platt_not_calibrated/lower_bounds.py
--logits_path=data/cifar_logits.dat --bins_list="2, 4, 8, 16, 32, 64, 128" --lp=2
--calibration_data_size=1000 --bin_data_size=1000 --plot_save_file=l2_lower_bound_cifar_plot.png
--binning=equal_bins --num_samples=1000'
--request-queue tag=nlp -n cifar_l2_lower_bound`
it will produce a bundle row
before the change: click edit source, then save source, the bundle row will become plain text lines.
after the change: click edit source, then save source, the bundle row stays as a bundle. In source, the long command is displayed as one line

However, bundle lines that have been saved as multiple text lines probably needs manual fixes still