### PR TITLE
Make cl workers show user-owned workers for non-root users

### DIFF
--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -1034,7 +1034,8 @@ class BundleCLI(object):
 
     @Commands.command(
         'workers',
-        help=['Display worker information of this CodaLab instance. Root user only.'],
+        help=['Display worker information of this CodaLab instance. '
+              'If not root user, only display information about your connected workers.'],
         arguments=(),
     )
     def do_workers_command(self, args):

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -1034,8 +1034,10 @@ class BundleCLI(object):
 
     @Commands.command(
         'workers',
-        help=['Display worker information of this CodaLab instance. '
-              'If not root user, only display information about your connected workers.'],
+        help=[
+            'Display worker information of this CodaLab instance. '
+            'If not root user, only display information about your connected workers.'
+        ],
         arguments=(),
     )
     def do_workers_command(self, args):

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -1034,9 +1034,7 @@ class BundleCLI(object):
 
     @Commands.command(
         'workers',
-        help=[
-            'Display information about workers that you have connected to the CodaLab instance.'
-        ],
+        help=['Display information about workers that you have connected to the CodaLab instance.'],
         arguments=(),
     )
     def do_workers_command(self, args):

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -1035,8 +1035,7 @@ class BundleCLI(object):
     @Commands.command(
         'workers',
         help=[
-            'Display worker information of this CodaLab instance. '
-            'If not root user, only display information about your connected workers.'
+            'Display information about workers that you have connected to the CodaLab instance.'
         ],
         arguments=(),
     )

--- a/codalab/rest/workers.py
+++ b/codalab/rest/workers.py
@@ -135,13 +135,13 @@ def start_bundle(worker_id, uuid):
 
 @get("/workers/info", name="workers_info", apply=AuthenticatedPlugin())
 def workers_info():
-    data = local.worker_model.get_workers()
+    workers = local.worker_model.get_workers()
     if request.user.user_id != local.model.root_user_id:
         # Filter to workers that only this user owns.
-        data = [worker for worker in data if worker['user_id'] == request.user.user_id]
+        workers = [worker for worker in workers if worker['user_id'] == request.user.user_id]
 
     # edit entries in data to make them suitable for human reading
-    for worker in data:
+    for worker in workers:
         # checkin_time: seconds since epoch
         worker["checkin_time"] = int(
             (worker["checkin_time"] - datetime.utcfromtimestamp(0)).total_seconds()
@@ -152,4 +152,4 @@ def workers_info():
         worker["cpus_in_use"] = sum(bundle.metadata.request_cpus for bundle in running_bundles)
         worker["gpus_in_use"] = sum(bundle.metadata.request_gpus for bundle in running_bundles)
 
-    return {"data": data}
+    return {"data": workers}

--- a/codalab/rest/workers.py
+++ b/codalab/rest/workers.py
@@ -135,10 +135,10 @@ def start_bundle(worker_id, uuid):
 
 @get("/workers/info", name="workers_info", apply=AuthenticatedPlugin())
 def workers_info():
-    if request.user.user_id != local.model.root_user_id:
-        abort(http.client.UNAUTHORIZED, "User is not root user")
-
     data = local.worker_model.get_workers()
+    if request.user.user_id != local.model.root_user_id:
+        # Filter to workers that only this user owns.
+        data = [worker for worker in data if worker['user_id'] == request.user.user_id]
 
     # edit entries in data to make them suitable for human reading
     for worker in data:

--- a/docs/CLI-Reference.md
+++ b/docs/CLI-Reference.md
@@ -449,7 +449,7 @@ Usage: `cl <command> <arguments>`
 
 ## Commands for managing server:
   ### workers:
-    Display worker information of this CodaLab instance. If not root user, only display information about your connected workers.
+    Display information about workers that you have connected to the CodaLab instance. For the root user, display all workers.
 
   ### bs-add-partition:
     Add another partition for storage (MultiDiskBundleStore only)

--- a/docs/CLI-Reference.md
+++ b/docs/CLI-Reference.md
@@ -449,7 +449,7 @@ Usage: `cl <command> <arguments>`
 
 ## Commands for managing server:
   ### workers:
-    Display worker information of this CodaLab instance. Root user only.
+    Display worker information of this CodaLab instance. If not root user, only display information about your connected workers.
 
   ### bs-add-partition:
     Add another partition for storage (MultiDiskBundleStore only)


### PR DESCRIPTION
I think the cl workers output is _super_ helpful, but it's locked behind root restrictions. This PR makes the command output the individual user's workers, if the user is not root.

I couldn't find a test for this anywhere...maybe I'm missing something?