### PR TITLE
Fix frontend container automatically stopping due to CRA upgrade

### DIFF
--- a/docker/compose_files/docker-compose.dev.yml
+++ b/docker/compose_files/docker-compose.dev.yml
@@ -6,6 +6,9 @@ services:
     command: npm start
     volumes:
       - ./../../frontend/src:/opt/frontend/src
+    # Fix for https://github.com/facebook/create-react-app/issues/8688
+    stdin_open: true
+    tty: true
   # 2) Hot load the alembic version files so that we can create new database migrations (which need to written out
   # of Docker into the `alembic` source directory)
   rest-server:


### PR DESCRIPTION
When we upgraded CRA to 3.4.1 as part of #2147, we ended up getting the following issue: https://github.com/facebook/create-react-app/issues/8688

This PR works around that issue by making sure CRA doesn't automatically stop.