### PR TITLE
Add flag to cl download to force overwriting of downloads

### DIFF
--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -1277,6 +1277,12 @@ class BundleCLI(object):
                 help='Path to download bundle to.  By default, the bundle or subpath name in the current directory is used.',
             ),
             Commands.Argument(
+                '-f',
+                '--force',
+                action='store_true',
+                help='Overwrite the output path if a file already exists.',
+            ),
+            Commands.Argument(
                 '-w',
                 '--worksheet-spec',
                 help='Operate on this worksheet (%s).' % WORKSHEET_SPEC_FORMAT,
@@ -1306,8 +1312,11 @@ class BundleCLI(object):
             )
         final_path = os.path.join(os.getcwd(), local_path)
         if os.path.exists(final_path):
-            print('Local file/directory \'%s\' already exists.' % local_path, file=self.stdout)
-            return
+            if args.force:
+                shutil.rmtree(final_path)
+            else:
+                print('Local file/directory \'%s\' already exists.' % local_path, file=self.stdout)
+                return
 
         # Do the download.
         target_info = client.fetch_contents_info(target, 0)

--- a/docs/CLI-Reference.md
+++ b/docs/CLI-Reference.md
@@ -196,6 +196,7 @@ Usage: `cl <command> <arguments>`
     Arguments:
       target_spec           [[(<alias>|<address>)::](<uuid>|<name>)//](<uuid>|<name>|^<index>)[/<subpath within bundle>]
       -o, --output-path     Path to download bundle to.  By default, the bundle or subpath name in the current directory is used.
+      -f, --force           Overwrite the output path if a file already exists.
       -w, --worksheet-spec  Operate on this worksheet ([(<alias>|<address>)::](<uuid>|<name>)).
 
 ### mimic:


### PR DESCRIPTION
This is especially pertinent when you're doing `cl down <bundlename>`, and the contents of `<bundlename>` might be changing on the worksheet / you might be on a different worksheet...