### PR TITLE
Fix chrome uploads by triggering uploads with a label

### DIFF
--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -142,7 +142,6 @@ class Worksheet extends React.Component {
             updatingBundleUuids: {},
             isUpdatingBundles: false,
             anchorEl: null,
-            showNewUpload: false,
             showNewRun: false,
             showNewText: false,
             showRerun: false,
@@ -470,7 +469,6 @@ class Worksheet extends React.Component {
             focusIndex: index,
             subFocusIndex: subIndex,
             focusedBundleUuidList: focusedBundleUuidList,
-            showNewUpload: false,
             showNewRun: false,
             showNewText: false,
             showNewRerun: false,
@@ -733,7 +731,7 @@ class Worksheet extends React.Component {
                         if (this.state.focusIndex < 0) {
                             $('html, body').animate({ scrollTop: $(document).height() }, 'fast');
                         }
-                        this.setState({ showNewUpload: true });
+                        document.querySelector('label[for=codalab-file-upload-input]').click();
                     }.bind(this),
                     'keyup',
                 );
@@ -1386,11 +1384,9 @@ class Worksheet extends React.Component {
                 openWorksheet={this.openWorksheet}
                 focusActionBar={this.focusActionBar}
                 ensureIsArray={this.ensureIsArray}
-                showNewUpload={this.state.showNewUpload}
                 showNewRun={this.state.showNewRun}
                 showNewText={this.state.showNewText}
                 showNewRerun={this.state.showNewRerun}
-                onHideNewUpload={() => this.setState({ showNewUpload: false })}
                 onHideNewRun={() => this.setState({ showNewRun: false })}
                 onHideNewText={() => this.setState({ showNewText: false })}
                 onHideNewRerun={() => this.setState({ showNewRerun: false })}
@@ -1438,7 +1434,6 @@ class Worksheet extends React.Component {
                     editButtons={editButtons}
                     anchorEl={anchorEl}
                     setAnchorEl={(e) => this.setState({ anchorEl: e })}
-                    onShowNewUpload={() => this.setState({ showNewUpload: true })}
                     onShowNewRun={() => this.setState({ showNewRun: true })}
                     onShowNewText={() => this.setState({ showNewText: true })}
                     handleSelectedBundleCommand={this.handleSelectedBundleCommand}

--- a/frontend/src/components/worksheets/Worksheet/WorksheetHeader.js
+++ b/frontend/src/components/worksheets/Worksheet/WorksheetHeader.js
@@ -20,7 +20,6 @@ const styles = {
 };
 
 export default ({
-    onShowNewUpload,
     onShowNewRun,
     onShowNewText,
     canEdit,
@@ -123,7 +122,6 @@ export default ({
                         <Grid item>
                             <ActionButtons
                                 info={info}
-                                onShowNewUpload={onShowNewUpload}
                                 onShowNewRun={onShowNewRun}
                                 onShowNewText={onShowNewText}
                                 handleSelectedBundleCommand={handleSelectedBundleCommand}

--- a/frontend/src/components/worksheets/WorksheetItemList.js
+++ b/frontend/src/components/worksheets/WorksheetItemList.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import Immutable from 'seamless-immutable';
 import $ from 'jquery';
 import * as Mousetrap from '../../util/ws_mousetrap_fork';
-import { buildTerminalCommand } from '../../util/worksheet_utils';
+import { buildTerminalCommand, getMinMaxKeys } from '../../util/worksheet_utils';
 import { ContextMenuEnum, ContextMenuMixin } from './ContextMenu';
 import ContentsItem from './items/ContentsItem';
 import GraphItem from './items/GraphItem';
@@ -12,6 +12,7 @@ import RecordItem from './items/RecordItem';
 import TableItem from './items/TableItem';
 import WorksheetItem from './items/WorksheetItem';
 import ItemWrapper from './items/ItemWrapper';
+import NewUpload from './NewUpload/NewUpload';
 
 ////////////////////////////////////////////////////////////
 
@@ -67,7 +68,6 @@ const addWorksheetItems = function(props, worksheet_items, prevItem, afterItem) 
             ws={props.ws}
             worksheetUUID={props.worksheetUUID}
             reloadWorksheet={props.reloadWorksheet}
-            showNewUpload={props.focusedForButtons && props.showNewUpload}
             showNewRun={props.focusedForButtons && props.showNewRun}
             showNewText={props.focusedForButtons && props.showNewText}
             onHideNewUpload={props.onHideNewUpload}
@@ -83,7 +83,9 @@ class WorksheetItemList extends React.Component {
     /** Constructor. */
     constructor(props) {
         super(props);
-        this.state = Immutable({});
+        this.state = Immutable({
+            newUploadKey: Math.random() + '',
+        });
     }
 
     static displayName = 'WorksheetItemList';
@@ -202,6 +204,7 @@ class WorksheetItemList extends React.Component {
                 },
             ];
         }
+        let focusedForButtonsItem;
         if (info && info.items.length > 0) {
             var worksheet_items = [];
             info.items.forEach(
@@ -214,6 +217,10 @@ class WorksheetItemList extends React.Component {
                     const focusedForButtons =
                         focused ||
                         (this.props.focusIndex === -1 && index === info.items.length - 1);
+
+                    if (focusedForButtons) {
+                        focusedForButtonsItem = item;
+                    }
                     var props = {
                         worksheetUUID: info.uuid,
                         item: item,
@@ -230,7 +237,6 @@ class WorksheetItemList extends React.Component {
                         handleContextMenu: this.handleContextMenu,
                         reloadWorksheet: this.props.reloadWorksheet,
                         ws: this.props.ws,
-                        showNewUpload: this.props.showNewUpload,
                         showNewRun: this.props.showNewRun,
                         showNewText: this.props.showNewText,
                         showNewRerun: this.props.showNewRerun,
@@ -251,7 +257,22 @@ class WorksheetItemList extends React.Component {
                     );
                 }.bind(this),
             );
-            items_display = worksheet_items;
+            items_display = (
+                <>
+                    {worksheet_items}
+                    <NewUpload
+                        key={this.state.newUploadKey}
+                        after_sort_key={(getMinMaxKeys(focusedForButtonsItem) || {}).maxKey}
+                        worksheetUUID={info.uuid}
+                        reloadWorksheet={this.props.reloadWorksheet}
+                        // Reset newUploadKey so that NewUpload gets re-rendered. This way,
+                        // it is possible to upload the same file multiple times in a row
+                        // (otherwise, chrome will not call onchange on a file input when
+                        // the file hasn't changed)
+                        onUploadFinish={(e) => this.setState({ newUploadKey: Math.random() + '' })}
+                    />
+                </>
+            );
         } else {
             items_display = null;
         }

--- a/frontend/src/components/worksheets/items/ActionButtons.js
+++ b/frontend/src/components/worksheets/items/ActionButtons.js
@@ -9,14 +9,12 @@ import BundleBulkActionMenu from '../BundleBulkActionMenu';
 
 class ActionButtons extends React.Component<{
     classes: {},
-    onShowNewUpload: () => void,
     onShowNewRun: () => void,
     onShowNewText: () => void,
 }> {
     render() {
         const {
             classes,
-            onShowNewUpload,
             onShowNewRun,
             onShowNewText,
             handleSelectedBundleCommand,
@@ -50,11 +48,13 @@ class ActionButtons extends React.Component<{
                         size='small'
                         color='inherit'
                         aria-label='Add New Upload'
-                        onClick={onShowNewUpload}
+                        className={classes.uploadButton}
                         disabled={!editPermission}
                     >
-                        <UploadIcon className={classes.buttonIcon} />
-                        Upload
+                        <label className={classes.uploadLabel} for='codalab-file-upload-input'>
+                            <UploadIcon className={classes.buttonIcon} />
+                            Upload
+                        </label>
                     </Button>
                 ) : null}
                 {!showBundleOperationButtons ? (
@@ -96,6 +96,17 @@ const styles = (theme) => ({
     },
     buttonIcon: {
         marginRight: theme.spacing.large,
+    },
+    uploadButton: {
+        padding: 0,
+    },
+    uploadLabel: {
+        width: '100%',
+        display: 'inherit',
+        padding: '4px 8px',
+        marginBottom: 0,
+        fontWeight: 'inherit',
+        cursor: 'inherit',
     },
 });
 

--- a/frontend/src/components/worksheets/items/ItemWrapper.js
+++ b/frontend/src/components/worksheets/items/ItemWrapper.js
@@ -2,7 +2,6 @@
 import * as React from 'react';
 import { withStyles } from '@material-ui/core/styles';
 import NewRun from '../NewRun';
-import NewUpload from '../NewUpload';
 import TextEditorItem from './TextEditorItem';
 import { getMinMaxKeys } from '../../../util/worksheet_utils';
 
@@ -19,7 +18,6 @@ function getIds(item) {
 
 class ItemWrapper extends React.Component {
     state = {
-        showNewUpload: false,
         showNewRun: false,
         showNewText: false,
     };
@@ -34,7 +32,7 @@ class ItemWrapper extends React.Component {
             worksheetUUID,
             reloadWorksheet,
         } = this.props;
-        const { showNewUpload, showNewRun, showNewText } = this.props;
+        const { showNewRun, showNewText } = this.props;
 
         if (!item) {
             return null;
@@ -54,14 +52,6 @@ class ItemWrapper extends React.Component {
         return (
             <div className={isDummyItem ? '' : classes.container}>
                 {!isDummyItem && <div className={classes.main}>{children}</div>}
-                {showNewUpload && (
-                    <NewUpload
-                        after_sort_key={itemKeys.maxKey}
-                        worksheetUUID={worksheetUUID}
-                        reloadWorksheet={reloadWorksheet}
-                        onClose={() => this.props.onHideNewUpload()}
-                    />
-                )}
                 {showNewRun && (
                     <div className={classes.insertBox}>
                         <NewRun


### PR DESCRIPTION
Fix uploads on Chrome by changing how uploads work. Fixes #1799 

Now, the `NewUpload` component is always rendered a single time, and clicking on the "Upload" button actually clicks a "label" element that then triggers the `<input type="file">` component to upload.

Previously, the issue was that the `handleFocusBack` function was called even when a file was selected for upload, thus causing the component to call `onClose` before the file could be uploaded. Additionally, Chrome does not call an `onchange` event when the value of an `<input type="file">` component does not change (if the same file is selected, or "Cancel" is selected when the input already has no value) -- this caused some race cases with the other logic. This PR simplifies a lot of the upload logic and should cause less issues than the previous approach.