### PR TITLE
Binding the actual cores that can be used

### DIFF
--- a/codalab/worker/main.py
+++ b/codalab/worker/main.py
@@ -230,8 +230,9 @@ def parse_cpuset_args(arg):
         arg: comma separated string of ints, or "ALL" representing all available cpus
     """
     try:
-        # Get number of cores that the process can actually use.
-        cpu_count = len(os.sched_getaffinity(0))
+        # Get the set of cores that the process can actually use.
+        # For instance, on Slurm, the returning value may contain only 4 cores: {2,3,20,21}.
+        return os.sched_getaffinity(0)
     except AttributeError:
         # os.sched_getaffinity() isn't available on all platforms,
         # so fallback to using the number of physical cores.


### PR DESCRIPTION
Partially fixed #1045 .

This PR is to concretize the actual cores that can be used in NLP cluster which uses Slurm as a workload manager.

When a user requests for a Slurm session, Slurm will allocate a certain amount of CPUs/GPUs/memory on a designated machine. Assuming the designated machine has 40 CPUs and the user asks for 4 CPUs to use, Slurm will pick 4 available cores based on its own algorithm. Then, in the end, it will return back 4 cores that are supposed to be used in the current session, e.g. 
```
>>> import os
>>> os.sched_getaffinity(0)
{20, 21, 4, 5}
```

However, our current code logic doesn't take the actual cores that returned from Slurm into consideration. Instead, it always assumes that the number of CPUs ranges from `0 to len(cpu_count)`. I guess binding the actual CPU cores that allocated to the current process could make the CPU assignment more accurate when running jobs in NLP cluster. Let me know if anyone has any ideas.