### PR TITLE
make docker image size check optional

### DIFF
--- a/codalab/worker/docker_image_manager.py
+++ b/codalab/worker/docker_image_manager.py
@@ -240,21 +240,35 @@ class DockerImageManager:
                 # Check docker image size before pulling from Docker Hub.
                 # Do not download images larger than self._max_image_size
                 # Download images if size cannot be obtained
-                try:
-                    image_size_bytes = docker_utils.get_image_size_without_pulling(image_spec)
-                    if image_size_bytes > self._max_image_size:
-                        failure_msg = (
-                            "The size of "
-                            + image_spec
-                            + ": {} exceeds the maximum image size allowed {}.".format(
-                                size_str(image_size_bytes), size_str(self._max_image_size)
+                if self._max_image_size:
+                    try:
+                        image_size_bytes = docker_utils.get_image_size_without_pulling(image_spec)
+                        if image_size_bytes is None:
+                            failure_msg = "Unable to find Docker image: {} from Docker HTTP API V2.".format(
+                                image_spec
                             )
+                            return ImageAvailabilityState(
+                                digest=None, stage=DependencyStage.FAILED, message=failure_msg
+                            )
+                        elif image_size_bytes > self._max_image_size:
+                            failure_msg = (
+                                "The size of "
+                                + image_spec
+                                + ": {} exceeds the maximum image size allowed {}.".format(
+                                    size_str(image_size_bytes), size_str(self._max_image_size)
+                                )
+                            )
+                            return ImageAvailabilityState(
+                                digest=None, stage=DependencyStage.FAILED, message=failure_msg
+                            )
+                    except Exception as ex:
+                        failure_msg = "Cannot fetch image size before pulling Docker image: {} from Docker Hub: {}.".format(
+                            image_spec, ex
                         )
+                        logger.error(failure_msg)
                         return ImageAvailabilityState(
                             digest=None, stage=DependencyStage.FAILED, message=failure_msg
                         )
-                except Exception as ex:
-                    logger.warn("Cannot fetch image size beforehands: %s", ex)
 
                 self._downloading.add_if_new(image_spec, threading.Thread(target=download, args=[]))
                 return ImageAvailabilityState(

--- a/codalab/worker/docker_utils.py
+++ b/codalab/worker/docker_utils.py
@@ -283,7 +283,8 @@ def get_image_size_without_pulling(image_spec):
     :param image_spec: image_spec can have two formats as follows:
             1. "repo:tag": 'codalab/default-cpu:latest'
             2. "repo@digest": studyfang/hotpotqa@sha256:f0ee6bc3b8deefa6bdcbb56e42ec97b498befbbca405a630b9ad80125dc65857
-    :return: the compressed image size in bytes
+    :return: 1. when fetching from Docker rest API V2 succeeded, return the compressed image size in bytes
+             2. when fetching from Docker rest API V2 failed, return None
     """
     logger.info("Downloading tag information for {}".format(image_spec))
 

--- a/codalab/worker/main.py
+++ b/codalab/worker/main.py
@@ -83,7 +83,7 @@ def parse_args():
         '--max-image-size',
         type=parse_size,
         metavar='SIZE',
-        default='10g',
+        default=None,
         help='Limit the size of Docker images to download from the Docker Hub'
         '(e.g. 3, 3k, 3m, 3g, 3t). If the limit is exceeded, '
         'the requested image will not be downloaded. '

--- a/docker/compose_files/docker-compose.yml
+++ b/docker/compose_files/docker-compose.yml
@@ -161,7 +161,13 @@ services:
 
   worker:
     image: codalab/worker:${CODALAB_VERSION}
-    command: cl-worker --server http://rest-server:${CODALAB_REST_PORT} --verbose --work-dir ${CODALAB_WORKER_DIR} --network-prefix ${CODALAB_WORKER_NETWORK_PREFIX} --id ${HOSTNAME}
+    command: |
+      cl-worker
+      --server http://rest-server:${CODALAB_REST_PORT}
+      --work-dir ${CODALAB_WORKER_DIR}
+      --network-prefix ${CODALAB_WORKER_NETWORK_PREFIX}
+      --id ${HOSTNAME}
+      --verbose
     <<: *codalab-base
     <<: *codalab-root  # Not ideal since worker files saved as root, but without it, can't use docker
     depends_on:
@@ -176,7 +182,14 @@ services:
 
   worker-shared-file-system:
     image: codalab/worker:${CODALAB_VERSION}
-    command: cl-worker --server http://rest-server:${CODALAB_REST_PORT} --verbose --work-dir ${CODALAB_WORKER_DIR} --network-prefix ${CODALAB_WORKER_NETWORK_PREFIX} --id ${HOSTNAME} --shared-file-system
+    command: |
+      cl-worker
+      --server http://rest-server:${CODALAB_REST_PORT}
+      --work-dir ${CODALAB_WORKER_DIR}
+      --network-prefix ${CODALAB_WORKER_NETWORK_PREFIX}
+      --id ${HOSTNAME}
+      --shared-file-system
+      --verbose
     <<: *codalab-base
     <<: *codalab-root  # Not ideal since worker files saved as root, but without it, can't use docker
     depends_on:


### PR DESCRIPTION
Fix #1984.
Changed the original request to make image size check optional. @bkgoksel when you pass `--max-image-size=0` it won't trigger the image size pre-check. Let me know if this is ok to you.
This PR should go together with https://github.com/codalab/deployment/pull/15