### PR TITLE
Fix broken cl edit function

### DIFF
--- a/codalab/lib/metadata_util.py
+++ b/codalab/lib/metadata_util.py
@@ -81,7 +81,7 @@ def parse_metadata_form(bundle_subclass, form_result):
     metadata_types = {spec.key: spec.type for spec in metadata_specs}
     result = {}
     for line in form_result:
-        line = line.strip().encode('UTF-8')
+        line = line.strip()
         if line != '' and not line.startswith('//'):
             if ':' not in line:
                 # TODO: don't delete everything; go back to the editor and show the error message
@@ -94,13 +94,14 @@ def parse_metadata_form(bundle_subclass, form_result):
             if metadata_key not in metadata_types:
                 raise UsageError('Unexpected metadata key: %s' % (metadata_key,))
             metadata_type = metadata_types[metadata_key]
+
             if metadata_type == list:
-                if any(unicode_util.contains_unicode(v) for v in result[metadata_key]):
+                remainders = remainder.split() if remainder else []
+                if any(unicode_util.contains_unicode(r) for r in remainders):
                     raise UsageError(
-                        'Metadata cannot contain unicode: %s = %s'
-                        % (metadata_key, result[metadata_key])
+                        'Metadata cannot contain unicode: %s = %s' % (metadata_key, remainder)
                     )
-                result[metadata_key] = remainder.split() if remainder else []
+                result[metadata_key] = remainders
             elif metadata_type == str:
                 if remainder is not None and unicode_util.contains_unicode(remainder):
                     raise UsageError(

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -1089,7 +1089,7 @@ class BundleModel(object):
             self.do_multirow_insert(connection, cl_bundle_metadata, metadata_values)
             bundle.id = result.lastrowid
 
-    def update_bundle(self, bundle, update, connection=None):
+    def update_bundle(self, bundle, update, connection=None, delete=False):
         """
         For each key-value pair in the update dictionary, add or update key-value pair. Note
         that metadata keys not in the update dictionary are not affected in the update operation.
@@ -1106,7 +1106,10 @@ class BundleModel(object):
         # Generate a list of metadata keys that will be deleted and udpate metadata key-value pair
         metadata_delete_keys = []
         for key, value in metadata_update.items():
-            if value is None:
+            # Delete the key,value pair when the following two conditions are met:
+            # 1. the delete flag is True
+            # 2. the value is None
+            if delete and value is None:
                 bundle.metadata.remove_metadata_key(key)
                 metadata_delete_keys.append(key)
             else:

--- a/codalab/server/bundle_manager.py
+++ b/codalab/server/bundle_manager.py
@@ -848,7 +848,9 @@ class BundleManager(object):
                     # Remove the uuid from self._bundles_without_matched_workers if a matched
                     # private worker is found in the system and update bundle's metadata
                     if bundle.uuid in self._bundles_without_matched_workers:
-                        self._model.update_bundle(bundle, {'metadata': {'staged_status': None}})
+                        self._model.update_bundle(
+                            bundle, {'metadata': {'staged_status': None}}, delete=True
+                        )
                         self._bundles_without_matched_workers.remove(bundle.uuid)
                     staged_bundles_to_run.append((bundle, bundle_resources))
             else:


### PR DESCRIPTION
Fixed #2237 

This PR will address the following two issues:
1. The original problem of `cl edit` reported in #2237 
1. Another problem is introduced from an old PR which added the functionality to delete `staged_status` using `None` value. Using `None` value to indicate deletion operation seems to be conflicting with existing features (e.g. `cl edit`). I added a new parameter to indicate the deletion operation for now. But I am open to any other suggestions. 