### PR TITLE
Fix tailing cl wait output

### DIFF
--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -2516,7 +2516,7 @@ class BundleCLI(object):
                     if not result:
                         break
                     subpath_offset[i] += len(result)
-                    self.stdout.write(result)
+                    self.stdout.write(ensure_str(result))
                     if len(result) < READ_LENGTH:
                         # No more to read.
                         break


### PR DESCRIPTION
Fixed #2195 

Tested locally and I was able to see the output from a running bundle with this fix.