### PR TITLE
Clean up unfinished bundles

### DIFF
--- a/codalab/worker/main.py
+++ b/codalab/worker/main.py
@@ -132,6 +132,12 @@ def parse_args():
         action='store_true',
         help='To be used when the worker should only run bundles that match the worker\'s tag.',
     )
+    parser.add_argument(
+        '--terminate',
+        action='store_true',
+        help='Terminate the worker and kill all the existing running bundles.',
+    )
+
     return parser.parse_args()
 
 
@@ -222,6 +228,7 @@ def main():
         args.tag_exclusive,
         docker_runtime=docker_runtime,
         docker_network_prefix=args.network_prefix,
+        terminate=args.terminate,
     )
 
     # Register a signal handler to ensure safe shutdown.


### PR DESCRIPTION
Fixed #1908 

This PR provides another solution to #1908 . Basically, the solution in #2167 doesn't wait until all the status being uploaded to the bundle page, whereas the solution in this PR adds this functionality. The tradeoff is the waiting time from the user who kills the worker process. This PR increases the waiting time after a user sends the termination signal to cl-worker. 