### PR TITLE
Enable bundle selection for copy on all worksheets

### DIFF
--- a/frontend/src/components/worksheets/BundleBulkActionMenu.js
+++ b/frontend/src/components/worksheets/BundleBulkActionMenu.js
@@ -31,6 +31,7 @@ class BundleBulkActionMenu extends React.Component {
                     size='small'
                     color='inherit'
                     aria-label='Delete'
+                    disabled={!this.props.editPermission}
                     onClick={this.props.toggleCmdDialog('rm')}
                 >
                     <DeleteForeverIcon fontSize='small' />
@@ -40,6 +41,7 @@ class BundleBulkActionMenu extends React.Component {
                     size='small'
                     color='inherit'
                     aria-label='Detach'
+                    disabled={!this.props.editPermission}
                     onClick={this.props.toggleCmdDialog('detach')}
                 >
                     <ExitToAppIcon fontSize='small' />
@@ -49,6 +51,7 @@ class BundleBulkActionMenu extends React.Component {
                     size='small'
                     color='inherit'
                     aria-label='Kill'
+                    disabled={!this.props.editPermission}
                     onClick={this.props.toggleCmdDialog('kill')}
                 >
                     <HighlightOffIcon fontSize='small' />

--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -949,7 +949,7 @@ class Worksheet extends React.Component {
                 this.toggleCmdDialogNoEvent('copy');
             });
 
-            if (this.state.editPermission) {
+            if (this.state.ws.info.editPermission) {
                 Mousetrap.bind(['backspace', 'del'], () => {
                     if (this.state.openDetach || this.state.openKill) {
                         return;

--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -942,24 +942,6 @@ class Worksheet extends React.Component {
         if (this.state.showBundleOperationButtons) {
             // Below are allowed shortcut even when a dialog is opened===================
             // The following three are bulk bundle operation shortcuts
-            Mousetrap.bind(['backspace', 'del'], () => {
-                if (this.state.openDetach || this.state.openKill) {
-                    return;
-                }
-                this.toggleCmdDialogNoEvent('rm');
-            });
-            Mousetrap.bind(['a d'], () => {
-                if (this.state.openDelete || this.state.openKill) {
-                    return;
-                }
-                this.toggleCmdDialogNoEvent('detach');
-            });
-            Mousetrap.bind(['a k'], () => {
-                if (this.state.openDetach || this.state.openDelete) {
-                    return;
-                }
-                this.toggleCmdDialogNoEvent('kill');
-            });
             Mousetrap.bind(['a c'], () => {
                 if (this.state.openDetach || this.state.openDelete || this.state.openKill) {
                     return;
@@ -967,31 +949,52 @@ class Worksheet extends React.Component {
                 this.toggleCmdDialogNoEvent('copy');
             });
 
-            // Confirm bulk bundle operation
-            if (this.state.openDelete || this.state.openKill || this.state.openDetach) {
-                Mousetrap.bind(
-                    ['enter'],
-                    function(e) {
-                        if (this.state.openDelete) {
-                            this.executeBundleCommandNoEvent('rm');
-                        } else if (this.state.openKill) {
-                            this.executeBundleCommandNoEvent('kill');
-                        } else if (this.state.openDetach) {
-                            this.executeBundleCommandNoEvent('detach');
-                        }
-                    }.bind(this),
-                );
+            if (this.state.editPermission) {
+                Mousetrap.bind(['backspace', 'del'], () => {
+                    if (this.state.openDetach || this.state.openKill) {
+                        return;
+                    }
+                    this.toggleCmdDialogNoEvent('rm');
+                });
+                Mousetrap.bind(['a d'], () => {
+                    if (this.state.openDelete || this.state.openKill) {
+                        return;
+                    }
+                    this.toggleCmdDialogNoEvent('detach');
+                });
+                Mousetrap.bind(['a k'], () => {
+                    if (this.state.openDetach || this.state.openDelete) {
+                        return;
+                    }
+                    this.toggleCmdDialogNoEvent('kill');
+                });
 
-                // Select/Deselect to force delete during deletion dialog
-                Mousetrap.bind(
-                    ['f'],
-                    function() {
-                        //force deletion through f
-                        if (this.state.openDelete) {
-                            this.setState({ forceDelete: !this.state.forceDelete });
-                        }
-                    }.bind(this),
-                );
+                // Confirm bulk bundle operation
+                if (this.state.openDelete || this.state.openKill || this.state.openDetach) {
+                    Mousetrap.bind(
+                        ['enter'],
+                        function(e) {
+                            if (this.state.openDelete) {
+                                this.executeBundleCommandNoEvent('rm');
+                            } else if (this.state.openKill) {
+                                this.executeBundleCommandNoEvent('kill');
+                            } else if (this.state.openDetach) {
+                                this.executeBundleCommandNoEvent('detach');
+                            }
+                        }.bind(this),
+                    );
+
+                    // Select/Deselect to force delete during deletion dialog
+                    Mousetrap.bind(
+                        ['f'],
+                        function() {
+                            //force deletion through f
+                            if (this.state.openDelete) {
+                                this.setState({ forceDelete: !this.state.forceDelete });
+                            }
+                        }.bind(this),
+                    );
+                }
             }
         }
         //====================Bulk bundle operations===================

--- a/frontend/src/components/worksheets/items/ActionButtons.js
+++ b/frontend/src/components/worksheets/items/ActionButtons.js
@@ -148,6 +148,7 @@ class ActionButtons extends React.Component<{
                 ) : null}
                 {showBundleOperationButtons ? (
                     <BundleBulkActionMenu
+                        editPermission={editPermission}
                         handleSelectedBundleCommand={handleSelectedBundleCommand}
                         toggleCmdDialog={toggleCmdDialog}
                         toggleCmdDialogNoEvent={toggleCmdDialogNoEvent}

--- a/frontend/src/components/worksheets/items/TableItem/BundleRow.js
+++ b/frontend/src/components/worksheets/items/TableItem/BundleRow.js
@@ -186,14 +186,14 @@ class BundleRow extends Component {
                     classes={{
                         root: classNames({
                             [classes.rootNoPad]: true,
-                            [classes.noCheckBox]: !(editPermission && checkBox),
-                            [classes.withCheckBox]: editPermission && checkBox,
+                            [classes.noCheckBox]: !checkBox,
+                            [classes.withCheckBox]: checkBox,
                         }),
                     }}
                     onMouseEnter={(e) => this.setState({ hovered: true })}
                     onMouseLeave={(e) => this.setState({ hovered: false })}
                 >
-                    {editPermission && checkBox}
+                    {checkBox}
                     {showDetailButton}
                     {rowContent}
                 </TableCell>
@@ -221,9 +221,6 @@ class BundleRow extends Component {
             );
             Mousetrap.bind(['escape'], () => this.setState({ showDetail: false }), 'keydown');
             Mousetrap.bind(['x'], (e) => {
-                if (!editPermission) {
-                    return;
-                }
                 if (!this.props.confirmBundleRowAction(e.code)) {
                     this.props.handleCheckBundle(
                         uuid,

--- a/frontend/src/components/worksheets/items/TableItem/TableItem.js
+++ b/frontend/src/components/worksheets/items/TableItem/TableItem.js
@@ -147,7 +147,6 @@ class TableItem extends React.Component<{
                                 <path d='M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-2 10H7v-2h10v2z' />
                             </SvgIcon>
                         }
-                        style={{ marginRight: 30, borderLeft: '3px solid transparent' }}
                     />
                 );
             }
@@ -157,9 +156,8 @@ class TableItem extends React.Component<{
                     onMouseLeave={(e) => this.setState({ hovered: false })}
                     component='th'
                     key={index}
-                    style={editPermission || index !== 0 ? { paddingLeft: 0 } : { paddingLeft: 30 }}
                 >
-                    {editPermission && checkbox}
+                    {checkbox}
                     {item}
                 </TableCell>
             );


### PR DESCRIPTION
Fix #2158 , this will allow users to copy bundles from dashboard or other users' worksheets