### PR TITLE
Use percentage for worksheet-editor width

### DIFF
--- a/frontend/src/css/imports.scss
+++ b/frontend/src/css/imports.scss
@@ -559,7 +559,7 @@ body {
   bottom: 0;
   left: 0;
   right: 0;
-  width: 1000px;
+  width: 100%;
   height: 700px;
 }
 #bundle-upload-form {


### PR DESCRIPTION
fix #1726 
Originally the editor width was hard coded:
![Screenshot from 2020-04-29 21-55-48](https://user-images.githubusercontent.com/23012631/80673515-54113d00-8a64-11ea-9718-22aef4ba5091.png)

Changed to use percentage, so it covers the whole worksheet area (notice the editor boarder to the worksheet area difference):
![Screenshot from 2020-04-29 21-55-25](https://user-images.githubusercontent.com/23012631/80673530-5f646880-8a64-11ea-88b3-e7908a703274.png)

Also tested with #2130 (expand button)