### PR TITLE
resolve deadlock condition in dependency cleanup

### DIFF
--- a/codalab/worker/dependency_manager.py
+++ b/codalab/worker/dependency_manager.py
@@ -255,6 +255,7 @@ class DependencyManager(StateTransitioner, BaseDependencyManager):
                         logger.info(
                             'Dependency quota full but there are only downloading dependencies, not cleaning up until downloads are over'
                         )
+                        self._release_all_locks()
                         break
                     if dep_key_to_remove:
                         self._delete_dependency(dep_key_to_remove)


### PR DESCRIPTION
Fixed #1827 , #1907 
This PR breaks the deadlock condition that happened in production when dependency cleanup mode is triggered. 
The following logs indicate how the deadlock happened:
```
2020-02-11 17:39:34,816 *ThreadId=140560356402944, [_cleanup] acquired: global_lock.
2020-02-11 17:39:34,816 *ThreadId=140560435255040, [_acquire_if_exists] start to acquire: global_lock.
2020-02-11 17:39:34,816 *ThreadId=140560356402944, [_cleanup] start to acquire: _acquire_all_locks.
2020-02-11 17:39:34,816 *ThreadId=140560356402944, [_acquire_all_locks] start to acquire: global_lock.
2020-02-11 17:39:34,816 *ThreadId=140560356402944, [_acquire_all_locks] acquired: global_lock.
2020-02-11 17:39:34,820 *ThreadId=140560356402944, [_acquire_all_locks: <dependency>] acquired: DependencyKey(parent_uuid='0xb6d4d176089f43cc9873bd4d2013eb93', parent_path='').
2020-02-11 17:39:34,821 *ThreadId=140560356402944, [_acquire_all_locks] released: global_lock.
2020-02-11 17:39:34,821 *ThreadId=140560356402944, [_cleanup] acquired: _acquire_all_locks.
2020-02-11 17:39:34,826 *ThreadId=140560356402944, [save_state] start to acquire: global_lock.
2020-02-11 17:39:34,826 *ThreadId=140560435255040, [_acquire_if_exists] acquired: global_lock.
2020-02-11 17:39:34,826 *ThreadId=140560435255040, [_acquire_if_exists: <dependency_key> does exist in dict] start to acquire: DependencyKey(parent_uuid='0xb6d4d176089f43cc9873bd4d2013eb93', parent_path='').
```
Basically, the dependency lock didn't get released after the break statement.
A straight forward graph describing the above situation:
<img width="709" alt="Screen Shot 2020-02-11 at 1 29 44 PM" src="https://user-images.githubusercontent.com/1483372/74281066-9c755600-4cd2-11ea-8b2b-3a11c3df03db.png">

With this change, we can make sure the dependency cleanup code won't bring down the worker.