### PR TITLE
1915: Log email failure exception

### DIFF
--- a/codalab/lib/emailer.py
+++ b/codalab/lib/emailer.py
@@ -47,7 +47,7 @@ class SMTPEmailer(Emailer):
         :param body: body of email
         :param recipient: recipient of email, must be valid email address
         :param sender: optional alternative 'From' header
-        :param mime_type: optional speficies the mime type
+        :param mime_type: optional specifies the mime type
         :param charset: optional specifies the character encoding; use 'utf-8'
                for unicode
         :return:
@@ -76,7 +76,7 @@ class SMTPEmailer(Emailer):
             log.debug(message.as_string())
 
         except smtplib.SMTPException:
-            log.error("Failed to send email, defaulting to console.")
+            log.exception("Failed to send email, defaulting to console.")
             ConsoleEmailer(sys.stderr).send_email(subject, body, recipient, sender)
 
 


### PR DESCRIPTION
Fixes #1915 

It is hard to tell what is causing email failures in `dev`. Hopefully, this change can shine some light on the problem.

@epicfaace I think we should deploy with this change.