### PR TITLE
Fix mathjax loading race condition

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -28,7 +28,24 @@
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
 
     <!--TODO: Figure out how to access these from the NPM module, not some random CDN-->
-    <script id="mathjaxjs" type="text/javascript" async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+    <script id="mathjaxjs" type="text/javascript" async src=""></script>
+    
+    <script>
+      (function() {
+        var el = document.createElement('script');
+        el.src = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML';
+        el.async = 'true';
+        el.addEventListener('load', function() {
+          MathJax.Hub.Config({
+            tex2jax: {
+              skipTags: ['script', 'noscript', 'style', 'textarea', 'pre'],
+              inlineMath: [['$','$']]
+            }
+          });
+        });
+        document.head.appendChild(el);
+      })();
+    </script>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/c3/0.6.12/c3.min.css" rel="stylesheet" type="text/css">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/themes/smoothness/jquery-ui.min.css" rel="stylesheet" type="text/css">
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.2.2/ace.js"></script>
@@ -51,17 +68,6 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
-
-    <script>
-      document.querySelector('#mathjaxjs').addEventListener('load', function() {
-        MathJax.Hub.Config({
-          tex2jax: {
-            skipTags: ['script', 'noscript', 'style', 'textarea', 'pre'],
-            inlineMath: [['$','$']]
-          }
-        });
-      });
-    </script>
     <script type="text/javascript" src="%PUBLIC_URL%/js/collapsible.js"></script>
 
   </body>

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -24,13 +24,12 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-
-    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
-
-    <!--TODO: Figure out how to access these from the NPM module, not some random CDN-->
-    <script id="mathjaxjs" type="text/javascript" async src=""></script>
     
+    <!-- TODO: Figure out how to access these from the NPM module, not some random CDN -->
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
     <script>
+      // Load mathjax programatically so that we can attach the load event listener before the script is added
+      // to the DOM. This fixes a race case in which the load event listener wasn't always called.
       (function() {
         var el = document.createElement('script');
         el.src = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML';


### PR DESCRIPTION
fixes #1851

Previously, there was a race condition in which the mathjax script's onload function would not fire -- thus, the math would not be formatted in some cases.

This change instead creates the script and then adds the onload function before appending it to the DOM.

I tested this by refreshing the sample worksheet ~20 times and saw no issues with mathjax (while previously, doing so without the change would sometimes show non-formatted issues).