### PR TITLE
Redirect self.stdout when buffer doesn't exist

### DIFF
--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -36,7 +36,14 @@ from codalab.bundles import get_bundle_subclass
 from codalab.bundles.make_bundle import MakeBundle
 from codalab.bundles.uploaded_bundle import UploadedBundle
 from codalab.bundles.run_bundle import RunBundle
-from codalab.common import CODALAB_VERSION, NotFoundError, PermissionError, precondition, UsageError
+from codalab.common import (
+    CODALAB_VERSION,
+    NotFoundError,
+    PermissionError,
+    precondition,
+    UsageError,
+    ensure_str,
+)
 from codalab.lib import (
     bundle_util,
     file_util,
@@ -2351,10 +2358,7 @@ class BundleCLI(object):
                     # self.stdout will have buffer attribute when it's an io.TextIOWrapper object. However, when
                     # self.stdout gets reassigned to an io.StringIO object, self.stdout.buffer won't exist.
                     # Therefore, we try to directly write file content as a String object to self.stdout.
-                    try:
-                        self.stdout.write(contents.read().decode())
-                    except UnicodeDecodeError:
-                        self.stdout.write("File contents cannot be decoded.")
+                    self.stdout.write(ensure_str(contents.read()))
 
             if self.headless:
                 print(


### PR DESCRIPTION
Fixed #1957 

First of all, I was trying to reproduce the original issue by rerunning the exact command that was reported in ticket #1957. However, I am not able to reproduce it after I tried several ways. 

I recently observed this issue when running `cl cat` through web interface as follows:
<img width="840" alt="Screen Shot 2020-03-31 at 10 34 51 AM" src="https://user-images.githubusercontent.com/1483372/78057330-6ac85500-733b-11ea-908c-bfae3b59d72d.png">

Once we apply the fix in this PR, running the same command will show the following information:
<img width="714" alt="Screen Shot 2020-03-31 at 10 35 37 AM" src="https://user-images.githubusercontent.com/1483372/78057410-86cbf680-733b-11ea-95f9-2288bfa29577.png">
As we can see from the terminal, a date is returned from `cl cat` command.