### PR TITLE
Revert "Tag public workers"

### DIFF
--- a/codalab/server/bundle_manager.py
+++ b/codalab/server/bundle_manager.py
@@ -313,17 +313,14 @@ class BundleManager(object):
 
     def _schedule_run_bundles_on_workers(self, workers, staged_bundles_to_run, user_info_cache):
         """
-        Schedule STAGED bundles to run on available workers based on the following logic:
-        1. If the bundle requests to run on a specific worker, tries to schedule the bundle
-           to run on a worker that has a tag exactly match with request_queue.
-        2. If the bundle doesn't request to run on a specific worker,
-          (1) try to schedule the bundle to run on a worker that belongs to the bundle's owner
-          (2) if there is no such qualified private worker, uses CodaLab-owned workers, which have user ID root_user_id.
+        Schedules STAGED bundles to run on the given workers. Always tries to schedule bundles to
+        run on workers that are owned by the owner of each bundle first. If there are no such qualified
+        private workers, uses CodaLab-owned workers, which have user ID root_user_id.
         :param workers: a WorkerInfoAccessor object containing worker related information e.g. running uuid.
         :param staged_bundles_to_run: a list of tuples each contains a valid bundle and its bundle resources.
         :param user_info_cache: a dictionary mapping user id to user information.
         """
