### PR TITLE
Do not upload results for killed bundles

### DIFF
--- a/codalab/worker/worker_run_state.py
+++ b/codalab/worker/worker_run_state.py
@@ -449,7 +449,7 @@ class RunStateMachine(StateTransitioner):
             except Exception:
                 logger.error(traceback.format_exc())
 
-        if not self.shared_file_system and run_state.has_contents:
+        if not self.shared_file_system and run_state.has_contents and not run_state.is_killed:
             # No need to upload results since results are directly written to bundle store
             return run_state._replace(
                 stage=RunStage.UPLOADING_RESULTS, run_status='Uploading results', container=None

--- a/codalab/worker/worker_run_state.py
+++ b/codalab/worker/worker_run_state.py
@@ -449,7 +449,12 @@ class RunStateMachine(StateTransitioner):
             except Exception:
                 logger.error(traceback.format_exc())
 
-        if not self.shared_file_system and run_state.has_contents and not run_state.is_killed:
+        if (
+            not self.shared_file_system
+            and run_state.has_contents
+            and not run_state.is_killed
+            and not run_state.failure_message
+        ):
             # No need to upload results since results are directly written to bundle store
             return run_state._replace(
                 stage=RunStage.UPLOADING_RESULTS, run_status='Uploading results', container=None

--- a/codalab/worker/worker_run_state.py
+++ b/codalab/worker/worker_run_state.py
@@ -449,12 +449,7 @@ class RunStateMachine(StateTransitioner):
             except Exception:
                 logger.error(traceback.format_exc())
 
-        if (
-            not self.shared_file_system
-            and run_state.has_contents
-            and not run_state.is_killed
-            and not run_state.failure_message
-        ):
+        if not self.shared_file_system and run_state.has_contents and not run_state.is_killed:
             # No need to upload results since results are directly written to bundle store
             return run_state._replace(
                 stage=RunStage.UPLOADING_RESULTS, run_status='Uploading results', container=None


### PR DESCRIPTION
Fixed #1135.

This PR will fix the first issue in #1135: When a bundle goes over its disk quota, it is killed by the worker when that is caught, but the worker still uploads all the results, making the disk quota effectively useless. 

When uploading the results, we might need to check `run_state` to see if the bundle status is killed or it has any failures. If there is a failure, we won't upload the results. 