### PR TITLE
Set user id vars of BundleModel properly

### DIFF
--- a/codalab/lib/codalab_manager.py
+++ b/codalab/lib/codalab_manager.py
@@ -340,11 +340,11 @@ class CodaLabManager(object):
             model = MySQLModel(
                 engine_url=self.config['server']['engine_url'],
                 default_user_info=self.default_user_info(),
+                root_user_id=self.root_user_id(),
+                system_user_id=self.system_user_id(),
             )
         else:
             raise UsageError('Unexpected model class: %s, expected MySQLModel' % (model_class,))
-        model.root_user_id = self.root_user_id()
-        model.system_user_id = self.system_user_id()
         return model
 
     @cached

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -68,12 +68,14 @@ def str_key_dict(row):
 
 
 class BundleModel(object):
-    def __init__(self, engine, default_user_info):
+    def __init__(self, engine, default_user_info, root_user_id, system_user_id):
         """
         Initialize a BundleModel with the given SQLAlchemy engine.
         """
         self.engine = engine
         self.default_user_info = default_user_info
+        self.root_user_id = root_user_id
+        self.system_user_id = system_user_id
         self.public_group_uuid = ''
         self.create_tables()
 

--- a/codalab/model/mysql_model.py
+++ b/codalab/model/mysql_model.py
@@ -38,7 +38,7 @@ def ping_connection(dbapi_connection, connection_record, connection_proxy):
 
 
 class MySQLModel(BundleModel):
-    def __init__(self, engine_url, default_user_info):
+    def __init__(self, engine_url, default_user_info, root_user_id, system_user_id):
         if not engine_url.startswith('mysql://'):
             raise UsageError('Engine URL should start with mysql://')
         engine = create_engine(
@@ -49,7 +49,7 @@ class MySQLModel(BundleModel):
             pool_recycle=3600,
             encoding='utf-8',
         )
-        super(MySQLModel, self).__init__(engine, default_user_info)
+        super(MySQLModel, self).__init__(engine, default_user_info, root_user_id, system_user_id)
 
     def do_multirow_insert(self, connection, table, values):
         # MySQL allows for more efficient multi-row insertions.


### PR DESCRIPTION
Before this instead of passing the `root_user_id` and `system_user_id`
properties properly through the constructor to `MySQLModel` and
`BundleModel`, we were setting these variables from outside. This is a
pretty bad code smell, makes it impossible to track where those values
come from and kept tripping up my Python linters as they screamed "Class
`BundleModel` has no variable `root_user_id`"