-        # Reorder the stage_bundles so that bundles which were requested to run on a specific worker
+        # Reorder the stage_bundles so that bundles which were requested to run on a personal worker
         # will be scheduled to run first
         staged_bundles_to_run.sort(
             key=lambda b: (b[0].metadata.request_queue is not None, b[0].metadata.request_queue),
@@ -335,21 +332,37 @@ class BundleManager(object):
 
         # Dispatch bundles
         for bundle, bundle_resources in staged_bundles_to_run:
-            # Check if there is enough parallel run quota left for this user
-            if (
-                self._model.get_user_parallel_run_quota_left(
-                    bundle.owner_id, user_info_cache[bundle.owner_id]
-                )
-                <= 0
-            ):
-                # Don't include CodaLab-owned workers, as there is no parallel_run_quota left for this user.
-                codalab_owned_workers = []
-            else:
-                codalab_owned_workers = workers.user_owned_workers(self._model.root_user_id)
-            user_owned_workers = workers.user_owned_workers(bundle.owner_id)
-            workers_list = user_owned_workers + codalab_owned_workers
-            workers_list = self._deduct_worker_resources(workers_list, running_bundles_info)
-            workers_list = self._filter_and_sort_workers(workers_list, bundle, bundle_resources)
+
+            def get_available_workers(user_id):
+                # Make a deepcopy of the workers list so the filtering and deducting don't modify the list
+                workers_list = copy.deepcopy(workers.user_owned_workers(user_id))
+                workers_list = self._deduct_worker_resources(workers_list, running_bundles_info)
+                workers_list = self._filter_and_sort_workers(workers_list, bundle, bundle_resources)
+                return workers_list
+
+            workers_list = None
+            if bundle.owner_id != self._model.root_user_id:
+                # First try private workers
+                workers_list = get_available_workers(bundle.owner_id)
+                # If there is no user_owned worker, try to schedule the current bundle to run on a CodaLab's public worker.
+                if len(workers_list) == 0:
+                    # Check if there is enough parallel run quota left for this user
+                    if (
+                        self._model.get_user_parallel_run_quota_left(
+                            bundle.owner_id, user_info_cache[bundle.owner_id]
+                        )
+                        <= 0
+                    ):
+                        logger.info(
+                            "User %s has no parallel run quota left, skipping job for now",
+                            bundle.owner_id,
+                        )
+                        # Don't start this bundle yet, as there is no parallel_run_quota left for this user.
+                        continue
+            if not workers_list:
+                # Length is 0 (private user with no workers) or is None (root user)
+                workers_list = get_available_workers(self._model.root_user_id)
+
             # Try starting bundles on the workers that have enough computing resources
             for worker in workers_list:
                 if self._try_start_bundle(workers, worker, bundle, bundle_resources):
@@ -357,9 +370,8 @@ class BundleManager(object):
 
     def _deduct_worker_resources(self, workers_list, running_bundles_info):
         """
-        From each worker, subtract resources used by running bundles.
+        From each worker, subtract resources used by running bundles. Modifies the list.
         """
-        workers_list = copy.deepcopy(workers_list)
         for worker in workers_list:
             for uuid in worker['run_uuids']:
                 # Verify if the current bundle exists in both the worker table and the bundle table
@@ -386,8 +398,9 @@ class BundleManager(object):
         the list sorted in order of preference for running the bundle.
         """
         # Filter by tag.
-        if bundle.metadata.request_queue:
-            workers_list = self._get_matched_workers(bundle.metadata.request_queue, workers_list)
+        request_queue = bundle.metadata.request_queue
+        if request_queue:
+            workers_list = self._get_matched_workers(request_queue, workers_list)
 
         # Filter by CPUs.
         workers_list = [


### PR DESCRIPTION
Reverts codalab/codalab-worksheets#2031

It caused the worksheets test to fail:

```
process: 
process: >> cl wedit --file=/tmp/sample-worksheet-temp.txt
process:  (exit code 0, expected 0)
process: 
process: Saved worksheet items for cl_small_worksheet(0x236950cb23394dce84fa4bd902702388).
process: 
process: Deleted worksheet file at /tmp/sample-worksheet-temp.txt.
process: Done.
process: >> cl print cl_small_worksheet
process:  (exit code 0, expected 0)
process: 
process: ### Worksheet: http://rest-server:2900::cl_small_worksheet(0x236950cb23394dce84fa4bd902702388)
process: ### Title: Small Worksheet
process: ### Tags: codalab-sample-worksheet
process: ### Owner: codalab(0)
process: ### Permissions: public(0x2219f5):read
process: 
process: ## Introduction
process: This is the **small** sample worksheet.
process: 
process: ## Worksheet References
process: 
process: #### Valid Worksheet References
process: 
process: [Worksheet valid_worksheet_rv3musbk48c7nmepp86jme3wd3qkbcnf(0xd749da36d93c4a7eb51973fa4f003bc8)]
process: [Worksheet valid_worksheet_qb44agj5b4uzcbwpvhnkjmprljoo73et(0xd297d1e644384d4a8b54ceb96c66a44e)]
process: [Worksheet valid_worksheet_vmaxje4sljq08oe0v1xfaz0vlcc0cydi(0xf670f25369934164ab175b25fe1e28f4)]
process: 
process: #### Private Worksheet References
process: 
process: [Worksheet valid_private_worksheet_rv3musbk48c7nmepp86jme3wd3qkbcnf(0xf1e9abb3842346dca2d7733d9f6c5883)]
process: [Worksheet valid_private_worksheet_qb44agj5b4uzcbwpvhnkjmprljoo73et(0x671abfbf65a7457694d4b34647401a4d)]
process: [Worksheet valid_private_worksheet_vmaxje4sljq08oe0v1xfaz0vlcc0cydi(0x3203881635ee4a5a873c45384f49a0c0)]
process: 
process: ## Bundle References
process: 
process: #### Valid Bundle Referen (...more...)
process: MISMATCH! line: 180 pattern: \s\s0x[a-z0-9]{6}\s*[\s\S]{0,100}\s*[\s\S]{0,1000}\s*[\s\S]{0,1000}\s*(uploading|created|staged|making|starting|preparing|running|finalizing|ready|failed|killed|worker_offline)\s*[\s\S]{0,1000} output: 
process: MISMATCH! line: 182 pattern: ##### Search\ for\ recently\ ready\ runs output: 
process: MISMATCH! line: 184 pattern: \s\suuid\[0:8\]\s*name\s*summary\s*data_size\s*state\s*description output:   -------------------------------------------------------------------------
process: MISMATCH! line: 187 pattern: \s\s0x[a-z0-9]{6}\s*[\s\S]{0,100}\s*[\s\S]{0,1000}\s*[\s\S]{0,1000}\s*(uploading|created|staged|making|starting|preparing|running|finalizing|ready|failed|killed|worker_offline)\s*[\s\S]{0,1000} output: 
process: MISMATCH! line: 188 pattern: \s\s0x[a-z0-9]{6}\s*[\s\S]{0,100}\s*[\s\S]{0,1000}\s*[\s\S]{0,1000}\s*(uploading|created|staged|making|starting|preparing|running|finalizing|ready|failed|killed|worker_offline)\s*[\s\S]{0,1000} output: ##### Search for worksheets (tag: codalab-sample-worksheet)
process: MISMATCH! line: 190 pattern: ##### Search\ for\ worksheets\ \(tag\:\ codalab\-sample\-worksheet\) output: [Worksheet cl_small_worksheet(0x236950cb23394dce84fa4bd902702388)]
process: MISMATCH! line: 193 pattern: \[Worksheet \S*\(0x[a-z0-9]{32}\)\] output: 
process: MISMATCH! line: 194 pattern: \[Worksheet \S*\(0x[a-z0-9]{32}\)\] output: ##### Search for recently created bundles
process: MISMATCH! line: 196 pattern: ##### Search\ for\ recently\ created\ bundles output:   name      owner  created            
process: MISMATCH! line: 198 pattern: \s\sname\s*owner\s*created output:   run-echo         2020-03-13 18:43:17
process: MISMATCH! line: 201 pattern: \s\s[\s\S]{0,100}\s*[\s\S]{0,1000}\s*[\s\S]{0,1000} output: 
process: MISMATCH! line: 202 pattern: \s\s[\s\S]{0,100}\s*[\s\S]{0,1000}\s*[\s\S]{0,1000} output: ## Invalid Directives
process: MISMATCH! line: 204 pattern: ## Invalid\ Directives output: Error in source line 161: unknown directive `hi`
process: MISMATCH! line: 206 pattern: Error in source line [\d]+: unknown directive `hi` output: Error in source line 162: unknown directive `hello`
process: MISMATCH! line: 208 pattern: Error in source line [\d]+: unknown directive `hello` output: ## Rendering
process: MISMATCH! line: 210 pattern: ## Rendering output: #### Markdown
process: MISMATCH! line: 212 pattern: #### Markdown output: Strong emphasis, aka bold, with **asterisks** or __underscores__.
process: MISMATCH! line: 213 pattern: Emphasis\,\ aka\ italics\,\ with\ \*asterisks\*\ or\ _underscores_\. output: Combined emphasis with **asterisks and _underscores_**.
process: MISMATCH! line: 214 pattern: Strong\ emphasis\,\ aka\ bold\,\ with\ \*\*asterisks\*\*\ or\ __underscores__\. output: Strikethrough uses two tildes. ~~Scratch this.~~
process: MISMATCH! line: 215 pattern: Combined\ emphasis\ with\ \*\*asterisks\ and\ _underscores_\*\*\. output: 
process: MISMATCH! line: 216 pattern: Strikethrough\ uses\ two\ tildes\.\ \~\~Scratch\ this\.\~\~ output: ##### Below is an ordered list
process: MISMATCH! line: 218 pattern: ##### Below\ is\ an\ ordered\ list output: 2. Second item
process: MISMATCH! line: 219 pattern: 1\.\ First\ item output: 
process: MISMATCH! line: 220 pattern: 2\.\ Second\ item output: ##### Below is an unordered list
process: MISMATCH! line: 222 pattern: ##### Below\ is\ an\ unordered\ list output: - Or minuses
process: MISMATCH! line: 223 pattern: \*\ Unordered\ list\ can\ use\ asterisks output: + Or pluses
process: MISMATCH! line: 224 pattern: \-\ Or\ minuses output: 
process: MISMATCH! line: 225 pattern: \+\ Or\ pluses output: ##### Below is a table
process: MISMATCH! line: 227 pattern: ##### Below\ is\ a\ table output: | ------------- |:-------------:| -----:|
process: MISMATCH! line: 228 pattern: \|\ Tables\ \ \ \ \ \ \ \ \|\ Are\ \ \ \ \ \ \ \ \ \ \ \|\ Cool\ \ \| output: | col 3 is      | right-aligned | 1600 |
process: MISMATCH! line: 229 pattern: \|\ \-\-\-\-\-\-\-\-\-\-\-\-\-\ \|\:\-\-\-\-\-\-\-\-\-\-\-\-\-\:\|\ \-\-\-\-\-\:\| output: | col 2 is      | centered      |   12 |
process: MISMATCH! line: 230 pattern: \|\ col\ 3\ is\ \ \ \ \ \ \|\ right\-aligned\ \|\ 1600\ \| output: | zebra stripes | are neat      |    1 |
process: MISMATCH! line: 231 pattern: \|\ col\ 2\ is\ \ \ \ \ \ \|\ centered\ \ \ \ \ \ \|\ \ \ 12\ \| output: 
process: MISMATCH! line: 232 pattern: \|\ zebra\ stripes\ \|\ are\ neat\ \ \ \ \ \ \|\ \ \ \ 1\ \| output: #### Unicode Characters
process: MISMATCH! line: 234 pattern: #### Unicode\ Characters output: Em-Dash &mdash; &#151;
process: MISMATCH! line: 235 pattern: En\-Dash\ \&ndash\;\ \&\#150\; output: Minus Symbol &minus; &#8722;
process: MISMATCH! line: 236 pattern: Em\-Dash\ \&mdash\;\ \&\#151\; output: 
process: MISMATCH! line: 237 pattern: Minus\ Symbol\ \&minus\;\ \&\#8722\; output: #### Code Block
process: MISMATCH! line: 239 pattern: #### Code\ Block output: def main():
process: MISMATCH! line: 240 pattern: \~\~\~\ Python output: 	# This is some Python code
process: MISMATCH! line: 241 pattern: def\ main\(\)\: output: 	print("Hello")
process: MISMATCH! line: 242 pattern: \	\#\ This\ is\ some\ Python\ code output: ~~~
process: MISMATCH! line: 243 pattern: \	print\(\"Hello\"\) output: 
process: MISMATCH! line: 244 pattern: \~\~\~ output: #### Some Latex and Math
process: MISMATCH! line: 246 pattern: #### Some\ Latex\ and\ Math output: The loss minimization framework is to cast learning as an optimization problem. We are estimating (fitting or learning) $\mathbf w$ using $ \mathcal{D}_\text{train}$. A loss function $ \text{Loss}(x, y, \mathbf w) $ quantifies how unhappy you would be if you used $\mathbf w$ to make a prediction on $x$ when the correct output is $y$. This is the object we want to minimize. Below is minimizing training loss across all training examples. Note that $ \text{TrainLoss}(\mathbf w) $ is just the average of loss for all training examples.
process: MISMATCH! line: 247 pattern: Source\:\ \[CS221\]\(http\:\/\/cs221\.stanford\.edu\/\) output: 
process: [!] ERROR: 
```