### PR TITLE
Fix worker default cpu count to reflect SLURM limits.

### DIFF
--- a/codalab/worker/main.py
+++ b/codalab/worker/main.py
@@ -11,7 +11,6 @@ import signal
 import socket
 import stat
 import sys
-import multiprocessing
 
 
 from codalab.lib.formatting import parse_size
@@ -229,7 +228,7 @@ def parse_cpuset_args(arg):
     Arguments:
         arg: comma separated string of ints, or "ALL" representing all available cpus
     """
-    cpu_count = multiprocessing.cpu_count()
+    cpu_count = len(os.sched_getaffinity(0))
     if arg == 'ALL':
         cpuset = list(range(cpu_count))
     else:

--- a/codalab/worker/main.py
+++ b/codalab/worker/main.py
@@ -11,6 +11,7 @@ import signal
 import socket
 import stat
 import sys
+import multiprocessing
 
 
 from codalab.lib.formatting import parse_size
@@ -228,7 +229,14 @@ def parse_cpuset_args(arg):
     Arguments:
         arg: comma separated string of ints, or "ALL" representing all available cpus
     """
-    cpu_count = len(os.sched_getaffinity(0))
+    try:
+        # Get number of cores that the process can actually use.
+        cpu_count = len(os.sched_getaffinity(0))
+    except AttributeError:
+        # os.sched_getaffinity() isn't available on all platforms,
+        # so fallback to using the number of physical cores.
+        cpu_count = multiprocessing.cpu_count()
+
     if arg == 'ALL':
         cpuset = list(range(cpu_count))
     else:


### PR DESCRIPTION
I've noticed that sometimes, when running codalab workers on the Slurm cluster with a certain number of CPUs requested (say, 10), jobs that require more than 10 cpus in aggregate can land on that worker (e.g., 3 jobs that require 4 cpus each). I think this is related to https://github.com/codalab/codalab-worksheets/issues/1045

Consider the following illustrative example:

```
(base) nfliu at sc in ~
$ nlprun -g 0 -c 8 -p jag-hi -p john
starting interactive session with this command:

srun --cpus-per-task=8 --gres=gpu:0 --job-name=nfliu-job-4605976 --mem=16G --open-mode=append --partition=john --time=10-0 --pty bash
(base) nfliu at john10 in ~
$ nproc
8
(base) nfliu at john10 in ~
$ python -c "import multiprocessing; print(multiprocessing.cpu_count())"
32
(base) nfliu at john10 in ~
$ python -c "import os; print(len(os.sched_getaffinity(0)))"
8
```

So, we start a Slurm job and request 8 CPUs. We land on a host that has 32 physical cpus. `nproc` confirms that we have 8 cpus at our disposal. python's `multiprocessing.cpu_count()` returns that we have 32 CPUs, because it's counting *physical* processors (rather than cpus we can actually use). Instead, we want to be using `len(os.sched_getaffinity(0))`, which correctly returns 8. This is because `len(os.sched_getaffinity(0))` correctly obeys the `sched_setaffinity` Linux system call, which is what Slurm uses to limit the CPUs a process can use. 

So, seems reasonable to use `len(os.sched_getaffinity(0))` by default in the absence of a cpuset.