### PR TITLE
Add mising parameter

### DIFF
--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -2332,8 +2332,9 @@ class BundleModel(object):
         time_used = user_info['time_used']
         return time_quota - time_used
 
-    def get_user_parallel_run_quota_left(self, user_id):
-        user_info = self.get_user_info(user_id)
+    def get_user_parallel_run_quota_left(self, user_id, user_info=None):
+        if not user_info:
+            user_info = self.get_user_info(user_id)
         parallel_run_quota = user_info['parallel_run_quota']
         with self.engine.begin() as connection:
             # Get all the runs belonging to this user whose workers are not personal workers

--- a/codalab/worker/docker_utils.py
+++ b/codalab/worker/docker_utils.py
@@ -284,20 +284,29 @@ def get_image_size_without_pulling(image_spec):
     logger.info("Downloading tag information for {}".format(image_spec))
     image_name, image_tag = image_spec.split(":")
     # Example URL:
-    # 1. image with namespace: https://hub.docker.com/v2/repositories/<namespace>/<image_name>/tags
-    #       e.g. https://hub.docker.com/v2/repositories/codalab/default-cpu/tags
-    # 2. image without namespace: https://hub.docker.com/v2/repositories/library/<image_name>/tags
-    #       e.g. https://hub.docker.com/v2/repositories/library/ubuntu/tags/
+    # 1. image with namespace: https://hub.docker.com/v2/repositories/<namespace>/<image_name>/tags/?page=1
+    #       e.g. https://hub.docker.com/v2/repositories/codalab/default-cpu/tags/?page=1
+    # 2. image without namespace: https://hub.docker.com/v2/repositories/library/<image_name>/tags/?page=1
+    #       e.g. https://hub.docker.com/v2/repositories/library/ubuntu/tags/?page=1
+    # Each page will return at most 10 tags
     # Note that since docker-py doesn't report the accurate compressed image size, e.g. the size reported
     # from the RegistryData object, we then switch to use Docker Registry HTTP API V2
     # URI prefix of an image without namespace will be adjusted to https://hub.docker.com/v2/repositories/library
     uri_prefix_adjusted = URI_PREFIX + '/library/' if '/' not in image_name else URI_PREFIX
-    request = uri_prefix_adjusted + image_name + '/tags'
-    response = requests.get(url=request)
-    data = response.json()
-
-    # Find all the full_size of the matched images
-    matched_image_sizes = [r['full_size'] for r in data['results'] if r['name'] == image_tag]
-    image_size_bytes = matched_image_sizes[0] if len(matched_image_sizes) == 1 else None
+    request = uri_prefix_adjusted + image_name + '/tags/?page='
+    image_size_bytes = None
+    page = 1
+    while True:
+        response = requests.get(url=request + str(page))
+        if len(response) == 0:
+            break
+        data = response.json()
+        # Get the list of size information for matched images
+        matched_image_sizes = [r['full_size'] for r in data['results'] if r['name'] == image_tag]
+        image_size_bytes = matched_image_sizes[0] if len(matched_image_sizes) == 1 else None
+        # Break the loop when we find a matched image
+        if image_size_bytes:
+            break
+        page += 1
 
     return image_size_bytes


### PR DESCRIPTION
Fix as part of #1930 

This issue was discovered after the release of v0.5.7 on production. However, both dev and staging didn't show the problem. Thinking through the dev/staging testing process, when we login as the root user to test out changes, some logic related to the regular users might not be exercised (e.g. `get_user_parallel_run_quota_left`). Then the testing will not be sufficient enough to discover all the potential bugs. 