### PR TITLE
Mount backend files as a volume

### DIFF
--- a/docker/compose_files/docker-compose.dev.yml
+++ b/docker/compose_files/docker-compose.dev.yml
@@ -11,3 +11,4 @@ services:
   rest-server:
     volumes:
       - ./../../alembic/:/opt/codalab-worksheets/alembic/
+      - ./../../codalab/:/opt/codalab-worksheets/codalab/

--- a/docker/compose_files/docker-compose.dev.yml
+++ b/docker/compose_files/docker-compose.dev.yml
@@ -7,7 +7,7 @@ services:
     volumes:
       - ./../../frontend/src:/opt/frontend/src
   # 2) Hot load the alembic version files so that we can create new database migrations (which need to written out
-  # of Docker into the `alembic` source directory)
+  # of Docker into the `alembic` source directory), as well as the backend files in codalab/
   rest-server:
     volumes:
       - ./../../alembic/:/opt/codalab-worksheets/alembic/


### PR DESCRIPTION
This way, when a backend file is changed, one can just re-start codalab in
dev mode for the backend files to be updated. Previously, one would have to
rebuild the docker images entirely when a backend file was updated.