### PR TITLE
1967: check fourth header as a back up

### DIFF
--- a/codalab/worker/worker.py
+++ b/codalab/worker/worker.py
@@ -368,7 +368,7 @@ class Worker:
                 lines = output.decode().split("\n")
                 headers = lines[0].split()
                 # The machine being attached as a worker may be using a different language other than
-                # english, so check the 4th header if "Available" is not present.
+                # English, so check the 4th header if "Available" is not present.
                 index = headers.index("Available") if "Available" in headers else 3
                 # We convert the original result from df command in unit of 1KB blocks into bytes.
                 return int(lines[1].split()[index]) * 1024

--- a/codalab/worker/worker.py
+++ b/codalab/worker/worker.py
@@ -366,7 +366,10 @@ class Worker:
 
             if output:
                 lines = output.decode().split("\n")
-                index = lines[0].split().index("Available")
+                headers = lines[0].split()
+                # The machine being attached as a worker may be using a different language other than
+                # english, so check the 4th header as a back up to checking "Available".
+                index = headers.index("Available") if "Available" in headers else 3
                 # We convert the original result from df command in unit of 1KB blocks into bytes.
                 return int(lines[1].split()[index]) * 1024
 

--- a/codalab/worker/worker.py
+++ b/codalab/worker/worker.py
@@ -368,7 +368,7 @@ class Worker:
                 lines = output.decode().split("\n")
                 headers = lines[0].split()
                 # The machine being attached as a worker may be using a different language other than
-                # english, so check the 4th header as a back up to checking "Available".
+                # english, so check the 4th header if "Available" is not present.
                 index = headers.index("Available") if "Available" in headers else 3
                 # We convert the original result from df command in unit of 1KB blocks into bytes.
                 return int(lines[1].split()[index]) * 1024


### PR DESCRIPTION
Follow up to user issue #1967.

The user had a different system language other than english, which caused failures when executing the `df` command to attach a worker. This fix just simply checks the fourth key (3rd index) if `Available` is not available.