### PR TITLE
547: Test Worksheets (Backend)

### DIFF
--- a/scripts/create-sample-worksheet.py
+++ b/scripts/create-sample-worksheet.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 import random
+import re
 import string
 import time
 
@@ -27,6 +28,21 @@ class SampleWorksheet:
         '_{\\text{train}}}\\text{Loss}(x, y, \mathbf w) \\ \n\min_{\mathbf w \in \mathbb{R}^d} \\text{TrainLoss}(\mathbf w)$$'
     )
 
+    _NAME_REGEX = '[\s\S]{0,100}'
+    _TEXT_REGEX = '[\s\S]{0,1000}'
+
+    _FULL_UUID_REGEX = '0x[a-z0-9]{32}'
+    _PARTIAL_UUID_REGEX = '0x[a-z0-9]{6}'
+    _BUNDLE_STATE_REGEX = (
+        '(uploading|created|staged|making|starting|preparing|running'
+        '|finalizing|ready|failed|killed|worker_offline)'
+    )
+    _PERMISSION_REGEX = '(read|all|none)'
+
+    _SIZE_REGEX = '[0-9.]{0,10}[tkgmb]{0,2}'
+    _IMAGE_REGEX = '\[Image\]'
+    _GRAPH_REGEX = '\[Graph\]'
+
     def __init__(self, cl, args):
         # For simplicity, reference a set number of entities for each section of the small and large worksheet.
         if args.large:
@@ -40,6 +56,10 @@ class SampleWorksheet:
         self._worksheet_name = 'cl_{}_worksheet'.format(self._description)
         self._content = []
 
+        # For testing, _expected_line holds the expected regex pattern for each line of the worksheet
+        self._expected_lines = []
+        self._test_mode = args.test
+
     def create(self):
         print('Creating a {} worksheet...'.format(self._description))
         self._create_dependencies()
@@ -49,10 +69,30 @@ class SampleWorksheet:
         self._add_schemas()
         self._add_display_modes()
         self._add_search()
-        self._add_rendering_logic()
         self._add_invalid_directives()
+        self._add_rendering_logic()
         self._create_sample_worksheet()
+        self._test_worksheet()
         print('Done.')
+
+    def _test_worksheet(self):
+        # Only test the output of the created worksheet if in test mode
+        if not self._test_mode:
+            return
+
+        has_error = False
+        output_lines = run_command([self._cl, 'print', self._worksheet_name]).split('\n')
+        for i in range(len(self._expected_lines)):
+            if not re.match(self._expected_lines[i], output_lines[i]):
+                has_error = True
+                # Output mismatch in red
+                print(
+                    '\033[91mMISMATCH! line: {} pattern: {} output: {}\033[0m'.format(
+                        i + 1, self._expected_lines[i], output_lines[i]
+                    )
+                )
+
+        assert not has_error
 
     def _create_dependencies(self):
         if self._preview_mode:
@@ -117,8 +157,18 @@ class SampleWorksheet:
         print('Deleted file {}.'.format(SampleWorksheet._FILE_NAME))
 
     def _add_introduction(self):
+        self._expected_lines.append(
+            f'### Worksheet: https?:\/\/[a-z\-.\d:]*cl_small_worksheet\({SampleWorksheet._FULL_UUID_REGEX}\)'
+        )
+        self._expected_lines.append('### Title: (Small|Large) Worksheet')
+        self._expected_lines.append(f'### Tags: {SampleWorksheet.TAG}')
+        self._expected_lines.append(f'### Owner: {SampleWorksheet._NAME_REGEX}')
+        self._expected_lines.append(
+            f'### Permissions: public\({SampleWorksheet._PARTIAL_UUID_REGEX}\):{SampleWorksheet._PERMISSION_REGEX}'
+        )
+
         self._add_header('Introduction')
-        self._add_line('This is the **{}** sample worksheet.'.format(self._description))
+        self._add_line('This is the **{}** sample worksheet.'.format(self._description), True)
 
     def _create_tagged_worksheet(self, name, title):
         uuid = run_command([self._cl, 'new', name])
@@ -137,8 +187,11 @@ class SampleWorksheet:
         self._add_header('Bundle References')
         self._add_subheader('Valid Bundle References')
         self._add_bundles(self._valid_bundles)
+        self._add_default_table_pattern(len(self._valid_bundles))
+
         self._add_subheader('Private Bundle References')
         self._add_bundles(self._private_bundles)
+        self._add_default_table_pattern(len(self._private_bundles))
 
     def _add_schemas(self):
         self._add_header('Schemas')
