### PR TITLE
1891: Print warning when CodaLab is not installed in $PATH

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,3 +1,14 @@
+### I installed CodaLab using `pip`. Why am I seeing `-bash: cl: command not found` when trying to use the CLI?
+
+When installing CodaLab, `pip` will output the following error if the executable path is not in your $PATH. 
+
+    WARNING: The scripts cl, cl-bundle-manager, cl-competitiond, cl-server, cl-worker, cl-worker-manager and codalab-service are installed in '<cl path>' which is not on PATH.
+    Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.
+
+For Mac and Linux users, you can resolve this by appending `export PATH="$PATH:<cl path>"` to your `~/.bashrc`.
+
+For Windows users, select `System` from the `Control Panel`, select `Advance System Settings`, go to `Environment Variables` and add the path to the list.
+
 ### Why is my run bundle in `staged` for a long time?
 
 The `staged` state means that the bundle is ready to run but it is waiting for appropriate resources to free up.  CodaLab has a limited set of machines available (we're offering it for free after all), so when there are a lot of people wanting to run jobs, you might have to wait a long time.  You can check out the [CodaLab status](https://worksheets.codalab.org/worksheets/0xa590fd1b68944a1a95c1c40c4931dc7b/) page to see where your jobs are in the queue (note that this page only sees public jobs, so there might be hidden bundles in the queue that you can't see).  If you'd like to run your job earlier, you can easily [attach your own compute workers](Execution.md#running-your-own-worker), which you might want to do anyway if you have fancier GPUs, say.

--- a/setup.py
+++ b/setup.py
@@ -36,17 +36,8 @@ class Install(install):
         self._check_path()
 
     def _check_path(self):
-        base_path = self.install_userbase if '--user' in install.user_options else self.install_base
-        cl_path = '{}/bin'.format(base_path)
+        cl_path = self.install_scripts
         executable_paths = os.environ['PATH'].split(os.pathsep)
-        # TODO: debug statement
-        attrs = vars(self)
-        print('\n\n\033[1m\033[93m')
-        print(',\n'.join("%s: %s" % item for item in attrs.items()))
-        print('\n\nArgs passed in:')
-        print(install.user_options)
-        print('--user' in install.user_options)
-        print('\033[0m')
         if cl_path not in executable_paths:
             # Prints a yellow, bold warning message in regards to the installation path not in $PATH
             print(


### PR DESCRIPTION
For #1891 

Print a warning when CodaLab is not installed in $PATH via pip. Below is an example output of the warning message:

<img width="673" alt="output" src="https://user-images.githubusercontent.com/16793796/73446942-98305c80-4312-11ea-87c5-37085545ff63.png">

Updated doc:
![Screen Shot 2020-02-03 at 11 33 04 PM](https://user-images.githubusercontent.com/16793796/73725578-879d2f00-46e2-11ea-8dc9-cf4132f55005.png)

--
I have looked into this issue for awhile and I believe this is the best solution. As a Python package, we have no control on how the user installs CodaLab. `pip install codalab` can drop the executable not in the PATH (can happen in both Python2 and Python3). Additionally, the `--user` option will install CodaLab on the user's path, which can vary. There is a pip issue that talks more about `--user` https://github.com/pypa/pip/issues/3813 in depth. The corresponding fix for it (https://github.com/pypa/pip/pull/4553) is similar to this one.

A couple of alternative solutions were:
1. Update our docs and let the users know that they might run into `command not found error` and show them how to resolve  this problem. I can also make the doc change in this PR.
2. Take the path where CodaLab is installed and include in the user's PATH by adding it to a `~/.bashrc` for example. However, this change is a bit invasive as we are modifying the user's environment for them.
