### PR TITLE
2067: Skip creating a sample worksheet if one already exists

### DIFF
--- a/scripts/create_sample_worksheet.py
+++ b/scripts/create_sample_worksheet.py
@@ -61,6 +61,18 @@ class SampleWorksheet:
         self._expected_lines = []
 
     def create(self):
+        # Skip creating a sample worksheet if one already exists
+        worksheet_uuids = run_command(
+            [self._cl, 'wsearch', self._worksheet_name, '--uuid-only']
+        ).split('\n')
+        if re.match(SampleWorksheet._FULL_UUID_REGEX, worksheet_uuids[0]):
+            print(
+                'There is already an existing {} with UUID {}. Skipping creating a sample worksheet...'.format(
+                    self._worksheet_name, worksheet_uuids[0]
+                )
+            )
+            return
+
         print('Creating a {} worksheet...'.format(self._description))
         self._create_dependencies()
         self._add_introduction()


### PR DESCRIPTION
Resolves #2067 

Since we are using the same sample worksheet for both front end and back end tests (CLI tests), we should bypass creating a sample worksheet if one already exists on an instance. 

If `--test` option is passed in when running `create_sample_worksheet.py` and the sample worksheet already exists, then the script will test against the output of the existing sample worksheet.