### PR TITLE
2108: Handle incompatible Cuda version specified in the user's Docker image

### DIFF
--- a/codalab/worker/docker_utils.py
+++ b/codalab/worker/docker_utils.py
@@ -24,7 +24,7 @@ URI_PREFIX = 'https://hub.docker.com/v2/repositories/'
 
 # This specific error happens when a user specifies an image with an incompatible version of Cuda
 NVIDIA_MOUNT_ERROR_REGEX = (
-    '[\s\S]*OCI runtime create failed[\s\S]*stderr: nvidia-container-cli: '
+    '[\s\S]*OCI runtime create failed[\s\S]*stderr:[\s\S]*nvidia-container-cli: '
     'mount error: file creation failed:[\s\S]*nvidia-smi'
 )
 

--- a/codalab/worker/worker_run_state.py
+++ b/codalab/worker/worker_run_state.py
@@ -287,6 +287,10 @@ class RunStateMachine(StateTransitioner):
                 runtime=self.docker_runtime,
             )
             self.worker_docker_network.connect(container)
+        except docker_utils.DockerUserErrorException as e:
+            message = 'Cannot start Docker container: {}'.format(e)
+            logger.warning(message)
+            return run_state._replace(stage=RunStage.CLEANING_UP, failure_message=message)
         except Exception as e:
             message = 'Cannot start Docker container: {}'.format(e)
             logger.error(message)

--- a/tests/worker/docker_utils_test.py
+++ b/tests/worker/docker_utils_test.py
@@ -1,0 +1,45 @@
+import docker
+import unittest
+
+from codalab.worker.docker_utils import DockerUserErrorException, DockerException, wrap_exception
+
+
+class DockerUtilsTest(unittest.TestCase):
+    def test_wrap_exception(self):
+        error = (
+            'Cannot start Docker container: Unable to start Docker container: 500 Server '
+            'Error: Internal Server Error "OCI runtime create failed: some other error"'
+        )
+
+        @wrap_exception('Should throw DockerException')
+        def throw_error():
+            raise docker.errors.ApiError(error)
+
+        try:
+            throw_error()
+        except Exception as e:
+            print(str(e))
+            self.assertEqual(str(e), 'Should throw DockerException: ' + error)
+            self.assertIsInstance(e, DockerException)
+
+    def test_wrap_exception_with_cuda_error(self):
+        error = (
+            'Cannot start Docker container: Unable to start Docker container: 500 Server '
+            'Error: Internal Server Error ("OCI runtime create failed: container_linux.go:'
+            '345: starting container process caused "process_linux.go:430: container init '
+            'caused "process_linux.go:413: running prestart hook 1 caused "error '
+            'running hook: exit status 1, stdout: ,  stderr: nvidia-container-cli: mount '
+            'error: file creation failed: /mnt/scratch/docker/overlay2/678d6b'
+            '19396c4ccd341786b21393f3f/merged/usr/bin/nvidia-smi'
+        )
+
+        @wrap_exception('Should throw DockerUserErrorException')
+        def throw_cuda_error():
+            raise docker.errors.ApiError(error)
+
+        try:
+            throw_cuda_error()
+        except Exception as e:
+            print(str(e))
+            self.assertEqual(str(e), 'Should throw DockerUserErrorException: ' + error)
+            self.assertIsInstance(e, DockerUserErrorException)

--- a/tests/worker/docker_utils_test.py
+++ b/tests/worker/docker_utils_test.py
@@ -1,4 +1,4 @@
-import docker
+from docker.errors import APIError
 import unittest
 
 from codalab.worker.docker_utils import DockerUserErrorException, DockerException, wrap_exception
@@ -13,12 +13,11 @@ class DockerUtilsTest(unittest.TestCase):
 
         @wrap_exception('Should throw DockerException')
         def throw_error():
-            raise docker.errors.ApiError(error)
+            raise APIError(error)
 
         try:
             throw_error()
         except Exception as e:
-            print(str(e))
             self.assertEqual(str(e), 'Should throw DockerException: ' + error)
             self.assertIsInstance(e, DockerException)
 
@@ -35,11 +34,10 @@ class DockerUtilsTest(unittest.TestCase):
 
         @wrap_exception('Should throw DockerUserErrorException')
         def throw_cuda_error():
-            raise docker.errors.ApiError(error)
+            raise APIError(error)
 
         try:
             throw_cuda_error()
         except Exception as e:
-            print(str(e))
             self.assertEqual(str(e), 'Should throw DockerUserErrorException: ' + error)
             self.assertIsInstance(e, DockerUserErrorException)


### PR DESCRIPTION
Resolves #2108 

GPU workers are going offline in `prod` when a user specifies a Docker image with a Cuda version that is incompatible with the Nvidia GPU's. 

Some example image that causes the failure:
https://hub.docker.com/layers/vzhong/nl2sql/0.04/images/sha256-9518f86aa6e3ea2b822788e0b08ba2e53c88610438b184ec3486d0d55353e6f2?context=explore
https://hub.docker.com/layers/soul1987/cuda8/6/images/sha256-d8c0cd0efcdfba8a69ac4c27d1386d362d1aa5f3de326d52c4362f3caea4c60c?context=explore

The fix is to catch this specific error by checking the exception message and treating it as a user error instead of raising an exception, which causes the worker to go offline. Checking the exception message might not be the best solution, but I can't find a better alternative method at the moment.

Related:
https://github.com/NVIDIA/nvidia-docker/issues/825
https://stackoverflow.com/questions/55389669/tensorflow-nvidia-cuda-docker-mismatched-versions