### PR TITLE
Async loading of worksheets

### DIFF
--- a/codalab/lib/worksheet_util.py
+++ b/codalab/lib/worksheet_util.py
@@ -604,12 +604,13 @@ def get_command(value_obj):  # For directives only
     return value_obj[0] if len(value_obj) > 0 else None
 
 
-def interpret_items(schemas, raw_items, db_model=None):
+def interpret_items(schemas, raw_items, db_model=None, brief=False):
     """
     Interpret different items based on their types.
     :param schemas: initial mapping from name to list of schema items (columns of a table)
     :param raw_items: list of (raw) worksheet items (triples) to interpret
     :param db_model: database model which is used to query database
+    :param brief: whether to return a brief version, in which case bundles are not fetched/resolved
     :return: {'items': interpreted_items, ...}, where interpreted_items is a list of:
     {
         'mode': display mode ('markup' | 'contents' | 'image' | 'html', etc.)
@@ -682,6 +683,14 @@ def interpret_items(schemas, raw_items, db_model=None):
         Having collected bundles in |bundle_infos|, flush them into |blocks|,
         potentially as a single table depending on the mode.
         """
+        if brief:
+            # Return a placeholder instead of actually loading bundle info.
+            # for item_index, bundle_info in bundle_infos:
+            if len(bundle_infos):
+                blocks.append(
+                    MarkupBlockSchema().load({'text': '<codalab_bundle_info_loading>'}).data
+                )
+            return
         if len(bundle_infos) == 0:
             return
 

--- a/codalab/rest/interpret.py
+++ b/codalab/rest/interpret.py
@@ -155,10 +155,13 @@ def fetch_interpreted_worksheet(uuid):
     Return information about a worksheet. Calls
     - get_worksheet_info: get basic info
     - resolve_interpreted_items: get more information about a worksheet.
