### PR TITLE
1895: Resolve key error

### DIFF
--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -280,7 +280,8 @@ def _create_bundles():
     bundles_dict = get_bundle_infos(created_uuids)
 
     # Return bundles in original order
-    # There is a chance that a bundle is created and deleted right after, while fetching bundles info's
+    # Need to check if the UUID is in the dict, since there is a chance that a bundle is deleted
+    # right after being created.
     bundles = [bundles_dict[uuid] for uuid in created_uuids if uuid in bundles_dict]
     return BundleSchema(many=True).dump(bundles).data
 
@@ -309,7 +310,8 @@ def _update_bundles():
     bundles_dict = get_bundle_infos(bundle_uuids)
 
     # Create list of bundles in original order
-    # There is a chance that a bundle is updated and deleted right after, while fetching bundles info's
+    # Need to check if the UUID is in the dict, since there is a chance that a bundle is deleted
+    # right after being updated.
     updated_bundles = [bundles_dict[uuid] for uuid in bundle_uuids if uuid in bundles_dict]
 
     return BundleSchema(many=True).dump(updated_bundles).data

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -280,7 +280,8 @@ def _create_bundles():
     bundles_dict = get_bundle_infos(created_uuids)
 
     # Return bundles in original order
-    bundles = [bundles_dict[uuid] for uuid in created_uuids]
+    # There is a chance that a bundle is created and deleted right after, while fetching bundles info's
+    bundles = [bundles_dict[uuid] for uuid in created_uuids if uuid in bundles_dict]
     return BundleSchema(many=True).dump(bundles).data
 
 
@@ -308,7 +309,8 @@ def _update_bundles():
     bundles_dict = get_bundle_infos(bundle_uuids)
 
     # Create list of bundles in original order
-    updated_bundles = [bundles_dict[uuid] for uuid in bundle_uuids]
+    # There is a chance that a bundle is updated and deleted right after, while fetching bundles info's
+    updated_bundles = [bundles_dict[uuid] for uuid in bundle_uuids if uuid in bundles_dict]
 
     return BundleSchema(many=True).dump(updated_bundles).data
 

--- a/codalab/rest/interpret.py
+++ b/codalab/rest/interpret.py
@@ -610,7 +610,10 @@ def expand_raw_item(raw_item):
                 bundle_uuids = search_result['result']
                 bundle_infos = rest_util.get_bundle_infos(bundle_uuids)
                 for bundle_uuid in bundle_uuids:
-                    raw_items.append(bundle_item(bundle_infos[bundle_uuid]) + (None, None))
+                    # Since bundle UUID's are queried first, we can't assume a UUID exists in
+                    # the subsequent bundle info query.
+                    if bundle_uuid in bundle_infos:
+                        raw_items.append(bundle_item(bundle_infos[bundle_uuid]) + (None, None))
         elif is_wsearch:
             worksheet_infos = search_worksheets(keywords)
             for worksheet_info in worksheet_infos:


### PR DESCRIPTION
Fixes #1895 

In a few places, we query for bundle UUIDs and then query for their corresponding bundle infos. However, there is a chance that bundles get deleted in between queries, which in turn, causes key errors to surface. This is a simple fix to prevent these errors. An alternative solution would be to change how we query for bundles.