### PR TITLE
Upgrade package version due to Travis CI changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,9 @@ jobs:
       install: pip install --upgrade black==18.9b0
       script: black . --check --diff
     - stage: check
-      language: javascript
+      language: node_js
+      node_js:
+        - 13
       install: cd frontend && npm install
       script:
         - npm run check-ci

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -46,6 +46,7 @@
   "devDependencies": {
     "flow-bin": "^0.91.0",
     "prettier": "^1.19.1",
+    "eslint": "^6.8.0",
     "react-scripts": "^3.2.0"
   },
   "browserslist": [


### PR DESCRIPTION
Fixed #2005 

Not sure if this is the best way to fix the front end Travis CI failure. `node` version seems to be outdated in the Travis CI build. Updating the `node` version and installing the required package seems to help the build to pass. It's unclear to me why the steps of Travis CI are suddenly different than before. If anyone has any ideas, please advise. 