### PR TITLE
Parallelize travis test steps to speed up tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,6 +89,7 @@ jobs:
         - export PATH=$PATH:/usr/bin/geckodriver
       script:
         - python3 codalab_service.py start --services default monitor --version ${TRAVIS_BRANCH}
+        - docker exec -it codalab_rest-server_1 /bin/bash -c "python3 scripts/create_sample_worksheet.py"
         - python3 tests/ui/ui_tester.py --headless
     - stage: deploy
       script: echo "Deploying"

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,21 +25,69 @@ jobs:
         - curl -L https://github.com/docker/compose/releases/download/1.23.2/docker-compose-`uname -s`-`uname -m` > docker-compose
         - chmod +x docker-compose
         - sudo mv docker-compose /usr/local/bin
-        - sudo service mysql stop
       install:
         - python3 codalab_service.py build services --version ${TRAVIS_BRANCH} --pull $([ -z "${CODALAB_DOCKER_USERNAME}" ] || [ "$TRAVIS_PULL_REQUEST_BRANCH" != "" ] || echo "--push")
-        - python3 codalab_service.py start --services default monitor --version ${TRAVIS_BRANCH}
-        - pip install -r requirements.txt
-      before_script:
-        - ./scripts/test-setup.sh
-        - export PATH=$PATH:/usr/bin/geckodriver
+    - stage: test
+      language: python
+      sudo: required
+      services:
+        - docker
+      env:
+        - CODALAB_USERNAME=codalab CODALAB_PASSWORD=codalab CI=true
+      python: 3.6
+      before_install:
+        - sudo rm /usr/local/bin/docker-compose
+        - curl -L https://github.com/docker/compose/releases/download/1.23.2/docker-compose-`uname -s`-`uname -m` > docker-compose
+        - chmod +x docker-compose
+        - sudo mv docker-compose /usr/local/bin
+      install:
+        - python3 codalab_service.py build services --version ${TRAVIS_BRANCH} --pull
       script:
+        - python3 codalab_service.py start --services default monitor --version ${TRAVIS_BRANCH}
         - python3 codalab_service.py test --version ${TRAVIS_BRANCH} default
+    - stage: test
+      language: python
+      sudo: required
+      services:
+        - docker
+      env:
+        - CODALAB_USERNAME=codalab CODALAB_PASSWORD=codalab CI=true
+      python: 3.6
+      before_install:
+        - sudo rm /usr/local/bin/docker-compose
+        - curl -L https://github.com/docker/compose/releases/download/1.23.2/docker-compose-`uname -s`-`uname -m` > docker-compose
+        - chmod +x docker-compose
+        - sudo mv docker-compose /usr/local/bin
+      install:
+        - python3 codalab_service.py build services --version ${TRAVIS_BRANCH} --pull
+      script:
+        - python3 codalab_service.py start --services default monitor --version ${TRAVIS_BRANCH}
           # Make sure restarting worker doesn't cause any issues (ie in serialization/deserialization)
         - docker restart codalab_worker_1 && python3 codalab_service.py test run --version ${TRAVIS_BRANCH}
         - docker stop codalab_worker_1
         - python3 codalab_service.py start --services worker --version ${TRAVIS_BRANCH} --shared-file-system
         - python3 codalab_service.py test --version ${TRAVIS_BRANCH} --shared-file-system basic run read write kill resources netcat netcurl workers
+    - stage: test
+      language: python
+      sudo: required
+      services:
+        - docker
+      env:
+        - CODALAB_USERNAME=codalab CODALAB_PASSWORD=codalab CI=true
+      python: 3.6
+      before_install:
+        - sudo rm /usr/local/bin/docker-compose
+        - curl -L https://github.com/docker/compose/releases/download/1.23.2/docker-compose-`uname -s`-`uname -m` > docker-compose
+        - chmod +x docker-compose
+        - sudo mv docker-compose /usr/local/bin
+      install:
+        - python3 codalab_service.py build services --version ${TRAVIS_BRANCH} --pull
+        - pip install -r requirements.txt
+      before_script:
+        - ./scripts/test-setup.sh
+        - export PATH=$PATH:/usr/bin/geckodriver
+      script:
+        - python3 codalab_service.py start --services default monitor --version ${TRAVIS_BRANCH}
         - python3 tests/ui/ui_tester.py --headless
     - stage: deploy
       script: echo "Deploying"

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,8 @@ jobs:
       script:
         - python3 codalab_service.py start --services default monitor --version ${TRAVIS_BRANCH}
           # Make sure restarting worker doesn't cause any issues (ie in serialization/deserialization)
-        - docker restart codalab_worker_1 && python3 codalab_service.py test run --version ${TRAVIS_BRANCH}
+        - docker restart codalab_worker_1
+        - python3 codalab_service.py test run --version ${TRAVIS_BRANCH}
         - docker stop codalab_worker_1
         - python3 codalab_service.py start --services worker --version ${TRAVIS_BRANCH} --shared-file-system
         - python3 codalab_service.py test --version ${TRAVIS_BRANCH} --shared-file-system basic run read write kill resources netcat netcurl workers

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ jobs:
         - curl -L https://github.com/docker/compose/releases/download/1.23.2/docker-compose-`uname -s`-`uname -m` > docker-compose
         - chmod +x docker-compose
         - sudo mv docker-compose /usr/local/bin
