### PR TITLE
Remove uninformative NaNyNaNd in bundle view

### DIFF
--- a/frontend/src/util/worksheet_utils.js
+++ b/frontend/src/util/worksheet_utils.js
@@ -7,7 +7,7 @@ export function renderDuration(s) {
     // s: number of seconds
     // Return a human-readable string.
     // Example: 100 => "1m40s", 10000 => "2h46m"
-    if (s === null) {
+    if (s == null) {
         return '<none>';
     }
 


### PR DESCRIPTION
Fixed #2036 

This PR is to fix the displaying issue for the **time** row in the **bundle view** page.
Currently, when a bundle is in the staged state, it has the following bundle view page (**time=NaNyNaNd** ):
<img width="1167" alt="Screen Shot 2020-02-25 at 3 21 35 PM" src="https://user-images.githubusercontent.com/1483372/75297048-b7bc8700-57e3-11ea-838d-b0efa655ecb7.png">

After the fix, its bundle view page becomes:
<img width="1184" alt="Screen Shot 2020-02-25 at 3 22 00 PM" src="https://user-images.githubusercontent.com/1483372/75296985-9491d780-57e3-11ea-99a3-0cf694b41cee.png">

Not sure if this is the best way to fix it. If not, please let me know.