### PR TITLE
Fix bundle manager bug for bad queue argument

### DIFF
--- a/codalab/server/bundle_manager.py
+++ b/codalab/server/bundle_manager.py
@@ -694,7 +694,8 @@ class BundleManager(object):
         if tagm != None:
             worker_tag = tagm.group(1)
             matched_workers = [worker for worker in workers if worker['tag'] == worker_tag]
-        return matched_workers or []
+            return matched_workers
+        return []
 
     def _get_staged_bundles_to_run(self, workers, user_info_cache):
         """

--- a/codalab/server/bundle_manager.py
+++ b/codalab/server/bundle_manager.py
@@ -690,11 +690,9 @@ class BundleManager(object):
         :param workers: a list of workers
         :return: a list of matched workers
         """
-        tagm = re.match('tag=(.+)', request_queue)
+        tag_match = re.match('tag=(.+)', request_queue)
         if tagm != None:
-            worker_tag = tagm.group(1)
-            matched_workers = [worker for worker in workers if worker['tag'] == worker_tag]
-            return matched_workers
+            return [worker for worker in workers if worker['tag'] == tag_match.group(1)]
         return []
 
     def _get_staged_bundles_to_run(self, workers, user_info_cache):

--- a/codalab/server/bundle_manager.py
+++ b/codalab/server/bundle_manager.py
@@ -691,7 +691,7 @@ class BundleManager(object):
         :return: a list of matched workers
         """
         tag_match = re.match('tag=(.+)', request_queue)
-        if tagm != None:
+        if tag_match != None:
             return [worker for worker in workers if worker['tag'] == tag_match.group(1)]
         return []
 


### PR DESCRIPTION
Small reference bug. If there's a run where `request_queue` is set but
the value is not `tag=<something>` the current code hits a buggy path.

This is a hotfix, but I think the whole `request_queue` semantics need
an update. As things as are `request_queue` can ONLY be used with
`--request_queue tag=<something>` and causes bugs if specified in any
other shape.
