### PR TITLE
Reduce cache miss when deducting worker resources

### DIFF
--- a/codalab/server/bundle_manager.py
+++ b/codalab/server/bundle_manager.py
@@ -10,7 +10,7 @@ import time
 import traceback
 
 from codalab.objects.permission import check_bundles_have_read_permission
-from codalab.common import PermissionError
+from codalab.common import PermissionError, NotFoundError
 from codalab.lib import bundle_util, formatting, path_util
 from codalab.server.worker_info_accessor import WorkerInfoAccessor
 from codalab.worker.file_util import remove_path
@@ -327,7 +327,7 @@ class BundleManager(object):
         )
 
         # Build a dictionary which maps from uuid to running bundle and bundle_resources
-        running_bundles_info = self._get_running_bundles_info(workers)
+        running_bundles_info = self._get_running_bundles_info(workers, staged_bundles_to_run)
 
         # Dispatch bundles
         for bundle, bundle_resources in staged_bundles_to_run:
@@ -372,7 +372,6 @@ class BundleManager(object):
         """
         From each worker, subtract resources used by running bundles. Modifies the list.
         """
-
         for worker in workers_list:
             for uuid in worker['run_uuids']:
                 # Verify if the current bundle exists in both the worker table and the bundle table
@@ -791,15 +790,17 @@ class BundleManager(object):
 
         return staged_bundles_to_run
 
-    def _get_running_bundles_info(self, workers):
+    def _get_running_bundles_info(self, workers, staged_bundles_to_run):
         """
-        Build a nested dictionary to store information (bundle and bundle_resources) of all the valid running bundles.
-        Note that the primary usage of this function is to improve efficiency when calling _compute_bundle_resources,
-        e.g. reusing constants (gpus, cpus, memory) from the returning values of _compute_bundle_resources as they
-        don't change over time.
-        However, be careful when using this function to improve efficiency for returning values like disk and time
-        from _compute_bundle_resources as they do depend on the number of jobs that are running during the time of
-        computation. Accuracy might be affected without considering this factor.
+        Build a nested dictionary to store information (bundle and bundle_resources) including 
+        the current running bundles and staged bundles.
+        Note that the primary usage of this function is to improve efficiency when calling 
+        self._compute_bundle_resources(), e.g. reusing constants (gpus, cpus, memory) from 
+        the returning values of self._compute_bundle_resources() as they don't change over time.
+        However, be careful when using this function to improve efficiency for returning values 
+        like disk and time from self._compute_bundle_resources() as they do depend on the number 
+        of jobs that are running during the time of computation. Accuracy might be affected 
+        without considering this factor.
         :param workers: a WorkerInfoAccessor object containing worker related information e.g. running uuid.
         :return: a nested dictionary structured as follows:
                 {
@@ -810,15 +811,27 @@ class BundleManager(object):
                 }
         """
         # Get uuid of all the running bundles from workers (a WorkerInfoAccessor object)
-        run_uuids = workers._uuid_to_worker.keys()
-        # Get the running bundles that exist in the bundle table
-        running_bundles = self._model.batch_get_bundles(uuid=run_uuids)
+        run_uuids = list(workers._uuid_to_worker.keys())
+        staged_bundles_to_run_dict = {
+            bundle.uuid: bundle_resources for (bundle, bundle_resources) in staged_bundles_to_run
+        }
+        # Get uuid of all the staged bundles that will be dispatched on workers
+        staged_uuids = list(staged_bundles_to_run_dict.keys())
+
+        # Get the running bundles (including the potential running bundles: staged bundles) that exist
+        # in the bundle table as well. Including staged bundles here is to avoid overestimating worker resources in
+        # the function self._deduct_worker_resources(). We could potentially be conservative on dispatching jobs to
+        # workers, but this is still better than over assigning jobs.
+        running_bundles = self._model.batch_get_bundles(uuid=run_uuids + staged_uuids)
         # Build a dictionary which maps from uuid to running bundle and bundle_resources
         running_bundles_info = {
             bundle.uuid: {
                 "bundle": bundle,
-                "bundle_resources": self._compute_bundle_resources(bundle),
+                "bundle_resources": self._compute_bundle_resources(bundle)
+                if bundle.uuid in run_uuids
+                else staged_bundles_to_run_dict[bundle.uuid],
             }
             for bundle in running_bundles
         }
+
         return running_bundles_info


### PR DESCRIPTION
Fixed #1968 

This PR will reduce cache miss when deducting worker resources for dispatching jobs. The cache miss is due to the fact that we don't consider those staged bundles that will be scheduled to run when we created the [running_bundles_info](https://github.com/codalab/codalab-worksheets/blob/bb20c4e522c5c9d4fc2d50e2930eca4fd2c037a2/codalab/server/bundle_manager.py#L760) object. 
Adding those staged bundles as part of the `running_bundles_info` will eliminate the cache miss. However, on the other side, we might be conservative in assigning jobs to workers, as there could be jobs that run extremely fast and finish before [the current dispatching for loop](https://github.com/codalab/codalab-worksheets/blob/bb20c4e522c5c9d4fc2d50e2930eca4fd2c037a2/codalab/server/bundle_manager.py#L330) finished. 