### PR TITLE
move cpu and gpu resource check to the beginning of _transition_from_…

### DIFF
--- a/codalab/worker/bundle_state.py
+++ b/codalab/worker/bundle_state.py
@@ -76,8 +76,8 @@ class BundleInfo(object):
         self.is_anonymous = is_anonymous
         self.metadata = metadata
         self.args = args
-        self.dependencies = [
-            Dependency(
+        self.dependencies = {
+            DependencyKey(dep["parent_uuid"], dep["parent_path"]): Dependency(
                 parent_name=dep["parent_name"],
                 parent_path=dep["parent_path"],
                 parent_uuid=dep["parent_uuid"],
@@ -86,14 +86,13 @@ class BundleInfo(object):
                 location=dep.get("location", None),
             )
             for dep in dependencies
-        ]  # type: List[Dependency]
-
+        }  # type: Dict[DependencyKey, Dependency]
         self.location = location  # set if local filesystem
 
     @property
     def as_dict(self):
         dct = generic_to_dict(self)
-        dct['dependencies'] = [generic_to_dict(d) for d in dct['dependencies']]
+        dct['dependencies'] = [v for k, v in dct['dependencies'].items()]
         return dct
 
     def __str__(self):

--- a/codalab/worker/bundle_state.py
+++ b/codalab/worker/bundle_state.py
@@ -76,8 +76,8 @@ class BundleInfo(object):
         self.is_anonymous = is_anonymous
         self.metadata = metadata
         self.args = args
-        self.dependencies = {
-            DependencyKey(dep["parent_uuid"], dep["parent_path"]): Dependency(
+        self.dependencies = [
+            Dependency(
                 parent_name=dep["parent_name"],
                 parent_path=dep["parent_path"],
                 parent_uuid=dep["parent_uuid"],
@@ -86,13 +86,14 @@ class BundleInfo(object):
                 location=dep.get("location", None),
             )
             for dep in dependencies
-        }  # type: Dict[DependencyKey, Dependency]
+        ]  # type: List[Dependency]
+
         self.location = location  # set if local filesystem
 
     @property
     def as_dict(self):
         dct = generic_to_dict(self)
-        dct['dependencies'] = [v for k, v in dct['dependencies'].items()]
+        dct['dependencies'] = [generic_to_dict(d) for d in dct['dependencies']]
         return dct
 
     def __str__(self):

--- a/codalab/worker/worker_run_state.py
+++ b/codalab/worker/worker_run_state.py
@@ -272,7 +272,11 @@ class RunStateMachine(StateTransitioner):
         else:
             docker_network = self.docker_network_internal.name
 
+<<<<<<< HEAD
         # 3) Start container
+=======
+        # 4) Start container
+>>>>>>> 0f2c9526... move cpu and gpu resource check to the beginning of _transition_from_PREPARING
         try:
             container = docker_utils.start_bundle_container(
                 run_state.bundle_path,

--- a/codalab/worker/worker_run_state.py
+++ b/codalab/worker/worker_run_state.py
@@ -164,6 +164,17 @@ class RunStateMachine(StateTransitioner):
         if run_state.is_killed:
             return run_state._replace(stage=RunStage.CLEANING_UP)
 
+        # Check CPU and GPU availability
+        try:
+            cpuset, gpuset = self.assign_cpu_and_gpu_sets_fn(
+                run_state.resources.cpus, run_state.resources.gpus
+            )
+        except Exception as e:
+            message = "Unexpectedly unable to assign enough resources: %s" % str(e)
+            logger.error(message)
+            logger.error(traceback.format_exc())
+            return run_state._replace(run_status=message)
+
         dependencies_ready = True
         status_messages = []
 
@@ -256,23 +267,12 @@ class RunStateMachine(StateTransitioner):
             #   dependency_path:docker_dependency_path:ro
             docker_dependencies.append((dependency_path, docker_dependency_path))
 
-        # 3) Set up container
         if run_state.resources.network:
             docker_network = self.docker_network_external.name
         else:
             docker_network = self.docker_network_internal.name
 
-        try:
-            cpuset, gpuset = self.assign_cpu_and_gpu_sets_fn(
-                run_state.resources.cpus, run_state.resources.gpus
-            )
-        except Exception as e:
-            message = "Cannot assign enough resources: %s" % str(e)
-            logger.error(message)
-            logger.error(traceback.format_exc())
-            return run_state._replace(run_status=message)
-
-        # 4) Start container
+        # 3) Start container
         try:
             container = docker_utils.start_bundle_container(
                 run_state.bundle_path,

--- a/codalab/worker/worker_run_state.py
+++ b/codalab/worker/worker_run_state.py
@@ -272,11 +272,7 @@ class RunStateMachine(StateTransitioner):
         else:
             docker_network = self.docker_network_internal.name
 
-<<<<<<< HEAD
         # 3) Start container
-=======
-        # 4) Start container
->>>>>>> 0f2c9526... move cpu and gpu resource check to the beginning of _transition_from_PREPARING
         try:
             container = docker_utils.start_bundle_container(
                 run_state.bundle_path,


### PR DESCRIPTION
Fixed #2096.

#2096 is caused by an outdated codalab package installed in NLP machine. While I was reading the code, I found that the resource check on CPU and GPU happens after the dependency downloading stage. I guess the order could be reversed so that the program can check for CPUs/GPUs first before it tries to download dependencies. Let me know if this is something we want to do.