### PR TITLE
1854: Display a more useful failure message when a run is killed

### DIFF
--- a/codalab/worker/worker_run_state.py
+++ b/codalab/worker/worker_run_state.py
@@ -525,7 +525,7 @@ class RunStateMachine(StateTransitioner):
             failure_message = (
                 "{}. {}".format(run_state.failure_message, run_state.kill_message)
                 if run_state.failure_message
-                else run_state.kill_messsage
+                else run_state.kill_message
             )
             run_state = run_state._replace(failure_message=failure_message)
         return run_state._replace(stage=RunStage.FINALIZING, run_status="Finalizing bundle")

--- a/codalab/worker/worker_run_state.py
+++ b/codalab/worker/worker_run_state.py
@@ -350,7 +350,7 @@ class RunStateMachine(StateTransitioner):
                     % (duration_str(container_time_total), duration_str(run_state.resources.time))
                 )
 
-            if run_state.max_memory > run_state.resources.memory or run_state.exitcode == '137':
+            if run_state.max_memory > run_state.resources.memory or run_state.exitcode == 137:
                 kill_messages.append(
                     'Memory limit %s exceeded.' % size_str(run_state.resources.memory)
                 )
@@ -362,7 +362,6 @@ class RunStateMachine(StateTransitioner):
 
             if kill_messages:
                 run_state = run_state._replace(kill_message=' '.join(kill_messages), is_killed=True)
-
             return run_state
 
         def check_disk_utilization():
@@ -521,7 +520,8 @@ class RunStateMachine(StateTransitioner):
         """
         Prepare the finalize message to be sent with the next checkin
         """
-        if not run_state.failure_message and run_state.is_killed:
+        if run_state.is_killed:
+            # Set the failure message as the kill_message, which contains useful information on why a run was killed.
             run_state = run_state._replace(failure_message=run_state.kill_message)
         return run_state._replace(stage=RunStage.FINALIZING, run_status="Finalizing bundle")
 

--- a/codalab/worker/worker_run_state.py
+++ b/codalab/worker/worker_run_state.py
@@ -521,8 +521,13 @@ class RunStateMachine(StateTransitioner):
         Prepare the finalize message to be sent with the next checkin
         """
         if run_state.is_killed:
-            # Set the failure message as the kill_message, which contains useful information on why a run was killed.
-            run_state = run_state._replace(failure_message=run_state.kill_message)
+            # Append kill_message, which contains more useful info on why a run was killed, to the failure message.
+            failure_message = (
+                "{}. {}".format(run_state.failure_message, run_state.kill_message)
+                if run_state.failure_message
+                else run_state.kill_messsage
+            )
+            run_state = run_state._replace(failure_message=failure_message)
         return run_state._replace(stage=RunStage.FINALIZING, run_status="Finalizing bundle")
 
     def _transition_from_FINALIZING(self, run_state):

--- a/codalab/worker/worker_run_state.py
+++ b/codalab/worker/worker_run_state.py
@@ -527,7 +527,8 @@ class RunStateMachine(StateTransitioner):
                 if run_state.failure_message
                 else run_state.kill_messsage
             )
-            run_state = run_state._replace(failure_message=failure_message)
+            print("DEBUG: " + failure_message)
+            run_state = run_state._replace(failure_message=run_state.kill_message)
         return run_state._replace(stage=RunStage.FINALIZING, run_status="Finalizing bundle")
 
     def _transition_from_FINALIZING(self, run_state):

--- a/codalab/worker/worker_run_state.py
+++ b/codalab/worker/worker_run_state.py
@@ -527,8 +527,7 @@ class RunStateMachine(StateTransitioner):
                 if run_state.failure_message
                 else run_state.kill_messsage
             )
-            print("DEBUG: " + failure_message)
-            run_state = run_state._replace(failure_message=run_state.kill_message)
+            run_state = run_state._replace(failure_message=failure_message)
         return run_state._replace(stage=RunStage.FINALIZING, run_status="Finalizing bundle")
 
     def _transition_from_FINALIZING(self, run_state):


### PR DESCRIPTION
Fixes #1854 

Display a more useful error message when a run is killed by a worker. Before this fix, the error message was something like "bash: line 1: 6 Killed". After the fix, it displays the reason why the run was killed.

![Screen Shot 2020-01-28 at 12 43 03 AM](https://user-images.githubusercontent.com/16793796/73248097-29fb6680-4167-11ea-9670-660836f7eb75.png)
