### PR TITLE
Modify job assignment algorithm

### DIFF
--- a/tests/server/bundle_manager_test.py
+++ b/tests/server/bundle_manager_test.py
@@ -5,14 +5,59 @@ from codalab.objects.metadata_spec import MetadataSpec
 from codalab.server.bundle_manager import BundleManager
 from codalab.worker.bundle_state import RunResources
 from codalab.bundles import RunBundle
+from codalab.lib.codalab_manager import CodaLabManager
 
 
 class BundleManagerTest(unittest.TestCase):
+    def setUp(self):
+        self.codalab_manager = Mock(CodaLabManager)
+        self.codalab_manager.config = {
+            "workers": {
+                'default_cpu_image': 'codalab/default-cpu:latest',
+                'default_gpu_image': 'codalab/default-gpu:latest',
+            }
+        }
+        self.bundle_manager = BundleManager(self.codalab_manager)
+        self.bundle = Mock(spec=RunBundle, metadata=Mock(spec=MetadataSpec))
+        self.bundle.dependencies = []
+        self.bundle.metadata.request_queue = None
+        self.bundle_resources = RunResources(
+            cpus=0, gpus=0, docker_image='', time=100, memory=1000, disk=1000, network=False
+        )
+        self.workers_list = self.get_sample_workers_list()
+
+    def tearDown(self):
+        del self.bundle
+        del self.bundle_manager
+        del self.codalab_manager
+        del self.bundle_resources
+        del self.workers_list
+
     def get_sample_workers_list(self):
         workers_list = [
             {
+                'worker_id': 0,
+                'cpus': 4,
+                'gpus': 1,
+                'memory_bytes': 4 * 1000,
+                'tag': None,
+                'run_uuids': [1, 2],
+                'dependencies': [],
+                'shared_file_system': False,
+            },
+            {
                 'worker_id': 1,
-                'cpus': 6,
+                'cpus': 4,
+                'gpus': 1,
+                'memory_bytes': 4 * 1000,
+                'tag': None,
+                'run_uuids': [1, 2, 3],
+                'dependencies': [],
+                'shared_file_system': False,
+            },
+            {
+                'worker_id': 2,
+                'cpus': 4,
                 'gpus': 1,
                 'memory_bytes': 4 * 1000,
                 'tag': None,
@@ -21,18 +66,18 @@ class BundleManagerTest(unittest.TestCase):
                 'shared_file_system': False,
             },
             {
-                'worker_id': 2,
-                'cpus': 4,
+                'worker_id': 3,
+                'cpus': 6,
                 'gpus': 0,
                 'memory_bytes': 4 * 1000,
                 'tag': None,
-                'run_uuids': [],
+                'run_uuids': [1],
                 'dependencies': [],
                 'shared_file_system': False,
             },
             {
-                'worker_id': 3,
-                'cpus': 4,
+                'worker_id': 4,
+                'cpus': 6,
                 'gpus': 0,
                 'memory_bytes': 2 * 1000,
                 'tag': None,
@@ -43,27 +88,22 @@ class BundleManagerTest(unittest.TestCase):
         ]
         return workers_list
 
-    def test__filter_and_sort_workers(self):
-        bundle = Mock(spec=RunBundle, metadata=Mock(spec=MetadataSpec))
-        bundle.dependencies = []
-        bundle.metadata.request_queue = None
-        bundle_resources = RunResources(
-            cpus=1, gpus=0, docker_image='', time=100, memory=1000, disk=1000, network=False
-        )
-
-        # gpu worker should be last in the filtered and sorted list
+    def test__filter_and_sort_workers_gpus(self):
+        # Only GPU workers should appear from the returning sorted worker list
+        self.bundle_resources.gpus = 1
         sorted_workers_list = BundleManager._filter_and_sort_workers(
-            self.get_sample_workers_list(), bundle, bundle_resources
+            self.workers_list, self.bundle, self.bundle_resources
         )
         self.assertEqual(len(sorted_workers_list), 3)
-        self.assertEqual(sorted_workers_list[0]['gpus'], 0)
-        self.assertEqual(sorted_workers_list[1]['gpus'], 0)
-        self.assertEqual(sorted_workers_list[-1]['gpus'], 1)
+        self.assertEqual(sorted_workers_list[0]['worker_id'], 2)
+        self.assertEqual(sorted_workers_list[1]['worker_id'], 0)
+        self.assertEqual(sorted_workers_list[-1]['worker_id'], 1)
 
-        # gpu worker should be the only worker in the filtered and sorted list
-        bundle_resources.gpus = 1
+    def test__filter_and_sort_workers_cpus(self):
+        # CPU workers should appear in the top from the returning sorted worker list
+        self.bundle_resources.cpus = 1
         sorted_workers_list = BundleManager._filter_and_sort_workers(
-            self.get_sample_workers_list(), bundle, bundle_resources
+            self.workers_list, self.bundle, self.bundle_resources
         )
-        self.assertEqual(len(sorted_workers_list), 1)
-        self.assertEqual(sorted_workers_list[0]['gpus'], 1)
+        self.assertEqual(len(sorted_workers_list), 5)
+        self.assertEqual(sorted_workers_list[0]['worker_id'], 4)


### PR DESCRIPTION
Fixed #1953 

This PR is to improve job assignment logic in `bundle_manager.py`. Based on the original ticket #1953, jobs are usually assigned to single workers but with many other workers in idle state. This PR has the following modifications:
1. Added the number of running jobs on each worker as one of the sorting keys to sort existing workers. 
2. `gpu_priority` can return `True`/`False` or a digit based on current logic. Since the returning value isn't quite intuitive, especially considering sorting some `Integer` values with `boolean` values, so I replaced this piece of logic to have only `Integer` value returned.
3. Adjusted the order of sorting keys: `gpu_priority` > number of running jobs > number of available dependencies > number of cpus >  the random seeds. (Open to discuss this order)

Here are some test results I did locally:
Assuming we have the following worker items in the `workers_list`:
```
workers_list = [
                {'worker_id': 6, 'gpus': 1, 'dep': 8, 'cpus':6, 'runs':[1,2,3]},
                {'worker_id': 5, 'gpus': 1, 'dep': 0, 'cpus':6, 'runs':[]},
                {'worker_id': 4, 'gpus': 1, 'dep': 8, 'cpus':6, 'runs':[1,2,3]},
                {'worker_id': 3, 'gpus': 1, 'dep': 2, 'cpus':6, 'runs':[1]},
                {'worker_id': 2, 'gpus': 1, 'dep': 4, 'cpus':6, 'runs':[1,2,3,4]},
                {'worker_id': 1, 'gpus': 0, 'dep': 5, 'cpus':8, 'runs':[1,2,3,4,5,6]},
                {'worker_id': 0, 'gpus': 0, 'dep': 7, 'cpus':8, 'runs':[]},]
```
1. When the current bundle requested for `0` gpus, sorting results become: 
```
stanford@Stanfords-MacBook-Pro competition % python3 sort.py
{'worker_id': 0, 'gpus': 0, 'dep': 7, 'cpus': 8, 'runs': []}
{'worker_id': 5, 'gpus': 1, 'dep': 0, 'cpus': 6, 'runs': []}
{'worker_id': 3, 'gpus': 1, 'dep': 2, 'cpus': 6, 'runs': [1]}
{'worker_id': 4, 'gpus': 1, 'dep': 8, 'cpus': 6, 'runs': [1, 2, 3]}
{'worker_id': 6, 'gpus': 1, 'dep': 8, 'cpus': 6, 'runs': [1, 2, 3]}
{'worker_id': 2, 'gpus': 1, 'dep': 4, 'cpus': 6, 'runs': [1, 2, 3, 4]}
{'worker_id': 1, 'gpus': 0, 'dep': 5, 'cpus': 8, 'runs': [1, 2, 3, 4, 5, 6]}
```
2. When the current bundle requested for `1` gpus, sorting results become:
```
stanford@Stanfords-MacBook-Pro competition % vim sort.py 
stanford@Stanfords-MacBook-Pro competition % python3 sort.py
{'worker_id': 5, 'gpus': 1, 'dep': 0, 'cpus': 6, 'runs': []}
{'worker_id': 3, 'gpus': 1, 'dep': 2, 'cpus': 6, 'runs': [1]}
{'worker_id': 6, 'gpus': 1, 'dep': 8, 'cpus': 6, 'runs': [1, 2, 3]}
{'worker_id': 4, 'gpus': 1, 'dep': 8, 'cpus': 6, 'runs': [1, 2, 3]}
{'worker_id': 2, 'gpus': 1, 'dep': 4, 'cpus': 6, 'runs': [1, 2, 3, 4]}
{'worker_id': 0, 'gpus': 0, 'dep': 7, 'cpus': 8, 'runs': []}
{'worker_id': 1, 'gpus': 0, 'dep': 5, 'cpus': 8, 'runs': [1, 2, 3, 4, 5, 6]}
```