### PR TITLE
Handle digest spec in docker images

### DIFF
--- a/codalab/worker/docker_utils.py
+++ b/codalab/worker/docker_utils.py
@@ -277,20 +277,29 @@ def get_container_running_time(container):
 @wrap_exception('Unable to get image size without pulling from Docker Hub')
 def get_image_size_without_pulling(image_spec):
     """
-    Get the compressed size of a docker image without pulling it from Docker Hub
-    :param image_spec: image_spec will be in the format of 'codalab/default-cpu:latest'
+    Get the compressed size of a docker image without pulling it from Docker Hub. Note that since docker-py doesn't
+    report the accurate compressed image size, e.g. the size reported from the RegistryData object, we then switch
+    to use Docker Registry HTTP API V2
+    :param image_spec: image_spec can have two formats as follows:
+            1. "repo:tag": 'codalab/default-cpu:latest'
+            2. "repo@digest": studyfang/hotpotqa@sha256:f0ee6bc3b8deefa6bdcbb56e42ec97b498befbbca405a630b9ad80125dc65857
     :return: the compressed image size in bytes
     """
     logger.info("Downloading tag information for {}".format(image_spec))
-    image_name, image_tag = image_spec.split(":")
+
+    # Both types of image_spec have the ':' character. The '@' character is unique in the type 1.
+    image_tag = None
+    image_digest = None
+    if '@' in image_spec:
+        image_name, image_digest = image_spec.split('@')
+    else:
+        image_name, image_tag = image_spec.split(":")
     # Example URL:
     # 1. image with namespace: https://hub.docker.com/v2/repositories/<namespace>/<image_name>/tags/?page=<page_number>
     #       e.g. https://hub.docker.com/v2/repositories/codalab/default-cpu/tags/?page=1
     # 2. image without namespace: https://hub.docker.com/v2/repositories/library/<image_name>/tags/?page=<page_number>
     #       e.g. https://hub.docker.com/v2/repositories/library/ubuntu/tags/?page=1
     # Each page will return at most 10 tags
-    # Note that since docker-py doesn't report the accurate compressed image size, e.g. the size reported
-    # from the RegistryData object, we then switch to use Docker Registry HTTP API V2
     # URI prefix of an image without namespace will be adjusted to https://hub.docker.com/v2/repositories/library
     uri_prefix_adjusted = URI_PREFIX + '/library/' if '/' not in image_name else URI_PREFIX
     request = uri_prefix_adjusted + image_name + '/tags/?page='
@@ -301,12 +310,19 @@ def get_image_size_without_pulling(image_spec):
         data = response.json()
         if len(data['results']) == 0:
             break
-        # Get the list of size information for matched images
-        matched_image_sizes = [r['full_size'] for r in data['results'] if r['name'] == image_tag]
-        image_size_bytes = matched_image_sizes[0] if len(matched_image_sizes) == 1 else None
-        # Break the loop when we find a matched image
-        if image_size_bytes:
-            break
+        # Get the size information from the matched image
+        if image_tag:
+            for result in data['results']:
+                if result['name'] == image_tag:
+                    image_size_bytes = result['full_size']
+                    return image_size_bytes
+        if image_digest:
+            for result in data['results']:
+                for image in result['images']:
+                    if image_digest in image['digest']:
+                        image_size_bytes = result['full_size']
+                        return image_size_bytes
+
         page_number += 1
 
     return image_size_bytes


### PR DESCRIPTION
Fixed #1955 .

The docker size checker doesn't consider image spec in the format of `repository:digest`, e.g. `studyfang/hotpotqa@sha256:f0ee6bc3b8deefa6bdcbb56e42ec97b498befbbca405a630b9ad80125dc65857`. This PR is to add the logic to parse image spec to function `get_image_size_without_pulling`.
I might need to either patch this change or deploy it to production as this might block people running competition script for ICML.