### PR TITLE
Set /bin/bash to bash shell in docker command.

### DIFF
--- a/codalab/worker/docker_utils.py
+++ b/codalab/worker/docker_utils.py
@@ -119,7 +119,9 @@ def start_bundle_container(
 ):
     if not command.endswith(';'):
         command = '{};'.format(command)
-    docker_command = ['bash', '-c', '( %s ) >stdout 2>stderr' % command]
+    # Explicitly specifying "/bin/bash" instead of "bash" for bash shell to avoid the situation when
+    # the program can't find the symbolic link (default is "/bin/bash") of bash in the environment
+    docker_command = ['/bin/bash', '-c', '( %s ) >stdout 2>stderr' % command]
     docker_bundle_path = '/' + uuid
     volumes = get_bundle_container_volume_binds(bundle_path, docker_bundle_path, dependencies)
     environment = {'HOME': docker_bundle_path, 'CODALAB': 'true'}


### PR DESCRIPTION
Fixed #1704. 
This PR will fix the problem caused by the following error: 
```"exec: \"bash\": executable file not found in $PATH": unknown"```

This error had periodically happened in production, shown as follows:
```
docker.errors.APIError: 400 Client Error: Bad Request ("OCI runtime create failed: container_linux.go:345: starting container process caused "exec: \"bash\": executable file not found in $PATH": unknown")
```
I had done some investigation, findings are all documented at the original ticket. Currently, PATH is set to have the following paths:
```
/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
```
Explicitly setting the path of bash shell in environment variable $PATH will help the program to navigate the right bash shell easier.