### PR TITLE
Fix disk usage check

### DIFF
--- a/codalab/worker/worker_run_state.py
+++ b/codalab/worker/worker_run_state.py
@@ -341,9 +341,6 @@ class RunStateMachine(StateTransitioner):
                     'Time limit exceeded. (Container uptime %s > time limit %s)'
                     % (duration_str(container_time_total), duration_str(run_state.resources.time))
                 )
-            logger.info("max_memory = {}".format(run_state.max_memory))
-            logger.info("run_state.resources.memory = {}".format(run_state.resources.memory))
-            logger.info("run_state.exitcode = {}".format(run_state.exitcode))
 
             if run_state.max_memory > run_state.resources.memory or run_state.exitcode == '137':
                 kill_messages.append(

--- a/codalab/worker/worker_run_state.py
+++ b/codalab/worker/worker_run_state.py
@@ -319,12 +319,6 @@ class RunStateMachine(StateTransitioner):
 
             run_stats = docker_utils.get_container_stats(run_state.container)
 
-            run_state = run_state._replace(
-                max_memory=max(run_state.max_memory, run_stats.get('memory', 0))
-            )
-
-            run_state = check_disk_utilization(run_state)
-
             container_time_total = docker_utils.get_container_running_time(run_state.container)
             run_state = run_state._replace(
                 container_time_total=container_time_total,
@@ -335,6 +329,12 @@ class RunStateMachine(StateTransitioner):
                     'container_time_system', run_state.container_time_system
                 ),
             )
+
+            run_state = run_state._replace(
+                max_memory=max(run_state.max_memory, run_stats.get('memory', 0))
+            )
+
+            run_state = check_disk_utilization(run_state)
 
             if run_state.resources.time and container_time_total > run_state.resources.time:
                 kill_messages.append(


### PR DESCRIPTION
Fixed the first issue in #1932

When comparing the disk resources at [`disk_utilization`](https://github.com/codalab/codalab-worksheets/blob/master/codalab/worker/worker_run_state.py#L390), the value returned from [self.disk_utilization](https://github.com/codalab/codalab-worksheets/blob/master/codalab/worker/worker_run_state.py#L386-L388) can sometimes be 0, even if the bundle is finished (`state.finished=True`). Then the `request-disk` constraint becomes invalid. So we see random failures in test_cli.py described in #1932 . Basically the calculating disk utilization in a separate thread here could be inaccurate when the bundle reaches `finished` state but the thread is in sleeping mode so that the main process never gets the final disk usage of the bundle. 
Before this PR, disk utilization calculation is running as a single thread. However, this piece of logic could be simplified by just adding the condition check whenever the bundle is in `RUNNING` state at [self._transition_from_RUNNING](https://github.com/codalab/codalab-worksheets/blob/master/codalab/worker/worker_run_state.py#L307). Then as soon as `disk_utilization` exceeds the upper limit of `request-disk`, then the `run_state` will be set to failure. 