@@ -152,10 +205,18 @@ class SampleWorksheet:
         self._add_line('% add group_permissions')
         self._add_line('% display table valid_schema')
         self._add_bundles(self._valid_bundles)
+        self._add_table_pattern(
+            ['uuid', 'name', 'summary', 'metadata', 'permission', 'group_permissions'],
+            len(self._valid_bundles),
+        )
 
         self._add_description('Attempting to reference private bundles with a valid schema')
         self._add_line('% display table valid_schema')
         self._add_bundles(self._private_bundles)
+        self._add_table_pattern(
+            ['uuid', 'name', 'summary', 'metadata', 'permission', 'group_permissions'],
+            len(self._private_bundles),
+        )
 
         self._add_subheader('Post-Processor Schema')
         self._add_line('% schema post_processor_schema')
@@ -165,6 +226,9 @@ class SampleWorksheet:
         self._add_line('% add uuid uuid "[0:8]"')
         self._add_line('% display table post_processor_schema')
         self._add_bundles(self._valid_bundles)
+        self._add_table_pattern(
+            ['duration', 'time', 'updated', 'size', 'uuid'], len(self._valid_bundles)
+        )
 
         self._add_subheader('Combine Schemas')
         self._add_line('% schema combined_schema')
@@ -172,13 +236,37 @@ class SampleWorksheet:
         self._add_line('% addschema post_processor_schema')
         self._add_line('% display table combined_schema')
         self._add_bundles(self._valid_bundles)
+        self._add_table_pattern(
+            [
+                'uuid',
+                'name',
+                'summary',
+                'metadata',
+                'permission',
+                'group_permissions',
+                'duration',
+                'time',
+                'updated',
+                'size',
+                'uuid',
+            ],
+            len(self._valid_bundles),
+        )
 
         self._add_subheader('Invalid Schemas')
         self._add_description('Attempting to add a field before referencing a schema')
         self._add_line('% add name')
+        self._add_blank_line_pattern()
+        self._expected_lines.append(
+            'Error on line [\d]+: `add` must be preceded by `schema` directive'
+        )
+
         self._add_description('Attempting to add a non-existing schema')
         self._add_line('% schema invalid_schema')
         self._add_line('% addschema nonexistent_schema')
+        self._add_blank_line_pattern()
+        self._expected_lines.append('Unexpected error while parsing line [\d]+')
+
         self._add_description('Attempting to create a schema with invalid functions')
         self._add_line('% schema invalid_functions_schema')
         self._add_line('% add time time duration2')
@@ -186,122 +274,168 @@ class SampleWorksheet:
         self._add_line('% add size data_size size2')
         self._add_line('% display table invalid_functions_schema')
         self._add_bundles(self._valid_bundles)
+        self._add_table_pattern(['time', 'updated', 'size'], 0)
+        for _ in range(len(self._valid_bundles)):
+            self._expected_lines.append(
+                '\s\s<invalid function: duration2>\s\s<invalid function: date2>\s\s<invalid function: size2>'
+            )
 
     def _add_display_modes(self):
         self._add_header('Display Modes')
         self._add_subheader('Table')
         self._add_line('% display table valid_schema')
         self._add_bundles(self._valid_bundles)
+        self._add_table_pattern(
+            ['uuid', 'name', 'summary', 'metadata', 'permission', 'group_permissions'],
+            len(self._valid_bundles),
+        )
 
         self._add_subheader('Image')
         for uuid in self._search_bundles('.png'):
             self._add_line('% display image / width=500')
             self._add_bundle(uuid)
+            self._add_blank_line_pattern()
+            self._expected_lines.append(SampleWorksheet._IMAGE_REGEX)
 
         self._add_subheader('Record')
         self._add_line('% display record valid_schema')
         self._add_bundles(self._valid_bundles)
+        self._add_records_pattern(
+            ['uuid', 'name', 'summary', 'metadata', 'permission', 'group_permissions'],
+            len(self._valid_bundles),
+        )
 
         self._add_subheader('HTML')
         for uuid in self._search_bundles('.html'):
             self._add_line('% display html /')
             self._add_bundle(uuid)
+            self._add_blank_line_pattern()
+            self._expected_lines.append(SampleWorksheet._TEXT_REGEX)
 
         self._add_subheader('Graph')
         for uuid in self._search_bundles('.tsv'):
             self._add_line('% display graph /')
             self._add_bundle(uuid)
+            self._add_blank_line_pattern()
+            self._expected_lines.append(SampleWorksheet._GRAPH_REGEX)
 
     def _add_search(self):
         self._add_header('Search')
         self._add_subheader('Bundle Search')
         self._add_line('% search python run .limit={}'.format(self._entities_count))