-      install:
+      script:
         - python3 codalab_service.py build services --version ${TRAVIS_BRANCH} --pull $([ -z "${CODALAB_DOCKER_USERNAME}" ] || [ "$TRAVIS_PULL_REQUEST_BRANCH" != "" ] || echo "--push")
     - stage: test
       language: python

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ jobs:
         - chmod +x docker-compose
         - sudo mv docker-compose /usr/local/bin
       install:
-        - python3 codalab_service.py build services --version ${TRAVIS_BRANCH} --pull
+        - python3 codalab_service.py pull --version ${TRAVIS_BRANCH}
       script:
         - python3 codalab_service.py start --services default monitor --version ${TRAVIS_BRANCH}
         - python3 codalab_service.py test --version ${TRAVIS_BRANCH} default
@@ -59,7 +59,7 @@ jobs:
         - chmod +x docker-compose
         - sudo mv docker-compose /usr/local/bin
       install:
-        - python3 codalab_service.py build services --version ${TRAVIS_BRANCH} --pull
+        - python3 codalab_service.py pull --version ${TRAVIS_BRANCH}
       script:
         - python3 codalab_service.py start --services default monitor --version ${TRAVIS_BRANCH}
           # Make sure restarting worker doesn't cause any issues (ie in serialization/deserialization)
@@ -81,7 +81,7 @@ jobs:
         - chmod +x docker-compose
         - sudo mv docker-compose /usr/local/bin
       install:
-        - python3 codalab_service.py build services --version ${TRAVIS_BRANCH} --pull
+        - python3 codalab_service.py pull --version ${TRAVIS_BRANCH}
         - pip install -r requirements.txt
       before_script:
         - ./scripts/test-setup.sh

--- a/scripts/test_util.py
+++ b/scripts/test_util.py
@@ -77,6 +77,7 @@ def run_command(
     include_stderr=False,
     binary=False,
     force_subprocess=False,
+    verbose=False,
 ):
     # We import the following imports here because codalab_service.py imports TestModule from
     # this file. If we kept the imports at the top, then anyone who ran codalab_service.py
@@ -94,8 +95,6 @@ def run_command(
         return string
 
     # If we don't care about the exit code, set `expected_exit_code` to None.
-    print(">>", *map(str, args), sep=" ")
-    sys.stdout.flush()
 
     try:
         kwargs = dict(env=env)
@@ -131,11 +130,19 @@ def run_command(
     else:
         colorize = Colorizer.cyan
         extra = ''
-    print(colorize(" (exit code %s, expected %s%s)" % (exitcode, expected_exit_code, extra)))
-    sys.stdout.flush()
-    print(sanitize(output, max_output_chars))
-    sys.stdout.flush()
-    assert expected_exit_code == exitcode, 'Exit codes don\'t match'
+    if exitcode != expected_exit_code:
+        verbose = True
+    if verbose:
+        print(">>", *map(str, args), sep=" ")
+        sys.stdout.flush()
+        print(colorize(" (exit code %s, expected %s%s)" % (exitcode, expected_exit_code, extra)))
+        sys.stdout.flush()
+        print(sanitize(output, max_output_chars))
+        sys.stdout.flush()
+    else:
+        print(".", end="")
+    if exitcode != expected_exit_code:
+        raise AssertionError('Exit codes don\'t match')
     return output.rstrip()
 
 

--- a/scripts/test_util.py
+++ b/scripts/test_util.py
@@ -141,6 +141,7 @@ def run_command(
         sys.stdout.flush()
     else:
         print(".", end="")
+        sys.stdout.flush()
     if exitcode != expected_exit_code:
         raise AssertionError('Exit codes don\'t match')
     return output.rstrip()

--- a/scripts/test_util.py
+++ b/scripts/test_util.py
@@ -95,6 +95,8 @@ def run_command(
         return string
 
     # If we don't care about the exit code, set `expected_exit_code` to None.
+    print(">>", *map(str, args), sep=" ")
+    sys.stdout.flush()
 
     try:
         kwargs = dict(env=env)
@@ -133,14 +135,9 @@ def run_command(
     if exitcode != expected_exit_code:
         verbose = True
     if verbose:
-        print(">>", *map(str, args), sep=" ")
-        sys.stdout.flush()
         print(colorize(" (exit code %s, expected %s%s)" % (exitcode, expected_exit_code, extra)))
         sys.stdout.flush()
         print(sanitize(output, max_output_chars))
-        sys.stdout.flush()
-    else:
-        print(">>", *map(str, args), sep=" ")
         sys.stdout.flush()
     if exitcode != expected_exit_code:
         raise AssertionError('Exit codes don\'t match')

--- a/scripts/test_util.py
+++ b/scripts/test_util.py
@@ -140,7 +140,7 @@ def run_command(
         print(sanitize(output, max_output_chars))
         sys.stdout.flush()
     else:
-        print(".", end="")
+        print(">>", *map(str, args), sep=" ")
         sys.stdout.flush()
     if exitcode != expected_exit_code:
         raise AssertionError('Exit codes don\'t match')


### PR DESCRIPTION
- Build docker images in a previous step, then run 3 parallel travis steps to actually run the tests
- Print less output for tests -- only print the results and "(expected exit code..)" text if tests have failed. This should make it easier to look through / search the output to investigate a failing test. The old behavior can still be achieved by passing `verbose=True` to `run_command`.