### PR TITLE
Ensure data type of urllib.error.HTTPError response to be string

### DIFF
--- a/codalab/client/json_api_client.py
+++ b/codalab/client/json_api_client.py
@@ -4,7 +4,7 @@ import sys
 import six
 import urllib.request, urllib.parse, urllib.error
 
-from codalab.common import http_error_to_exception, precondition, UsageError
+from codalab.common import http_error_to_exception, precondition, ensure_str, UsageError
 from codalab.worker.rest_client import RestClient, RestClientException
 from codalab.worker.download_util import BundleTarget
 
@@ -16,7 +16,7 @@ def wrap_exception(message):
                 return f(*args, **kwargs)
             except urllib.error.HTTPError as e:
                 # Translate known errors to the standard CodaLab errors
-                error_body = e.read()
+                error_body = ensure_str(e.read())
                 exc = http_error_to_exception(e.code, error_body)
                 # All standard CodaLab errors are subclasses of UsageError
                 if isinstance(exc, UsageError):

--- a/codalab/common.py
+++ b/codalab/common.py
@@ -9,6 +9,7 @@ import http.client
 # Increment this on master when ready to cut a release.
 # http://semver.org/
 CODALAB_VERSION = '0.5.9'
+BINARY_PLACEHOLDER = '<binary>'
 
 
 class IntegrityError(ValueError):
@@ -93,3 +94,17 @@ def http_error_to_exception(code, message):
 def precondition(condition, message):
     if not condition:
         raise PreconditionViolation(message)
+
+
+def ensure_str(response):
+    """
+    Ensure the data type of input response to be string
+    :param response: a response in bytes or string
+    :return: the input response in string
+    """
+    if isinstance(response, str):
+        return response
+    try:
+        return response.decode()
+    except UnicodeDecodeError:
+        return BINARY_PLACEHOLDER

--- a/codalab/worker/bundle_service_client.py
+++ b/codalab/worker/bundle_service_client.py
@@ -8,7 +8,8 @@ import time
 import urllib.request, urllib.parse, urllib.error
 
 from .rest_client import RestClient, RestClientException
-from .file_util import tar_gzip_directory, BINARY_PLACEHOLDER
+from .file_util import tar_gzip_directory
+from codalab.common import ensure_str
 
 
 def wrap_exception(message):
@@ -42,20 +43,6 @@ def wrap_exception(message):
         return wrapper
 
     return decorator
-
-
-def ensure_str(response):
-    """
-    Ensure the data type of input response to be string
-    :param response: a response in bytes or string
-    :return: the input response in string
-    """
-    if isinstance(response, str):
-        return response
-    try:
-        return response.decode()
-    except UnicodeDecodeError:
-        return BINARY_PLACEHOLDER
 
 
 class BundleAuthException(RestClientException):

--- a/codalab/worker/file_util.py
+++ b/codalab/worker/file_util.py
@@ -8,7 +8,8 @@ import tarfile
 import zlib
 import bz2
 
-BINARY_PLACEHOLDER = '<binary>'
+from codalab.common import BINARY_PLACEHOLDER
+
 NONE_PLACEHOLDER = '<none>'
 GIT_PATTERN = '.git'
 

--- a/docker/dockerfiles/Dockerfile.worker
+++ b/docker/dockerfiles/Dockerfile.worker
@@ -37,6 +37,7 @@ RUN python3.6 -m pip install --user --upgrade pip; \
 # Install code
 COPY codalab/lib codalab/lib
 COPY codalab/worker codalab/worker
+COPY codalab/common.py codalab/common.py
 COPY setup.py setup.py
 
 RUN python3 -m pip install -e .


### PR DESCRIPTION
Fixed #2058

urllib.error.HTTPError response type could be string or bytes in [json_api_client.py](https://github.com/codalab/codalab-worksheets/blob/master/codalab/client/json_api_client.py#L19)