-    In the future, for large worksheets, might want to break this up so
-    that we can render something basic.
+    
+    This endpoint can be called with &brief=1 in order to give an abbreviated version,
+    which does not resolve any bundle infos. Omitting the brief parameter resolves
+    all bundles.
     """
     bundle_uuids = request.query.getall('bundle_uuid')
+    brief = request.query.get("brief", "0") == "1"
     worksheet_info = get_worksheet_info(uuid, fetch_items=True, fetch_permissions=True)
 
     # Shim in additional data for the frontend
@@ -190,7 +193,7 @@ def fetch_interpreted_worksheet(uuid):
     # resolving the interpreted items.
     try:
         interpreted_blocks = interpret_items(
-            get_default_schemas(), worksheet_info['items'], db_model=local.model
+            get_default_schemas(), worksheet_info['items'], db_model=local.model, brief=brief
         )
     except UsageError as e:
         interpreted_blocks = {'blocks': []}

--- a/frontend/src/components/worksheets/WorksheetItemList.js
+++ b/frontend/src/components/worksheets/WorksheetItemList.js
@@ -12,6 +12,7 @@ import RecordItem from './items/RecordItem';
 import TableItem from './items/TableItem';
 import WorksheetItem from './items/WorksheetItem';
 import ItemWrapper from './items/ItemWrapper';
+import ItemPlaceholder from './items/ItemPlaceholder';
 import NewUpload from './NewUpload/NewUpload';
 
 ////////////////////////////////////////////////////////////
@@ -60,23 +61,27 @@ const addWorksheetItems = function(props, worksheet_items, prevItem, afterItem) 
             React.createElement('strong', null, 'Internal error: ', item.mode),
         );
     }
-    worksheet_items.push(
-        <ItemWrapper
-            prevItem={prevItem}
-            item={item}
-            afterItem={afterItem}
-            ws={props.ws}
-            worksheetUUID={props.worksheetUUID}
-            reloadWorksheet={props.reloadWorksheet}
-            showNewRun={props.focusedForButtons && props.showNewRun}
-            showNewText={props.focusedForButtons && props.showNewText}
-            onHideNewUpload={props.onHideNewUpload}
-            onHideNewRun={props.onHideNewRun}
-            onHideNewText={props.onHideNewText}
-        >
-            {elem}
-        </ItemWrapper>,
-    );
+    if (item.text === '<codalab_bundle_info_loading>') {
+        worksheet_items.push(<ItemPlaceholder />);
+    } else {
+        worksheet_items.push(
+            <ItemWrapper
+                prevItem={prevItem}
+                item={item}
+                afterItem={afterItem}
+                ws={props.ws}
+                worksheetUUID={props.worksheetUUID}
+                reloadWorksheet={props.reloadWorksheet}
+                showNewRun={props.focusedForButtons && props.showNewRun}
+                showNewText={props.focusedForButtons && props.showNewText}
+                onHideNewUpload={props.onHideNewUpload}
+                onHideNewRun={props.onHideNewRun}
+                onHideNewText={props.onHideNewText}
+            >
+                {elem}
+            </ItemWrapper>,
+        );
+    }
 };
 
 class WorksheetItemList extends React.Component {

--- a/frontend/src/components/worksheets/items/ItemPlaceholder.js
+++ b/frontend/src/components/worksheets/items/ItemPlaceholder.js
@@ -1,0 +1,5 @@
+import React from 'react';
+import './ItemPlaceholder.scss';
+export default () => {
+    return <div className='codalab-item-placeholder'></div>;
+};

--- a/frontend/src/components/worksheets/items/ItemPlaceholder.scss
+++ b/frontend/src/components/worksheets/items/ItemPlaceholder.scss
@@ -1,0 +1,32 @@
+// originally from https://codepen.io/brucevang/pen/qZOPwR
+
+ .codalab-item-placeholder {
+  height: 15px;
+  width: 100%;
+//  background: #F6F6F6;
+  margin: 5px 0;
+  @extend .codalab-animated-background;
+ }
+ 
+ // Animation
+ @keyframes placeHolderShimmer{
+     0%{
+         background-position: -468px 0
+     }
+     100%{
+         background-position: 468px 0
+     }
+ }
+ 
+ .codalab-animated-background {
+     animation-duration: 1.25s;
+     animation-fill-mode: forwards;
+     animation-iteration-count: infinite;
+     animation-name: placeHolderShimmer;
+     animation-timing-function: linear;
+     background: #F6F6F6;
+     background: linear-gradient(to right, #F6F6F6 8%, #F0F0F0 18%, #F6F6F6 33%);
+     background-size: 800px 104px;
+     position: relative;
+ }
+ 

--- a/frontend/src/components/worksheets/items/MarkdownItem.js
+++ b/frontend/src/components/worksheets/items/MarkdownItem.js
@@ -120,6 +120,7 @@ class MarkdownItem extends React.Component {
     render() {
         const { classes, item, editPermission } = this.props;
         var { showEdit } = this.state;
+
         var contents = item.text;
         // Order is important!
         contents = this.processMarkdown(contents);


### PR DESCRIPTION
Does async loading of worksheets (fixes #1234). When a worksheet loads:
- First, it calls the endpoint `/rest/interpret/worksheet/...?brief=1` -- this gets the data but does not resolve / query for bundle infos.
- Then, it calls the endpoint `/rest/interpret/worksheet/...?brief=0` -- this gets all the data, including bundle infos, which is how the interpret endpoint behaved previously.

After the first endpoint is queried, everything except for the bundle data shows up. It shows animated placeholders for the actual bundle infos as below:

![image](https://user-images.githubusercontent.com/1689183/73815157-ec679080-4799-11ea-83a9-8930f1e346f4.png)

The above placeholder is loaded whenever a text item with text equal to `"<codalab_bundle_info_loading>"` is retrieved from the server.

This PR also refactors much of the worksheet fetch logic on the frontend to use async/await instead of callbacks.