### PR TITLE
Fix exception caused by wrong data type in error.code

### DIFF
--- a/codalab/server/rest_server.py
+++ b/codalab/server/rest_server.py
@@ -6,8 +6,6 @@ import sys
 import textwrap
 import traceback
 import logging
-import urllib.error
-from io import StringIO
 
 import bottle
 from bottle import (
@@ -15,6 +13,7 @@ from bottle import (
     Bottle,
     default_app,
     get,
+    HTTPError,
     HTTPResponse,
     install,
     JSONPlugin,
@@ -114,7 +113,7 @@ class ErrorAdapter(object):
                     message = "Unexpected Internal Error ({}). The administrators have been notified.".format(
                         message
                     )
-                raise urllib.error.HTTPError(None, code, message, None, StringIO(message))
+                raise HTTPError(code, message)
 
         return wrapper
 

--- a/codalab/server/rest_server.py
+++ b/codalab/server/rest_server.py
@@ -6,6 +6,8 @@ import sys
 import textwrap
 import traceback
 import logging
+import urllib.error
+from io import StringIO
 
 import bottle
 from bottle import (
@@ -13,7 +15,6 @@ from bottle import (
     Bottle,
     default_app,
     get,
-    HTTPError,
     HTTPResponse,
     install,
     JSONPlugin,
@@ -113,7 +114,7 @@ class ErrorAdapter(object):
                     message = "Unexpected Internal Error ({}). The administrators have been notified.".format(
                         message
                     )
-                raise HTTPError(code, message)
+                raise urllib.error.HTTPError(None, code, message, None, StringIO(message))
 
         return wrapper
 

--- a/codalab/worker/bundle_service_client.py
+++ b/codalab/worker/bundle_service_client.py
@@ -23,14 +23,15 @@ def wrap_exception(message):
             except urllib.error.HTTPError as e:
                 try:
                     client_error = e.read()
+                    error_code = e.code.decode() if isinstance(e.code, bytes) else e.code
                     if e.reason == 'invalid_grant':
                         raise BundleAuthException(
-                            message + ': ' + http.client.responses[e.code] + ' - ' + client_error,
+                            message + ': ' + http.client.responses[error_code] + ' - ' + client_error,
                             True,
                         )
                     else:
                         raise BundleServiceException(
-                            message + ': ' + http.client.responses[e.code] + ' - ' + client_error,
+                            message + ': ' + http.client.responses[error_code] + ' - ' + client_error,
                             e.code >= 400 and e.code < 500,
                         )
                 except json.decoder.JSONDecodeError as e:


### PR DESCRIPTION
I noticed that `e.code` can be `bytes` sometimes. So I added a typecasting in the error handling as well.