### PR TITLE
Add staged_status and filter out unqualified bundles before scheduling

### DIFF
--- a/codalab/bundles/run_bundle.py
+++ b/codalab/bundles/run_bundle.py
@@ -44,6 +44,8 @@ class RunBundle(DerivedBundle):
     METADATA_SPECS.append(MetadataSpec('started', int, 'Time when this bundle started executing.', generated=True, formatting='date'))
     METADATA_SPECS.append(MetadataSpec('last_updated', int, 'Time when information about this bundle was last updated.', generated=True, formatting='date'))
     METADATA_SPECS.append(MetadataSpec('run_status', str, 'Execution status of the bundle.', generated=True))
+    METADATA_SPECS.append(MetadataSpec('staged_status', str, 'Information about the status of the staged bundle.', generated=True))
+
 
     # Information about running
     METADATA_SPECS.append(MetadataSpec('docker_image', str, 'Which docker image was used to run the process.', generated=True, hide_when_anonymous=True))

--- a/codalab/objects/metadata.py
+++ b/codalab/objects/metadata.py
@@ -56,6 +56,11 @@ class Metadata(object):
         self._metadata_keys.add(key)
         setattr(self, key, value)
 
+    def remove_metadata_key(self, key):
+        if key in self._metadata_keys:
+            self._metadata_keys.remove(key)
+            delattr(self, key)
+
     @classmethod
     def collapse_dicts(cls, metadata_specs, rows):
         '''

--- a/codalab/server/bundle_manager.py
+++ b/codalab/server/bundle_manager.py
@@ -10,7 +10,7 @@ import time
 import traceback
 
 from codalab.objects.permission import check_bundles_have_read_permission
-from codalab.common import PermissionError, NotFoundError
+from codalab.common import PermissionError
 from codalab.lib import bundle_util, formatting, path_util
 from codalab.server.worker_info_accessor import WorkerInfoAccessor
 from codalab.worker.file_util import remove_path
@@ -51,6 +51,8 @@ class BundleManager(object):
 
         self._make_uuids_lock = threading.Lock()
         self._make_uuids = set()
+        # Set of bundle UUIDs with an unknown requested worker
+        self._bundles_without_matched_workers = set()
 
         def parse(to_value, field):
             return to_value(config[field]) if field in config else None
@@ -356,7 +358,9 @@ class BundleManager(object):
                         )
                         # Don't start this bundle yet, as there is no parallel_run_quota left for this user.
                         continue
-            if not workers_list: # Length is 0 (private user with no workers) or is None (root user)
+            if (
+                not workers_list
+            ):  # Length is 0 (private user with no workers) or is None (root user)
                 workers_list = get_available_workers(self._model.root_user_id)
 
             # Try starting bundles on the workers that have enough computing resources
@@ -389,8 +393,7 @@ class BundleManager(object):
                 worker['memory_bytes'] -= bundle_resources.memory
         return workers_list
 
-    @staticmethod
-    def _filter_and_sort_workers(workers_list, bundle, bundle_resources):
+    def _filter_and_sort_workers(self, workers_list, bundle, bundle_resources):
         """
         Filters the workers to those that can run the given bundle and returns
         the list sorted in order of preference for running the bundle.
@@ -404,12 +407,7 @@ class BundleManager(object):
         # Filter by tag.
         request_queue = bundle.metadata.request_queue
         if request_queue:
-            tagm = re.match('tag=(.+)', request_queue)
-            if tagm:
-                workers_list = [worker for worker in workers_list if worker['tag'] == tagm.group(1)]
-            else:
-                # We don't know how to handle this type of request queue argument
-                return []
+            workers_list = self._get_matched_workers(request_queue, workers_list)
 
         # Filter by CPUs.
         workers_list = [
@@ -641,7 +639,8 @@ class BundleManager(object):
         self._acknowledge_recently_finished_bundles(workers)
         # A dictionary structured as {user id : user information} to track those visited user information
         user_info_cache = {}
-        staged_bundles_to_run = self._get_staged_bundles_to_run(user_info_cache)
+        staged_bundles_to_run = self._get_staged_bundles_to_run(workers, user_info_cache)
+
         # Schedule, preferring user-owned workers.
         self._schedule_run_bundles_on_workers(workers, staged_bundles_to_run, user_info_cache)
 
@@ -672,11 +671,26 @@ class BundleManager(object):
                 return global_fail_string % (pretty_print(value), pretty_print(global_min))
         return None
 
-    def _get_staged_bundles_to_run(self, user_info_cache):
+    @staticmethod
+    def _get_matched_workers(request_queue, workers):
+        """
+        Get all of the workers that match with the name of the requested worker
+        :param request_queue: a tag that can be used to match workers
+        :param workers: a list of workers
+        :return: a list of matched workers
+        """
+        tagm = re.match('tag=(.+)', request_queue)
+        if tagm != None:
+            worker_tag = tagm.group(1)
+            matched_workers = [worker for worker in workers if worker['tag'] == worker_tag]
+        return matched_workers or []
+
+    def _get_staged_bundles_to_run(self, workers, user_info_cache):
         """
         Fails bundles that request more resources than available for the given user.
         Note: allow more resources than available on any worker because new
         workers might get spun up in response to the presence of this run.
+        :param workers: a WorkerInfoAccessor object containing worker related information e.g. running uuid.
         :param user_info_cache: a dictionary mapping user id to user information.
         :return: a list of tuple which contains valid staged bundles and their bundle_resources.
         """
@@ -745,6 +759,33 @@ class BundleManager(object):
                     bundle,
                     {'state': State.FAILED, 'metadata': {'failure_message': failure_message}},
                 )
+            elif bundle.metadata.request_queue:
+                matched_workers = self._get_matched_workers(
+                    bundle.metadata.request_queue, workers.workers()
+                )
+                # For those bundles that were requested to run on a worker which does not exist in the system
+                # temporarily, we filter out those bundles so that they won't be dispatched to run on workers.
+                if len(matched_workers) == 0:
+                    if bundle.uuid not in self._bundles_without_matched_workers:
+                        self._model.update_bundle(
+                            bundle,
+                            {
+                                'metadata': {
+                                    'staged_status': 'Bundle is requested to run on a worker {} which has '
+                                    'not been connected to the CodaLab server yet.'.format(
+                                        bundle.metadata.request_queue
+                                    )
+                                }
+                            },
+                        )
+                        self._bundles_without_matched_workers.add(bundle.uuid)
+                else:
+                    # Remove the uuid from self._bundles_without_matched_workers if a matched
+                    # private worker is found in the system and update bundle's metadata
+                    if bundle.uuid in self._bundles_without_matched_workers:
+                        self._model.update_bundle(bundle, {'metadata': {'staged_status': None}})
+                        self._bundles_without_matched_workers.remove(bundle.uuid)
+                    staged_bundles_to_run.append((bundle, bundle_resources))
             else:
                 staged_bundles_to_run.append((bundle, bundle_resources))
 

--- a/tests/server/bundle_manager_test.py
+++ b/tests/server/bundle_manager_test.py
@@ -5,9 +5,24 @@ from codalab.objects.metadata_spec import MetadataSpec
 from codalab.server.bundle_manager import BundleManager
 from codalab.worker.bundle_state import RunResources
 from codalab.bundles import RunBundle
+from codalab.lib.codalab_manager import CodaLabManager
 
 
 class BundleManagerTest(unittest.TestCase):
+    def setUp(self):
+        self.codalab_manager = Mock(CodaLabManager)
+        self.codalab_manager.config = {
+            "workers": {
+                'default_cpu_image': 'codalab/default-cpu:latest',
+                'default_gpu_image': 'codalab/default-gpu:latest',
+            }
+        }
+        self.bundle_manager = BundleManager(self.codalab_manager)
+
+    def tearDown(self):
+        del self.bundle_manager
+        del self.codalab_manager
+
     def get_sample_workers_list(self):
         workers_list = [
             {
@@ -52,7 +67,7 @@ class BundleManagerTest(unittest.TestCase):
         )
 
         # gpu worker should be last in the filtered and sorted list
-        sorted_workers_list = BundleManager._filter_and_sort_workers(
+        sorted_workers_list = self.bundle_manager._filter_and_sort_workers(
             self.get_sample_workers_list(), bundle, bundle_resources
         )
         self.assertEqual(len(sorted_workers_list), 3)
@@ -62,7 +77,7 @@ class BundleManagerTest(unittest.TestCase):
 
         # gpu worker should be the only worker in the filtered and sorted list
         bundle_resources.gpus = 1
-        sorted_workers_list = BundleManager._filter_and_sort_workers(
+        sorted_workers_list = self.bundle_manager._filter_and_sort_workers(
             self.get_sample_workers_list(), bundle, bundle_resources
         )
         self.assertEqual(len(sorted_workers_list), 1)


### PR DESCRIPTION
Original PR #1801 . Fixed #1800 
1. Added a new metadata field called `staged_status`
2. Filtered out those bundles which are requested to run on a private worker that hasn't been connected to the server yet. (Currently only considering bad `request-queue`, will add filters for invalid `cpus`/`gpus`/`memory` in another PR)
3. Added metadata delete operation in `update_bundles`

Testing is done locally in the following steps:
1. Start local development instances and stop the worker container.
2. Submit a bundle which is requested to run on a worker with `--request-queue a`
3. Go to the bundle's web page, verify that the bundle is staged and `staged_status` shows the correct information
4. Attach my local machine as a private worker with `tag=a`
5. Verify that the previously staged job is able to proceed and the `staged_status` column is removed from metadata list.