### PR TITLE
Empty args

### DIFF
--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -28,6 +28,7 @@ import textwrap
 from collections import defaultdict
 from contextlib import closing
 from io import BytesIO
+from shlex import quote
 
 import argcomplete
 from argcomplete.completers import FilesCompleter, ChoicesCompleter
@@ -803,7 +804,9 @@ class BundleCLI(object):
         """
         try:
             i = argv.index('---')
-            argv = argv[0:i] + [' '.join(argv[i + 1 :])]  # TODO: quote command properly
+            # Convert the command after '---' to a shell-escaped version of the string.
+            shell_escaped_command = [quote(x) for x in argv[i+1 : ]]
+            argv = argv[0:i] + [' '.join(shell_escaped_command)]
         except:
             pass
 

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -805,7 +805,7 @@ class BundleCLI(object):
         try:
             i = argv.index('---')
             # Convert the command after '---' to a shell-escaped version of the string.
-            shell_escaped_command = [quote(x) for x in argv[i+1 : ]]
+            shell_escaped_command = [quote(x) for x in argv[i + 1 :]]
             argv = argv[0:i] + [' '.join(shell_escaped_command)]
         except:
             pass

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -28,7 +28,6 @@ import textwrap
 from collections import defaultdict
 from contextlib import closing
 from io import BytesIO
-from shlex import quote
 
 import argcomplete
 from argcomplete.completers import FilesCompleter, ChoicesCompleter
@@ -804,9 +803,7 @@ class BundleCLI(object):
         """
         try:
             i = argv.index('---')
-            # Convert each element after '---' to a shell-escaped version of string.
-            shell_escaped_command = [quote(x) for x in argv[i + 1 :]]
-            argv = argv[0:i] + [' '.join(shell_escaped_command)]
+            argv = argv[0:i] + [' '.join(argv[i + 1 :])]  # TODO: quote command properly
         except:
             pass
 

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -1562,7 +1562,6 @@ class BundleCLI(object):
 
         targets = self.resolve_key_targets(client, worksheet_uuid, args.target_spec)
         params = {'worksheet': worksheet_uuid}
-        '''
         if args.after_sort_key:
             params['after_sort_key'] = args.after_sort_key
         new_bundle = client.create(
@@ -1573,7 +1572,6 @@ class BundleCLI(object):
 
         print(new_bundle['uuid'], file=self.stdout)
         self.wait(client, args, new_bundle['uuid'])
-        '''
 
     @Commands.command(
         'docker',

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -28,6 +28,7 @@ import textwrap
 from collections import defaultdict
 from contextlib import closing
 from io import BytesIO
+from shlex import quote
 
 import argcomplete
 from argcomplete.completers import FilesCompleter, ChoicesCompleter
@@ -803,7 +804,9 @@ class BundleCLI(object):
         """
         try:
             i = argv.index('---')
-            argv = argv[0:i] + [' '.join(argv[i + 1 :])]  # TODO: quote command properly
+            # Convert each element after '---' to a shell-escaped version of string.
+            shell_escaped_command = [quote(x) for x in argv[i + 1 :]]
+            argv = argv[0:i] + [' '.join(shell_escaped_command)]
         except:
             pass
 
@@ -1559,6 +1562,7 @@ class BundleCLI(object):
 
         targets = self.resolve_key_targets(client, worksheet_uuid, args.target_spec)
         params = {'worksheet': worksheet_uuid}
+        '''
         if args.after_sort_key:
             params['after_sort_key'] = args.after_sort_key
         new_bundle = client.create(
@@ -1569,6 +1573,7 @@ class BundleCLI(object):
 
         print(new_bundle['uuid'], file=self.stdout)
         self.wait(client, args, new_bundle['uuid'])
+        '''
 
     @Commands.command(
         'docker',

--- a/tests/files/netcat-test.py
+++ b/tests/files/netcat-test.py
@@ -17,7 +17,7 @@ while True:
     if not data:
         conn.close()
         continue
-    if data == b'yo dawg!':
+    if data == b"'yo dawg!'":
         conn.send(b'Hi this is dawg')
     else:
         conn.send(b'No, this is dawg')

--- a/tests/lib/bundle_cli_test.py
+++ b/tests/lib/bundle_cli_test.py
@@ -1,0 +1,16 @@
+import unittest
+from codalab.lib.bundle_cli import BundleCLI
+
+
+class BundleCliTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.bundle_cli = BundleCLI
+
+    def tearDown(self) -> None:
+        del self.bundle_cli
+
+    def test_collapse_bare_command_empty_args(self):
+        argv = ['cl', 'run', '---', 'echo', '']
+        expected_result = ['cl', 'run', "echo ''"]
+        actual_result = self.bundle_cli.collapse_bare_command(argv)
+        self.assertEqual(actual_result, expected_result)

--- a/tests/lib/bundle_cli_test.py
+++ b/tests/lib/bundle_cli_test.py
@@ -14,3 +14,15 @@ class BundleCliTest(unittest.TestCase):
         expected_result = ['cl', 'run', "echo ''"]
         actual_result = self.bundle_cli.collapse_bare_command(argv)
         self.assertEqual(actual_result, expected_result)
+
+    def test_collapse_bare_command_non_empty_str_args(self):
+        argv = ['cl', 'run', '---', 'echo', 'hello']
+        expected_result = ['cl', 'run', "echo hello"]
+        actual_result = self.bundle_cli.collapse_bare_command(argv)
+        self.assertEqual(actual_result, expected_result)
+
+    def test_collapse_bare_command_non_empty_str_args_with_escaped_char(self):
+        argv = ['cl', 'run', '---', 'echo', 'hello world!']
+        expected_result = ['cl', 'run', "echo 'hello world!'"]
+        actual_result = self.bundle_cli.collapse_bare_command(argv)
+        self.assertEqual(actual_result, expected_result)


### PR DESCRIPTION
Fixed #2114 

The fix in this PR will not preserve the original double quotes `""` as the command from the command line arguments. Instead, it will display single quotes `''` as a substitution as follows:
<img width="680" alt="Screen Shot 2020-04-01 at 9 30 20 AM" src="https://user-images.githubusercontent.com/1483372/78162998-8ba4af00-73fc-11ea-98a9-0f334539f384.png">
 