### PR TITLE
Add identifier to GPU workers

### DIFF
--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -1585,6 +1585,7 @@ class BundleCLI(object):
                 {'child_path': key, 'parent_uuid': bundle_target.bundle_uuid}
                 for key, bundle_target in targets
             ]
+            # A list of matched uuids in the order they were created.
             memoized_bundles = client.fetch(
                 'bundles',
                 params={'command': args.command, 'dependencies': json.dumps(dependencies)},

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -25,6 +25,7 @@ import shutil
 import sys
 import time
 import textwrap
+import json
 from collections import defaultdict
 from contextlib import closing
 from io import BytesIO
@@ -791,6 +792,12 @@ class BundleCLI(object):
             help='Operate on this worksheet (%s).' % WORKSHEET_SPEC_FORMAT,
             completer=WorksheetsCompleter,
         ),
+        Commands.Argument(
+            '-m',
+            '--memoize',
+            help='If a bundle with the same command and dependencies already exists, return it instead of creating a new one.',
+            action='store_true',
+        ),
     ) + WAIT_ARGUMENTS
 
     @staticmethod
@@ -1552,6 +1559,12 @@ class BundleCLI(object):
             Commands.Argument(  # Internal for web FE positioned insert.
                 '-a', '--after_sort_key', help='Insert after this sort_key', completer=NullCompleter
             ),
+            Commands.Argument(
+                '-m',
+                '--memoize',
+                help='If a bundle with the same command and dependencies already exists, return it instead of creating a new one.',
+                action='store_true',
+            ),
         )
         + Commands.metadata_arguments([RunBundle])
         + EDIT_ARGUMENTS
@@ -1564,16 +1577,38 @@ class BundleCLI(object):
 
         targets = self.resolve_key_targets(client, worksheet_uuid, args.target_spec)
         params = {'worksheet': worksheet_uuid}
+
         if args.after_sort_key:
             params['after_sort_key'] = args.after_sort_key
-        new_bundle = client.create(
-            'bundles',
-            self.derive_bundle(RunBundle.BUNDLE_TYPE, args.command, targets, metadata),
-            params=params,
-        )
+        if args.memoize:
+            dependencies = [
+                {'child_path': key, 'parent_uuid': bundle_target.bundle_uuid}
+                for key, bundle_target in targets
+            ]
+            memoized_bundles = client.fetch(
+                'bundles',
+                params={'command': args.command, 'dependencies': json.dumps(dependencies)},
+            )
 
-        print(new_bundle['uuid'], file=self.stdout)
-        self.wait(client, args, new_bundle['uuid'])
+        if args.memoize and len(memoized_bundles) > 0:
+            new_bundle = memoized_bundles[-1]
+            print(new_bundle['uuid'], file=self.stdout)
+            self.copy_bundle(
+                source_client=client,
+                source_bundle_uuid=new_bundle['uuid'],
+                dest_client=client,
+                dest_worksheet_uuid=worksheet_uuid,
+                copy_dependencies=False,
+                add_to_worksheet=True,
+            )
+        else:
+            new_bundle = client.create(
+                'bundles',
+                self.derive_bundle(RunBundle.BUNDLE_TYPE, args.command, targets, metadata),
+                params=params,
+            )
+            print(new_bundle['uuid'], file=self.stdout)
+            self.wait(client, args, new_bundle['uuid'])
 
     @Commands.command(
         'docker',
@@ -2646,6 +2681,7 @@ class BundleCLI(object):
             args.shadow,
             args.dry_run,
             metadata_override=metadata,
+            memoize=args.memoize,
         )
         for (old, new) in plan:
             print(

--- a/codalab/lib/bundle_util.py
+++ b/codalab/lib/bundle_util.py
@@ -193,6 +193,7 @@ def mimic_bundles(
 
             # Fetch the memoized bundle if the memoize option is set to be True
             if memoize:
+                # A list of matched uuids in the order they were created.
                 memoized_bundles = client.fetch(
                     'bundles',
                     params={

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -701,13 +701,13 @@ class BundleModel(object):
 
     def get_memoized_bundles(self, user_id, command, dependencies):
         '''
-        Get a list of bundles that match with input command and dependencies in the order they were created.
+        Get a list of bundle UUIDs that match with input command and dependencies in the order they were created.
         :param user_id: a string that specifies the current user id.
         :param command: a string that defines the command that is used to search for memoized bundles in the database.
         :param dependencies: a string in the form of '[{"child_path": key1, "parent_uuid": uuid1},
                                                        {"child_path": key2, "parent_uuid": uuid2}]'
-                             to search for matched dependencies in the database.
-        :return: a list of matched uuids in the order they were created.
+                             to search for memoized bundles in the database.
+        :return: a list of matched UUIDs in the order they were created.
         '''
         # Decode json formatted dependencies string to a list of key value pairs
         dependencies = json.loads(dependencies)
@@ -766,7 +766,7 @@ class BundleModel(object):
                 select([join.c.child_uuid])
                 .select_from(join)
                 .where(join.c.cnt == len(dependencies))
-                # Ensure the order of the returning bundles will be in the order of they were created.
+                # Ensure the order of the returning bundles will be in the order they were created.
                 .order_by(join.c.id)
             )
         return self._execute_query(query)

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -705,8 +705,8 @@ class BundleModel(object):
         :param user_id: a string that specifies the current user id.
         :param command: a string that defines the command that is used to search for memoized bundles in the database.
         :param dependencies: a string in the form of '[{"child_path": key1, "parent_uuid": uuid1},
-                                                       {"child_path" : key2, "parent_uuid": uuid2}]'
-                            to search for matched dependencies in the database.
+                                                       {"child_path": key2, "parent_uuid": uuid2}]'
+                             to search for matched dependencies in the database.
         :return: a list of matched uuids in the order they were created.
         '''
         # Decode json formatted dependencies string to a list of key value pairs

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -701,13 +701,13 @@ class BundleModel(object):
 
     def get_memoized_bundles(self, user_id, command, dependencies):
         '''
-        Get a list of bundles that match with input command and dependencies in the order of they were created.
+        Get a list of bundles that match with input command and dependencies in the order they were created.
         :param user_id: a string that specifies the current user id.
         :param command: a string that defines the command that is used to search for memoized bundles in the database.
         :param dependencies: a string in the form of '[{"child_path": key1, "parent_uuid": uuid1},
-                                                    {"child_path" : key2, "parent_uuid": uuid2}]'
+                                                       {"child_path" : key2, "parent_uuid": uuid2}]'
                             to search for matched dependencies in the database.
