### PR TITLE
Cleanup docker process if cl-worker gets terminated

### DIFF
--- a/codalab/worker/main.py
+++ b/codalab/worker/main.py
@@ -90,6 +90,13 @@ def parse_args():
         'The bundle depends on this image will fail accordingly.',
     )
     parser.add_argument(
+        '--max-memory',
+        type=parse_size,
+        metavar='SIZE',
+        default=None,
+        help='Limit the amount of memory to a worker in bytes' '(e.g. 3, 3k, 3m, 3g, 3t).',
+    )
+    parser.add_argument(
         '--password-file',
         help='Path to the file containing the username and '
         'password for logging into the bundle service, '
@@ -203,6 +210,7 @@ def main():
         os.path.join(args.work_dir, 'worker-state.json'),
         args.cpuset,
         args.gpuset,
+        args.max_memory,
         args.id,
         args.tag,
         args.work_dir,
@@ -217,7 +225,7 @@ def main():
     )
 
     # Register a signal handler to ensure safe shutdown.
-    for sig in [signal.SIGTERM, signal.SIGINT, signal.SIGHUP]:
+    for sig in [signal.SIGTERM, signal.SIGINT, signal.SIGHUP, signal.SIGTSTP]:
         signal.signal(sig, lambda signup, frame: worker.signal())
 
     # BEGIN: DO NOT CHANGE THIS LINE UNLESS YOU KNOW WHAT YOU ARE DOING

--- a/codalab/worker/main.py
+++ b/codalab/worker/main.py
@@ -225,7 +225,7 @@ def main():
     )
 
     # Register a signal handler to ensure safe shutdown.
-    for sig in [signal.SIGTERM, signal.SIGINT, signal.SIGHUP, signal.SIGTSTP]:
+    for sig in [signal.SIGTERM, signal.SIGINT, signal.SIGHUP]:
         signal.signal(sig, lambda signup, frame: worker.signal())
 
     # BEGIN: DO NOT CHANGE THIS LINE UNLESS YOU KNOW WHAT YOU ARE DOING

--- a/codalab/worker/worker.py
+++ b/codalab/worker/worker.py
@@ -93,8 +93,6 @@ class Worker:
         self.last_checkin_successful = False
         self.last_time_ran = None  # type: Optional[bool]
 
-        self.containers = set()
-
         self.runs = {}  # type: Dict[str, RunState]
         self.init_docker_networks(docker_network_prefix)
         self.run_state_manager = RunStateMachine(
@@ -107,7 +105,6 @@ class Worker:
             upload_bundle_callback=self.upload_bundle_contents,
             assign_cpu_and_gpu_sets_fn=self.assign_cpu_and_gpu_sets,
             shared_file_system=self.shared_file_system,
-            containers=self.containers,
         )
 
     def init_docker_networks(self, docker_network_prefix):


### PR DESCRIPTION
Fixed #1908

This PR is to fix orphan processes that were left after kill the current `cl-worker` session in Slurm.
Currently, I am killing the container directly. Let me know if we want to have any other behaviors.