### PR TITLE
Allow crawling up bundle dependencies

### DIFF
--- a/codalab/client/json_api_client.py
+++ b/codalab/client/json_api_client.py
@@ -583,26 +583,25 @@ class JsonApiClient(RestClient):
         return response
 
     @wrap_exception('Unable to fetch contents info of bundle {1}')
-    def fetch_contents_info(self, bundle_id, target_path='', depth=0):
-        request_path = '/bundles/%s/contents/info/%s' % (bundle_id, urllib.parse.quote(target_path))
+    def fetch_contents_info(self, target, depth=0):
+        request_path = '/bundles/%s/contents/info/%s' % (target[0], urllib.parse.quote(target[1]))
         response = self._make_request('GET', request_path, query_params={'depth': depth})
         return response['data']
 
     @wrap_exception('Unable to fetch contents blob of bundle {1}')
-    def fetch_contents_blob(
-        self, bundle_id, target_path='', range_=None, head=None, tail=None, truncation_text=None
-    ):
+    def fetch_contents_blob(self, target, range_=None, head=None, tail=None, truncation_text=None):
         """
         Returns a file-like object for the target on the given bundle.
 
-        :param bundle_id: id of target bundle
-        :param target_path: path to target in bundle
+        :param target: A tuple of bundle_id, path where:
+            bundle_id: id of target bundle
+            path: path to target in bundle
         :param range_: range of bytes to fetch
         :param head: number of lines to summarize from beginning of file
         :param tail: number of lines to summarize from end of file
         :return: file-like object containing requested data blob
         """
-        request_path = '/bundles/%s/contents/blob/%s' % (bundle_id, urllib.parse.quote(target_path))
+        request_path = '/bundles/%s/contents/blob/%s' % (target[0], urllib.parse.quote(target[1]))
         headers = {'Accept-Encoding': 'gzip'}
         if range_ is not None:
             headers['Range'] = 'bytes=%d-%d' % range_

--- a/codalab/client/json_api_client.py
+++ b/codalab/client/json_api_client.py
@@ -6,6 +6,7 @@ import urllib.request, urllib.parse, urllib.error
 
 from codalab.common import http_error_to_exception, precondition, UsageError
 from codalab.worker.rest_client import RestClient, RestClientException
+from codalab.worker.download_util import BundleTarget
 
 
 def wrap_exception(message):
@@ -594,6 +595,10 @@ class JsonApiClient(RestClient):
             urllib.parse.quote(target.subpath),
         )
         response = self._make_request('GET', request_path, query_params={'depth': depth})
+        # Deserialize the target. See /rest/bundles/_fetch_contents_info for serialization side
+        response['data']['resolved_target'] = BundleTarget.from_dict(
+            response['data']['resolved_target']
+        )
         return response['data']
 
     @wrap_exception('Unable to fetch contents blob of bundle {1}')

--- a/codalab/client/json_api_client.py
+++ b/codalab/client/json_api_client.py
@@ -584,7 +584,15 @@ class JsonApiClient(RestClient):
 
     @wrap_exception('Unable to fetch contents info of bundle {1}')
     def fetch_contents_info(self, target, depth=0):
-        request_path = '/bundles/%s/contents/info/%s' % (target[0], urllib.parse.quote(target[1]))
+        """
+        Calls download_manager.get_target_info server-side and returns the target_info.
+        For details on return value look at worker.download_util.get_target_info
+        :param target: a worker.download_util.BundleTarget
+        """
+        request_path = '/bundles/%s/contents/info/%s' % (
+            target.bundle_uuid,
+            urllib.parse.quote(target.subpath),
+        )
         response = self._make_request('GET', request_path, query_params={'depth': depth})
         return response['data']
 
@@ -593,15 +601,16 @@ class JsonApiClient(RestClient):
         """
         Returns a file-like object for the target on the given bundle.
 
-        :param target: A tuple of bundle_id, path where:
-            bundle_id: id of target bundle
-            path: path to target in bundle
+        :param target: A worker.download_util.BundleTarget
         :param range_: range of bytes to fetch
         :param head: number of lines to summarize from beginning of file
         :param tail: number of lines to summarize from end of file
         :return: file-like object containing requested data blob
         """
-        request_path = '/bundles/%s/contents/blob/%s' % (target[0], urllib.parse.quote(target[1]))
+        request_path = '/bundles/%s/contents/blob/%s' % (
+            target.bundle_uuid,
+            urllib.parse.quote(target.subpath),
+        )
         headers = {'Accept-Encoding': 'gzip'}
         if range_ is not None:
             headers['Range'] = 'bytes=%d-%d' % range_

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -2423,7 +2423,7 @@ class BundleCLI(object):
             while run_state not in State.FINAL_STATES:
                 run_state = client.fetch('bundles', bundle_uuid)['state']
                 try:
-                    client.fetch_contents_info((bundle_uuid, subpath), 0)
+                    client.fetch_contents_info(BundleTarget(bundle_uuid, subpath), 0)
                 except NotFoundError:
                     time.sleep(SLEEP_PERIOD)
                     continue

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -5,8 +5,7 @@ a list of CodaLab bundle system command-line arguments and executes them.
 Each of the supported commands corresponds to a method on this class.
 This function takes an argument list and does the action.
 
-For example:
-
+For example: 
   cl upload foo
 
 results in the following:
@@ -84,6 +83,7 @@ from codalab.lib.completers import (
 from codalab.lib.bundle_store import MultiDiskBundleStore
 from codalab.lib.print_util import FileTransferProgress
 from codalab.worker.file_util import un_tar_directory
+from codalab.worker.download_util import BundleTarget
 
 from codalab.lib.spec_util import generate_uuid
 from codalab.worker.docker_utils import get_available_runtime, start_bundle_container
@@ -517,7 +517,9 @@ class BundleCLI(object):
         supported
         """
         return [
-            self.resolve_target(default_client, default_worksheet_uuid, spec, allow_remote)[2][0]
+            self.resolve_target(default_client, default_worksheet_uuid, spec, allow_remote)[
+                2
+            ].bundle_uuid
             for spec in target_specs
         ]
 
@@ -535,9 +537,7 @@ class BundleCLI(object):
             - worksheet_uuid: The uuid of the worksheet the target bundle is from,
                 a new uuid if the target spec includes a worksheet spec
                 same as default_worksheet_uuid otherwise
-            - target: tuple of (bundle_uuid, subpath) where:
-                - bundle_uuid: The uuid of the target bundle
-                - subpath: The subpath from the target_spec
+            - target: a worker.download_util.BundleTarget
         Raises UsageError if allow_remote is False but an instance is specified in the target_spec
         """
         instance, worksheet_spec, bundle_spec, subpath = parse_target_spec(target_spec)
@@ -566,12 +566,12 @@ class BundleCLI(object):
         # Rest of CLI treats empty string as no subpath and can't handle subpath being None
         subpath = '' if subpath is None else subpath
 
-        return (client, worksheet_uuid, (bundle_uuid, subpath))
+        return (client, worksheet_uuid, BundleTarget(bundle_uuid, subpath))
 
     def resolve_key_targets(self, client, worksheet_uuid, target_specs):
         """
         Helper: target_specs is a list of strings which are [<key>]:<target>
-        Returns: [(key, (bundle_uuid, subpath)), ...]
+        Returns: [(key, worker.download_util.BundleTarget), ...]
         """
         keys = set()
         targets = []
@@ -1262,14 +1262,14 @@ class BundleCLI(object):
         )
 
         # Figure out where to download.
