### PR TITLE
Reuse db calls

### DIFF
--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -2325,8 +2325,9 @@ class BundleModel(object):
         user_info['time_used'] += amount
         self.update_user_info(user_info)
 
-    def get_user_time_quota_left(self, user_id):
-        user_info = self.get_user_info(user_id)
+    def get_user_time_quota_left(self, user_id, user_info=None):
+        if not user_info:
+            user_info = self.get_user_info(user_id)
         time_quota = user_info['time_quota']
         time_used = user_info['time_used']
         return time_quota - time_used
@@ -2363,8 +2364,9 @@ class BundleModel(object):
             or 0
         )
 
-    def get_user_disk_quota_left(self, user_id):
-        user_info = self.get_user_info(user_id)
+    def get_user_disk_quota_left(self, user_id, user_info=None):
+        if not user_info:
+            user_info = self.get_user_info(user_id)
         return user_info['disk_quota'] - user_info['disk_used']
 
     def update_user_disk_used(self, user_id):


### PR DESCRIPTION
Partial fix of #1254 
Cache visited `user_info` to avoid duplicate database queries.
Without this changes, the profiling results (with 100 staged bundles) are:
```
Fri Jan 24 00:07:19 2020    _get_staged_bundles_to_run.profile

         371431 function calls (361088 primitive calls) in 1.701 seconds

   Ordered by: cumulative time
   List reduced from 319 to 20 due to restriction <20>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.002    0.002    1.702    1.702 /opt/codalab-worksheets/codalab/server/bundle_manager.py:653(_get_staged_bundles_to_run)
      404    0.011    0.000    1.330    0.003 /opt/codalab-worksheets/codalab/model/bundle_model.py:2283(get_user_info)
      202    0.004    0.000    0.839    0.004 /opt/codalab-worksheets/codalab/model/bundle_model.py:2328(get_user_time_quota_left)
      101    0.001    0.000    0.834    0.008 /opt/codalab-worksheets/codalab/server/bundle_manager.py:564(_compute_bundle_resources)
      202    0.003    0.000    0.826    0.004 /opt/codalab-worksheets/codalab/model/bundle_model.py:2366(get_user_disk_quota_left)
      407    0.001    0.000    0.636    0.002 /usr/local/lib/python3.6/dist-packages/sqlalchemy/engine/base.py:1974(execute)
      407    0.001    0.000    0.633    0.002 /usr/local/lib/python3.6/dist-packages/sqlalchemy/engine/base.py:846(execute)
      407    0.000    0.000    0.632    0.002 /usr/local/lib/python3.6/dist-packages/sqlalchemy/sql/elements.py:322(_execute_on_connection)
      407    0.003    0.000    0.632    0.002 /usr/local/lib/python3.6/dist-packages/sqlalchemy/engine/base.py:975(_execute_clauseelement)
      407    0.005    0.000    0.472    0.001 /usr/local/lib/python3.6/dist-packages/sqlalchemy/engine/base.py:1061(_execute_context)
      101    0.000    0.000    0.424    0.004 /opt/codalab-worksheets/codalab/server/bundle_manager.py:515(_compute_request_time)
      101    0.001    0.000    0.407    0.004 /opt/codalab-worksheets/codalab/server/bundle_manager.py:504(_compute_request_disk)
      407    0.001    0.000    0.403    0.001 /usr/local/lib/python3.6/dist-packages/sqlalchemy/engine/default.py:449(do_execute)
      407    0.003    0.000    0.403    0.001 /usr/local/lib/python3.6/dist-packages/MySQLdb/cursors.py:163(execute)
      407    0.002    0.000    0.395    0.001 /usr/local/lib/python3.6/dist-packages/MySQLdb/cursors.py:301(_query)
      407    0.367    0.001    0.367    0.001 /usr/local/lib/python3.6/dist-packages/MySQLdb/connections.py:213(query)
      405    0.002    0.000    0.356    0.001 /usr/local/lib/python3.6/dist-packages/sqlalchemy/engine/threadlocal.py:84(begin)
      812    0.005    0.000    0.351    0.000 /usr/local/lib/python3.6/dist-packages/sqlalchemy/engine/threadlocal.py:52(contextual_connect)
      405    0.001    0.000    0.330    0.001 /usr/local/lib/python3.6/dist-packages/sqlalchemy/engine/base.py:2071(_wrap_pool_connect)
      405    0.001    0.000    0.329    0.001 /usr/local/lib/python3.6/dist-packages/sqlalchemy/pool.py:367(connect)
```
With this changes, the profiling results (with 100 staged bundles) changed to :
```
Fri Jan 24 01:10:13 2020    _get_staged_bundles_to_run.profile

         33012 function calls (32744 primitive calls) in 0.039 seconds

   Ordered by: cumulative time
   List reduced from 320 to 20 due to restriction <20>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.001    0.001    0.039    0.039 /opt/codalab-worksheets/codalab/server/bundle_manager.py:653(_get_staged_bundles_to_run)
        1    0.001    0.001    0.033    0.033 /opt/codalab-worksheets/codalab/model/bundle_model.py:677(batch_get_bundles)
        4    0.000    0.000    0.016    0.004 /usr/local/lib/python3.6/dist-packages/sqlalchemy/engine/base.py:1974(execute)
        4    0.000    0.000    0.016    0.004 /usr/local/lib/python3.6/dist-packages/sqlalchemy/engine/base.py:846(execute)
        4    0.000    0.000    0.016    0.004 /usr/local/lib/python3.6/dist-packages/sqlalchemy/sql/elements.py:322(_execute_on_connection)
        4    0.000    0.000    0.016    0.004 /usr/local/lib/python3.6/dist-packages/sqlalchemy/engine/base.py:975(_execute_clauseelement)
        4    0.000    0.000    0.013    0.003 /usr/local/lib/python3.6/dist-packages/sqlalchemy/engine/base.py:1061(_execute_context)
        4    0.000    0.000    0.012    0.003 /usr/local/lib/python3.6/dist-packages/sqlalchemy/engine/default.py:449(do_execute)
        4    0.000    0.000    0.012    0.003 /usr/local/lib/python3.6/dist-packages/MySQLdb/cursors.py:163(execute)
        4    0.000    0.000    0.011    0.003 /usr/local/lib/python3.6/dist-packages/MySQLdb/cursors.py:301(_query)
        1    0.000    0.000    0.011    0.011 /opt/codalab-worksheets/codalab/model/bundle_model.py:714(<listcomp>)
      101    0.000    0.000    0.011    0.000 /opt/codalab-worksheets/codalab/model/orm_object.py:16(__init__)
      101    0.001    0.000    0.010    0.000 /opt/codalab-worksheets/codalab/objects/bundle.py:52(update_in_memory)
        4    0.008    0.002    0.008    0.002 /usr/local/lib/python3.6/dist-packages/MySQLdb/connections.py:213(query)
      101    0.001    0.000    0.007    0.000 /opt/codalab-worksheets/codalab/objects/metadata.py:11(__init__)
      101    0.003    0.000    0.005    0.000 /opt/codalab-worksheets/codalab/objects/metadata.py:59(collapse_dicts)
        4    0.000    0.000    0.003    0.001 /usr/local/lib/python3.6/dist-packages/sqlalchemy/sql/elements.py:431(compile)
        4    0.000    0.000    0.003    0.001 /usr/local/lib/python3.6/dist-packages/sqlalchemy/sql/elements.py:496(_compiler)
        4    0.000    0.000    0.003    0.001 /usr/local/lib/python3.6/dist-packages/sqlalchemy/sql/compiler.py:329(__init__)
        4    0.000    0.000    0.003    0.001 /usr/local/lib/python3.6/dist-packages/sqlalchemy/sql/compiler.py:167(__init__)
```
Also note that the above results are measured by all 100 staged bundles submitted by one single user. The improvements will vary due to the amount of unique users in staged bundles. 
The current performance improvement is about 40X speedup.