### PR TITLE
1959: Fix completers call

### DIFF
--- a/codalab/lib/completers.py
+++ b/codalab/lib/completers.py
@@ -29,7 +29,7 @@ class WorksheetsCompleter(CodaLabCompleter):
     Complete worksheet specs with suggestions pulled from the current client.
     """
 
-    def __call__(self, prefix, **kwargs):
+    def __call__(self, prefix, action=None, parser=None, parsed_args=None):
         client, worksheet_spec = self.cli.parse_spec(prefix)
         worksheets = client.fetch('worksheets', params={'keywords': worksheet_spec})
 
@@ -55,7 +55,7 @@ class BundlesCompleter(CodaLabCompleter):
     worksheet specified in the current arguments if one exists.
     """
 
-    def __call__(self, prefix, action=None, parsed_args=None, worksheet_uuid=None):
+    def __call__(self, prefix, action=None, parser=None, parsed_args=None, worksheet_uuid=None):
         worksheet_spec = getattr(parsed_args, 'worksheet_spec', None)
         client, worksheet_uuid = self.cli.parse_client_worksheet_uuid(worksheet_spec)
 
@@ -82,7 +82,7 @@ class AddressesCompleter(CodaLabCompleter):
     Complete address with suggestions from the current worksheet.
     """
 
-    def __call__(self, prefix, action=None, parsed_args=None):
+    def __call__(self, prefix, action=None, parser=None, parsed_args=None):
         return (a for a in self.cli.manager.config.get('aliases', {}) if a.startswith(prefix))
 
 
@@ -91,7 +91,7 @@ class GroupsCompleter(CodaLabCompleter):
     Complete group specs with suggestions pulled from the current client.
     """
 
-    def __call__(self, prefix, action=None, parsed_args=None):
+    def __call__(self, prefix, action=None, parser=None, parsed_args=None):
         client = self.cli.manager.current_client()
         # TODO: allow fetch slice of attributes in API to optimize this
         group_dicts = client.fetch('groups')
@@ -134,7 +134,7 @@ def UnionCompleter(*completers):
 # TODO: fix, or building our own argument parsing/completion framework (e.g. like aws-cli).
 # TODO: https://github.com/codalab/codalab-worksheets/issues/223
 class TargetsCompleter(CodaLabCompleter):
-    def __call__(self, prefix, action=None, parsed_args=None):
+    def __call__(self, prefix, action=None, parser=None, parsed_args=None):
         key, target = cli_util.parse_key_target(prefix)
         if target is None:
             return ()
@@ -198,7 +198,7 @@ class DockerImagesCompleter(CodaLabCompleter):
     Completes names of Docker images available on DockerHub.
     """
 
-    def __call__(self, prefix, action=None, parsed_args=None):
+    def __call__(self, prefix, action=None, parser=None, parsed_args=None):
         if prefix == "":
             prefix = "codalab"
         first_slash = prefix.find('/')


### PR DESCRIPTION
Fixes #1959.

Quick timeline of how this bug was introduced:
1. An argument (`parser`) in `completers` was accidentally removed for `argcomplete` (see https://github.com/kislyuk/argcomplete/pull/77) which was released in `v0.7.1`.
2. CodaLab was using `v1.1.0` and implemented `completers` without passing in `parser`.
3. `argcomplete` added back the parameter in https://github.com/kislyuk/argcomplete/issues/200 and released in `v1.8.2`.
4. CodaLab bumped version to `v1.9.4` couple of years back.

I think the `argcomplete` and autocomplete logic has been broken for awhile. The fix is to add the argument back.