### PR TITLE
Uncheck bundles when click on edit source

### DIFF
--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -863,8 +863,14 @@ class Worksheet extends React.Component {
             }
         } else {
             // Go into edit mode.
-            this.setState({ editMode: editMode }); // Needs to be before focusing
-            $('#worksheet-editor').focus();
+            this.setState({
+                editMode: editMode,
+                uuidBundlesCheckedCount: {},
+                checkedBundles: {},
+                showBundleOperationButtons: false,
+                updating: false,
+            });
+            $('#worksheet-editor').focus(); // Needs to be before focusing
         }
     }
 


### PR DESCRIPTION
Currently if we select bundles and click edit source, the header will stay in bundle operation mode, but if we save/discard, the checked bundles are gone (rerendered), so need to uncheck when clicking