-        :return: a list of matched uuids.
+        :return: a list of matched uuids in the order they were created.
         '''
         # Decode json formatted dependencies string to a list of key value pairs
         dependencies = json.loads(dependencies)

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -8,9 +8,9 @@ import os
 import re
 import time
 import logging
+import json
 
 from dateutil import parser
-
 from uuid import uuid4
 
 from sqlalchemy import and_, or_, not_, select, union, desc, func
@@ -697,6 +697,78 @@ class BundleModel(object):
                 query = select([cl_bundle.c.uuid]).where(clause)
                 query = query.order_by(cl_bundle.c.id.desc()).limit(max_results)
 
+        return self._execute_query(query)
+
+    def get_memoized_bundles(self, user_id, command, dependencies):
+        '''
+        Get a list of bundles that match with input command and dependencies in the order of they were created.
+        :param user_id: a string that specifies the current user id.
+        :param command: a string that defines the command that is used to search for memoized bundles in the database.
+        :param dependencies: a string in the form of '[{"child_path": key1, "parent_uuid": uuid1},
+                                                    {"child_path" : key2, "parent_uuid": uuid2}]'
+                            to search for matched dependencies in the database.
+        :return: a list of matched uuids.
+        '''
+        # Decode json formatted dependencies string to a list of key value pairs
+        dependencies = json.loads(dependencies)
+        # When there is no dependency to be matched, the target memozied bundle
+        # should only exist in the bundle table but not in the bundle_dependency table.
+        if len(dependencies) == 0:
+            query = (
+                select([cl_bundle.c.uuid])
+                .select_from(cl_bundle)
+                .where(
+                    and_(
+                        cl_bundle.c.command == command,
+                        cl_bundle.c.owner_id == user_id,
+                        cl_bundle.c.uuid.notin_(
+                            select([cl_bundle_dependency.c.child_uuid]).select_from(
+                                cl_bundle_dependency
+                            )
+                        ),
+                    )
+                )
+                .order_by(cl_bundle.c.id)
+            )
+        else:
+            clause = []
+            for dep in dependencies:
+                clause.append(
+                    and_(
+                        cl_bundle_dependency.c.child_path == dep['child_path'],
+                        cl_bundle_dependency.c.parent_uuid == dep['parent_uuid'],
+                    )
+                )
+            join = (
+                select(
+                    [
+                        cl_bundle_dependency.c.id,
+                        cl_bundle_dependency.c.child_uuid,
+                        func.count(cl_bundle_dependency.c.parent_uuid).label("cnt"),
+                    ]
+                )
+                .select_from(
+                    cl_bundle.join(
+                        cl_bundle_dependency, cl_bundle.c.uuid == cl_bundle_dependency.c.child_uuid
+                    )
+                )
+                .where(
+                    and_(
+                        cl_bundle.c.command == command,
+                        cl_bundle.c.owner_id == user_id,
+                        or_(*clause),
+                    )
+                )
+                .group_by(cl_bundle_dependency.c.child_uuid)
+                .alias()
+            )
+            query = (
+                select([join.c.child_uuid])
+                .select_from(join)
+                .where(join.c.cnt == len(dependencies))
+                # Ensure the order of the returning bundles will be in the order of they were created.
+                .order_by(join.c.id)
+            )
         return self._execute_query(query)
 
     def batch_get_bundles(self, **kwargs):

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -62,7 +62,8 @@ def _fetch_bundle(uuid):
 @get('/bundles')
 def _fetch_bundles():
     """
-    Fetch bundles by bundle `specs` OR search `keywords`. Behavior is undefined
+    Fetch bundles in the following two ways:
+    1. By bundle `specs` OR search `keywords` . Behavior is undefined
     when both `specs` and `keywords` are provided.
 
     Query parameters:
@@ -99,12 +100,24 @@ def _fetch_bundles():
         }
     }
     ```
+    2. By bundle `command` and/or `dependencies` (for `--memoized` option in cl [run/mimic] command).
+    When `dependencies` is not defined, the searching result will include bundles that match with command only.
 
+    Query parameters:
+     - `command`      : the command of a bundle in string
+     - `dependencies` : the dependencies of a bundle in the format of
+                        '[{"child_path":key1, "parent_uuid":UUID1},
+                        {"child_path":key2, "parent_uuid":UUID2}]'
+        1. a UUID should be in the format of 32 hex characters with a preceding '0x' (partial UUID is not allowed).
+        2. the key should be able to uniquely identify a (child_path, parent_uuid) pair in the list.
+    The returning result will be aggregated in the same way as 1.
     """
     keywords = query_get_list('keywords')
     specs = query_get_list('specs')
     worksheet_uuid = request.query.get('worksheet')
     descendant_depth = query_get_type(int, 'depth', None)
+    command = query_get_type(str, 'command', '')
+    dependencies = query_get_type(str, 'dependencies', '[]')
 
     if keywords:
         # Handle search keywords
@@ -120,6 +133,8 @@ def _fetch_bundles():
         bundle_uuids = canonicalize.get_bundle_uuids(
             local.model, request.user, worksheet_uuid, specs
         )
+    elif command:
+        bundle_uuids = local.model.get_memoized_bundles(request.user.user_id, command, dependencies)
     else:
         abort(
             http.client.BAD_REQUEST,

--- a/codalab/server/bundle_manager.py
+++ b/codalab/server/bundle_manager.py
@@ -475,7 +475,7 @@ class BundleManager(object):
             # 6. break ties randomly by a random seed.
             return (
                 not worker['tag_exclusive'],
-                worker['gpus'],
+                worker['gpus'] or worker['has_gpus'],
                 -num_available_deps,
                 worker['cpus'],
                 len(worker['run_uuids']),

--- a/codalab/server/worker_info_accessor.py
+++ b/codalab/server/worker_info_accessor.py
@@ -33,6 +33,7 @@ class WorkerInfoAccessor(object):
             for uuid in worker['run_uuids']:
                 self._uuid_to_worker[uuid] = worker
             self._user_id_to_workers[worker['user_id']].append(worker)
+            worker['has_gpus'] = True if worker['gpus'] > 0 else False
 
     @refresh_cache
     def workers(self):


### PR DESCRIPTION
Fixed #2153 

In [filter_and_sort_workers](https://github.com/codalab/codalab-worksheets/blob/master/codalab/server/bundle_manager.py#L413), the computing resource values (CPU/GPU/Memory) in `workers_list` have already been altered and cannot reflect their original value. Then, in the sorting logic, when prioritizing GPU workers by `worker['gpus'] == 0`, it couldn't truly reflect if the worker has GPUs or not. 

There are two ways of changing adding this flag:
1. add an additional `has_gpus` flag in the `WorkerInfoAccessor` object
    1. Pros: each worker will come with this flag and easy to query. 
    1. Cons: alters the original worker object as it is retrieved from the database module (mis-match on length)
1. pass an additional parameter between functions in `bundle_manager.py`. 
    1. Pros: doesn't affect other parts of the logic, only scheduling part
    1. Cons: may not look clean.