### PR TITLE
Adjust timezone information when calculating current container runnin…

### DIFF
--- a/codalab/worker/docker_utils.py
+++ b/codalab/worker/docker_utils.py
@@ -266,7 +266,7 @@ def get_container_running_time(container):
     end_time = (
         container.attrs['State']['FinishedAt']
         if container.attrs['State']['Status'] == 'exited'
-        else str(datetime.datetime.now().replace(tzinfo=tz.tzutc()))
+        else str(datetime.datetime.now(tz.tzutc()))
     )
     # Docker reports both the start_time and the end_time in ISO format. We currently use dateutil.parser.isoparse to
     # parse them. In Python3.7 or above, the built-in function datetime.fromisoformat() can be used to parse ISO


### PR DESCRIPTION
Fixed #2112 

Based on documentation at [`datetime.datetime.replace`](https://docs.python.org/3/library/datetime.html#datetime.datetime.replace), it doesn't convert the date and time data to UTC timezone. In NLP cluster machine, since it's using Los Angeles time zone, the time zone calculation doesn't report the correct value. This PR is to fix this issue. 