### PR TITLE
Using physical cores when calculating available CPUs on any platform

### DIFF
--- a/codalab/worker/main.py
+++ b/codalab/worker/main.py
@@ -11,8 +11,7 @@ import signal
 import socket
 import stat
 import sys
-import multiprocessing
-
+import psutil
 
 from codalab.lib.formatting import parse_size
 from .bundle_service_client import BundleServiceClient, BundleAuthException
@@ -257,7 +256,7 @@ def parse_cpuset_args(arg):
     except AttributeError:
         # os.sched_getaffinity() isn't available on all platforms,
         # so fallback to using the number of physical cores.
-        cpu_count = multiprocessing.cpu_count()
+        cpu_count = psutil.cpu_count(logical=False)
 
     if arg == 'ALL':
         cpuset = list(range(cpu_count))


### PR DESCRIPTION
Fixed #2187

Changes in this PR will enforce CPU allocation to use only physical cores instead of logical cores by default. On some platforms where hyper-threading is enabled, `cl-worker` will fail when assigning CPUs to jobs. For instance, the following results are gathered on MacOS Catalina where hyper-threading is enabled:
```
>>> import multiprocessing
>>> multiprocessing.cpu_count()
8
>>> import psutil
>>> psutil.cpu_count(logical=True)
8
>>> psutil.cpu_count(logical=False)
4
```