+        self._add_default_table_pattern(self._entities_count)
 
         self._add_subheader('Partial UUID Matching')
         self._add_line('% search 0x .limit={}'.format(self._entities_count))
+        self._add_default_table_pattern(self._entities_count)
 
         self._add_subheader('Worksheet Search')
         self._add_line('% wsearch test .limit={}'.format(self._entities_count))
+        self._add_worksheets_pattern(self._entities_count)
 
         self._add_subheader('More Examples')
         self._add_description('Search for total disk usage')
         self._add_line('Total Disk Usage:')
         self._add_line('% search size=.sum .format=size')
+        self._expected_lines.extend(['Total Disk Usage:', SampleWorksheet._SIZE_REGEX])
+
         self._add_description('Search for my bundles')
         self._add_line('% search .mine .limit={}'.format(self._entities_count))
+        self._add_default_table_pattern(self._entities_count)
+
         self._add_description('Search for the largest bundles')
         self._add_line('% search size=.sort- .limit={}'.format(self._entities_count))
+        self._add_default_table_pattern(self._entities_count)
+
         self._add_description('Search for recently failed runs')
         self._add_line('% search state=failed .limit={} id=.sort-'.format(self._entities_count))
+        self._add_default_table_pattern(self._entities_count)
+
         self._add_description('Search for datasets (worksheets with tag "data")')
         self._add_line('% wsearch tag=data id=.sort- .limit={}'.format(self._entities_count))
+        self._add_worksheets_pattern(self._entities_count)
 
         self._add_description('Search for recently created bundles')
         self._add_line('% schema recently_created_schema')
         self._add_line('% add name')
         self._add_line('% add owner owner_name')
         self._add_line('% add created created date')
-        self._add_line('% display table created')
+        self._add_line('% display table recently_created_schema')
         self._add_line('% search created=.sort- .limit={}'.format(self._entities_count))
+        self._add_table_pattern(['name', 'owner', 'created'], self._entities_count)
 
     def _add_invalid_directives(self):
         self._add_header('Invalid Directives')
         self._add_line('% hi')
+        self._add_blank_line_pattern()
+        self._expected_lines.append('Error on line [\d]+: unknown directive `hi`')
         self._add_line('% hello')
+        self._add_blank_line_pattern()
+        self._expected_lines.append('Error on line [\d]+: unknown directive `hello`')
 
     def _add_rendering_logic(self):
         self._add_header('Rendering')
         self._add_subheader('Markdown')
-        self._add_line('\nEmphasis, aka italics, with *asterisks* or _underscores_.')
-        self._add_line('\nStrong emphasis, aka bold, with **asterisks** or __underscores__.')
-        self._add_line('\nCombined emphasis with **asterisks and _underscores_**.')
-        self._add_line('\nStrikethrough uses two tildes. ~~Scratch this.~~')
+        self._add_line('Emphasis, aka italics, with *asterisks* or _underscores_.', True)
+        self._add_line('Strong emphasis, aka bold, with **asterisks** or __underscores__.', True)
+        self._add_line('Combined emphasis with **asterisks and _underscores_**.', True)
+        self._add_line('Strikethrough uses two tildes. ~~Scratch this.~~', True)
 
         self._add_description('Below is an ordered list')
-        self._add_line('1. First item')
-        self._add_line('2. Second item')
+        self._add_line('1. First item', True)
+        self._add_line('2. Second item', True)
+
         self._add_description('Below is an unordered list')
-        self._add_line('* Unordered list can use asterisks')
-        self._add_line('- Or minuses')
-        self._add_line('+ Or pluses')
+        self._add_line('* Unordered list can use asterisks', True)
+        self._add_line('- Or minuses', True)
+        self._add_line('+ Or pluses', True)
 
         self._add_description('Below is a table')
-        self._add_line('| Tables        | Are           | Cool  |')
-        self._add_line('| ------------- |:-------------:| -----:|')
-        self._add_line('| col 3 is      | right-aligned | 1600 |')
-        self._add_line('| col 2 is      | centered      |   12 |')
-        self._add_line('| zebra stripes | are neat      |    1 |')
+        self._add_line('| Tables        | Are           | Cool  |', True)
+        self._add_line('| ------------- |:-------------:| -----:|', True)
+        self._add_line('| col 3 is      | right-aligned | 1600 |', True)
+        self._add_line('| col 2 is      | centered      |   12 |', True)
+        self._add_line('| zebra stripes | are neat      |    1 |', True)
 
         self._add_subheader('Unicode Characters')
