### PR TITLE
fix-time-quota-calculation

### DIFF
--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -964,7 +964,7 @@ class BundleModel(object):
             self.update_bundle(bundle, bundle_update, connection)
         return True
 
-    def transition_bundle_finalizing(self, bundle, user_id, worker_run, connection):
+    def transition_bundle_finalizing(self, bundle, worker_run, connection):
         """
         Transitions bundle to FINALIZING state:
             Saves the failure message and exit code from the worker
@@ -1060,7 +1060,7 @@ class BundleModel(object):
                 self.transition_bundle_running(
                     bundle, worker_run, row, user_id, worker_id, connection
                 )
-                return self.transition_bundle_finalizing(bundle, user_id, worker_run, connection)
+                return self.transition_bundle_finalizing(bundle, worker_run, connection)
 
             if worker_run.state in [State.PREPARING, State.RUNNING]:
                 return self.transition_bundle_running(

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -984,10 +984,6 @@ class BundleModel(object):
         bundle_update = {'state': State.FINALIZING, 'metadata': metadata}
 
         self.update_bundle(bundle, bundle_update, connection)
-
-        if user_id == self.root_user_id:
-            self.increment_user_time_used(bundle.owner_id, getattr(bundle.metadata, 'time', 0))
-
         return True
 
     def transition_bundle_finished(self, bundle, bundle_location):
@@ -1002,6 +998,9 @@ class BundleModel(object):
         state = State.FAILED if failure_message or exitcode else State.READY
         if failure_message == 'Kill requested':
             state = State.KILLED
+
+        # Increment the amount of time used for the current user
+        self.increment_user_time_used(bundle.owner_id, metadata.get('time', 0))
 
         worker = self.get_bundle_worker(bundle.uuid)
         if worker['shared_file_system']:

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -999,10 +999,12 @@ class BundleModel(object):
         if failure_message == 'Kill requested':
             state = State.KILLED
 
-        # Increment the amount of time used for the current user
-        self.increment_user_time_used(bundle.owner_id, metadata.get('time', 0))
-
         worker = self.get_bundle_worker(bundle.uuid)
+
+        # Increment the amount of time used for the user whose bundles run on CodaLab's public instances
+        if worker['user_id'] == self.root_user_id:
+            self.increment_user_time_used(bundle.owner_id, metadata.get('time', 0))
+
         if worker['shared_file_system']:
             self.update_disk_metadata(bundle, bundle_location)
 


### PR DESCRIPTION
Fixed #2229 

### Overview of the Root Cause
In our scheduling logic, the `acknowledge_recently_finished_bundles` which moves bundles from `FINALIZING` state to `FINISHED` state, happens after the dispatching function `_schedule_run_bundles_on_workers`:
 https://github.com/codalab/codalab-worksheets/blob/d09bcc962d14c69ccbff4233493e3101f90db48b/codalab/server/bundle_manager.py#L650-L675
Then when there are a significant number of jobs in `STAGED` state, `_schedule_run_bundles_on_workers` will take longer time than usual, and this increases the waiting time for jobs in `FINALIZING` state to be moved to `FINISHED` state. When a job stays longer in `FINALIZING` state, the job is still alive in a designated worker, then it keeps checking in to the rest-server with `FINALIZING` state. The server will keep calling `transition_bundle_finalizing` function, which contains the logic to increment the amount of time the user used, then the user's time quota gets added by `n` times (`n` will depend on waiting time and checkin frequency, so no one knows how many times exactly)
https://github.com/codalab/codalab-worksheets/blob/d09bcc962d14c69ccbff4233493e3101f90db48b/codalab/model/bundle_model.py#L967-L991

Currently, I moved the time quota update function to `transition_bundle_finished`, so this can ensure we add up the current time usage for one time only. This might not be the best solution. Ideally, moving a bundle from finalizing to the finished state shouldn't be blocked in this way. After all, there aren't too many things left in the `finalizing` state. (We might want to change the current state transition to allow non-blocking transition from finalizing to finished). But let me know if anyone has any suggestions. 