### PR TITLE
Fix travis CI random failures due to cl kill command

### DIFF
--- a/codalab/rest/bundle_actions.py
+++ b/codalab/rest/bundle_actions.py
@@ -17,20 +17,34 @@ def create_bundle_actions():
     actions = BundleActionSchema(strict=True, many=True).load(request.json).data
 
     check_bundles_have_all_permission(local.model, request.user, [a['uuid'] for a in actions])
-
     for action in actions:
         bundle = local.model.get_bundle(action['uuid'])
-        if bundle.state not in [State.RUNNING, State.PREPARING]:
-            raise UsageError('Cannot execute this action on a bundle that is not running.')
+        if bundle.state in [
+            State.READY,
+            State.FAILED,
+            State.KILLED,
+        ]:
+            raise UsageError(
+                'Cannot execute this action on a bundle that is in the following states: ready, failed, killed. '
+                'Kill action can be executed on bundles in created, uploading, staged, making, starting, '
+                'running, preparing, or finalizing state.'
+            )
 
         worker = local.model.get_bundle_worker(action['uuid'])
-        precondition(
-            local.worker_model.send_json_message(worker['socket_id'], action, 60),
-            'Unable to reach worker.',
-        )
-
         new_actions = getattr(bundle.metadata, 'actions', []) + [BundleAction.as_string(action)]
-        db_update = {'metadata': {'actions': new_actions}}
-        local.model.update_bundle(bundle, db_update)
+
+        # The state updates of bundles in PREPARING, RUNNING, or FINALIZING state will be handled on the worker side.
+        if worker:
+            precondition(
+                local.worker_model.send_json_message(worker['socket_id'], action, 60),
+                'Unable to reach worker.',
+            )
+            local.model.update_bundle(bundle, {'metadata': {'actions': new_actions}})
+        else:
+            # The state updates of bundles in CREATED, UPLOADING, MAKING, STARTING or STAGED state
+            # will be handled on the rest-server side.
+            local.model.update_bundle(
+                bundle, {'state': State.KILLED, 'metadata': {'actions': new_actions}}
+            )
 
     return BundleActionSchema(many=True).dump(actions).data

--- a/docs/CLI-Reference.md
+++ b/docs/CLI-Reference.md
@@ -253,7 +253,9 @@ This file is auto-generated from the output of `cl help -v` and provides the lis
           -v, --verbose                Display verbose output.
 
       kill:
-        Instruct the appropriate worker to terminate the running bundle(s).
+        Terminate the bundle(s) execution if it's being executed or remove it from the execution queue. 
+        Valid bundle states include:
+         created, uploading, staged, making, starting, running, preparing, or finalizing.
         Arguments:
           bundle_spec           [[(<alias>|<address>)::](<uuid>|<name>)//](<uuid>|<name>|^<index>)
           -w, --worksheet-spec  Operate on this worksheet ([(<alias>|<address>)::](<uuid>|<name>)).

--- a/test_cli.py
+++ b/test_cli.py
@@ -443,7 +443,11 @@ class ModuleContext(object):
         if len(self.bundles) > 0:
             for bundle in set(self.bundles):
                 try:
-                    if run_command([cl, 'info', '-f', 'state', bundle]) not in ('ready', 'failed'):
+                    if run_command([cl, 'info', '-f', 'state', bundle]) not in (
+                        'ready',
+                        'failed',
+                        'killed',
+                    ):
                         run_command([cl, 'kill', bundle])
                         run_command([cl, 'wait', bundle], expected_exit_code=1)
                 except AssertionError:


### PR DESCRIPTION
This is to fix Travis CI tests failed to `kill` bundles. 
Bundles in `staged` state can't be killed directly. It needs to be removed instead.