-        info = client.fetch('bundles', target[0])
+        info = client.fetch('bundles', target.bundle_uuid)
         if args.output_path:
             local_path = args.output_path
         else:
             local_path = (
                 nested_dict_get(info, 'metadata', 'name', default='untitled')
-                if target[1] == ''
-                else os.path.basename(target[1])
+                if target.subpath == ''
+                else os.path.basename(target.subpath)
             )
         final_path = os.path.join(os.getcwd(), local_path)
         if os.path.exists(final_path):
@@ -1282,7 +1282,7 @@ class BundleCLI(object):
             raise UsageError('Downloading symlinks is not allowed.')
 
         print(
-            'Downloading %s/%s => %s' % (self.simple_bundle_str(info), target[1], final_path),
+            'Downloading %s/%s => %s' % (self.simple_bundle_str(info), target.subpath, final_path),
             file=self.stdout,
         )
 
@@ -1482,9 +1482,13 @@ class BundleCLI(object):
     def derive_bundle(self, bundle_type, command, targets, metadata):
         # List the dependencies of this bundle on its targets.
         dependencies = []
-        for (child_path, (parent_uuid, parent_path)) in targets:
+        for (child_path, parent_target) in targets:
             dependencies.append(
-                {'child_path': child_path, 'parent_uuid': parent_uuid, 'parent_path': parent_path}
+                {
+                    'child_path': child_path,
+                    'parent_uuid': parent_target.bundle_uuid,
+                    'parent_path': parent_target.subpath,
+                }
             )
         return {
             'bundle_type': bundle_type,
@@ -2167,13 +2171,13 @@ class BundleCLI(object):
 
         print(wrap('contents'), file=self.stdout)
         bundle_uuid = info['uuid']
-        info = self.print_target_info(client, (bundle_uuid, ''), head=10)
+        info = self.print_target_info(client, BundleTarget(bundle_uuid, ''), head=10)
         if info is not None and info['type'] == 'directory':
             for item in info['contents']:
                 if item['name'] not in ['stdout', 'stderr']:
                     continue
                 print(wrap(item['name']), file=self.stdout)
-                self.print_target_info(client, (bundle_uuid, item['name']), head=10)
+                self.print_target_info(client, BundleTarget(bundle_uuid, item['name']), head=10)
 
     @Commands.command(
         'mount',
@@ -2206,19 +2210,18 @@ class BundleCLI(object):
             client, worksheet_uuid, target = self.resolve_target(
                 default_client, default_worksheet_uuid, args.target_spec
             )
-            bundle_uuid, subpath = target
 
             mountpoint = path_util.normalize(args.mountpoint)
             path_util.check_isvalid(mountpoint, 'mount')
             print(
-                'BundleFUSE mounting bundle {} on {}'.format(bundle_uuid, mountpoint),
+                'BundleFUSE mounting bundle {} on {}'.format(target.bundle_uuid, mountpoint),
                 file=self.stdout,
             )
             print(
                 'BundleFUSE will run and maintain the mounted filesystem in the foreground. CTRL-C to cancel.',
                 file=self.stdout,
             )
-            bundle_fuse.bundle_mount(client, mountpoint, bundle_uuid, args.verbose)
+            bundle_fuse.bundle_mount(client, mountpoint, target.bundle_uuid, args.verbose)
             print('BundleFUSE shutting down.', file=self.stdout)
         else:
             print('fuse is not installed', file=self.stdout)
@@ -2254,12 +2257,11 @@ class BundleCLI(object):
         client, worksheet_uuid, target = self.resolve_target(
             client, worksheet_uuid, args.bundle_spec
         )
-        bundle_uuid = target[0]
         message = args.message
         if args.file:
             with open(args.file) as f:
                 message += f.read()
-        contents = client.netcat(bundle_uuid, port=args.port, data={"message": message})
+        contents = client.netcat(target.bundle_uuid, port=args.port, data={"message": message})
         with closing(contents):
             shutil.copyfileobj(contents, self.stdout.buffer)
 
@@ -2295,7 +2297,9 @@ class BundleCLI(object):
         )
         info = self.print_target_info(client, target, head=args.head, tail=args.tail)
         if info is None:
-            raise UsageError('Target {} doesn\'t exist in bundle {}'.format(*target))
+            raise UsageError(
+                'Target {} doesn\'t exist in bundle {}'.format(target.subpath, target.bundle_uuid)
+            )
 
     # Helper: shared between info and cat
     def print_target_info(self, client, target, head=None, tail=None):
@@ -2383,19 +2387,18 @@ class BundleCLI(object):
         client, worksheet_uuid, target = self.resolve_target(
             default_client, default_worksheet_uuid, args.target_spec
         )
-        bundle_uuid, subpath = target
 
         # Figure files to display
         subpaths = []
         if args.tail:
-            if subpath == '':
+            if target.subpath == '':
                 subpaths = ['stdout', 'stderr']
             else:
-                subpaths = [subpath]
-        state = self.follow_targets(client, bundle_uuid, subpaths)
+                subpaths = [target.subpath]
+        state = self.follow_targets(client, target.bundle_uuid, subpaths)
         if state != State.READY:
             self.exit(state)
-        print(bundle_uuid, file=self.stdout)
+        print(target.bundle_uuid, file=self.stdout)
 
     def follow_targets(self, client, bundle_uuid, subpaths, from_start=False):
         """
@@ -2435,7 +2438,9 @@ class BundleCLI(object):
                 # If the subpath we're interested in appears, check if it's a
                 # file and if so, initialize the offset.
                 if subpath_is_file[i] is None:
-                    target_info = client.fetch_contents_info((bundle_uuid, subpaths[i]), 0)
+                    target_info = client.fetch_contents_info(
+                        BundleTarget(bundle_uuid, subpaths[i]), 0
+                    )
                     subpath_targets[i] = target_info['resolved_target']
                     if target_info['type'] == 'file':
                         subpath_is_file[i] = True
@@ -2660,9 +2665,14 @@ class BundleCLI(object):
         )
         client.create(
             'bundle-actions',
-            {'type': 'write', 'uuid': target[0], 'subpath': target[1], 'string': args.string},
+            {
+                'type': 'write',
+                'uuid': target.bundle_uuid,
+                'subpath': target.subpath,
+                'string': args.string,
+            },
         )
-        print(target[0], file=self.stdout)
+        print(target.bundle_uuid, file=self.stdout)
 
     #############################################################################
     # CLI methods for worksheet-related commands follow!
@@ -2789,7 +2799,7 @@ class BundleCLI(object):
                 # copy (or add only if bundle already exists on destination)
                 self.copy_bundle(
                     source_client,
-                    source_target[0],
+                    source_target.bundle_uuid,
                     dest_client,
                     dest_worksheet_uuid,
                     copy_dependencies=args.copy_dependencies,
@@ -3073,7 +3083,9 @@ class BundleCLI(object):
                     maxlines = int(maxlines)
                 try:
                     self.print_target_info(
-                        client, (bundle_info['uuid'], block['target_genpath']), head=maxlines
+                        client,
+                        BundleTarget(bundle_info['uuid'], block['target_genpath']),
+                        head=maxlines,
                     )
                 except UsageError as e:
                     print('ERROR:', e, file=self.stdout)

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -1277,6 +1277,8 @@ class BundleCLI(object):
 
         # Do the download.
         target_info = client.fetch_contents_info(bundle_uuid, subpath, 0)
+        bundle_uuid = target_info.get('resolved_uuid', bundle_uuid)
+        resolved_subpath = target_info.get('resolved_path', subpath)
         if target_info['type'] == 'link':
             raise UsageError('Downloading symlinks is not allowed.')
 
@@ -1287,7 +1289,7 @@ class BundleCLI(object):
 
         progress = FileTransferProgress('Received ', f=self.stderr)
         contents = file_util.tracked(
-            client.fetch_contents_blob(bundle_uuid, subpath), progress.update
+            client.fetch_contents_blob(bundle_uuid, resolved_subpath), progress.update
         )
         with progress, closing(contents):
             if target_info['type'] == 'directory':
@@ -2300,6 +2302,8 @@ class BundleCLI(object):
             return None
 
         info_type = info.get('type')
+        bundle_uuid = info.get('resolved_uuid', bundle_uuid)
+        subpath = info.get('resolved_path', subpath)
         if info_type == 'file':
             kwargs = {}
             if head is not None:
@@ -2413,6 +2417,8 @@ class BundleCLI(object):
                 run_state = client.fetch('bundles', bundle_uuid)['state']
                 try:
                     client.fetch_contents_info(bundle_uuid, subpath, 0)
+                    bundle_uuid = info.get('resolved_uuid', bundle_uuid)
+                    subpath = info.get('resolved_path', subpath)
                 except NotFoundError:
                     time.sleep(SLEEP_PERIOD)
                     continue
@@ -2428,6 +2434,8 @@ class BundleCLI(object):
                 # file and if so, initialize the offset.
                 if subpath_is_file[i] is None:
                     target_info = client.fetch_contents_info(bundle_uuid, subpaths[i], 0)
+                    bundle_uuid = info.get('resolved_uuid', bundle_uuid)
+                    subpath = info.get('resolved_path', subpath)
                     if target_info['type'] == 'file':
                         subpath_is_file[i] = True
                         if from_start:

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -517,7 +517,7 @@ class BundleCLI(object):
         supported
         """
         return [
-            self.resolve_target(default_client, default_worksheet_uuid, spec, allow_remote)[2]
+            self.resolve_target(default_client, default_worksheet_uuid, spec, allow_remote)[2][0]
             for spec in target_specs
         ]
 
@@ -535,8 +535,9 @@ class BundleCLI(object):
             - worksheet_uuid: The uuid of the worksheet the target bundle is from,
                 a new uuid if the target spec includes a worksheet spec
                 same as default_worksheet_uuid otherwise
-            - bundle_uuid: The uuid of the target bundle
-            - subpath: The subpath from the target_spec
+            - target: tuple of (bundle_uuid, subpath) where:
+                - bundle_uuid: The uuid of the target bundle
+                - subpath: The subpath from the target_spec
         Raises UsageError if allow_remote is False but an instance is specified in the target_spec
         """
         instance, worksheet_spec, bundle_spec, subpath = parse_target_spec(target_spec)
@@ -565,7 +566,7 @@ class BundleCLI(object):
         # Rest of CLI treats empty string as no subpath and can't handle subpath being None
         subpath = '' if subpath is None else subpath
 
-        return (client, worksheet_uuid, bundle_uuid, subpath)
+        return (client, worksheet_uuid, (bundle_uuid, subpath))
 
     def resolve_key_targets(self, client, worksheet_uuid, target_specs):
         """
@@ -581,10 +582,10 @@ class BundleCLI(object):
                     raise UsageError('Duplicate key: %s' % (key,))
                 else:
                     raise UsageError('Must specify keys when packaging multiple targets!')
-            _, worksheet_uuid, bundle_uuid, subpath = self.resolve_target(
+            _, worksheet_uuid, target = self.resolve_target(
                 client, worksheet_uuid, target_spec, allow_remote=False
             )
-            targets.append((key, (bundle_uuid, subpath)))
+            targets.append((key, target))
             keys.add(key)
         return targets
 
@@ -1256,19 +1257,19 @@ class BundleCLI(object):
         default_client, default_worksheet_uuid = self.parse_client_worksheet_uuid(
             args.worksheet_spec
         )
-        client, worksheet_uuid, bundle_uuid, subpath = self.resolve_target(
+        client, worksheet_uuid, target = self.resolve_target(
             default_client, default_worksheet_uuid, args.target_spec
         )
 
         # Figure out where to download.
-        info = client.fetch('bundles', bundle_uuid)
+        info = client.fetch('bundles', target[0])
         if args.output_path:
             local_path = args.output_path
         else:
             local_path = (
                 nested_dict_get(info, 'metadata', 'name', default='untitled')
-                if subpath == ''
-                else os.path.basename(subpath)
+                if target[1] == ''
+                else os.path.basename(target[1])
             )
         final_path = os.path.join(os.getcwd(), local_path)
         if os.path.exists(final_path):
@@ -1276,20 +1277,18 @@ class BundleCLI(object):
             return
 
         # Do the download.
-        target_info = client.fetch_contents_info(bundle_uuid, subpath, 0)
-        bundle_uuid = target_info.get('resolved_uuid', bundle_uuid)
-        resolved_subpath = target_info.get('resolved_path', subpath)
+        target_info = client.fetch_contents_info(target, 0)
         if target_info['type'] == 'link':
             raise UsageError('Downloading symlinks is not allowed.')
 
         print(
-            'Downloading %s/%s => %s' % (self.simple_bundle_str(info), subpath, final_path),
+            'Downloading %s/%s => %s' % (self.simple_bundle_str(info), target[1], final_path),
             file=self.stdout,
         )
 
         progress = FileTransferProgress('Received ', f=self.stderr)
         contents = file_util.tracked(
-            client.fetch_contents_blob(bundle_uuid, resolved_subpath), progress.update
+            client.fetch_contents_blob(target_info['resolved_target']), progress.update
         )
         with progress, closing(contents):
             if target_info['type'] == 'directory':
@@ -1341,7 +1340,7 @@ class BundleCLI(object):
         # TODO: sync the metadata.
         try:
             dest_client.fetch('bundles', source_bundle_uuid)
-        except NotFoundError as e:
+        except NotFoundError:
             bundle_exists = False
         else:
             bundle_exists = True
@@ -1389,7 +1388,7 @@ class BundleCLI(object):
 
         # If bundle contents don't exist, finish after just copying metadata
         try:
-            target_info = source_client.fetch_contents_info(source_bundle_uuid)
+            target_info = source_client.fetch_contents_info((source_bundle_uuid, ''))
         except NotFoundError:
             return
 
@@ -1411,7 +1410,7 @@ class BundleCLI(object):
 
         # Send file over
         progress = FileTransferProgress('Copied ', f=self.stderr)
-        source = source_client.fetch_contents_blob(source_bundle_uuid)
+        source = source_client.fetch_contents_blob((source_bundle_uuid, ''))
         with closing(source), progress:
             dest_client.upload_contents_blob(
                 dest_bundle['id'],
@@ -2168,13 +2167,13 @@ class BundleCLI(object):
 
         print(wrap('contents'), file=self.stdout)
         bundle_uuid = info['uuid']
-        info = self.print_target_info(client, bundle_uuid, '', head=10)
+        info = self.print_target_info(client, (bundle_uuid, ''), head=10)
         if info is not None and info['type'] == 'directory':
             for item in info['contents']:
                 if item['name'] not in ['stdout', 'stderr']:
                     continue
                 print(wrap(item['name']), file=self.stdout)
-                self.print_target_info(client, bundle_uuid, item['name'], head=10)
+                self.print_target_info(client, (bundle_uuid, item['name']), head=10)
 
     @Commands.command(
         'mount',
@@ -2204,18 +2203,22 @@ class BundleCLI(object):
             default_client, default_worksheet_uuid = self.parse_client_worksheet_uuid(
                 args.worksheet_spec
             )
-            client, worksheet_uuid, uuid, path = self.resolve_target(
+            client, worksheet_uuid, target = self.resolve_target(
                 default_client, default_worksheet_uuid, args.target_spec
             )
+            bundle_uuid, subpath = target
 
             mountpoint = path_util.normalize(args.mountpoint)
             path_util.check_isvalid(mountpoint, 'mount')
-            print('BundleFUSE mounting bundle {} on {}'.format(uuid, mountpoint), file=self.stdout)
+            print(
+                'BundleFUSE mounting bundle {} on {}'.format(bundle_uuid, mountpoint),
+                file=self.stdout,
+            )
             print(
                 'BundleFUSE will run and maintain the mounted filesystem in the foreground. CTRL-C to cancel.',
                 file=self.stdout,
             )
-            bundle_fuse.bundle_mount(client, mountpoint, uuid, args.verbose)
+            bundle_fuse.bundle_mount(client, mountpoint, bundle_uuid, args.verbose)
             print('BundleFUSE shutting down.', file=self.stdout)
         else:
             print('fuse is not installed', file=self.stdout)
@@ -2248,9 +2251,10 @@ class BundleCLI(object):
     )
     def do_netcat_command(self, args):
         client, worksheet_uuid = self.parse_client_worksheet_uuid(args.worksheet_spec)
-        client, worksheet_uuid, bundle_uuid, subpath = self.resolve_target(
+        client, worksheet_uuid, target = self.resolve_target(
             client, worksheet_uuid, args.bundle_spec
         )
+        bundle_uuid = target[0]
         message = args.message
         if args.file:
             with open(args.file) as f:
@@ -2286,24 +2290,22 @@ class BundleCLI(object):
         default_client, default_worksheet_uuid = self.parse_client_worksheet_uuid(
             args.worksheet_spec
         )
-        client, worksheet_uuid, bundle_uuid, subpath = self.resolve_target(
+        client, worksheet_uuid, target = self.resolve_target(
             default_client, default_worksheet_uuid, args.target_spec
         )
-        info = self.print_target_info(client, bundle_uuid, subpath, head=args.head, tail=args.tail)
+        info = self.print_target_info(client, target, head=args.head, tail=args.tail)
         if info is None:
-            raise UsageError('Target {} doesn\'t exist in bundle {}'.format(subpath, bundle_uuid))
+            raise UsageError('Target {} doesn\'t exist in bundle {}'.format(*target))
 
     # Helper: shared between info and cat
-    def print_target_info(self, client, bundle_uuid, subpath, head=None, tail=None):
+    def print_target_info(self, client, target, head=None, tail=None):
         try:
-            info = client.fetch_contents_info(bundle_uuid, subpath, 1)
+            info = client.fetch_contents_info(target, 1)
         except NotFoundError:
             print(formatting.verbose_contents_str(None), file=self.stdout)
             return None
 
         info_type = info.get('type')
-        bundle_uuid = info.get('resolved_uuid', bundle_uuid)
-        subpath = info.get('resolved_path', subpath)
         if info_type == 'file':
             kwargs = {}
             if head is not None:
@@ -2317,7 +2319,7 @@ class BundleCLI(object):
                 kwargs['tail'] = 50
                 kwargs['truncation_text'] = '\n... truncated ...\n\n'
 
-            contents = client.fetch_contents_blob(bundle_uuid, subpath, **kwargs)
+            contents = client.fetch_contents_blob(info['resolved_target'], **kwargs)
             with closing(contents):
                 shutil.copyfileobj(contents, self.stdout.buffer)
 
@@ -2378,9 +2380,10 @@ class BundleCLI(object):
         default_client, default_worksheet_uuid = self.parse_client_worksheet_uuid(
             args.worksheet_spec
         )
-        client, worksheet_uuid, bundle_uuid, subpath = self.resolve_target(
+        client, worksheet_uuid, target = self.resolve_target(
             default_client, default_worksheet_uuid, args.target_spec
         )
+        bundle_uuid, subpath = target
 
         # Figure files to display
         subpaths = []
@@ -2407,6 +2410,7 @@ class BundleCLI(object):
         """
         subpath_is_file = [None] * len(subpaths)
         subpath_offset = [None] * len(subpaths)
+        subpath_targets = [None] * len(subpaths)
 
         SLEEP_PERIOD = 1.0
 
@@ -2416,9 +2420,7 @@ class BundleCLI(object):
             while run_state not in State.FINAL_STATES:
                 run_state = client.fetch('bundles', bundle_uuid)['state']
                 try:
-                    client.fetch_contents_info(bundle_uuid, subpath, 0)
-                    bundle_uuid = info.get('resolved_uuid', bundle_uuid)
-                    subpath = info.get('resolved_path', subpath)
+                    client.fetch_contents_info((bundle_uuid, subpath), 0)
                 except NotFoundError:
                     time.sleep(SLEEP_PERIOD)
                     continue
@@ -2433,9 +2435,8 @@ class BundleCLI(object):
                 # If the subpath we're interested in appears, check if it's a
                 # file and if so, initialize the offset.
                 if subpath_is_file[i] is None:
-                    target_info = client.fetch_contents_info(bundle_uuid, subpaths[i], 0)
-                    bundle_uuid = info.get('resolved_uuid', bundle_uuid)
-                    subpath = info.get('resolved_path', subpath)
+                    target_info = client.fetch_contents_info((bundle_uuid, subpaths[i]), 0)
+                    subpath_targets[i] = target_info['resolved_target']
                     if target_info['type'] == 'file':
                         subpath_is_file[i] = True
                         if from_start:
@@ -2454,7 +2455,7 @@ class BundleCLI(object):
                     READ_LENGTH = 16384
                     byte_range = (subpath_offset[i], subpath_offset[i] + READ_LENGTH - 1)
                     with closing(
-                        client.fetch_contents_blob(bundle_uuid, subpaths[i], byte_range)
+                        client.fetch_contents_blob(subpath_targets[i], byte_range)
                     ) as contents:
                         result = contents.read()
                     if not result:
@@ -2654,14 +2655,14 @@ class BundleCLI(object):
         default_client, default_worksheet_uuid = self.parse_client_worksheet_uuid(
             args.worksheet_spec
         )
-        client, worksheet_uuid, bundle_uuid, subpath = self.resolve_target(
+        client, worksheet_uuid, target = self.resolve_target(
             default_client, default_worksheet_uuid, args.target_spec
         )
         client.create(
             'bundle-actions',
-            {'type': 'write', 'uuid': bundle_uuid, 'subpath': subpath, 'string': args.string},
+            {'type': 'write', 'uuid': target[0], 'subpath': target[1], 'string': args.string},
         )
-        print(bundle_uuid, file=self.stdout)
+        print(target[0], file=self.stdout)
 
     #############################################################################
     # CLI methods for worksheet-related commands follow!
@@ -2782,16 +2783,13 @@ class BundleCLI(object):
 
         elif args.item_type == 'bundle':
             for bundle_spec in args.item_spec:
-                (
-                    source_client,
-                    source_worksheet_uuid,
-                    source_bundle_uuid,
-                    subpath,
-                ) = self.resolve_target(curr_client, curr_worksheet_uuid, bundle_spec)
+                (source_client, source_worksheet_uuid, source_target) = self.resolve_target(
+                    curr_client, curr_worksheet_uuid, bundle_spec
+                )
                 # copy (or add only if bundle already exists on destination)
                 self.copy_bundle(
                     source_client,
-                    source_bundle_uuid,
+                    source_target[0],
                     dest_client,
                     dest_worksheet_uuid,
                     copy_dependencies=args.copy_dependencies,
@@ -3075,7 +3073,7 @@ class BundleCLI(object):
                     maxlines = int(maxlines)
                 try:
                     self.print_target_info(
-                        client, bundle_info['uuid'], block['target_genpath'], head=maxlines
+                        client, (bundle_info['uuid'], block['target_genpath']), head=maxlines
                     )
                 except UsageError as e:
                     print('ERROR:', e, file=self.stdout)

--- a/codalab/lib/bundle_fuse.py
+++ b/codalab/lib/bundle_fuse.py
@@ -77,7 +77,7 @@ if fuse_is_available:
                 chunk_id * self.chunk_size + self.chunk_size - 1,
             )
             with closing(
-                self.client.fetch_contents_blob(self.bundle_uuid, path, byte_range)
+                self.client.fetch_contents_blob((self.bundle_uuid, path), byte_range)
             ) as contents:
                 arr = contents.read()
 
@@ -176,7 +176,7 @@ if fuse_is_available:
         def _get_info(self, path):
             ''' Set a request through the json api client to get info about the bundle '''
             try:
-                info = self.client.fetch_contents_info(self.bundle_uuid, path, 1)
+                info = self.client.fetch_contents_info((self.bundle_uuid, path), 1)
             except NotFoundError:
                 raise FuseOSError(errno.ENOENT)
             return info

--- a/codalab/lib/bundle_fuse.py
+++ b/codalab/lib/bundle_fuse.py
@@ -8,6 +8,7 @@ import time
 from collections import OrderedDict
 
 from contextlib import closing
+from codalab.worker.download_util import BundleTarget
 
 try:
     from fuse import FUSE, FuseOSError, Operations
@@ -77,7 +78,7 @@ if fuse_is_available:
                 chunk_id * self.chunk_size + self.chunk_size - 1,
             )
             with closing(
-                self.client.fetch_contents_blob((self.bundle_uuid, path), byte_range)
+                self.client.fetch_contents_blob(BundleTarget(self.bundle_uuid, path), byte_range)
             ) as contents:
                 arr = contents.read()
 
@@ -176,7 +177,7 @@ if fuse_is_available:
         def _get_info(self, path):
             ''' Set a request through the json api client to get info about the bundle '''
             try:
-                info = self.client.fetch_contents_info((self.bundle_uuid, path), 1)
+                info = self.client.fetch_contents_info(BundleTarget(self.bundle_uuid, path), 1)
             except NotFoundError:
                 raise FuseOSError(errno.ENOENT)
             return info

--- a/codalab/lib/completers.py
+++ b/codalab/lib/completers.py
@@ -167,9 +167,10 @@ class TargetsCompleter(CodaLabCompleter):
             )
         else:
             # then suggest completions for subpath
-            resolved_target = self.cli.resolve_target(client, worksheet_uuid, target)
-            bundle_uuid = resolved_target[2]
-            dir_target = BundleTarget(bundle_uuid, os.path.dirname(subpath))
+            client, worksheet_uuid, resolved_target = self.cli.resolve_target(
+                client, worksheet_uuid, target
+            )
+            dir_target = BundleTarget(resolved_target.bundle_uuid, os.path.dirname(subpath))
             try:
                 info = client.fetch_contents_info(dir_target, depth=1)
             except NotFoundError:

--- a/codalab/lib/completers.py
+++ b/codalab/lib/completers.py
@@ -13,6 +13,7 @@ from argcomplete import warn
 
 from codalab.common import NotFoundError
 from codalab.lib import spec_util, worksheet_util, cli_util
+from codalab.worker.download_util import BundleTarget
 
 
 class CodaLabCompleter(object):
@@ -168,7 +169,7 @@ class TargetsCompleter(CodaLabCompleter):
             # then suggest completions for subpath
             resolved_target = self.cli.resolve_target(client, worksheet_uuid, target)
             bundle_uuid = resolved_target[2]
-            dir_target = (bundle_uuid, os.path.dirname(subpath))
+            dir_target = BundleTarget(bundle_uuid, os.path.dirname(subpath))
             try:
                 info = client.fetch_contents_info(dir_target, depth=1)
             except NotFoundError:
@@ -180,7 +181,7 @@ class TargetsCompleter(CodaLabCompleter):
                     if child['name'].startswith(basename):
                         matching_child_names.append(child['name'])
                 return (
-                    suggestion_format.format(os.path.join(dir_target[1], child_name))
+                    suggestion_format.format(os.path.join(dir_target.subpath, child_name))
                     for child_name in matching_child_names
                 )
             else:

--- a/codalab/lib/completers.py
+++ b/codalab/lib/completers.py
@@ -170,7 +170,7 @@ class TargetsCompleter(CodaLabCompleter):
             bundle_uuid = resolved_target[2]
             dir_target = (bundle_uuid, os.path.dirname(subpath))
             try:
-                info = client.fetch_contents_info(dir_target[0], dir_target[1], depth=1)
+                info = client.fetch_contents_info(dir_target, depth=1)
             except NotFoundError:
                 return ()
             if info['type'] == 'directory':

--- a/codalab/lib/download_manager.py
+++ b/codalab/lib/download_manager.py
@@ -63,11 +63,11 @@ class DownloadManager(object):
             child_path_to_dep = {
                 dep.child_path: dep for dep in self._bundle_model.get_bundle_dependencies(uuid)
             }
-            matching_dep = child_path_to_dep.get(os.path.split(path)[0], None)
+            matching_dep = child_path_to_dep.get(path.split(os.path.sep)[0], None)
             if matching_dep:
                 # The path actually belongs to a dependency of this bundle
                 return self.get_target_info(
-                    matching_dep.parent_uuid, os.path.split(path)[1:], depth
+                    matching_dep.parent_uuid, os.path.sep.join(path.split(os.path.sep)[1:]), depth
                 )
             raise err
 

--- a/codalab/lib/download_manager.py
+++ b/codalab/lib/download_manager.py
@@ -132,7 +132,12 @@ class DownloadManager(object):
                     )
                 elif 'error_code' in result:
                     raise http_error_to_exception(result['error_code'], result['error_message'])
-                return result['target_info']
+                target_info = result['target_info']
+                # Deserialize dict response sent over JSON
+                target_info['resolved_target'] = download_util.BundleTarget.from_dict(
+                    target_info['resolved_target']
+                )
+                return target_info
             finally:
                 self._worker_model.deallocate_socket(response_socket_id)
 

--- a/codalab/lib/download_manager.py
+++ b/codalab/lib/download_manager.py
@@ -66,9 +66,10 @@ class DownloadManager(object):
             matching_dep = child_path_to_dep.get(path.split(os.path.sep)[0], None)
             if matching_dep:
                 # The path actually belongs to a dependency of this bundle
-                return self.get_target_info(
-                    matching_dep.parent_uuid, os.path.sep.join(path.split(os.path.sep)[1:]), depth
-                )
+                parent_path = matching_dep.parent_path
+                parent_subpath = path.split(os.path.sep)[1:]
+                new_path = os.path.sep.join([parent_path] + parent_subpath)
+                return self.get_target_info(matching_dep.parent_uuid, new_path, depth)
             raise err
 
         if bundle_state == State.PREPARING:

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -47,6 +47,7 @@ from codalab.model.tables import (
 from codalab.objects.worksheet import item_sort_key, Worksheet
 from codalab.objects.oauth2 import OAuth2AuthCode, OAuth2Client, OAuth2Token
 from codalab.objects.user import User
+from codalab.objects.dependency import Dependency
 from codalab.rest.util import get_group_info
 from codalab.worker.bundle_state import State
 
@@ -1051,6 +1052,15 @@ class BundleModel(object):
         else:
             with self.engine.begin() as connection:
                 do_update(connection)
+
+    def get_bundle_dependencies(self, uuid):
+        with self.engine.begin() as connection:
+            dependency_rows = connection.execute(
+                cl_bundle_dependency.select()
+                .where(cl_bundle_dependency.c.child_uuid == uuid)
+                .order_by(cl_bundle_dependency.c.id)
+            ).fetchall()
+        return [Dependency(dep_val) for dep_val in dependency_rows]
 
     def get_bundle_state(self, uuid):
         result_dict = self.get_bundle_states([uuid])

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -403,6 +403,8 @@ def _fetch_bundle_contents_info(uuid, path=''):
     check_bundles_have_read_permission(local.model, request.user, [uuid])
     try:
         info = local.download_manager.get_target_info(target, depth)
+        # Object is not JSON serializable so get its dict
+        info['resolved_target'] = info['resolved_target'].__dict__
     except NotFoundError as e:
         abort(http.client.NOT_FOUND, str(e))
     except Exception as e:

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -395,12 +395,13 @@ def _fetch_bundle_contents_info(uuid, path=''):
     ```
     """
     depth = query_get_type(int, 'depth', default=0)
+    target = (uuid, path)
     if depth < 0:
         abort(http.client.BAD_REQUEST, "Depth must be at least 0")
 
     check_bundles_have_read_permission(local.model, request.user, [uuid])
     try:
-        info = local.download_manager.get_target_info(uuid, path, depth)
+        info = local.download_manager.get_target_info(target, depth)
     except NotFoundError as e:
         abort(http.client.NOT_FOUND, str(e))
     except Exception as e:
@@ -541,20 +542,22 @@ def _fetch_bundle_contents_blob(uuid, path=''):
     truncation_text = query_get_type(str, 'truncation_text', default='')
     max_line_length = query_get_type(int, 'max_line_length', default=128)
     check_bundles_have_read_permission(local.model, request.user, [uuid])
+    target = (uuid, path)
 
     try:
-        target_info = local.download_manager.get_target_info(uuid, path, 0)
-        if target_info['resolved_uuid'] != uuid:
-            uuid = target_info['resolved_uuid']
-            path = target_info['resolved_path']
-            check_bundles_have_read_permission(local.model, request.user, [uuid])
+        target_info = local.download_manager.get_target_info(target, 0)
+        if target_info['resolved_target'] != target:
+            check_bundles_have_read_permission(
+                local.model, request.user, [target_info['resolved_target'][0]]
+            )
+        target = target_info['resolved_target']
     except NotFoundError as e:
         abort(http.client.NOT_FOUND, str(e))
     except Exception as e:
         abort(http.client.BAD_REQUEST, str(e))
 
     # Figure out the file name.
-    bundle_name = local.model.get_bundle(uuid).metadata.name
+    bundle_name = local.model.get_bundle(target[0]).metadata.name
     if not path and bundle_name:
         filename = bundle_name
     else:
@@ -569,7 +572,7 @@ def _fetch_bundle_contents_blob(uuid, path=''):
         gzipped_stream = False  # but don't set the encoding to 'gzip'
         mimetype = 'application/gzip'
         filename += '.tar.gz'
-        fileobj = local.download_manager.stream_tarred_gzipped_directory(uuid, path)
+        fileobj = local.download_manager.stream_tarred_gzipped_directory(target)
     elif target_info['type'] == 'file':
         # Let's gzip to save bandwidth.
         # For simplicity, we do this even if the file is already a packed
@@ -592,14 +595,14 @@ def _fetch_bundle_contents_blob(uuid, path=''):
         elif byte_range:
             start, end = byte_range
             fileobj = local.download_manager.read_file_section(
-                uuid, path, start, end - start + 1, gzipped_stream
+                target, start, end - start + 1, gzipped_stream
             )
         elif head_lines or tail_lines:
             fileobj = local.download_manager.summarize_file(
-                uuid, path, head_lines, tail_lines, max_line_length, truncation_text, gzipped_stream
+                target, head_lines, tail_lines, max_line_length, truncation_text, gzipped_stream
             )
         else:
-            fileobj = local.download_manager.stream_file(uuid, path, gzipped_stream)
+            fileobj = local.download_manager.stream_file(target, gzipped_stream)
     else:
         # Symlinks.
         abort(

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -403,7 +403,8 @@ def _fetch_bundle_contents_info(uuid, path=''):
     check_bundles_have_read_permission(local.model, request.user, [uuid])
     try:
         info = local.download_manager.get_target_info(target, depth)
-        # Object is not JSON serializable so get its dict
+        # Object is not JSON serializable so submit its dict in API response
+        # The client is responsible for deserializing it
         info['resolved_target'] = info['resolved_target'].__dict__
     except NotFoundError as e:
         abort(http.client.NOT_FOUND, str(e))

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -544,7 +544,7 @@ def _fetch_bundle_contents_blob(uuid, path=''):
 
     try:
         target_info = local.download_manager.get_target_info(uuid, path, 0)
-        if target_info['uuid'] != uuid:
+        if target_info['resolved_uuid'] != uuid:
             uuid = target_info['resolved_uuid']
             path = target_info['resolved_path']
             check_bundles_have_read_permission(local.model, request.user, [uuid])

--- a/codalab/rest/interpret.py
+++ b/codalab/rest/interpret.py
@@ -312,8 +312,6 @@ def resolve_interpreted_blocks(interpreted_blocks):
         if block is None:
             continue
         mode = block['mode']
-        bundle_uuid = block['bundles_spec']['bundle_infos'][0]['uuid']
-        target_path = block['target_genpath']
 
         try:
             # Replace data with a resolved version.
@@ -328,6 +326,8 @@ def resolve_interpreted_blocks(interpreted_blocks):
 
                 block['rows'] = contents
             elif mode == BlockModes.contents_block or mode == BlockModes.image_block:
+                bundle_uuid = block['bundles_spec']['bundle_infos'][0]['uuid']
+                target_path = block['target_genpath']
                 try:
                     target_info = rest_util.get_target_info(bundle_uuid, target_path, 0)
                     target_uuid = target_info['resolved_uuid']
@@ -364,7 +364,9 @@ def resolve_interpreted_blocks(interpreted_blocks):
                 # Add a 'points' field that contains the contents of the target.
                 for info in block['trajectories']:
                     try:
-                        target_info = rest_util.get_target_info(bundle_uuid, target_path, 0)
+                        target_info = rest_util.get_target_info(
+                            info['bundle_uuid'], info['target_genpath'], 0
+                        )
                         target_uuid = target_info['resolved_uuid']
                         target_path = target_info['resolved_path']
                     except NotFoundError as e:

--- a/codalab/rest/interpret.py
+++ b/codalab/rest/interpret.py
@@ -273,7 +273,7 @@ def head_target(target, max_num_lines):
 
     The caller should ensure that the target is a file.
 
-    :param target: A target dict with uuid and path as keys
+    :param target: A worker.download_util.BundleTarget with bundle_uuid and subpath
     :param max_num_lines: max number of lines to fetch
     """
     rest_util.check_target_has_read_permission(target)

--- a/codalab/rest/util.py
+++ b/codalab/rest/util.py
@@ -205,13 +205,18 @@ def check_target_has_read_permission(target):
     check_bundles_have_read_permission(local.model, request.user, [target[0]])
 
 
-def get_target_info(target, depth):
+def get_target_info(bundle_uuid, subpath, depth):
     """
     Returns information about an individual target inside the bundle
     Raises NotFoundError if target bundle or path don't exist
     """
-    check_target_has_read_permission(target)
-    return local.download_manager.get_target_info(target[0], target[1], depth)
+    check_target_has_read_permission((bundle_uuid, subpath))
+    target_info = local.download_manager.get_target_info(bundle_uuid, subpath, depth)
+    if target_info['resolved_uuid'] != bundle_uuid:
+        check_target_has_read_permission(
+            (target_info['resolved_uuid'], target_info['resolved_path'])
+        )
+    return target_info
 
 
 #############################################################

--- a/codalab/rest/util.py
+++ b/codalab/rest/util.py
@@ -202,7 +202,7 @@ def _filter_readable_worksheet_uuids(model, worksheet_uuids):
 
 
 def check_target_has_read_permission(target):
-    check_bundles_have_read_permission(local.model, request.user, [target[0]])
+    check_bundles_have_read_permission(local.model, request.user, [target.bundle_uuid])
 
 
 def get_target_info(target, depth):

--- a/codalab/rest/util.py
+++ b/codalab/rest/util.py
@@ -205,17 +205,15 @@ def check_target_has_read_permission(target):
     check_bundles_have_read_permission(local.model, request.user, [target[0]])
 
 
-def get_target_info(bundle_uuid, subpath, depth):
+def get_target_info(target, depth):
     """
     Returns information about an individual target inside the bundle
     Raises NotFoundError if target bundle or path don't exist
     """
-    check_target_has_read_permission((bundle_uuid, subpath))
-    target_info = local.download_manager.get_target_info(bundle_uuid, subpath, depth)
-    if target_info['resolved_uuid'] != bundle_uuid:
-        check_target_has_read_permission(
-            (target_info['resolved_uuid'], target_info['resolved_path'])
-        )
+    check_target_has_read_permission(target)
+    target_info = local.download_manager.get_target_info(target, depth)
+    if target_info['resolved_target'] != target:
+        check_target_has_read_permission(target_info['resolved_target'])
     return target_info
 
 

--- a/codalab/server/bundle_manager.py
+++ b/codalab/server/bundle_manager.py
@@ -10,7 +10,7 @@ import time
 import traceback
 
 from codalab.objects.permission import check_bundles_have_read_permission
-from codalab.common import PermissionError
+from codalab.common import NotFoundError, PermissionError
 from codalab.lib import bundle_util, formatting, path_util
 from codalab.server.worker_info_accessor import WorkerInfoAccessor
 from codalab.worker.file_util import remove_path

--- a/codalab/worker/download_util.py
+++ b/codalab/worker/download_util.py
@@ -25,6 +25,10 @@ class BundleTarget:
     def __hash__(self):
         return hash(self.bundle_uuid, self.subpath)
 
+    @classmethod
+    def from_dict(cls, dct):
+        return cls(dct['bundle_uuid'], dct['subpath'])
+
 
 def get_target_info(bundle_path, target, depth):
     """

--- a/codalab/worker/download_util.py
+++ b/codalab/worker/download_util.py
@@ -13,6 +13,10 @@ class BundleTarget:
             the path resolves to a dependency, then the first component of the
             path is the dependency key and should not be used within the actual
             dependency bundle. This field strips that value.
+
+        for example if a bundle has the dependency key:dep-bundle/dep-subpath
+        the bundle target (bundle, key/subpath) would resolve to
+        (dep-bundle, dep-subpath/subpath)
     """
 
     def __init__(self, bundle_uuid, subpath):

--- a/codalab/worker/download_util.py
+++ b/codalab/worker/download_util.py
@@ -16,6 +16,14 @@ def get_target_info(bundle_path, uuid, path, depth):
         link: If type is 'link', where the symbolic link points to.
         contents: If type is 'directory', a list of entries for the contents.
 
+    For the top level entry, also contains:
+        resolved_uuid: UUID of the bundle the path is actually found on. This is
+            used for when a path resolves to a dependency of a bundle.
+        resolved_path: the particular path to resolve in the bundle UUID in the end. If
+            the path resolves to a dependency, then the first component of the
+            path is the dependency key and should not be used within the actual
+            dependency bundle. This field strips that value.
+
     Any entries more than depth levels deep are filtered out. Depth 0, for
     example, means only the top-level entry is included, and no contents. Depth
     1 means the contents of the top-level are included, but nothing deeper.
@@ -30,6 +38,8 @@ def get_target_info(bundle_path, uuid, path, depth):
         raise PathException('Path {} in bundle {} not found'.format(path, uuid))
 
     info = _compute_target_info(final_path, depth)
+    info['resolved_uuid'] = uuid
+    info['resolved_path'] = path
 
     return info
 

--- a/codalab/worker/download_util.py
+++ b/codalab/worker/download_util.py
@@ -23,7 +23,7 @@ class BundleTarget:
         return self.bundle_uuid == other.bundle_uuid and self.subpath == other.subpath
 
     def __hash__(self):
-        return hash(self.bundle_uuid, self.subpath)
+        return hash((self.bundle_uuid, self.subpath))
 
     @classmethod
     def from_dict(cls, dct):

--- a/codalab/worker/reader.py
+++ b/codalab/worker/reader.py
@@ -84,7 +84,9 @@ class Reader(object):
             target_info['contents'] = [
                 child for child in target_info['contents'] if child['name'] not in dep_paths
             ]
-
+        # Object is not JSON serializable so submit its dict in API response
+        # The client is responsible for deserializing it
+        target_info['resolved_target'] = target_info['resolved_target'].__dict__
         reply_fn(None, {'target_info': target_info}, None)
 
     def stream_directory(self, run_state, path, args, reply_fn):

--- a/codalab/worker/reader.py
+++ b/codalab/worker/reader.py
@@ -46,7 +46,7 @@ class Reader(object):
             - Otherwise starts a thread calling stream_fn on the computed final path
         """
         try:
-            final_path = get_target_path(run_state.bundle_path, run_state.bundle.uuid, path)
+            final_path = get_target_path(run_state.bundle_path, (run_state.bundle.uuid, path))
         except PathException as e:
             reply_fn((http.client.NOT_FOUND, str(e)), None, None)
         read_thread = threading.Thread(target=stream_fn, args=[final_path])
@@ -71,7 +71,7 @@ class Reader(object):
         else:
             try:
                 target_info = download_util.get_target_info(
-                    run_state.bundle_path, run_state.bundle.uuid, path, args['depth']
+                    run_state.bundle_path, (run_state.bundle.uuid, path), args['depth']
                 )
             except PathException as e:
                 err = (http.client.NOT_FOUND, str(e))

--- a/codalab/worker/reader.py
+++ b/codalab/worker/reader.py
@@ -4,7 +4,7 @@ import os
 import threading
 
 import codalab.worker.download_util as download_util
-from codalab.worker.download_util import get_target_path, PathException
+from codalab.worker.download_util import get_target_path, PathException, BundleTarget
 from codalab.worker.file_util import (
     gzip_file,
     gzip_bytestring,
@@ -46,7 +46,9 @@ class Reader(object):
             - Otherwise starts a thread calling stream_fn on the computed final path
         """
         try:
-            final_path = get_target_path(run_state.bundle_path, (run_state.bundle.uuid, path))
+            final_path = get_target_path(
+                run_state.bundle_path, BundleTarget(run_state.bundle.uuid, path)
+            )
         except PathException as e:
             reply_fn((http.client.NOT_FOUND, str(e)), None, None)
         read_thread = threading.Thread(target=stream_fn, args=[final_path])
@@ -71,7 +73,7 @@ class Reader(object):
         else:
             try:
                 target_info = download_util.get_target_info(
-                    run_state.bundle_path, (run_state.bundle.uuid, path), args['depth']
+                    run_state.bundle_path, BundleTarget(run_state.bundle.uuid, path), args['depth']
                 )
             except PathException as e:
                 err = (http.client.NOT_FOUND, str(e))

--- a/test_cli.py
+++ b/test_cli.py
@@ -1694,7 +1694,7 @@ def test(ctx):
     response = ctx.client.fetch_contents_info(BundleTarget(uuid, ''))
     check_equals(response['name'], uuid)
     check_equals(
-        open(path, 'rb').read(), ctx.client.fetch_contents_blob(BundleTarget(uuid, '/')).read()
+        open(path, 'rb').read(), ctx.client.fetch_contents_blob(BundleTarget(uuid, '')).read()
     )
 
     # Display image - should not crash

--- a/test_cli.py
+++ b/test_cli.py
@@ -1693,7 +1693,9 @@ def test(ctx):
     uuid = _run_command([cl, 'upload', path])
     response = ctx.client.fetch_contents_info(BundleTarget(uuid, ''))
     check_equals(response['name'], uuid)
-    check_equals(open(path, 'rb').read(), ctx.client.fetch_contents_blob(BundleTarget(uuid, '/')).read())
+    check_equals(
+        open(path, 'rb').read(), ctx.client.fetch_contents_blob(BundleTarget(uuid, '/')).read()
+    )
 
     # Display image - should not crash
     wuuid = _run_command([cl, 'work', '-u'])

--- a/test_cli.py
+++ b/test_cli.py
@@ -1090,8 +1090,12 @@ def test(ctx):
         dir_cat = _run_command([cl, 'cat', uuid])
         assert 'dir' not in dir_cat, '"dir" should not be in bundle'
         assert 'file' not in dir_cat, '"file" should not be in bundle'
-        _run_command([cl, 'cat', uuid + '/dir'], 1)
-        _run_command([cl, 'cat', uuid + '/file'], 1)
+
+        # You should be able to cat dependencies if specified directly
+        dep_cat_output = _run_command([cl, 'cat', uuid + '/dir'])
+        check_contains('-AmMDnVl4s8', dep_cat_output)
+        dep_cat_output = _run_command([cl, 'cat', uuid + '/file'])
+        check_contains('This is a simple text file for CodaLab.', dep_cat_output)
 
         # Download the whole bundle.
         path = temp_path('')

--- a/test_cli.py
+++ b/test_cli.py
@@ -18,6 +18,7 @@ Things not tested:
 
 from collections import namedtuple, OrderedDict
 from contextlib import contextmanager
+from codalab.worker.download_util import BundleTarget
 from scripts.create_sample_worksheet import SampleWorksheet
 from scripts.test_util import Colorizer, run_command
 
@@ -1690,9 +1691,9 @@ def test(ctx):
     # Basic getting info and blob contents of a bundle
     path = test_path('a.txt')
     uuid = _run_command([cl, 'upload', path])
-    response = ctx.client.fetch_contents_info((uuid, ''))
+    response = ctx.client.fetch_contents_info(BundleTarget(uuid, ''))
     check_equals(response['name'], uuid)
-    check_equals(open(path, 'rb').read(), ctx.client.fetch_contents_blob((uuid, '/')).read())
+    check_equals(open(path, 'rb').read(), ctx.client.fetch_contents_blob(BundleTarget(uuid, '/')).read())
 
     # Display image - should not crash
     wuuid = _run_command([cl, 'work', '-u'])

--- a/test_cli.py
+++ b/test_cli.py
@@ -1689,9 +1689,9 @@ def test(ctx):
     # Basic getting info and blob contents of a bundle
     path = test_path('a.txt')
     uuid = _run_command([cl, 'upload', path])
-    response = ctx.client.fetch_contents_info(uuid)
+    response = ctx.client.fetch_contents_info((uuid, ''))
     check_equals(response['name'], uuid)
-    check_equals(open(path, 'rb').read(), ctx.client.fetch_contents_blob(uuid, '/').read())
+    check_equals(open(path, 'rb').read(), ctx.client.fetch_contents_blob((uuid, '/')).read())
 
     # Display image - should not crash
     wuuid = _run_command([cl, 'work', '-u'])


### PR DESCRIPTION
## Description
This PR allows accessing a bundle's dependencies via their keys, as if they are local directories within the bundle. This allows doing things like building worksheet tables that aggregate stats from bundles and their dependencies, or downloading dependency files without having to know the dependency bundles themselves.

At a high level, this is made possible by having `get_target_info` -which allows clients to get information about paths requested by users from the server- also return a `resolved_uuid` and a `resolved_path`, basically letting it redirect path requests to other bundles. 

Once a call is made to `get_target_info`, it still attempts to find the path info using the old code paths, but if that fails, makes an extra call to the database to get all the dependencies. It then tries to match the first component of the path on the dependency keys, and if it finds a match, recursively calls itself on that dependency bundle and the rest of the path.

This also allows arbitrary traversals since it's a recursive call, and in the end it resolves to one uuid and one subpath.

I modified the rest of the codebase to consume these `resolved_uuid` and `resolved_path` fields that `get_target_info` returns when making any file-related request, effectively obeying the redirect.

## Testing
The following were manually tested, on top of adding a couple unit tests:
- Frontend file content schemas
- Frontend table schemas (ie json reading)
- `cl cat`
- `cl down <bundle>/<dep>/<path>` downloads `<dep>/<path>`
- `cl down <bundle>` doesn't download `<dep>` by itself
- all read ops while the bundle is still running

## Screenshots

![image](https://user-images.githubusercontent.com/6436274/74496077-772d4700-4e8e-11ea-829b-09f2855bc5fd.png)
