### PR TITLE
Merge master into staging (#2121)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CodaLab Worksheets
 
-[![Build Status](https://travis-ci.org/codalab/codalab-worksheets.svg?branch=master)](https://travis-ci.org/codalab/codalab-worksheets.svg?branch=master)
+[![Build Status](https://travis-ci.org/codalab/codalab-worksheets.svg?branch=master)](https://travis-ci.org/codalab/codalab-worksheets)
 [![Downloads](https://pepy.tech/badge/codalab)](https://pepy.tech/project/codalab)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -140,6 +140,9 @@ SERVER_COMMANDS = (
 )
 
 OTHER_COMMANDS = ('help', 'status', 'alias', 'config', 'logout')
+# Markdown headings
+HEADING_LEVEL_2 = '## '
+HEADING_LEVEL_3 = '### '
 
 
 class CodaLabArgumentParser(argparse.ArgumentParser):
@@ -258,7 +261,7 @@ class Commands(object):
         return register_command
 
     @classmethod
-    def help_text(cls, verbose):
+    def help_text(cls, verbose, markdown):
         def command_name(command):
             name = command
             aliases = cls.commands[command].aliases
@@ -307,6 +310,8 @@ class Commands(object):
                 )
 
             if verbose:
+                if markdown:
+                    name = HEADING_LEVEL_3 + name
                 return '%s%s:\n%s\n%s' % (
                     ' ' * indent,
                     name,
@@ -324,31 +329,39 @@ class Commands(object):
         def command_group_help_text(commands):
             return '\n'.join([command_help_text(command) for command in commands])
 
+        def doc_formatter():
+            return HEADING_LEVEL_2 if verbose and markdown else ''
+
+        def command_formatter():
+            return '`' if verbose and markdown else ''
+
         return (
             textwrap.dedent(
                 """
-        Usage: cl <command> <arguments>
+        Usage: {inline_code}cl <command> <arguments>{inline_code}
 
-        Commands for bundles:
+        {heading}Commands for bundles:
         {bundle_commands}
 
-        Commands for worksheets:
+        {heading}Commands for worksheets:
         {worksheet_commands}
 
-        Commands for groups and permissions:
+        {heading}Commands for groups and permissions:
         {group_and_permission_commands}
 
-        Commands for users:
+        {heading}Commands for users:
         {user_commands}
 
-        Commands for managing server:
+        {heading}Commands for managing server:
         {server_commands}
 
-        Other commands:
+        {heading}Other commands:
         {other_commands}
         """
             )
             .format(
+                heading=doc_formatter(),
+                inline_code=command_formatter(),
                 bundle_commands=command_group_help_text(BUNDLE_COMMANDS),
                 worksheet_commands=command_group_help_text(WORKSHEET_COMMANDS),
                 group_and_permission_commands=command_group_help_text(
@@ -857,12 +870,19 @@ class BundleCLI(object):
             'Show usage information for commands.',
             '  help           : Show brief description for all commands.',
             '  help -v        : Show full usage information for all commands.',
+            '  help -v -m     : Show full usage information for all commands in Markdown format.',
             '  help <command> : Show full usage information for <command>.',
         ],
         arguments=(
             Commands.Argument('command', help='name of command to look up', nargs='?'),
             Commands.Argument(
                 '-v', '--verbose', action='store_true', help='Display all options of all commands.'
+            ),
+            Commands.Argument(
+                '-m',
+                '--markdown',
+                action='store_true',
+                help='Auto-generate all options of all commands for CLI markdown in Markdown format.',
             ),
         ),
     )
@@ -871,7 +891,7 @@ class BundleCLI(object):
         if args.command:
             self.do_command([args.command, '--help'])
             return
-        print(Commands.help_text(args.verbose), file=self.stdout)
+        print(Commands.help_text(args.verbose, args.markdown), file=self.stdout)
 
     @Commands.command('status', aliases=('st',), help='Show current client status.')
     def do_status_command(self, args):
@@ -1014,7 +1034,7 @@ class BundleCLI(object):
 
     @Commands.command(
         'workers',
-        help=['Display worker information of this CodaLab instance. Root user only.'],
+        help=['Display information about workers that you have connected to the CodaLab instance.'],
         arguments=(),
     )
     def do_workers_command(self, args):
@@ -1630,8 +1650,7 @@ class BundleCLI(object):
             Commands.Argument('-d', '--description', help='New bundle description.'),
             Commands.Argument(
                 '--anonymous',
-                help='Set bundle to be anonymous (identity of the owner will NOT \n'
-                'be visible to users without \'all\' permission on the bundle).',
+                help='Set bundle to be anonymous (identity of the owner will NOT be visible to users without \'all\' permission on the bundle).',
                 dest='anonymous',
                 action='store_true',
                 default=None,
@@ -2930,8 +2949,7 @@ class BundleCLI(object):
             ),
             Commands.Argument(
                 '--anonymous',
-                help='Set worksheet to be anonymous (identity of the owner will NOT \n'
-                'be visible to users without \'all\' permission on the worksheet).',
+                help='Set worksheet to be anonymous (identity of the owner will NOT be visible to users without \'all\' permission on the worksheet).',
                 dest='anonymous',
                 action='store_true',
                 default=None,

--- a/codalab/lib/cli_util.py
+++ b/codalab/lib/cli_util.py
@@ -62,7 +62,8 @@ def nested_dict_get(obj, *args, **kwargs):
 
 def parse_key_target(spec):
     """
-    Parses a keyed target spec into its key and the rest of the target spec
+    Parses a keyed target spec into its key and the rest of the target spec.
+    Raise UsageError when the value of the spec is empty.
     :param spec: a target spec in the form of
         [[<key>]:][<instance>::][<worksheet_spec>//]<bundle_spec>[/<subpath>]
     where <bundle_spec> is required and the rest are optional.
@@ -71,11 +72,19 @@ def parse_key_target(spec):
         - <key>: (<key> if present,
                     empty string if ':' in spec but no <key>,
                     None otherwise)
-        - <value> (where value is everyhing after a <key>: (or everything if no key specified)
+        - <value> (where value is everything after a <key>: (or everything if no key specified)
     """
-
     match = re.match(TARGET_KEY_REGEX, spec)
-    return match.groups()
+    key, value = match.groups()
+    # This check covers three usage errors:
+    # 1. both key and value are empty, e.g. "cl run : 'echo a'"
+    # 2. key is not empty, value is empty, e.g. "cl run a.txt: 'echo a'"
+    if value == '':
+        raise UsageError(
+            'target_spec (%s) in wrong format. Please provide a valid target_spec in the format of %s.'
+            % (spec, RUN_TARGET_SPEC_FORMAT)
+        )
+    return (key, value)
 
 
 def parse_target_spec(spec):
@@ -132,13 +141,6 @@ def desugar_command(orig_target_spec, command):
                     'key %s exists with multiple values: %s and %s' % (key, key2val[key], val)
                 )
         else:
-            if key is None:
-                raise UsageError(
-                    'target_spec is empty. Please provide a valid target_spec in the format of {}.'.format(
-                        RUN_TARGET_SPEC_FORMAT
-                    )
-                )
-
             key2val[key] = val
             target_spec.append(key + ':' + val)
         return key

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -491,9 +491,12 @@ def _netcurl_bundle(uuid, port, path=''):
             response.headers[k] = new_response.headers[k]
         # Return the response (which sends back the body)
         return new_response
-
     except Exception:
-        logger.error("{}".format(request.environ), file=sys.stderr)
+        logger.exception(
+            "Failed to forward HTTP request for the bundle with uuid: {} for environment: {}".format(
+                uuid, request.environ
+            )
+        )
         raise
     finally:
         request.path_shift(-4)  # restore the URL

--- a/codalab/server/bundle_manager.py
+++ b/codalab/server/bundle_manager.py
@@ -313,14 +313,17 @@ class BundleManager(object):
 
     def _schedule_run_bundles_on_workers(self, workers, staged_bundles_to_run, user_info_cache):
         """
-        Schedules STAGED bundles to run on the given workers. Always tries to schedule bundles to
-        run on workers that are owned by the owner of each bundle first. If there are no such qualified
-        private workers, uses CodaLab-owned workers, which have user ID root_user_id.
+        Schedule STAGED bundles to run on available workers based on the following logic:
+        1. If the bundle requests to run on a specific worker, tries to schedule the bundle
+           to run on a worker that has a tag exactly match with request_queue.
+        2. If the bundle doesn't request to run on a specific worker,
+          (1) try to schedule the bundle to run on a worker that belongs to the bundle's owner
+          (2) if there is no such qualified private worker, uses CodaLab-owned workers, which have user ID root_user_id.
         :param workers: a WorkerInfoAccessor object containing worker related information e.g. running uuid.
         :param staged_bundles_to_run: a list of tuples each contains a valid bundle and its bundle resources.
         :param user_info_cache: a dictionary mapping user id to user information.
         """
-        # Reorder the stage_bundles so that bundles which were requested to run on a personal worker
+        # Reorder the stage_bundles so that bundles which were requested to run on a specific worker
         # will be scheduled to run first
         staged_bundles_to_run.sort(
             key=lambda b: (b[0].metadata.request_queue is not None, b[0].metadata.request_queue),
@@ -332,37 +335,21 @@ class BundleManager(object):
 
         # Dispatch bundles
         for bundle, bundle_resources in staged_bundles_to_run:
-
-            def get_available_workers(user_id):
-                # Make a deepcopy of the workers list so the filtering and deducting don't modify the list
-                workers_list = copy.deepcopy(workers.user_owned_workers(user_id))
-                workers_list = self._deduct_worker_resources(workers_list, running_bundles_info)
-                workers_list = self._filter_and_sort_workers(workers_list, bundle, bundle_resources)
-                return workers_list
-
-            workers_list = None
-            if bundle.owner_id != self._model.root_user_id:
-                # First try private workers
-                workers_list = get_available_workers(bundle.owner_id)
-                # If there is no user_owned worker, try to schedule the current bundle to run on a CodaLab's public worker.
-                if len(workers_list) == 0:
-                    # Check if there is enough parallel run quota left for this user
-                    if (
-                        self._model.get_user_parallel_run_quota_left(
-                            bundle.owner_id, user_info_cache[bundle.owner_id]
-                        )
-                        <= 0
-                    ):
-                        logger.info(
-                            "User %s has no parallel run quota left, skipping job for now",
-                            bundle.owner_id,
-                        )
-                        # Don't start this bundle yet, as there is no parallel_run_quota left for this user.
-                        continue
-            if not workers_list:
-                # Length is 0 (private user with no workers) or is None (root user)
-                workers_list = get_available_workers(self._model.root_user_id)
-
+            # Check if there is enough parallel run quota left for this user
+            if (
+                self._model.get_user_parallel_run_quota_left(
+                    bundle.owner_id, user_info_cache[bundle.owner_id]
+                )
+                <= 0
+            ):
+                # Don't include CodaLab-owned workers, as there is no parallel_run_quota left for this user.
+                codalab_owned_workers = []
+            else:
+                codalab_owned_workers = workers.user_owned_workers(self._model.root_user_id)
+            user_owned_workers = workers.user_owned_workers(bundle.owner_id)
+            workers_list = user_owned_workers + codalab_owned_workers
+            workers_list = self._deduct_worker_resources(workers_list, running_bundles_info)
+            workers_list = self._filter_and_sort_workers(workers_list, bundle, bundle_resources)
             # Try starting bundles on the workers that have enough computing resources
             for worker in workers_list:
                 if self._try_start_bundle(workers, worker, bundle, bundle_resources):
@@ -370,8 +357,9 @@ class BundleManager(object):
 
     def _deduct_worker_resources(self, workers_list, running_bundles_info):
         """
-        From each worker, subtract resources used by running bundles. Modifies the list.
+        From each worker, subtract resources used by running bundles.
         """
+        workers_list = copy.deepcopy(workers_list)
         for worker in workers_list:
             for uuid in worker['run_uuids']:
                 # Verify if the current bundle exists in both the worker table and the bundle table
@@ -398,9 +386,8 @@ class BundleManager(object):
         the list sorted in order of preference for running the bundle.
         """
         # Filter by tag.
-        request_queue = bundle.metadata.request_queue
-        if request_queue:
-            workers_list = self._get_matched_workers(request_queue, workers_list)
+        if bundle.metadata.request_queue:
+            workers_list = self._get_matched_workers(bundle.metadata.request_queue, workers_list)
 
         # Filter by CPUs.
         workers_list = [

--- a/codalab/worker/docker_utils.py
+++ b/codalab/worker/docker_utils.py
@@ -11,6 +11,7 @@ import os
 import docker
 from dateutil import parser, tz
 import datetime
+import re
 import requests
 
 
@@ -21,6 +22,12 @@ DEFAULT_TIMEOUT = 720
 # Docker Registry HTTP API v2 URI prefix
 URI_PREFIX = 'https://hub.docker.com/v2/repositories/'
 
+# This specific error happens when a user specifies an image with an incompatible version of Cuda
+NVIDIA_MOUNT_ERROR_REGEX = (
+    '[\s\S]*OCI runtime create failed[\s\S]*stderr:[\s\S]*nvidia-container-cli: '
+    'mount error: file creation failed:[\s\S]*nvidia-smi'
+)
+
 
 logger = logging.getLogger(__name__)
 client = docker.from_env(timeout=DEFAULT_TIMEOUT)
@@ -29,16 +36,24 @@ client = docker.from_env(timeout=DEFAULT_TIMEOUT)
 def wrap_exception(message):
     def decorator(f):
         def wrapper(*args, **kwargs):
+            def format_error_message(exception):
+                return '{}: {}'.format(message, exception)
+
+            def check_for_user_error(exception):
+                error_message = format_error_message(e)
+                if re.match(NVIDIA_MOUNT_ERROR_REGEX, str(exception)):
+                    raise DockerUserErrorException(error_message)
+                else:
+                    raise DockerException(error_message)
+
             try:
                 return f(*args, **kwargs)
             except DockerException as e:
-                raise DockerException(message + ': ' + str(e))
-            except (
-                docker.errors.APIError,
-                docker.errors.ImageNotFound,
-                docker.errors.NotFound,
-            ) as e:
-                raise DockerException(message + ': ' + str(e))
+                raise DockerException(format_error_message(e))
+            except docker.errors.APIError as e:
+                check_for_user_error(e)
+            except (docker.errors.ImageNotFound, docker.errors.NotFound) as e:
+                raise DockerException(format_error_message(e))
 
         return wrapper
 
@@ -48,6 +63,11 @@ def wrap_exception(message):
 class DockerException(Exception):
     def __init__(self, message):
         super(DockerException, self).__init__(message)
+
+
+class DockerUserErrorException(Exception):
+    def __init__(self, message):
+        super(DockerUserErrorException, self).__init__(message)
 
 
 @wrap_exception('Unable to use Docker')
@@ -266,7 +286,7 @@ def get_container_running_time(container):
     end_time = (
         container.attrs['State']['FinishedAt']
         if container.attrs['State']['Status'] == 'exited'
-        else str(datetime.datetime.now().replace(tzinfo=tz.tzutc()))
+        else str(datetime.datetime.now(tz.tzutc()))
     )
     # Docker reports both the start_time and the end_time in ISO format. We currently use dateutil.parser.isoparse to
     # parse them. In Python3.7 or above, the built-in function datetime.fromisoformat() can be used to parse ISO

--- a/codalab/worker/main.py
+++ b/codalab/worker/main.py
@@ -230,8 +230,9 @@ def parse_cpuset_args(arg):
         arg: comma separated string of ints, or "ALL" representing all available cpus
     """
     try:
-        # Get number of cores that the process can actually use.
-        cpu_count = len(os.sched_getaffinity(0))
+        # Get the set of cores that the process can actually use.
+        # For instance, on Slurm, the returning value may contain only 4 cores: {2,3,20,21}.
+        return os.sched_getaffinity(0)
     except AttributeError:
         # os.sched_getaffinity() isn't available on all platforms,
         # so fallback to using the number of physical cores.

--- a/codalab_service.py
+++ b/codalab_service.py
@@ -96,14 +96,18 @@ def main():
     service_manager.execute()
 
 
+def clean_version(version):
+    """Clean version name (usually a branch name) so it can be used as a
+    tag name for a Docker image."""
+    return version.replace("/", "_").replace("-", "_")
+
+
 def get_default_version():
     """Get the current git branch."""
-    return (
-        subprocess.check_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD'], encoding='utf-8')
-        .strip()
-        # This is required so that branches with special names do not fail CI.
-        .replace("/", "_")
-        .replace("-", "_")
+    return clean_version(
+        subprocess.check_output(
+            ['git', 'rev-parse', '--abbrev-ref', 'HEAD'], encoding='utf-8'
+        ).strip()
     )
 
 
@@ -508,6 +512,9 @@ class CodalabServiceManager(object):
 
     def __init__(self, args):
         self.args = args
+
+        if self.args.version:
+            self.args.version = clean_version(self.args.version)
         self.compose_cwd = os.path.join(BASE_DIR, 'docker', 'compose_files')
 
         self.compose_files = ['docker-compose.yml']

--- a/docs/CLI-Reference.md
+++ b/docs/CLI-Reference.md
@@ -1,513 +1,513 @@
 # CLI Reference
 
-This file is auto-generated from the output of `cl help -v` and provides the list of all CLI commands.
+This file is auto-generated from the output of `cl help -v -m` and provides the list of all CLI commands.
 
-    Usage: cl <command> <arguments>
+Usage: `cl <command> <arguments>`
 
-    Commands for bundles:
-      upload (up):
-        Create a bundle by uploading an existing file/directory.
-          upload <path>            : Upload contents of file/directory <path> as a bundle.
-          upload <path> ... <path> : Upload one bundle whose directory contents contain <path> ... <path>.
-          upload -c <text>         : Upload one bundle whose file contents is <text>.
-          upload <url>             : Upload one bundle whose file contents is downloaded from <url>.
-        Most of the other arguments specify metadata fields.
-        Arguments:
-          path                     Paths (or URLs) of the files/directories to upload.
-          -c, --contents           Specify the string contents of the bundle.
-          -L, --follow-symlinks    Always dereference (follow) symlinks.
-          -x, --exclude-patterns   Exclude these file patterns.
-          -g, --git                Path is a git repository, git clone it.
-          -p, --pack               If path is an archive file (e.g., zip, tar.gz), keep it packed.
-          -z, --force-compression  Always use compression (this may speed up single-file uploads over a slow network).
-          -w, --worksheet-spec     Upload to this worksheet ([(<alias>|<address>)::](<uuid>|<name>)).
-          -i, --ignore             Name of file containing patterns matching files and directories to exclude from upload. This option is currently only supported with the GNU tar library.
-          -n, --name               Short variable name (not necessarily unique); must conform to ^[a-zA-Z_][a-zA-Z0-9_\.\-]*$.
-          -d, --description        Full description of the bundle.
-          --tags                   Space-separated list of tags used for search (e.g., machine-learning).
-          --license                The license under which this program/dataset is released.
-          --source-url             URL corresponding to the original source of this bundle.
-          -e, --edit               Show an editor to allow editing of the bundle metadata.
+## Commands for bundles:
+  ### upload (up):
+    Create a bundle by uploading an existing file/directory.
+      upload <path>            : Upload contents of file/directory <path> as a bundle.
+      upload <path> ... <path> : Upload one bundle whose directory contents contain <path> ... <path>.
+      upload -c <text>         : Upload one bundle whose file contents is <text>.
+      upload <url>             : Upload one bundle whose file contents is downloaded from <url>.
+    Most of the other arguments specify metadata fields.
+    Arguments:
+      path                     Paths (or URLs) of the files/directories to upload.
+      -c, --contents           Specify the string contents of the bundle.
+      -L, --follow-symlinks    Always dereference (follow) symlinks.
+      -x, --exclude-patterns   Exclude these file patterns.
+      -g, --git                Path is a git repository, git clone it.
+      -p, --pack               If path is an archive file (e.g., zip, tar.gz), keep it packed.
+      -z, --force-compression  Always use compression (this may speed up single-file uploads over a slow network).
+      -w, --worksheet-spec     Upload to this worksheet ([(<alias>|<address>)::](<uuid>|<name>)).
+      -i, --ignore             Name of file containing patterns matching files and directories to exclude from upload. This option is currently only supported with the GNU tar library.
+      -n, --name               Short variable name (not necessarily unique); must conform to ^[a-zA-Z_][a-zA-Z0-9_\.\-]*$.
+      -d, --description        Full description of the bundle.
+      --tags                   Space-separated list of tags used for search (e.g., machine-learning).
+      --license                The license under which this program/dataset is released.
+      --source-url             URL corresponding to the original source of this bundle.
+      -e, --edit               Show an editor to allow editing of the bundle metadata.
 
-      make:
-        Create a bundle by combining parts of existing bundles.
-          make <bundle>/<subpath>                : New bundle's contents are copied from <subpath> in <bundle>.
-          make <key>:<bundle> ... <key>:<bundle> : New bundle contains file/directories <key> ... <key>, whose contents are given.
-        Arguments:
-          target_spec                  [<key>:][[(<alias>|<address>)::](<uuid>|<name>)//](<uuid>|<name>|^<index>)[/<subpath within bundle>]
-          -w, --worksheet-spec         Operate on this worksheet ([(<alias>|<address>)::](<uuid>|<name>)).
-          -n, --name                   Short variable name (not necessarily unique); must conform to ^[a-zA-Z_][a-zA-Z0-9_\.\-]*$.
-          -d, --description            Full description of the bundle.
-          --tags                       Space-separated list of tags used for search (e.g., machine-learning).
-          --allow-failed-dependencies  Whether to allow this bundle to have failed or killed dependencies.
-          -e, --edit                   Show an editor to allow editing of the bundle metadata.
+  ### make:
+    Create a bundle by combining parts of existing bundles.
+      make <bundle>/<subpath>                : New bundle's contents are copied from <subpath> in <bundle>.
+      make <key>:<bundle> ... <key>:<bundle> : New bundle contains file/directories <key> ... <key>, whose contents are given.
+    Arguments:
+      target_spec                  [<key>:][[(<alias>|<address>)::](<uuid>|<name>)//](<uuid>|<name>|^<index>)[/<subpath within bundle>]
+      -w, --worksheet-spec         Operate on this worksheet ([(<alias>|<address>)::](<uuid>|<name>)).
+      -n, --name                   Short variable name (not necessarily unique); must conform to ^[a-zA-Z_][a-zA-Z0-9_\.\-]*$.
+      -d, --description            Full description of the bundle.
+      --tags                       Space-separated list of tags used for search (e.g., machine-learning).
+      --allow-failed-dependencies  Whether to allow this bundle to have failed or killed dependencies.
+      -e, --edit                   Show an editor to allow editing of the bundle metadata.
 
-      run:
-        Create a bundle by running a program bundle on an input bundle.
-        Arguments:
-          target_spec                  [<key>]:[[(<alias>|<address>)::](<uuid>|<name>)//](<uuid>|<name>|^<index>)[/<subpath within bundle>]
-          command                      Arbitrary Linux command to execute.
-          -w, --worksheet-spec         Operate on this worksheet ([(<alias>|<address>)::](<uuid>|<name>)).
-          -a, --after_sort_key         Insert after this sort_key
-          -n, --name                   Short variable name (not necessarily unique); must conform to ^[a-zA-Z_][a-zA-Z0-9_\.\-]*$.
-          -d, --description            Full description of the bundle.
-          --tags                       Space-separated list of tags used for search (e.g., machine-learning).
-          --allow-failed-dependencies  Whether to allow this bundle to have failed or killed dependencies.
-          --request-docker-image       Which docker image (either tag or digest, e.g., codalab/default-cpu:latest) we wish to use.
-          --request-time               Amount of time (e.g., 3, 3m, 3h, 3d) allowed for this run. Defaults to user time quota left.
-          --request-memory             Amount of memory (e.g., 3, 3k, 3m, 3g, 3t) allowed for this run.
-          --request-disk               Amount of disk space (e.g., 3, 3k, 3m, 3g, 3t) allowed for this run. Defaults to user disk quota left.
-          --request-cpus               Number of CPUs allowed for this run.
-          --request-gpus               Number of GPUs allowed for this run.
-          --request-queue              Submit run to this job queue.
-          --request-priority           Job priority (higher is more important).
-          --request-network            Whether to allow network access.
-          -e, --edit                   Show an editor to allow editing of the bundle metadata.
-          -W, --wait                   Wait until run finishes.
-          -t, --tail                   Wait until run finishes, displaying stdout/stderr.
-          -v, --verbose                Display verbose output.
+  ### run:
+    Create a bundle by running a program bundle on an input bundle.
+    Arguments:
+      target_spec                  [<key>]:[[(<alias>|<address>)::](<uuid>|<name>)//](<uuid>|<name>|^<index>)[/<subpath within bundle>]
+      command                      Arbitrary Linux command to execute.
+      -w, --worksheet-spec         Operate on this worksheet ([(<alias>|<address>)::](<uuid>|<name>)).
+      -a, --after_sort_key         Insert after this sort_key
+      -n, --name                   Short variable name (not necessarily unique); must conform to ^[a-zA-Z_][a-zA-Z0-9_\.\-]*$.
+      -d, --description            Full description of the bundle.
+      --tags                       Space-separated list of tags used for search (e.g., machine-learning).
+      --allow-failed-dependencies  Whether to allow this bundle to have failed or killed dependencies.
+      --request-docker-image       Which docker image (either tag or digest, e.g., codalab/default-cpu:latest) we wish to use.
+      --request-time               Amount of time (e.g., 3, 3m, 3h, 3d) allowed for this run. Defaults to user time quota left.
+      --request-memory             Amount of memory (e.g., 3, 3k, 3m, 3g, 3t) allowed for this run.
+      --request-disk               Amount of disk space (e.g., 3, 3k, 3m, 3g, 3t) allowed for this run. Defaults to user disk quota left.
+      --request-cpus               Number of CPUs allowed for this run.
+      --request-gpus               Number of GPUs allowed for this run.
+      --request-queue              Submit run to this job queue.
+      --request-priority           Job priority (higher is more important).
+      --request-network            Whether to allow network access.
+      -e, --edit                   Show an editor to allow editing of the bundle metadata.
+      -W, --wait                   Wait until run finishes.
+      -t, --tail                   Wait until run finishes, displaying stdout/stderr.
+      -v, --verbose                Display verbose output.
 
-      docker:
-        Beta feature. Simulate a run bundle locally, producing bundle contents in the local environment and mounting local dependencies.
-        Arguments:
-          target_spec                  [<key>]:[[(<alias>|<address>)::](<uuid>|<name>)//](<uuid>|<name>|^<index>)[/<subpath within bundle>]
-          command                      Arbitrary Linux command to execute.
-          -w, --worksheet-spec         Operate on this worksheet ([(<alias>|<address>)::](<uuid>|<name>)).
-          -n, --name                   Short variable name (not necessarily unique); must conform to ^[a-zA-Z_][a-zA-Z0-9_\.\-]*$.
-          -d, --description            Full description of the bundle.
-          --tags                       Space-separated list of tags used for search (e.g., machine-learning).
-          --allow-failed-dependencies  Whether to allow this bundle to have failed or killed dependencies.
-          --request-docker-image       Which docker image (either tag or digest, e.g., codalab/default-cpu:latest) we wish to use.
-          --request-time               Amount of time (e.g., 3, 3m, 3h, 3d) allowed for this run. Defaults to user time quota left.
-          --request-memory             Amount of memory (e.g., 3, 3k, 3m, 3g, 3t) allowed for this run.
-          --request-disk               Amount of disk space (e.g., 3, 3k, 3m, 3g, 3t) allowed for this run. Defaults to user disk quota left.
-          --request-cpus               Number of CPUs allowed for this run.
-          --request-gpus               Number of GPUs allowed for this run.
-          --request-queue              Submit run to this job queue.
-          --request-priority           Job priority (higher is more important).
-          --request-network            Whether to allow network access.
-          -e, --edit                   Show an editor to allow editing of the bundle metadata.
-          -W, --wait                   Wait until run finishes.
-          -t, --tail                   Wait until run finishes, displaying stdout/stderr.
-          -v, --verbose                Display verbose output.
+  ### docker:
+    Beta feature. Simulate a run bundle locally, producing bundle contents in the local environment and mounting local dependencies.
+    Arguments:
+      target_spec                  [<key>]:[[(<alias>|<address>)::](<uuid>|<name>)//](<uuid>|<name>|^<index>)[/<subpath within bundle>]
+      command                      Arbitrary Linux command to execute.
+      -w, --worksheet-spec         Operate on this worksheet ([(<alias>|<address>)::](<uuid>|<name>)).
+      -n, --name                   Short variable name (not necessarily unique); must conform to ^[a-zA-Z_][a-zA-Z0-9_\.\-]*$.
+      -d, --description            Full description of the bundle.
+      --tags                       Space-separated list of tags used for search (e.g., machine-learning).
+      --allow-failed-dependencies  Whether to allow this bundle to have failed or killed dependencies.
+      --request-docker-image       Which docker image (either tag or digest, e.g., codalab/default-cpu:latest) we wish to use.
+      --request-time               Amount of time (e.g., 3, 3m, 3h, 3d) allowed for this run. Defaults to user time quota left.
+      --request-memory             Amount of memory (e.g., 3, 3k, 3m, 3g, 3t) allowed for this run.
+      --request-disk               Amount of disk space (e.g., 3, 3k, 3m, 3g, 3t) allowed for this run. Defaults to user disk quota left.
+      --request-cpus               Number of CPUs allowed for this run.
+      --request-gpus               Number of GPUs allowed for this run.
+      --request-queue              Submit run to this job queue.
+      --request-priority           Job priority (higher is more important).
+      --request-network            Whether to allow network access.
+      -e, --edit                   Show an editor to allow editing of the bundle metadata.
+      -W, --wait                   Wait until run finishes.
+      -t, --tail                   Wait until run finishes, displaying stdout/stderr.
+      -v, --verbose                Display verbose output.
 
-      edit (e):
-        Edit an existing bundle's metadata.
-          edit           : Popup an editor.
-          edit -n <name> : Edit the name metadata field (same for other fields).
-          edit -T <tag> ... <tag> : Set the tags of the bundle (e.g., training-dataset).
-        Arguments:
-          bundle_spec           [[(<alias>|<address>)::](<uuid>|<name>)//](<uuid>|<name>|^<index>)
-          -n, --name            Change the bundle name (format: ^[a-zA-Z_][a-zA-Z0-9_\.\-]*$).
-          -T, --tags            Change tags (must appear after worksheet_spec).
-          -d, --description     New bundle description.
-          --anonymous           Set bundle to be anonymous (identity of the owner will NOT 
-    be visible to users without 'all' permission on the bundle).
-          --not-anonymous       Set bundle to be NOT anonymous.
-          -w, --worksheet-spec  Operate on this worksheet ([(<alias>|<address>)::](<uuid>|<name>)).
+  ### edit (e):
+    Edit an existing bundle's metadata.
+      edit           : Popup an editor.
+      edit -n <name> : Edit the name metadata field (same for other fields).
+      edit -T <tag> ... <tag> : Set the tags of the bundle (e.g., training-dataset).
+    Arguments:
+      bundle_spec           [[(<alias>|<address>)::](<uuid>|<name>)//](<uuid>|<name>|^<index>)
+      -n, --name            Change the bundle name (format: ^[a-zA-Z_][a-zA-Z0-9_\.\-]*$).
+      -T, --tags            Change tags (must appear after worksheet_spec).
+      -d, --description     New bundle description.
+      --anonymous           Set bundle to be anonymous (identity of the owner will NOT be visible to users without 'all' permission on the bundle).
+      --not-anonymous       Set bundle to be NOT anonymous.
+      -w, --worksheet-spec  Operate on this worksheet ([(<alias>|<address>)::](<uuid>|<name>)).
 
-      detach (de):
-        Detach a bundle from this worksheet, but doesn't remove the bundle.
-        Arguments:
-          bundle_spec           [[(<alias>|<address>)::](<uuid>|<name>)//](<uuid>|<name>|^<index>)
-          -n, --index           Specifies which occurrence (1, 2, ...) of the bundle to detach, counting from the end.
-          -w, --worksheet-spec  Operate on this worksheet ([(<alias>|<address>)::](<uuid>|<name>)).
+  ### detach (de):
+    Detach a bundle from this worksheet, but doesn't remove the bundle.
+    Arguments:
+      bundle_spec           [[(<alias>|<address>)::](<uuid>|<name>)//](<uuid>|<name>|^<index>)
+      -n, --index           Specifies which occurrence (1, 2, ...) of the bundle to detach, counting from the end.
+      -w, --worksheet-spec  Operate on this worksheet ([(<alias>|<address>)::](<uuid>|<name>)).
 
-      rm:
-        Remove a bundle (permanent!).
-        Arguments:
-          bundle_spec           [[(<alias>|<address>)::](<uuid>|<name>)//](<uuid>|<name>|^<index>)
-          --force               Delete bundle (DANGEROUS - breaking dependencies!)
-          -r, --recursive       Delete all bundles downstream that depend on this bundle (DANGEROUS - could be a lot!).
-          -d, --data-only       Keep the bundle metadata, but remove the bundle contents on disk.
-          -i, --dry-run         Perform a dry run (just show what will be done without doing it).
-          -w, --worksheet-spec  Operate on this worksheet ([(<alias>|<address>)::](<uuid>|<name>)).
+  ### rm:
+    Remove a bundle (permanent!).
+    Arguments:
+      bundle_spec           [[(<alias>|<address>)::](<uuid>|<name>)//](<uuid>|<name>|^<index>)
+      --force               Delete bundle (DANGEROUS - breaking dependencies!)
+      -r, --recursive       Delete all bundles downstream that depend on this bundle (DANGEROUS - could be a lot!).
+      -d, --data-only       Keep the bundle metadata, but remove the bundle contents on disk.
+      -i, --dry-run         Perform a dry run (just show what will be done without doing it).
+      -w, --worksheet-spec  Operate on this worksheet ([(<alias>|<address>)::](<uuid>|<name>)).
 
-      search (s):
-        Search for bundles on a CodaLab instance (returns 10 results by default).
-          search <keyword> ... <keyword>         : Name or uuid contains each <keyword>.
-          search name=<value>                    : Name is <value>, where `name` can be any metadata field (e.g., description).
-          search type=<type>                     : Bundle type is <type> (`run` or `dataset`).
-          search id=<id>                         : Has <id> (integer used for sorting, strictly increasing over time).
-          search uuid=<uuid>                     : UUID is <uuid> (e.g., 0x...).
-          search state=<state>                   : State is <state> (e.g., staged, running, ready, failed).
-          search command=<command>               : Command to run is <command>.
-          search dependency=<uuid>               : Has a dependency with <uuid>.
-          search dependency/<name>=<uuid>        : Has a dependency <name>:<uuid>.
-        
-          search owner=<owner>                   : Owned by <owner> (e.g., `pliang`).
-          search .mine                           : Owned by me.
-          search group=<group>                   : Shared with <group>.
-          search .shared                         : Shared with any of the groups I'm in.
-        
-          search host_worksheet=<worksheet>      : On <worksheet>.
-          search .floating                       : Not on any worksheet.
-        
-          search .limit=<limit>                  : Limit the number of results to the top <limit> (e.g., 50).
-          search .offset=<offset>                : Return results starting at <offset>.
-        
-          search size=.sort                      : Sort by a particular field (where `size` can be any metadata field).
-          search size=.sort-                     : Sort by a particular field in reverse (e.g., `size`).
-          search .last                           : Sort in reverse chronological order (equivalent to id=.sort-).
-          search .count                          : Count the number of matching bundles.
-          search size=.sum                       : Compute total of a particular field (e.g., `size`).
-          search .format=<format>                : Apply <format> function (see worksheet markdown).
-        Arguments:
-          keywords              Keywords to search for.
-          -a, --append          Append these bundles to the current worksheet.
-          -u, --uuid-only       Print only uuids.
-          -w, --worksheet-spec  Operate on this worksheet ([(<alias>|<address>)::](<uuid>|<name>)).
+  ### search (s):
+    Search for bundles on a CodaLab instance (returns 10 results by default).
+      search <keyword> ... <keyword>         : Name or uuid contains each <keyword>.
+      search name=<value>                    : Name is <value>, where `name` can be any metadata field (e.g., description).
+      search type=<type>                     : Bundle type is <type> (`run` or `dataset`).
+      search id=<id>                         : Has <id> (integer used for sorting, strictly increasing over time).
+      search uuid=<uuid>                     : UUID is <uuid> (e.g., 0x...).
+      search state=<state>                   : State is <state> (e.g., staged, running, ready, failed).
+      search command=<command>               : Command to run is <command>.
+      search dependency=<uuid>               : Has a dependency with <uuid>.
+      search dependency/<name>=<uuid>        : Has a dependency <name>:<uuid>.
+    
+      search owner=<owner>                   : Owned by <owner> (e.g., `pliang`).
+      search .mine                           : Owned by me.
+      search group=<group>                   : Shared with <group>.
+      search .shared                         : Shared with any of the groups I'm in.
+    
+      search host_worksheet=<worksheet>      : On <worksheet>.
+      search .floating                       : Not on any worksheet.
+    
+      search .limit=<limit>                  : Limit the number of results to the top <limit> (e.g., 50).
+      search .offset=<offset>                : Return results starting at <offset>.
+    
+      search size=.sort                      : Sort by a particular field (where `size` can be any metadata field).
+      search size=.sort-                     : Sort by a particular field in reverse (e.g., `size`).
+      search .last                           : Sort in reverse chronological order (equivalent to id=.sort-).
+      search .count                          : Count the number of matching bundles.
+      search size=.sum                       : Compute total of a particular field (e.g., `size`).
+      search .format=<format>                : Apply <format> function (see worksheet markdown).
+    Arguments:
+      keywords              Keywords to search for.
+      -a, --append          Append these bundles to the current worksheet.
+      -u, --uuid-only       Print only uuids.
+      -w, --worksheet-spec  Operate on this worksheet ([(<alias>|<address>)::](<uuid>|<name>)).
 
-      ls:
-        List bundles in a worksheet.
-        Arguments:
-          -u, --uuid-only       Print only uuids.
-          -w, --worksheet-spec  Operate on this worksheet ([(<alias>|<address>)::](<uuid>|<name>)).
+  ### ls:
+    List bundles in a worksheet.
+    Arguments:
+      -u, --uuid-only       Print only uuids.
+      -w, --worksheet-spec  Operate on this worksheet ([(<alias>|<address>)::](<uuid>|<name>)).
 
-      info (i):
-        Show detailed information for a bundle.
-        Arguments:
-          bundle_spec           [[(<alias>|<address>)::](<uuid>|<name>)//](<uuid>|<name>|^<index>)
-          -f, --field           Print out these comma-separated fields.
-          -r, --raw             Print out raw information (no rendering of numbers/times).
-          -v, --verbose         Print top-level contents of bundle, children bundles, and host worksheets.
-          -w, --worksheet-spec  Operate on this worksheet ([(<alias>|<address>)::](<uuid>|<name>)).
+  ### info (i):
+    Show detailed information for a bundle.
+    Arguments:
+      bundle_spec           [[(<alias>|<address>)::](<uuid>|<name>)//](<uuid>|<name>|^<index>)
+      -f, --field           Print out these comma-separated fields.
+      -r, --raw             Print out raw information (no rendering of numbers/times).
+      -v, --verbose         Print top-level contents of bundle, children bundles, and host worksheets.
+      -w, --worksheet-spec  Operate on this worksheet ([(<alias>|<address>)::](<uuid>|<name>)).
 
-      cat:
-        Print the contents of a file/directory in a bundle.
-        Note that cat on a directory will list its files.
-        Arguments:
-          target_spec           [[(<alias>|<address>)::](<uuid>|<name>)//](<uuid>|<name>|^<index>)[/<subpath within bundle>]
-          --head                Display first NUM lines of contents.
-          -t, --tail            Display last NUM lines of contents
-          -w, --worksheet-spec  Operate on this worksheet ([(<alias>|<address>)::](<uuid>|<name>)).
+  ### cat:
+    Print the contents of a file/directory in a bundle.
+    Note that cat on a directory will list its files.
+    Arguments:
+      target_spec           [[(<alias>|<address>)::](<uuid>|<name>)//](<uuid>|<name>|^<index>)[/<subpath within bundle>]
+      --head                Display first NUM lines of contents.
+      -t, --tail            Display last NUM lines of contents
+      -w, --worksheet-spec  Operate on this worksheet ([(<alias>|<address>)::](<uuid>|<name>)).
 
-      wait:
-        Wait until a run bundle finishes.
-        Arguments:
-          target_spec           [[(<alias>|<address>)::](<uuid>|<name>)//](<uuid>|<name>|^<index>)[/<subpath within bundle>]
-          -t, --tail            Print out the tail of the file or bundle and block until the run bundle has finished running.
-          -w, --worksheet-spec  Operate on this worksheet ([(<alias>|<address>)::](<uuid>|<name>)).
+  ### wait:
+    Wait until a run bundle finishes.
+    Arguments:
+      target_spec           [[(<alias>|<address>)::](<uuid>|<name>)//](<uuid>|<name>|^<index>)[/<subpath within bundle>]
+      -t, --tail            Print out the tail of the file or bundle and block until the run bundle has finished running.
+      -w, --worksheet-spec  Operate on this worksheet ([(<alias>|<address>)::](<uuid>|<name>)).
 
-      download (down):
-        Download bundle from a CodaLab instance.
-        Arguments:
-          target_spec           [[(<alias>|<address>)::](<uuid>|<name>)//](<uuid>|<name>|^<index>)[/<subpath within bundle>]
-          -o, --output-path     Path to download bundle to.  By default, the bundle or subpath name in the current directory is used.
-          -w, --worksheet-spec  Operate on this worksheet ([(<alias>|<address>)::](<uuid>|<name>)).
+  ### download (down):
+    Download bundle from a CodaLab instance.
+    Arguments:
+      target_spec           [[(<alias>|<address>)::](<uuid>|<name>)//](<uuid>|<name>|^<index>)[/<subpath within bundle>]
+      -o, --output-path     Path to download bundle to.  By default, the bundle or subpath name in the current directory is used.
+      -w, --worksheet-spec  Operate on this worksheet ([(<alias>|<address>)::](<uuid>|<name>)).
 
-      mimic:
-        Creates a set of bundles based on analogy with another set.
-          mimic <run>      : Rerun the <run> bundle.
-          mimic A B        : For all run bundles downstream of A, rerun with B instead.
-          mimic A X B -n Y : For all run bundles used to produce X depending on A, rerun with B instead to produce Y.
-        Any provided metadata arguments will override the original metadata in mimicked bundles.
-        Arguments:
-          bundles                      Bundles: old_input_1 ... old_input_n old_output new_input_1 ... new_input_n ([[(<alias>|<address>)::](<uuid>|<name>)//](<uuid>|<name>|^<index>)).
-          -n, --name                   Short variable name (not necessarily unique); must conform to ^[a-zA-Z_][a-zA-Z0-9_\.\-]*$. (for makes and runs)
-          -d, --description            Full description of the bundle. (for makes and runs)
-          --tags                       Space-separated list of tags used for search (e.g., machine-learning). (for makes and runs)
-          --allow-failed-dependencies  Whether to allow this bundle to have failed or killed dependencies. (for makes and runs)
-          --request-docker-image       Which docker image (either tag or digest, e.g., codalab/default-cpu:latest) we wish to use. (for runs)
-          --request-time               Amount of time (e.g., 3, 3m, 3h, 3d) allowed for this run. Defaults to user time quota left. (for runs)
-          --request-memory             Amount of memory (e.g., 3, 3k, 3m, 3g, 3t) allowed for this run. (for runs)
-          --request-disk               Amount of disk space (e.g., 3, 3k, 3m, 3g, 3t) allowed for this run. Defaults to user disk quota left. (for runs)
-          --request-cpus               Number of CPUs allowed for this run. (for runs)
-          --request-gpus               Number of GPUs allowed for this run. (for runs)
-          --request-queue              Submit run to this job queue. (for runs)
-          --request-priority           Job priority (higher is more important). (for runs)
-          --request-network            Whether to allow network access. (for runs)
-          --depth                      Number of parents to look back from the old output in search of the old input.
-          -s, --shadow                 Add the newly created bundles right after the old bundles that are being mimicked.
-          -i, --dry-run                Perform a dry run (just show what will be done without doing it)
-          -w, --worksheet-spec         Operate on this worksheet ([(<alias>|<address>)::](<uuid>|<name>)).
-          -W, --wait                   Wait until run finishes.
-          -t, --tail                   Wait until run finishes, displaying stdout/stderr.
-          -v, --verbose                Display verbose output.
+  ### mimic:
+    Creates a set of bundles based on analogy with another set.
+      mimic <run>      : Rerun the <run> bundle.
+      mimic A B        : For all run bundles downstream of A, rerun with B instead.
+      mimic A X B -n Y : For all run bundles used to produce X depending on A, rerun with B instead to produce Y.
+    Any provided metadata arguments will override the original metadata in mimicked bundles.
+    Arguments:
+      bundles                      Bundles: old_input_1 ... old_input_n old_output new_input_1 ... new_input_n ([[(<alias>|<address>)::](<uuid>|<name>)//](<uuid>|<name>|^<index>)).
+      -n, --name                   Short variable name (not necessarily unique); must conform to ^[a-zA-Z_][a-zA-Z0-9_\.\-]*$. (for makes and runs)
+      -d, --description            Full description of the bundle. (for makes and runs)
+      --tags                       Space-separated list of tags used for search (e.g., machine-learning). (for makes and runs)
+      --allow-failed-dependencies  Whether to allow this bundle to have failed or killed dependencies. (for makes and runs)
+      --request-docker-image       Which docker image (either tag or digest, e.g., codalab/default-cpu:latest) we wish to use. (for runs)
+      --request-time               Amount of time (e.g., 3, 3m, 3h, 3d) allowed for this run. Defaults to user time quota left. (for runs)
+      --request-memory             Amount of memory (e.g., 3, 3k, 3m, 3g, 3t) allowed for this run. (for runs)
+      --request-disk               Amount of disk space (e.g., 3, 3k, 3m, 3g, 3t) allowed for this run. Defaults to user disk quota left. (for runs)
+      --request-cpus               Number of CPUs allowed for this run. (for runs)
+      --request-gpus               Number of GPUs allowed for this run. (for runs)
+      --request-queue              Submit run to this job queue. (for runs)
+      --request-priority           Job priority (higher is more important). (for runs)
+      --request-network            Whether to allow network access. (for runs)
+      --depth                      Number of parents to look back from the old output in search of the old input.
+      -s, --shadow                 Add the newly created bundles right after the old bundles that are being mimicked.
+      -i, --dry-run                Perform a dry run (just show what will be done without doing it)
+      -w, --worksheet-spec         Operate on this worksheet ([(<alias>|<address>)::](<uuid>|<name>)).
+      -W, --wait                   Wait until run finishes.
+      -t, --tail                   Wait until run finishes, displaying stdout/stderr.
+      -v, --verbose                Display verbose output.
 
-      macro:
-        Use mimicry to simulate macros.
-          macro M A B <name1>:C <name2>:D <=> mimic M-in1 M-in2 M-in-name1 M-in-name2 M-out A B C D
-        Arguments:
-          macro_name                   Name of the macro (look for <macro_name>-in1, <macro_name>-in-<name>, ..., and <macro_name>-out bundles).
-          bundles                      Bundles: new_input_1 ... new_input_n named_input_name:named_input_bundle other_named_input_name:other_named_input_bundle ([[(<alias>|<address>)::](<uuid>|<name>)//](<uuid>|<name>|^<index>))
-          -n, --name                   Short variable name (not necessarily unique); must conform to ^[a-zA-Z_][a-zA-Z0-9_\.\-]*$. (for makes and runs)
-          -d, --description            Full description of the bundle. (for makes and runs)
-          --tags                       Space-separated list of tags used for search (e.g., machine-learning). (for makes and runs)
-          --allow-failed-dependencies  Whether to allow this bundle to have failed or killed dependencies. (for makes and runs)
-          --request-docker-image       Which docker image (either tag or digest, e.g., codalab/default-cpu:latest) we wish to use. (for runs)
-          --request-time               Amount of time (e.g., 3, 3m, 3h, 3d) allowed for this run. Defaults to user time quota left. (for runs)
-          --request-memory             Amount of memory (e.g., 3, 3k, 3m, 3g, 3t) allowed for this run. (for runs)
-          --request-disk               Amount of disk space (e.g., 3, 3k, 3m, 3g, 3t) allowed for this run. Defaults to user disk quota left. (for runs)
-          --request-cpus               Number of CPUs allowed for this run. (for runs)
-          --request-gpus               Number of GPUs allowed for this run. (for runs)
-          --request-queue              Submit run to this job queue. (for runs)
-          --request-priority           Job priority (higher is more important). (for runs)
-          --request-network            Whether to allow network access. (for runs)
-          --depth                      Number of parents to look back from the old output in search of the old input.
-          -s, --shadow                 Add the newly created bundles right after the old bundles that are being mimicked.
-          -i, --dry-run                Perform a dry run (just show what will be done without doing it)
-          -w, --worksheet-spec         Operate on this worksheet ([(<alias>|<address>)::](<uuid>|<name>)).
-          -W, --wait                   Wait until run finishes.
-          -t, --tail                   Wait until run finishes, displaying stdout/stderr.
-          -v, --verbose                Display verbose output.
+  ### macro:
+    Use mimicry to simulate macros.
+      macro M A B <name1>:C <name2>:D <=> mimic M-in1 M-in2 M-in-name1 M-in-name2 M-out A B C D
+    Arguments:
+      macro_name                   Name of the macro (look for <macro_name>-in1, <macro_name>-in-<name>, ..., and <macro_name>-out bundles).
+      bundles                      Bundles: new_input_1 ... new_input_n named_input_name:named_input_bundle other_named_input_name:other_named_input_bundle ([[(<alias>|<address>)::](<uuid>|<name>)//](<uuid>|<name>|^<index>))
+      -n, --name                   Short variable name (not necessarily unique); must conform to ^[a-zA-Z_][a-zA-Z0-9_\.\-]*$. (for makes and runs)
+      -d, --description            Full description of the bundle. (for makes and runs)
+      --tags                       Space-separated list of tags used for search (e.g., machine-learning). (for makes and runs)
+      --allow-failed-dependencies  Whether to allow this bundle to have failed or killed dependencies. (for makes and runs)
+      --request-docker-image       Which docker image (either tag or digest, e.g., codalab/default-cpu:latest) we wish to use. (for runs)
+      --request-time               Amount of time (e.g., 3, 3m, 3h, 3d) allowed for this run. Defaults to user time quota left. (for runs)
+      --request-memory             Amount of memory (e.g., 3, 3k, 3m, 3g, 3t) allowed for this run. (for runs)
+      --request-disk               Amount of disk space (e.g., 3, 3k, 3m, 3g, 3t) allowed for this run. Defaults to user disk quota left. (for runs)
+      --request-cpus               Number of CPUs allowed for this run. (for runs)
+      --request-gpus               Number of GPUs allowed for this run. (for runs)
+      --request-queue              Submit run to this job queue. (for runs)
+      --request-priority           Job priority (higher is more important). (for runs)
+      --request-network            Whether to allow network access. (for runs)
+      --depth                      Number of parents to look back from the old output in search of the old input.
+      -s, --shadow                 Add the newly created bundles right after the old bundles that are being mimicked.
+      -i, --dry-run                Perform a dry run (just show what will be done without doing it)
+      -w, --worksheet-spec         Operate on this worksheet ([(<alias>|<address>)::](<uuid>|<name>)).
+      -W, --wait                   Wait until run finishes.
+      -t, --tail                   Wait until run finishes, displaying stdout/stderr.
+      -v, --verbose                Display verbose output.
 
-      kill:
-        Instruct the appropriate worker to terminate the running bundle(s).
-        Arguments:
-          bundle_spec           [[(<alias>|<address>)::](<uuid>|<name>)//](<uuid>|<name>|^<index>)
-          -w, --worksheet-spec  Operate on this worksheet ([(<alias>|<address>)::](<uuid>|<name>)).
+  ### kill:
+    Instruct the appropriate worker to terminate the running bundle(s).
+    Arguments:
+      bundle_spec           [[(<alias>|<address>)::](<uuid>|<name>)//](<uuid>|<name>|^<index>)
+      -w, --worksheet-spec  Operate on this worksheet ([(<alias>|<address>)::](<uuid>|<name>)).
 
-      write:
-        Instruct the appropriate worker to write a small file into the running bundle(s).
-        Arguments:
-          target_spec           [[(<alias>|<address>)::](<uuid>|<name>)//](<uuid>|<name>|^<index>)[/<subpath within bundle>]
-          string                Write this string to the target file.
-          -w, --worksheet-spec  Operate on this worksheet ([(<alias>|<address>)::](<uuid>|<name>)).
+  ### write:
+    Instruct the appropriate worker to write a small file into the running bundle(s).
+    Arguments:
+      target_spec           [[(<alias>|<address>)::](<uuid>|<name>)//](<uuid>|<name>|^<index>)[/<subpath within bundle>]
+      string                Write this string to the target file.
+      -w, --worksheet-spec  Operate on this worksheet ([(<alias>|<address>)::](<uuid>|<name>)).
 
-      mount:
-        Beta feature: this command may change in a future release. Mount the contents of a bundle at a read-only mountpoint.
-        Arguments:
-          target_spec           [[(<alias>|<address>)::](<uuid>|<name>)//](<uuid>|<name>|^<index>)[/<subpath within bundle>]
-          --mountpoint          Empty directory path to set up as the mountpoint for FUSE.
-          --verbose             Verbose mode for BundleFUSE.
-          -w, --worksheet-spec  Operate on this worksheet ([(<alias>|<address>)::](<uuid>|<name>)).
+  ### mount:
+    Beta feature: this command may change in a future release. Mount the contents of a bundle at a read-only mountpoint.
+    Arguments:
+      target_spec           [[(<alias>|<address>)::](<uuid>|<name>)//](<uuid>|<name>|^<index>)[/<subpath within bundle>]
+      --mountpoint          Empty directory path to set up as the mountpoint for FUSE.
+      --verbose             Verbose mode for BundleFUSE.
+      -w, --worksheet-spec  Operate on this worksheet ([(<alias>|<address>)::](<uuid>|<name>)).
 
-      netcat:
-        Beta feature: this command may change in a future release. Send raw data into a port of a running bundle
-        Arguments:
-          bundle_spec           [[(<alias>|<address>)::](<uuid>|<name>)//](<uuid>|<name>|^<index>)
-          port                  Port
-          message               Arbitrary message to send.
-          -f, --file            Add this file at end of message
-          --verbose             Verbose mode.
-          -w, --worksheet-spec  Operate on this worksheet ([(<alias>|<address>)::](<uuid>|<name>)).
-
-
-    Commands for worksheets:
-      new:
-        Create a new worksheet.
-        Arguments:
-          name                  Name of worksheet (^[a-zA-Z_][a-zA-Z0-9_\.\-]*$).
-          -w, --worksheet-spec  Operate on this worksheet ([(<alias>|<address>)::](<uuid>|<name>)).
-
-      add:
-        Append text items, bundles, or subworksheets to a worksheet (possibly on a different instance).
-        Bundles that do not yet exist on the destination instance will be copied over.
-        Arguments:
-          item_type                Type of item(s) to add {text, bundle, worksheet}.
-          item_spec                Item specifications, with the format depending on the specified item_type.
-        text:      (<text>|%%<directive>)
-        bundle:    [[(<alias>|<address>)::](<uuid>|<name>)//](<uuid>|<name>|^<index>)
-        worksheet: [(<alias>|<address>)::](<uuid>|<name>)
-          --dest-worksheet         Worksheet to which to add items ([(<alias>|<address>)::](<uuid>|<name>)).
-          -d, --copy-dependencies  If adding bundles, also add dependencies of the bundles.
-
-      wadd:
-        Append all the items of the source worksheet to the destination worksheet.
-        Bundles that do not yet exist on the destination service will be copied over.
-        The existing items on the destination worksheet are not affected unless the -r/--replace flag is set.
-        Arguments:
-          source_worksheet_spec  [(<alias>|<address>)::](<uuid>|<name>)
-          dest_worksheet_spec    [(<alias>|<address>)::](<uuid>|<name>)
-          -r, --replace          Replace everything on the destination worksheet with the items from the source worksheet, instead of appending (does not delete old bundles, just detaches).
-
-      work (w):
-        Set the current instance/worksheet.
-          work <worksheet>          : Switch to the given worksheet on the current instance.
-          work <alias>::            : Switch to the home worksheet on instance <alias>.
-          work <alias>::<worksheet> : Switch to the given worksheet on instance <alias>.
-        Arguments:
-          -u, --uuid-only  Print only the worksheet uuid.
-          worksheet_spec   [(<alias>|<address>)::](<uuid>|<name>)
-
-      print (p):
-        Print the rendered contents of a worksheet.
-        Arguments:
-          worksheet_spec  [(<alias>|<address>)::](<uuid>|<name>)
-          -r, --raw       Print out the raw contents (for editing).
-
-      wedit (we):
-        Edit the contents of a worksheet.
-        See https://codalab-worksheets.readthedocs.io/en/latest/User_Worksheet-Markdown for the markdown syntax.
-          wedit -n <name>          : Change the name of the worksheet.
-          wedit -T <tag> ... <tag> : Set the tags of the worksheet (e.g., paper).
-          wedit -o <username>      : Set the owner of the worksheet to <username>.
-        Arguments:
-          worksheet_spec    [(<alias>|<address>)::](<uuid>|<name>)
-          -n, --name        Changes the name of the worksheet (^[a-zA-Z_][a-zA-Z0-9_\.\-]*$).
-          -t, --title       Change title of worksheet.
-          -T, --tags        Change tags (must appear after worksheet_spec).
-          -o, --owner-spec  Change owner of worksheet.
-          --freeze          Freeze worksheet to prevent future modification (PERMANENT!).
-          --anonymous       Set worksheet to be anonymous (identity of the owner will NOT 
-    be visible to users without 'all' permission on the worksheet).
-          --not-anonymous   Set bundle to be NOT anonymous.
-          -f, --file        Replace the contents of the current worksheet with this file.
-
-      wrm:
-        Delete a worksheet.
-        To be safe, you can only delete a worksheet if it has no items and is not frozen.
-        Arguments:
-          worksheet_spec  [(<alias>|<address>)::](<uuid>|<name>)
-          --force         Delete worksheet even if it is non-empty and frozen.
-
-      wls (wsearch, ws):
-        List worksheets on the current instance matching the given keywords (returns 10 results by default).
-          wls tag=paper           : List worksheets tagged as "paper".
-          wls group=<group_spec>  : List worksheets shared with the group identfied by group_spec.
-          wls .mine               : List my worksheets.
-          wls .shared             : List worksheets that have been shared with any of the groups I am in.
-          wls .limit=10           : Limit the number of results to the top 10.
-        Arguments:
-          keywords         Keywords to search for.
-          -a, --address    (<alias>|<address>)
-          -u, --uuid-only  Print only uuids.
+  ### netcat:
+    Beta feature: this command may change in a future release. Send raw data into a port of a running bundle
+    Arguments:
+      bundle_spec           [[(<alias>|<address>)::](<uuid>|<name>)//](<uuid>|<name>|^<index>)
+      port                  Port
+      message               Arbitrary message to send.
+      -f, --file            Add this file at end of message
+      --verbose             Verbose mode.
+      -w, --worksheet-spec  Operate on this worksheet ([(<alias>|<address>)::](<uuid>|<name>)).
 
 
-    Commands for groups and permissions:
-      gls:
-        Show groups to which you belong.
-        Arguments:
-          -w, --worksheet-spec  Operate on this worksheet ([(<alias>|<address>)::](<uuid>|<name>)).
+## Commands for worksheets:
+  ### new:
+    Create a new worksheet.
+    Arguments:
+      name                  Name of worksheet (^[a-zA-Z_][a-zA-Z0-9_\.\-]*$).
+      -w, --worksheet-spec  Operate on this worksheet ([(<alias>|<address>)::](<uuid>|<name>)).
 
-      gnew:
-        Create a new group.
-        Arguments:
-          name  Name of new group (^[a-zA-Z_][a-zA-Z0-9_\.\-]*$).
+  ### add:
+    Append text items, bundles, or subworksheets to a worksheet (possibly on a different instance).
+    Bundles that do not yet exist on the destination instance will be copied over.
+    Arguments:
+      item_type                Type of item(s) to add {text, bundle, worksheet}.
+      item_spec                Item specifications, with the format depending on the specified item_type.
+    text:      (<text>|%%<directive>)
+    bundle:    [[(<alias>|<address>)::](<uuid>|<name>)//](<uuid>|<name>|^<index>)
+    worksheet: [(<alias>|<address>)::](<uuid>|<name>)
+      --dest-worksheet         Worksheet to which to add items ([(<alias>|<address>)::](<uuid>|<name>)).
+      -d, --copy-dependencies  If adding bundles, also add dependencies of the bundles.
 
-      grm:
-        Delete a group.
-        Arguments:
-          group_spec  Group to delete ((<uuid>|<name>|public)).
+  ### wadd:
+    Append all the items of the source worksheet to the destination worksheet.
+    Bundles that do not yet exist on the destination service will be copied over.
+    The existing items on the destination worksheet are not affected unless the -r/--replace flag is set.
+    Arguments:
+      source_worksheet_spec  [(<alias>|<address>)::](<uuid>|<name>)
+      dest_worksheet_spec    [(<alias>|<address>)::](<uuid>|<name>)
+      -r, --replace          Replace everything on the destination worksheet with the items from the source worksheet, instead of appending (does not delete old bundles, just detaches).
 
-      ginfo:
-        Show detailed information for a group.
-        Arguments:
-          group_spec  Group to show information about ((<uuid>|<name>|public)).
+  ### work (w):
+    Set the current instance/worksheet.
+      work <worksheet>          : Switch to the given worksheet on the current instance.
+      work <alias>::            : Switch to the home worksheet on instance <alias>.
+      work <alias>::<worksheet> : Switch to the given worksheet on instance <alias>.
+    Arguments:
+      -u, --uuid-only  Print only the worksheet uuid.
+      worksheet_spec   [(<alias>|<address>)::](<uuid>|<name>)
 
-      uadd:
-        Add a user to a group.
-        Arguments:
-          user_spec    Username to add.
-          group_spec   Group to add user to ((<uuid>|<name>|public)).
-          -a, --admin  Give admin privileges to the user for the group.
+  ### print (p):
+    Print the rendered contents of a worksheet.
+    Arguments:
+      worksheet_spec  [(<alias>|<address>)::](<uuid>|<name>)
+      -r, --raw       Print out the raw contents (for editing).
 
-      urm:
-        Remove a user from a group.
-        Arguments:
-          user_spec   Username to remove.
-          group_spec  Group to remove user from ((<uuid>|<name>|public)).
+  ### wedit (we):
+    Edit the contents of a worksheet.
+    See https://codalab-worksheets.readthedocs.io/en/latest/User_Worksheet-Markdown for the markdown syntax.
+      wedit -n <name>          : Change the name of the worksheet.
+      wedit -T <tag> ... <tag> : Set the tags of the worksheet (e.g., paper).
+      wedit -o <username>      : Set the owner of the worksheet to <username>.
+    Arguments:
+      worksheet_spec    [(<alias>|<address>)::](<uuid>|<name>)
+      -n, --name        Changes the name of the worksheet (^[a-zA-Z_][a-zA-Z0-9_\.\-]*$).
+      -t, --title       Change title of worksheet.
+      -T, --tags        Change tags (must appear after worksheet_spec).
+      -o, --owner-spec  Change owner of worksheet.
+      --freeze          Freeze worksheet to prevent future modification (PERMANENT!).
+      --anonymous       Set worksheet to be anonymous (identity of the owner will NOT be visible to users without 'all' permission on the worksheet).
+      --not-anonymous   Set bundle to be NOT anonymous.
+      -f, --file        Replace the contents of the current worksheet with this file.
 
-      perm:
-        Set a group's permissions for a bundle.
-        Arguments:
-          bundle_spec           [[(<alias>|<address>)::](<uuid>|<name>)//](<uuid>|<name>|^<index>)
-          group_spec            (<uuid>|<name>|public)
-          permission_spec       ((n)one|(r)ead|(a)ll)
-          -w, --worksheet-spec  Operate on this worksheet ([(<alias>|<address>)::](<uuid>|<name>)).
+  ### wrm:
+    Delete a worksheet.
+    To be safe, you can only delete a worksheet if it has no items and is not frozen.
+    Arguments:
+      worksheet_spec  [(<alias>|<address>)::](<uuid>|<name>)
+      --force         Delete worksheet even if it is non-empty and frozen.
 
-      wperm:
-        Set a group's permissions for a worksheet.
-        Arguments:
-          worksheet_spec   [(<alias>|<address>)::](<uuid>|<name>)
-          group_spec       (<uuid>|<name>|public)
-          permission_spec  ((n)one|(r)ead|(a)ll)
-
-      chown:
-        Set the owner of bundles.
-        Arguments:
-          user_spec             Username to set as the owner.
-          bundle_spec           [[(<alias>|<address>)::](<uuid>|<name>)//](<uuid>|<name>|^<index>)
-          -w, --worksheet-spec  Operate on this worksheet ([(<alias>|<address>)::](<uuid>|<name>)).
-
-
-    Commands for users:
-      uinfo:
-        Show user information.
-        Arguments:
-          user_spec    Username or id of user to show [default: the authenticated user]
-          -f, --field  Print out these comma-separated fields.
-
-      uedit:
-        Edit user information.
-        Note that password and email can only be changed through the web interface.
-        Arguments:
-          user_spec                 Username or id of user to update [default: the authenticated user]
-          --first-name              First name
-          --last-name               Last name
-          --affiliation             Affiliation
-          --url                     Website URL
-          -t, --time-quota          Total amount of time allowed (e.g., 3, 3m, 3h, 3d)
-          -p, --parallel-run-quota  Total amount of runs the user may have running at a time on shared public workers
-          -d, --disk-quota          Total amount of disk allowed (e.g., 3, 3k, 3m, 3g, 3t)
-
-      ufarewell:
-        Delete user permanently. Root user only.
-        To be safe, you can only delete a user if user does not own any bundles, worksheets, or groups.
-        Arguments:
-          user_spec  Username or id of user to delete.
+  ### wls (wsearch, ws):
+    List worksheets on the current instance matching the given keywords (returns 10 results by default).
+      wls tag=paper           : List worksheets tagged as "paper".
+      wls group=<group_spec>  : List worksheets shared with the group identfied by group_spec.
+      wls .mine               : List my worksheets.
+      wls .shared             : List worksheets that have been shared with any of the groups I am in.
+      wls .limit=10           : Limit the number of results to the top 10.
+    Arguments:
+      keywords         Keywords to search for.
+      -a, --address    (<alias>|<address>)
+      -u, --uuid-only  Print only uuids.
 
 
-    Commands for managing server:
-      workers:
-        Display worker information of this CodaLab instance. Root user only.
+## Commands for groups and permissions:
+  ### gls:
+    Show groups to which you belong.
+    Arguments:
+      -w, --worksheet-spec  Operate on this worksheet ([(<alias>|<address>)::](<uuid>|<name>)).
 
-      bs-add-partition:
-        Add another partition for storage (MultiDiskBundleStore only)
-        Arguments:
-          name  The name you'd like to give this partition for CodaLab.
-          path  The target location you would like to use for storing bundles. This directory should be underneath a mountpoint for the partition you would like to use. You are responsible for configuring the mountpoint yourself.
+  ### gnew:
+    Create a new group.
+    Arguments:
+      name  Name of new group (^[a-zA-Z_][a-zA-Z0-9_\.\-]*$).
 
-      bs-rm-partition:
-        Remove a partition by its number (MultiDiskBundleStore only)
-        Arguments:
-          partition  The partition you want to remove.
+  ### grm:
+    Delete a group.
+    Arguments:
+      group_spec  Group to delete ((<uuid>|<name>|public)).
 
-      bs-ls-partitions:
-        List available partitions (MultiDiskBundleStore only)
+  ### ginfo:
+    Show detailed information for a group.
+    Arguments:
+      group_spec  Group to show information about ((<uuid>|<name>|public)).
 
-      bs-health-check:
-        Perform a health check on the bundle store, garbage collecting bad files in the store. Performs a dry run by default, use -f to force removal.
-        Arguments:
-          -f, --force      Perform all garbage collection and database updates instead of just printing what would happen
-          -d, --data-hash  Compute the digest for every bundle and compare against data_hash for consistency
-          -r, --repair     When used with --force and --data-hash, repairs incorrect data_hash in existing bundles
+  ### uadd:
+    Add a user to a group.
+    Arguments:
+      user_spec    Username to add.
+      group_spec   Group to add user to ((<uuid>|<name>|public)).
+      -a, --admin  Give admin privileges to the user for the group.
+
+  ### urm:
+    Remove a user from a group.
+    Arguments:
+      user_spec   Username to remove.
+      group_spec  Group to remove user from ((<uuid>|<name>|public)).
+
+  ### perm:
+    Set a group's permissions for a bundle.
+    Arguments:
+      bundle_spec           [[(<alias>|<address>)::](<uuid>|<name>)//](<uuid>|<name>|^<index>)
+      group_spec            (<uuid>|<name>|public)
+      permission_spec       ((n)one|(r)ead|(a)ll)
+      -w, --worksheet-spec  Operate on this worksheet ([(<alias>|<address>)::](<uuid>|<name>)).
+
+  ### wperm:
+    Set a group's permissions for a worksheet.
+    Arguments:
+      worksheet_spec   [(<alias>|<address>)::](<uuid>|<name>)
+      group_spec       (<uuid>|<name>|public)
+      permission_spec  ((n)one|(r)ead|(a)ll)
+
+  ### chown:
+    Set the owner of bundles.
+    Arguments:
+      user_spec             Username to set as the owner.
+      bundle_spec           [[(<alias>|<address>)::](<uuid>|<name>)//](<uuid>|<name>|^<index>)
+      -w, --worksheet-spec  Operate on this worksheet ([(<alias>|<address>)::](<uuid>|<name>)).
 
 
-    Other commands:
-      help:
-        Show usage information for commands.
-          help           : Show brief description for all commands.
-          help -v        : Show full usage information for all commands.
-          help <command> : Show full usage information for <command>.
-        Arguments:
-          command        name of command to look up
-          -v, --verbose  Display all options of all commands.
+## Commands for users:
+  ### uinfo:
+    Show user information.
+    Arguments:
+      user_spec    Username or id of user to show [default: the authenticated user]
+      -f, --field  Print out these comma-separated fields.
 
-      status (st):
-        Show current client status.
+  ### uedit:
+    Edit user information.
+    Note that password and email can only be changed through the web interface.
+    Arguments:
+      user_spec                 Username or id of user to update [default: the authenticated user]
+      --first-name              First name
+      --last-name               Last name
+      --affiliation             Affiliation
+      --url                     Website URL
+      -t, --time-quota          Total amount of time allowed (e.g., 3, 3m, 3h, 3d)
+      -p, --parallel-run-quota  Total amount of runs the user may have running at a time on shared public workers
+      -d, --disk-quota          Total amount of disk allowed (e.g., 3, 3k, 3m, 3g, 3t)
 
-      alias:
-        Manage CodaLab instance aliases. These are mappings from names to CodaLab Worksheet servers.
-          alias                   : List all aliases.
-          alias <name>            : Shows which instance <name> is bound to.
-          alias <name> <instance> : Binds <name> to <instance>.
-        Arguments:
-          name          Name of the alias (e.g., main).
-          instance      Instance to bind the alias to (e.g., https://worksheets.codalab.org).
-          -r, --remove  Remove this alias.
+  ### ufarewell:
+    Delete user permanently. Root user only.
+    To be safe, you can only delete a user if user does not own any bundles, worksheets, or groups.
+    Arguments:
+      user_spec  Username or id of user to delete.
 
-      config:
-        Set CodaLab configuration.
-          config <key>         : Shows the value of <key>.
-          config <key> <value> : Sets <key> to <value>.
-        Arguments:
-          key           key to set (e.g., cli/verbose).
-          value         Instance to bind the alias to (e.g., https://worksheets.codalab.org).
-          -r, --remove  Remove this key.
 
-      logout:
-        Logout of the current session, or a specific instance.
-        Arguments:
-          alias  Alias or URL of instance from which to logout. Default is the current session.
+## Commands for managing server:
+  ### workers:
+    Display information about workers that you have connected to the CodaLab instance. For the root user, display all workers.
+
+  ### bs-add-partition:
+    Add another partition for storage (MultiDiskBundleStore only)
+    Arguments:
+      name  The name you'd like to give this partition for CodaLab.
+      path  The target location you would like to use for storing bundles. This directory should be underneath a mountpoint for the partition you would like to use. You are responsible for configuring the mountpoint yourself.
+
+  ### bs-rm-partition:
+    Remove a partition by its number (MultiDiskBundleStore only)
+    Arguments:
+      partition  The partition you want to remove.
+
+  ### bs-ls-partitions:
+    List available partitions (MultiDiskBundleStore only)
+
+  ### bs-health-check:
+    Perform a health check on the bundle store, garbage collecting bad files in the store. Performs a dry run by default, use -f to force removal.
+    Arguments:
+      -f, --force      Perform all garbage collection and database updates instead of just printing what would happen
+      -d, --data-hash  Compute the digest for every bundle and compare against data_hash for consistency
+      -r, --repair     When used with --force and --data-hash, repairs incorrect data_hash in existing bundles
+
+
+## Other commands:
+  ### help:
+    Show usage information for commands.
+      help           : Show brief description for all commands.
+      help -v        : Show full usage information for all commands.
+      help -v -m     : Show full usage information for all commands in Markdown format.
+      help <command> : Show full usage information for <command>.
+    Arguments:
+      command         name of command to look up
+      -v, --verbose   Display all options of all commands.
+      -m, --markdown  Auto-generate all options of all commands for CLI markdown in Markdown format.
+
+  ### status (st):
+    Show current client status.
+
+  ### alias:
+    Manage CodaLab instance aliases. These are mappings from names to CodaLab Worksheet servers.
+      alias                   : List all aliases.
+      alias <name>            : Shows which instance <name> is bound to.
+      alias <name> <instance> : Binds <name> to <instance>.
+    Arguments:
+      name          Name of the alias (e.g., main).
+      instance      Instance to bind the alias to (e.g., https://worksheets.codalab.org).
+      -r, --remove  Remove this alias.
+
+  ### config:
+    Set CodaLab configuration.
+      config <key>         : Shows the value of <key>.
+      config <key> <value> : Sets <key> to <value>.
+    Arguments:
+      key           key to set (e.g., cli/verbose).
+      value         Instance to bind the alias to (e.g., https://worksheets.codalab.org).
+      -r, --remove  Remove this key.
+
+  ### logout:
+    Logout of the current session, or a specific instance.
+    Arguments:
+      alias  Alias or URL of instance from which to logout. Default is the current session.

--- a/docs/REST-API-Reference.md
+++ b/docs/REST-API-Reference.md
@@ -175,7 +175,7 @@ Name | Type
 
 Name | Type
 --- | ---
-`id` | Integer
+`id` | CompatibleInteger
 `bundle` | Relationship([bundles](#bundles))
 `group` | Relationship([groups](#groups))
 `group_name` | String
@@ -234,7 +234,7 @@ Name | Type
 
 Name | Type
 --- | ---
-`id` | Integer
+`id` | CompatibleInteger
 `worksheet` | Relationship([worksheets](#worksheets))
 `subworksheet` | Relationship([worksheets](#worksheets))
 `bundle` | Relationship([bundles](#bundles))
@@ -247,7 +247,7 @@ Name | Type
 
 Name | Type
 --- | ---
-`id` | Integer
+`id` | CompatibleInteger
 `worksheet` | Relationship([worksheets](#worksheets))
 `group` | Relationship([groups](#groups))
 `group_name` | String

--- a/docs/Server-Setup.md
+++ b/docs/Server-Setup.md
@@ -24,6 +24,7 @@ worker) with one command:
 
     ./codalab_service.py start
 
+Make sure to run the command **without** sudo. Running the service start up script with sudo can cause initialization of the mysql database to fail. See [Troubleshooting](#Troubleshooting) for how to resolve this.
 You can then go to `http://localhost`, sign in with the root `codalab` user
 (password `codalab`), try running some bundles.  Normally, you'd install the
 CLI using `pip`, but to use the version of the CLI from the repo, you can run
@@ -242,6 +243,17 @@ service on the same machine, be careful about the following:
   `http-port` of later instances to something other than `80`.
 
 ## Troubleshooting
+
+If you run the codalab_service script with root privileges and see an error about either of the following:
+
+    Unknown MySQL server host 'mysql' (0)
+    Host '*.*.*.*' is not allowed to connect to this MySQL server
+
+Make sure you can run docker commands without root privileges. If you cannot, make sure to run:
+
+    sudo usermod -aG docker ${USER}
+
+Exit the terminal window in which that command is run. Once you ensure docker commands can be run without sudo, Remove the `var` folder from within the `/codalab-worksheets` directory. **Warning: Removing the `var` folder leads to data loss for your local Codalab instance.** Backup any necessary data first.
 
 For macOS, you might come across an error with `gunicorn` when running `./codalab_service.py start -bd`
 

--- a/frontend/src/components/EditableField.js
+++ b/frontend/src/components/EditableField.js
@@ -104,6 +104,9 @@ class EditableFieldBase extends React.Component<{
     }
 
     render() {
+        if (!this.props.canEdit) {
+            return <span style={{ color: '#225ea8' }}>{this.state.value || '<none>'}</span>;
+        }
         if (!this.state.editing) {
             return (
                 <span

--- a/frontend/src/components/worksheets/BundleDetail/BundleActions.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/BundleActions.jsx
@@ -37,6 +37,7 @@ class BundleActions extends React.Component<
 		run.docker = bundleInfo.metadata.request_docker_image;
 		run.networkAccess = bundleInfo.metadata.request_network;
 		run.failedDependencies = bundleInfo.metadata.allow_failed_dependencies;
+		run.queue = bundleInfo.metadata.request_queue;
 		this.props.rerunItem(run);
 	}
 

--- a/frontend/src/components/worksheets/NewRun/NewRun.jsx
+++ b/frontend/src/components/worksheets/NewRun/NewRun.jsx
@@ -166,6 +166,7 @@ class NewRun extends React.Component<{
         docker: kDefaultDockerCpu,
         networkAccess: false,
         failedDependencies: false,
+        queue: '',
     }
 
     /**
@@ -227,6 +228,7 @@ class NewRun extends React.Component<{
             docker,
             networkAccess,
             failedDependencies,
+            queue,
         } = this.state;
         const { after_sort_key } = this.props;
 
@@ -241,6 +243,7 @@ class NewRun extends React.Component<{
         if (cpu) args.push(`--request-cpus=${cpu}`);
         if (gpu) args.push(`--request-gpus=${gpu}`);
         if (docker) args.push(`--request-docker-image=${docker}`);
+        if (queue) args.push(`--request-queue=${queue}`);
         if (networkAccess) args.push(`--request-network`);
         if (failedDependencies) args.push(`--allow-failed-dependencies`);
 
@@ -352,7 +355,6 @@ class NewRun extends React.Component<{
                                 (state) => ({ tags: [...state.tags.slice(0, idx), ...state.tags.slice(idx+1)] })
                             )}
                         />
-
                         <div className={classes.spacer}/>
                         <Typography variant='subtitle1'>Resources</Typography>
 
@@ -434,6 +436,18 @@ class NewRun extends React.Component<{
                                     placeholder={`${kDefaultDockerCpu}`}
                                 />
                             </Grid>
+                            <ConfigLabel
+                                label="Queue"
+                                tooltip="Tag of the queue, this will add '--request-queue {input}' to the run"
+                                optional
+                            />
+                            <ConfigTextInput
+                                value={this.state.queue}
+                                onValueChange={(value) => {
+                                    this.setState({ queue: value })
+                                }}
+                                placeholder={''}
+                            />
                             <Grid item xs={12}>
                                 <ConfigSwitchInput
                                     value={this.state.networkAccess}

--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -956,7 +956,9 @@ class Worksheet extends React.Component {
             editor.$blockScrolling = Infinity;
             editor.session.setUseWrapMode(false);
             editor.setShowPrintMargin(false);
-            editor.session.setMode('ace/mode/markdown');
+            editor.session.setMode('ace/mode/markdown', function() {
+                editor.session.$mode.blockComment = { start: '//', end: '' };
+            });
             if (!this.canEdit()) {
                 editor.setOptions({
                     readOnly: true,

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -11,9 +11,9 @@ fi
 venv/bin/pip install -e .
 
 # Generate docs
-venv/bin/python scripts/gen-rest-docs.py || exit 1  # Outputs to `docs`
-venv/bin/python scripts/gen-cli-docs.py || exit 1  # Outputs to `docs`
-venv/bin/mkdocs build || exit 1  # Outputs to `site`
+venv/bin/python scripts/gen-rest-docs.py || { rm -rf venv; exit 1; }  # Outputs to `docs`
+venv/bin/python scripts/gen-cli-docs.py || { rm -rf venv; exit 1; }  # Outputs to `docs`
+venv/bin/mkdocs build || { rm -rf venv; exit 1; }  # Outputs to `site`
 # Note: run `venv/bin/mkdocs serve` for a live preview
 
 # Fix Python and JavaScript style (mutates code!)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ marshmallow==2.15.1
 setuptools>=40.0.0
 argcomplete==1.9.4
 PyYAML==5.1
-psutil==5.4.6
+psutil==5.6.6
 six==1.11.0
 SQLAlchemy==1.3.0
 watchdog==0.8.3

--- a/scripts/create_sample_worksheet.py
+++ b/scripts/create_sample_worksheet.py
@@ -87,6 +87,7 @@ class SampleWorksheet:
         print('Done.')
 
     def test_print(self):
+        self._wait_for_bundles_to_finish()
         output_lines = run_command([self._cl, 'print', self._worksheet_name]).split('\n')
         has_error = False
         for i in range(len(self._expected_lines)):
@@ -150,6 +151,12 @@ class SampleWorksheet:
             )
             run_command([self._cl, 'perm', uuid, 'public', 'none'])
             self._private_bundles.append(uuid)
+
+    def _wait_for_bundles_to_finish(self):
+        if self._valid_bundles:
+            for bundle in self._valid_bundles:
+                run_command([self._cl, 'wait', bundle])
+                print('Bundle {} is finished.'.format(bundle))
 
     def _create_sample_worksheet(self):
         # Write out the contents to a temporary file

--- a/scripts/gen-cli-docs.py
+++ b/scripts/gen-cli-docs.py
@@ -2,20 +2,17 @@
 Generate CLI docs.
 """
 import os
-import sys
 import argparse
-from codalab.bin import cl  # Important to put here to register the commands.
 from codalab.lib.bundle_cli import Commands
 
 INTRODUCTION = """# CLI Reference
 
-This file is auto-generated from the output of `cl help -v` and provides the list of all CLI commands.
+This file is auto-generated from the output of `cl help -v -m` and provides the list of all CLI commands.
 """
 
 
-def indent(s, padding='    '):
-    # Add `padding` in front of each non-empty line.
-    return '\n'.join(padding + line if line else '' for line in s.split('\n'))
+def indent(s):
+    return '\n'.join(line if line else '' for line in s.split('\n'))
 
 
 def main():
@@ -25,7 +22,7 @@ def main():
 
     with open(os.path.join(args.docs, 'CLI-Reference.md'), 'w') as f:
         print(INTRODUCTION, file=f)
-        print(indent(Commands.help_text(True)), file=f)
+        print(indent(Commands.help_text(verbose=True, markdown=True)), file=f)
 
 
 if __name__ == '__main__':

--- a/tests/lib/cli_util_test.py
+++ b/tests/lib/cli_util_test.py
@@ -59,6 +59,10 @@ class CLIUtilTest(unittest.TestCase):
         for spec, expected_parse in cases:
             self.assertEqual(cli_util.parse_key_target(spec), expected_parse)
 
+        usage_error_cases = [':', 'a:', '']
+        for spec in usage_error_cases:
+            self.assertRaises(UsageError, lambda: cli_util.parse_key_target(spec))
+
     def test_parse_target_spec(self):
         cases = [
             (
@@ -107,3 +111,6 @@ class CLIUtilTest(unittest.TestCase):
         )
         self.assertRaises(UsageError, lambda: cli_util.desugar_command([], 'echo %a:b% %a:c%'))
         self.assertRaises(UsageError, lambda: cli_util.desugar_command([':b'], 'echo %b:c%'))
+        self.assertRaises(UsageError, lambda: cli_util.desugar_command(['b:'], 'echo %b:c%'))
+        self.assertRaises(UsageError, lambda: cli_util.desugar_command([':'], 'echo %b:c%'))
+        self.assertRaises(UsageError, lambda: cli_util.desugar_command([''], 'echo %b:c%'))

--- a/tests/worker/docker_utils_test.py
+++ b/tests/worker/docker_utils_test.py
@@ -1,0 +1,43 @@
+from docker.errors import APIError
+import unittest
+
+from codalab.worker.docker_utils import DockerUserErrorException, DockerException, wrap_exception
+
+
+class DockerUtilsTest(unittest.TestCase):
+    def test_wrap_exception(self):
+        error = (
+            'Cannot start Docker container: Unable to start Docker container: 500 Server '
+            'Error: Internal Server Error "OCI runtime create failed: some other error"'
+        )
+
+        @wrap_exception('Should throw DockerException')
+        def throw_error():
+            raise APIError(error)
+
+        try:
+            throw_error()
+        except Exception as e:
+            self.assertEqual(str(e), 'Should throw DockerException: ' + error)
+            self.assertIsInstance(e, DockerException)
+
+    def test_wrap_exception_with_cuda_error(self):
+        error = (
+            'Cannot start Docker container: Unable to start Docker container: 500 Server '
+            'Error: Internal Server Error ("OCI runtime create failed: container_linux.go:'
+            '345: starting container process caused "process_linux.go:430: container init '
+            'caused "process_linux.go:413: running prestart hook 1 caused "error '
+            'running hook: exit status 1, stdout: ,  stderr: nvidia-container-cli: mount '
+            'error: file creation failed: /mnt/scratch/docker/overlay2/678d6b'
+            '19396c4ccd341786b21393f3f/merged/usr/bin/nvidia-smi'
+        )
+
+        @wrap_exception('Should throw DockerUserErrorException')
+        def throw_cuda_error():
+            raise APIError(error)
+
+        try:
+            throw_cuda_error()
+        except Exception as e:
+            self.assertEqual(str(e), 'Should throw DockerUserErrorException: ' + error)
+            self.assertIsInstance(e, DockerUserErrorException)


### PR DESCRIPTION
* Update pre-commit script to cleanup venv on failure and add new troubleshooting steps (#1992)

* Update stress test script. (#2076)

* Fix build issue in Travis (#2091)

Closed via #2090

* worksheet title should not be editable when user doesn't have permission' (#2085)

Co-authored-by: Ashwin Ramaswami <aramaswamis@gmail.com>

* Improve error handling for CLI (#2049)

Closed via #1958

* Support tagging CodaLab's public instances (#2093)

Closed via #2031

* Use "//"  comment for editor ctrl + / behavior (#2063)

* change blockComment style

Co-authored-by: Ashwin Ramaswami <aramaswamis@gmail.com>

* Bump psutil from 5.4.6 to 5.6.6 (#2087)

* Bump psutil from 5.4.6 to 5.6.6

Bumps [psutil](https://github.com/giampaolo/psutil) from 5.4.6 to 5.6.6.
- [Release notes](https://github.com/giampaolo/psutil/releases)
- [Changelog](https://github.com/giampaolo/psutil/blob/master/HISTORY.rst)
- [Commits](https://github.com/giampaolo/psutil/compare/release-5.4.6...release-5.6.6)

Signed-off-by: dependabot[bot] <support@github.com>

* don't pass version arg to .travis.yml

* Update .travis.yml

* use old travis with --version

* fix format

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Co-authored-by: Ashwin Ramaswami <aramaswamis@gmail.com>

* get rid of invalid argument file when logging (#2103)

* Improve CLI documentation and add -m option for auto generating CLI docs (#2057)

Co-authored-by: Jing Ge <stanford@Stanfords-MacBook-Pro.local>

* Check the existence of valid_bundle before further actions (#2107)

Closed via #2106

* move cpu and gpu resource check to the beginning of _transition_from_… (#2104)

Closed via #2096

* Adjust timezone information when calculating current container running time (#2113)

Closed via #2112

* Binding the actual cores that can be used to the current process (#2110)

Closed via #1045

* Make Travis badge link to build status (#2116)

Co-authored-by: Percy Liang <percyliang@gmail.com>

* Add queue in new run field (#2040)

* add queue in new run field


Co-authored-by: Ashwin Ramaswami <aramaswamis@gmail.com>

* Make cl workers show user-owned workers for non-root users (#2118)

* Show cl workers for non-root users, limiting to ones they own

* Black format

* Update CLI reference

* Fix CLI reference string for cl workers.

* Cosmetic changes to /workers/info

* Simplify cl workers CLI help string

* Lint

* 2108: Handle incompatible Cuda version specified in the user's Docker image (#2119)

Co-authored-by: armantajback <armantajback@users.noreply.github.com>
Co-authored-by: Jing Ge <jingge2@illinois.edu>
Co-authored-by: yipenghe <yipenghe@stanford.edu>
Co-authored-by: Ashwin Ramaswami <aramaswamis@gmail.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Co-authored-by: Jing Ge <stanford@Stanfords-MacBook-Pro.local>
Co-authored-by: Nelson Liu <nelson-liu@users.noreply.github.com>
Co-authored-by: Percy Liang <percyliang@gmail.com>