### PR TITLE
Add missing parameter to get_user_parallel_run_quota_left

### DIFF
--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -2332,8 +2332,9 @@ class BundleModel(object):
         time_used = user_info['time_used']
         return time_quota - time_used
 
-    def get_user_parallel_run_quota_left(self, user_id):
-        user_info = self.get_user_info(user_id)
+    def get_user_parallel_run_quota_left(self, user_id, user_info=None):
+        if not user_info:
+            user_info = self.get_user_info(user_id)
         parallel_run_quota = user_info['parallel_run_quota']
         with self.engine.begin() as connection:
             # Get all the runs belonging to this user whose workers are not personal workers


### PR DESCRIPTION
Fix as part of #1930

This issue was discovered after the release of v0.5.7 on production. However, both dev and staging didn't show the problem. Thinking through the dev/staging testing process, when we login as the root user to test out changes, some logic related to the regular users might not be exercised (e.g. `get_user_parallel_run_quota_left`). Then the testing will not be sufficient enough to discover all the potential bugs. Need to use non-root user for testing in the future.