### PR TITLE
Add padding for table standard cells

### DIFF
--- a/frontend/src/components/worksheets/Worksheet/Worksheet.scss
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.scss
@@ -204,9 +204,6 @@
     position: relative;
     /*margin-bottom: 20px;*/
   }
-  .worksheet_content .ws-item table > tbody > tr > td {
-    padding-right: 8px !important;
-  }
   .worksheet_content .ws-item .ws-checkbox {
     margin: 0;
     position: absolute;

--- a/frontend/src/components/worksheets/Worksheet/Worksheet.scss
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.scss
@@ -204,6 +204,9 @@
     position: relative;
     /*margin-bottom: 20px;*/
   }
+  .worksheet_content .ws-item table > tbody > tr > td {
+    padding-right: 8px !important;
+  }
   .worksheet_content .ws-item .ws-checkbox {
     margin: 0;
     position: absolute;

--- a/frontend/src/components/worksheets/items/TableItem/BundleRow.js
+++ b/frontend/src/components/worksheets/items/TableItem/BundleRow.js
@@ -385,7 +385,7 @@ const styles = (theme) => ({
     rootNoPad: {
         verticalAlign: 'middle !important',
         border: 'none !important',
-        padding: '0px !important',
+        padding: '0px 4px !important',
         wordWrap: 'break-word',
     },
     noCheckBox: {


### PR DESCRIPTION
Fixes #1796

Add padding for table standard cells to avoid too little space between columns.

Before the change:
<img width="1009" alt="little_space_between_command_and_state" src="https://user-images.githubusercontent.com/63320611/80929297-8b7f3280-8d5f-11ea-9ee5-30929f8993ac.png">

After the change:
<img width="1005" alt="after_change" src="https://user-images.githubusercontent.com/63320611/80929301-95089a80-8d5f-11ea-976b-f3f5e06ef98c.png">