-        self._add_line('\nEn-Dash &ndash; &#150;')
-        self._add_line('\nEm-Dash &mdash; &#151;')
-        self._add_line('\nMinus Symbol &minus; &#8722;')
+        self._add_line('En-Dash &ndash; &#150;', True)
+        self._add_line('Em-Dash &mdash; &#151;', True)
+        self._add_line('Minus Symbol &minus; &#8722;', True)
 
         self._add_subheader('Code Block')
-        self._add_line('~~~ Python')
-        self._add_line('def main():')
-        self._add_line('\t# This is some Python code')
-        self._add_line('\tprint("Hello")')
-        self._add_line('~~~')
+        self._add_line('~~~ Python', True)
+        self._add_line('def main():', True)
+        self._add_line('\t# This is some Python code', True)
+        self._add_line('\tprint("Hello")', True)
+        self._add_line('~~~', True)
 
         self._add_subheader('Some Latex and Math')
+        self._add_line('Source: [CS221](http://cs221.stanford.edu/)', True)
         for _ in range(self._entities_count):
             self._add_line(SampleWorksheet._TEX_AND_MATH)
-        self._add_line('\nSource: [CS221](http://cs221.stanford.edu/)')
+            self._expected_lines.append(SampleWorksheet._TEXT_REGEX)
 
     # Helpers
     def _add_header(self, title):
         self._add_line('\n## %s' % title)
+        self._add_blank_line_pattern()
+        self._expected_lines.append('## %s' % re.escape(title))
 
     def _add_subheader(self, title):
         self._add_line('\n#### %s' % title)
+        self._add_blank_line_pattern()
+        self._expected_lines.append('#### %s' % re.escape(title))
 
     def _add_description(self, description):
         self._add_line('\n##### %s' % description)
+        self._add_blank_line_pattern()
+        self._expected_lines.append('##### %s' % re.escape(description))
 
     def _add_worksheets(self, worksheets):
+        self._add_blank_line_pattern()
         for uuid in worksheets:
             self._add_line('{{%s}}' % uuid)
+            self._expected_lines.append(f'\[Worksheet \S*\({SampleWorksheet._FULL_UUID_REGEX}\)\]')
 
     def _add_bundles(self, bundles):
         for uuid in bundles:
@@ -310,8 +444,10 @@ class SampleWorksheet:
     def _add_bundle(self, uuid):
         self._add_line('{%s}' % uuid)
 
-    def _add_line(self, line):
+    def _add_line(self, line, add_pattern=False):
         self._content.append(line)
+        if add_pattern:
+            self._expected_lines.append(re.escape(line))
 
     def _search_bundles(self, query):
         if self._preview_mode:
@@ -328,6 +464,54 @@ class SampleWorksheet:
                 '--uuid-only',
             ]
         ).split('\n')
+
+    def _add_table_pattern(self, headers, row_count):
+        def add_row_pattern(values):
+            self._expected_lines.append('\s\s%s' % '\s*'.join(values))
+
+        self._add_blank_line_pattern()
+        add_row_pattern(headers)
+        self._add_dash_pattern()
+        row_patterns = [self._get_pattern(header) for header in headers]
+        for _ in range(row_count):
+            add_row_pattern(row_patterns)
+
+    def _add_default_table_pattern(self, row_count):
+        self._add_table_pattern(
+            ['uuid\[0:8\]', 'name', 'summary', 'data_size', 'state', 'description'], row_count
+        )
+
+    def _add_records_pattern(self, headers, record_count):
+        def format_record_entity(header):
+            return '\s\s{}:\s*{}'.format(header, self._get_pattern(header))
+
+        for _ in range(record_count):
+            self._add_blank_line_pattern()
+            self._add_dash_pattern()
+            self._expected_lines.extend([format_record_entity(header) for header in headers])
+
+    def _add_worksheets_pattern(self, worksheet_count):
+        self._add_blank_line_pattern()
+        for _ in range(worksheet_count):
+            self._expected_lines.append(f'\[Worksheet \S*\({SampleWorksheet._FULL_UUID_REGEX}\)\]')
+
+    def _add_dash_pattern(self):
+        self._expected_lines.append('\s\s[-]*')
+
+    def _add_blank_line_pattern(self):
+        self._expected_lines.append('')
+
+    def _get_pattern(self, header_type):
+        if 'uuid' in header_type:
+            return SampleWorksheet._PARTIAL_UUID_REGEX
+        elif header_type == 'permission':
+            return SampleWorksheet._PERMISSION_REGEX
+        elif header_type == 'name':
+            return SampleWorksheet._NAME_REGEX
+        elif header_type == 'state':
+            return SampleWorksheet._BUNDLE_STATE_REGEX
+        else:
+            return SampleWorksheet._TEXT_REGEX
 
     def _random_id(self):
         return ''.join(random.choice(string.ascii_lowercase + string.digits) for _ in range(32))
