### PR TITLE
Prioritize bundle scheduling with request_priority

### DIFF
--- a/codalab/bundles/run_bundle.py
+++ b/codalab/bundles/run_bundle.py
@@ -30,7 +30,7 @@ class RunBundle(DerivedBundle):
     METADATA_SPECS.append(MetadataSpec('request_cpus', int, 'Number of CPUs allowed for this run.', default=1))
     METADATA_SPECS.append(MetadataSpec('request_gpus', int, 'Number of GPUs allowed for this run.', default=0))
     METADATA_SPECS.append(MetadataSpec('request_queue', str, 'Submit run to this job queue.', hide_when_anonymous=True, default=None))
-    METADATA_SPECS.append(MetadataSpec('request_priority', int, 'Job priority (higher is more important).', default=None))
+    METADATA_SPECS.append(MetadataSpec('request_priority', int, 'Job priority (higher is more important).', default=0))
     METADATA_SPECS.append(MetadataSpec('request_network', bool, 'Whether to allow network access.', default=False))
 
     METADATA_SPECS.append(MetadataSpec('actions', list, 'Actions (e.g., kill) that were performed on this run.', generated=True))

--- a/codalab/bundles/run_bundle.py
+++ b/codalab/bundles/run_bundle.py
@@ -30,7 +30,7 @@ class RunBundle(DerivedBundle):
     METADATA_SPECS.append(MetadataSpec('request_cpus', int, 'Number of CPUs allowed for this run.', default=1))
     METADATA_SPECS.append(MetadataSpec('request_gpus', int, 'Number of GPUs allowed for this run.', default=0))
     METADATA_SPECS.append(MetadataSpec('request_queue', str, 'Submit run to this job queue.', hide_when_anonymous=True, default=None))
-    METADATA_SPECS.append(MetadataSpec('request_priority', int, 'Job priority (higher is more important).', default=0))
+    METADATA_SPECS.append(MetadataSpec('request_priority', int, 'Job priority (higher is more important).', default=None))
     METADATA_SPECS.append(MetadataSpec('request_network', bool, 'Whether to allow network access.', default=False))
 
     METADATA_SPECS.append(MetadataSpec('actions', list, 'Actions (e.g., kill) that were performed on this run.', generated=True))

--- a/codalab/server/bundle_manager.py
+++ b/codalab/server/bundle_manager.py
@@ -327,7 +327,13 @@ class BundleManager(object):
         :param user_info_cache: a dictionary mapping user id to user information.
         """
         # Build a dictionary which maps from user id to positions in the queue of the
-        # user's staged bundles.
+        # user's staged bundles. We use this to sort bundles within each user. For example,
+        # Suppose we have 4 staged bundles with the following attributes from 2 users:
+        # Users: [A, B, A, B, A]
+        # Bundle Priorities: [1, 2, 3, 1, 1]
+        # Bundle specified request_queue: [False, False, False, False, True]
+        # Original Bundle Order: [B1, B2, B3, B4, B5]
+        # Sorted bundle order: [B3, B2, B5, B4, B1]
         user_queue_positions = defaultdict(list)
         for queue_position, staged_bundle in enumerate(staged_bundles_to_run):
             user_queue_positions[staged_bundle[0].owner_id].append(queue_position)

--- a/codalab/server/bundle_manager.py
+++ b/codalab/server/bundle_manager.py
@@ -314,8 +314,10 @@ class BundleManager(object):
     def _schedule_run_bundles_on_workers(self, workers, staged_bundles_to_run, user_info_cache):
         """
         Schedule STAGED bundles to run on available workers based on the following logic:
-        1. If the bundle requests to run on a specific worker, tries to schedule the bundle
-           to run on a worker that has a tag exactly match with request_queue.
+        1. For a given user, schedule the highest-priority bundles first, followed by bundles
+           that request to run on a specific worker.
+        2. If the bundle requests to run on a specific worker, schedule the bundle
+           to run on a worker that has a tag that exactly matches the bundle's request_queue.
         2. If the bundle doesn't request to run on a specific worker,
           (1) try to schedule the bundle to run on a worker that belongs to the bundle's owner
           (2) if there is no such qualified private worker, uses CodaLab-owned workers, which have user ID root_user_id.

