### PR TITLE
Convert only empty string to a shell-escaped version of the string

### DIFF
--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -815,8 +815,8 @@ class BundleCLI(object):
         """
         try:
             i = argv.index('---')
-            # Convert the command after '---' to a shell-escaped version of the string.
-            shell_escaped_command = [quote(x) for x in argv[i + 1 :]]
+            # Convert empty string after '---' to a shell-escaped version of the string.
+            shell_escaped_command = [quote(x) if not x else x for x in argv[i + 1 :]]
             argv = argv[0:i] + [' '.join(shell_escaped_command)]
         except:
             pass

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -29,7 +29,6 @@ import json
 from collections import defaultdict
 from contextlib import closing
 from io import BytesIO
-from shlex import quote
 
 import argcomplete
 from argcomplete.completers import FilesCompleter, ChoicesCompleter
@@ -816,7 +815,7 @@ class BundleCLI(object):
         try:
             i = argv.index('---')
             # Convert empty string after '---' to a shell-escaped version of the string.
-            shell_escaped_command = [quote(x) if not x else x for x in argv[i + 1 :]]
+            shell_escaped_command = [shlex.quote(x) if not x else x for x in argv[i + 1 :]]
             argv = argv[0:i] + [' '.join(shell_escaped_command)]
         except:
             pass


### PR DESCRIPTION
Fixed #2261 

Not sure if this is the optimal solution. But changing only the empty string to a shell-escaped version of string work for both use cases when user submit command from CLI and from rest cli endpoint: https://github.com/codalab/codalab-worksheets/blob/962189207c363bc26c76b5d3a6d765d687d8c70e/codalab/rest/cli.py#L18-L20