@@ -369,6 +553,11 @@ if __name__ == '__main__':
         '--cleanup',
         action='store_true',
         help='Whether to clean up bundles and worksheets created from previous sample worksheets (defaults to false)',
+    )
+    parser.add_argument(
+        '--test',
+        action='store_true',
+        help='Whether to test the content of sample worksheet after it is created (defaults to false)',
     )
 
     # Parse args and run this script

--- a/scripts/create_sample_worksheet.py
+++ b/scripts/create_sample_worksheet.py
@@ -33,6 +33,7 @@ class SampleWorksheet:
 
     _FULL_UUID_REGEX = '0x[a-z0-9]{32}'
     _PARTIAL_UUID_REGEX = '0x[a-z0-9]{6}'
+    """The list of bundle states is populated from :ref:`codalab.worker.bundle_state`."""
     _BUNDLE_STATE_REGEX = (
         '(uploading|created|staged|making|starting|preparing|running'
         '|finalizing|ready|failed|killed|worker_offline)'
@@ -73,7 +74,7 @@ class SampleWorksheet:
         self._create_sample_worksheet()
         print('Done.')
 
-    def validate_content(self):
+    def test_print(self):
         output_lines = run_command([self._cl, 'print', self._worksheet_name]).split('\n')
         has_error = False
         for i in range(len(self._expected_lines)):
@@ -443,6 +444,8 @@ class SampleWorksheet:
         self._add_line('{%s}' % uuid)
 
     def _add_line(self, line, add_pattern=False):
+        # Add the line to the worksheet. If add_pattern is true, the regex form of the line will also be added
+        # to the list of expected patterns for testing purposes.
         self._content.append(line)
         if add_pattern:
             self._expected_lines.append(re.escape(line))
@@ -527,8 +530,8 @@ def main():
     ws = SampleWorksheet(cl, args.large, args.preview)
     start_time = time.time()
     ws.create()
-    if args.test:
-        ws.validate_content()
+    if args.test_print:
+        ws.test_print()
     duration_seconds = time.time() - start_time
     print("--- Completion Time: {} minutes---".format(duration_seconds / 60))
 
@@ -559,9 +562,9 @@ if __name__ == '__main__':
         help='Whether to clean up bundles and worksheets created from previous sample worksheets (defaults to false)',
     )
     parser.add_argument(
-        '--test',
+        '--test-print',
         action='store_true',
-        help='Whether to test the content of sample worksheet after it is created (defaults to false)',
+        help='Whether to test the content of sample worksheet after it is created by running cl print (defaults to false)',
     )
 
     # Parse args and run this script

--- a/test_cli.py
+++ b/test_cli.py
@@ -1701,10 +1701,10 @@ def test(ctx):
 
 @TestModule.register('worksheets')
 def test(ctx):
-    # Create a comprehensive worksheet and validate its content
+    # Create a comprehensive worksheet and test the output of cl print
     test_worksheet = SampleWorksheet(cl)
     test_worksheet.create()
-    test_worksheet.validate_content()
+    test_worksheet.test_print()
 
 
 if __name__ == '__main__':

--- a/test_cli.py
+++ b/test_cli.py
@@ -1702,7 +1702,7 @@ def test(ctx):
 @TestModule.register('worksheets')
 def test(ctx):
     # Create a comprehensive worksheet and validate its content
-    test_worksheet = SampleWorksheet()
+    test_worksheet = SampleWorksheet(cl)
     test_worksheet.create()
     test_worksheet.validate_content()
 

--- a/test_cli.py
+++ b/test_cli.py
@@ -18,6 +18,7 @@ Things not tested:
 
 from collections import namedtuple, OrderedDict
 from contextlib import contextmanager
+from scripts.create_sample_worksheet import SampleWorksheet
 from scripts.test_util import Colorizer, run_command
 
 import argparse
@@ -1696,6 +1697,14 @@ def test(ctx):
     _run_command([cl, 'add', 'bundle', uuid])
     response = ctx.client.fetch_interpreted_worksheet(wuuid)
     check_equals(response['uuid'], wuuid)
+
+
+@TestModule.register('worksheets')
+def test(ctx):
+    # Create a comprehensive worksheet and validate its content
+    test_worksheet = SampleWorksheet()
+    test_worksheet.create()
+    test_worksheet.validate_content()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #547 

- Use regex to validate the output of `cl print` for the sample worksheet
- Hook it up to `test_cli`

I had to modify some of the example search criteria in order to not add any new dependencies (e.g. search for `ready` runs instead of `failed` runs).