--- a/codalab/server/bundle_manager.py
+++ b/codalab/server/bundle_manager.py
@@ -333,7 +333,7 @@ class BundleManager(object):
             user_queue_positions[staged_bundle[0].owner_id].append(queue_position)
 
         for user, queue_positions in user_queue_positions.items():
-            sorted_queue_positions = sorted(queue_positions)
+            assert queue_positions == sorted(queue_positions)
             # Get this user's staged bundles
             user_staged_bundles = [
                 staged_bundles_to_run[queue_position] for queue_position in queue_positions
@@ -350,7 +350,7 @@ class BundleManager(object):
                 ),
                 reverse=True,
             )
-            for queue_position, bundle in zip(sorted_queue_positions, sorted_user_staged_bundles):
+            for queue_position, bundle in zip(queue_positions, sorted_user_staged_bundles):
                 staged_bundles_to_run[queue_position] = bundle
 
         # Build a dictionary which maps from uuid to running bundle and bundle_resources

--- a/codalab/server/bundle_manager.py
+++ b/codalab/server/bundle_manager.py
@@ -339,7 +339,9 @@ class BundleManager(object):
                 staged_bundles_to_run[queue_position] for queue_position in queue_positions
             ]
             # Sort the staged bundles for this user, according to
-            # (1) their priority and (2) whether it requested to run on a specific worker.
+            # (1) their priority (larger values indicate higher priority) and
+            # (2) whether it requested to run on a specific worker (bundles with a specified
+            # worker have higher priority).
             sorted_user_staged_bundles = sorted(
                 user_staged_bundles,
                 key=lambda b: (

--- a/codalab/server/bundle_manager.py
+++ b/codalab/server/bundle_manager.py
@@ -1,4 +1,5 @@
 import copy
+from collections import defaultdict
 import datetime
 import logging
 import os
@@ -327,10 +328,8 @@ class BundleManager(object):
         """
         # Build a dictionary which maps from user id to positions in the queue of the
         # user's staged bundles.
-        user_queue_positions = {}
+        user_queue_positions = defaultdict(list)
         for queue_position, staged_bundle in enumerate(staged_bundles_to_run):
-            if staged_bundle[0].owner_id not in user_queue_positions:
-                user_queue_positions[staged_bundle[0].owner_id] = []
             user_queue_positions[staged_bundle[0].owner_id].append(queue_position)
 
         for user, queue_positions in user_queue_positions.items():

--- a/codalab/server/bundle_manager.py
+++ b/codalab/server/bundle_manager.py
@@ -318,7 +318,7 @@ class BundleManager(object):
            that request to run on a specific worker.
         2. If the bundle requests to run on a specific worker, schedule the bundle
            to run on a worker that has a tag that exactly matches the bundle's request_queue.
-        2. If the bundle doesn't request to run on a specific worker,
+        3. If the bundle doesn't request to run on a specific worker,
           (1) try to schedule the bundle to run on a worker that belongs to the bundle's owner
           (2) if there is no such qualified private worker, uses CodaLab-owned workers, which have user ID root_user_id.
         :param workers: a WorkerInfoAccessor object containing worker related information e.g. running uuid.


### PR DESCRIPTION
This PR changes the scheduling logic to use the bundle's `request_priority` metadata.

Before, bundles that were requested to run on specific machines (i.e., they provided a value for `request_queue`) were scheduled to run before all other bundles.

After this PR:

(1) all bundle sorting is done within-user. I made this change for the `request_queue` case as well because, if we tag public instances (https://github.com/codalab/codalab-worksheets/pull/2093), a user could jump the public queue by just specifying the right `request_queue`.
(2) The bundle ordering is determined first by the bundle's priority—higher priority bundles get scheduled first, regardless if they have a `request_queue` or not. Then, the normal logic applies (bundles with `request_queue` prioritized above those that don't).

Some thoughts:

I feel like the default value for `request_priority`, `None`, is a bit funky. Should I change this? There might be some backward-compatibility issues?

I'm also not entirely sure I'm happy with the way that the current code handles 0 priority and negative priority (currently, 0 priority or negative priority bundles have precedence over bundles with no priority specified).

Ideally, I'd like `None` priority to just be `0` priority, but I'm not sure what compatibility things I need to be worried about when making this change. Thoughts?