### PR TITLE
Fix CPU assignment issue

### DIFF
--- a/codalab/worker/worker.py
+++ b/codalab/worker/worker.py
@@ -317,7 +317,7 @@ class Worker:
 
         Throws an exception if unsuccessful.
         """
-        cpuset, gpuset = set(self.cpuset), set(self.gpuset)
+        cpuset, gpuset = set(map(str, self.cpuset)), set(map(str, self.gpuset))
 
         for run_state in self.runs.values():
             if run_state.stage == RunStage.RUNNING:


### PR DESCRIPTION
Partially fixed  #1911.

This is to fix the CPU assignment issue: 
Currently, `self.cpuset` and `self.gpuset` are defined as a set of integers. However, when the program assigns CPUs and GPUs to start a container, it uses `string` in the returning cpuset and gpuset value (see the logic in [propose_set()](https://github.com/codalab/codalab-worksheets/blob/master/codalab/worker/worker.py#L338-L339)). Then there is a data type mismatch when we calculating the available CPUs/GPUs to use (see the logic in [resource deduction](https://github.com/codalab/codalab-worksheets/blob/master/codalab/worker/worker.py#L322-L325)). Since the assigned CPUs/GPUs never appears in the original `self.cpuset` and `self.gpuset`, when there are a list of bundles request for `1` CPU, CPU `0` will always be assigned to all of those bundles and the rest of the logic won't be exercised. 