### PR TITLE
Making command parsing robust

### DIFF
--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -29,7 +29,6 @@ import json
 from collections import defaultdict
 from contextlib import closing
 from io import BytesIO
-from shlex import quote
 
 import argcomplete
 from argcomplete.completers import FilesCompleter, ChoicesCompleter
@@ -156,6 +155,7 @@ HEADING_LEVEL_2 = '## '
 HEADING_LEVEL_3 = '### '
 
 NO_RESULTS_FOUND = 'No results found'
+COMMAND_PLACEHOLDER = '<cmd>'
 
 
 class CodaLabArgumentParser(argparse.ArgumentParser):
@@ -815,8 +815,15 @@ class BundleCLI(object):
         """
         try:
             i = argv.index('---')
-            # Convert the command after '---' to a shell-escaped version of the string.
-            shell_escaped_command = [quote(x) for x in argv[i + 1 :]]
+            # This is to get the default list of punctuation chars from shlex. When punctuation_chars = True,
+            # the class property punctuation_chars is set as '();<>|&'. Otherwise, an empty string will be returned.
+            punctuation_chars = list(
+                shlex.shlex(COMMAND_PLACEHOLDER, punctuation_chars=True).punctuation_chars
+            )
+            # Convert string that is not a punctuation char after '---' to a shell-escaped version of the string.
+            shell_escaped_command = [
+                shlex.quote(x) if x not in punctuation_chars else x for x in argv[i + 1 :]
+            ]
             argv = argv[0:i] + [' '.join(shell_escaped_command)]
         except:
             pass

--- a/codalab/rest/cli.py
+++ b/codalab/rest/cli.py
@@ -126,13 +126,12 @@ def general_command(worksheet_uuid, command):
     if isinstance(command, str):
         # shlex throws ValueError on incorrectly formatted commands
         try:
-            # see https://docs.python.org/2/library/shlex.html#shlex.shlex.escapedquotes
+            # see https://docs.python.org/3.4/library/shlex.html#shlex.shlex.escapedquotes
             # By default, the double quote can be escaped. By setting the
             # escapedquotes property, we are able to escape single quotes as well
             # examples: run '\''
-            lexer = shlex.shlex(command, posix=True)
+            lexer = shlex.shlex(command, posix=True, punctuation_chars=True)
             lexer.escapedquotes = '\'"'
-            lexer.whitespace_split = True
             args = list(lexer)
         except ValueError as e:
             raise UsageError(str(e))

--- a/tests/lib/bundle_cli_test.py
+++ b/tests/lib/bundle_cli_test.py
@@ -26,3 +26,13 @@ class BundleCliTest(unittest.TestCase):
         expected_result = ['cl', 'run', "echo 'hello world!'"]
         actual_result = self.bundle_cli.collapse_bare_command(argv)
         self.assertEqual(actual_result, expected_result)
+
+    def test_collapse_bare_command_punctuation_char_semicolon(self):
+        argv = ['cl', 'run', '---', 'date', ';', 'sleep', '10']
+        expected_result = ['cl', 'run', 'date ; sleep 10']
+        actual_result = self.bundle_cli.collapse_bare_command(argv)
+        self.assertEqual(actual_result, expected_result)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/lib/bundle_cli_test.py
+++ b/tests/lib/bundle_cli_test.py
@@ -32,7 +32,3 @@ class BundleCliTest(unittest.TestCase):
         expected_result = ['cl', 'run', 'date ; sleep 10']
         actual_result = self.bundle_cli.collapse_bare_command(argv)
         self.assertEqual(actual_result, expected_result)
-
-
-if __name__ == '__main__':
-    unittest.main()


### PR DESCRIPTION
Fixed #2261 

The changes made in this PR will fix the command string parsing issue discovered in #2261 when a user submits a command via rest API endpoint: https://github.com/codalab/codalab-worksheets/blob/962189207c363bc26c76b5d3a6d765d687d8c70e/codalab/rest/cli.py#L18-L20

Basically, the exiting command parsing from CLI is not compatible with parsing from rest api. This PR aims to fix this.
 
Things changed in this PR: 
1. in rest api call: I removed the `whitespace_split=True`.  There are two types of chars in command: punctuation chars and whitespace. Punctuation chars should be parsed in the first place and then whitespace. Based on [shlex.whitespace_split](https://docs.python.org/3.4/library/shlex.html#shlex.shlex.whitespace_split), when it sets to True, the command string will just be split by whitespace but not punctuation chars, which can be error-prone.
1. To get the list of default punctuation chars from shlex, I used a dummy command to initialize a shlex object. This is because of punctuation chars defined as a property to the class. If there are better ways to do this, please let me know.

Example of use cases from **rest api endpoint** :
1. `cl run --- date;sleep 10`
```
>>> command = 'cl run --- date;sleep 10'
>>> lexer = shlex.shlex(command, posix=True, punctuation_chars=True)
>>> lexer.escapedquotes = '\'"'
>>> list(lexer)
['cl', 'run', '---', 'date', ';', 'sleep', '10']
```
2. `cl run --- date; sleep 10`
```
>>> command = 'cl run --- date; sleep 10'
>>> lexer = shlex.shlex(command, posix=True, punctuation_chars=True)
>>> lexer.escapedquotes = '\'"'
>>> list(lexer)
['cl', 'run', '---', 'date', ';', 'sleep', '10']
```
3. `cl run --- python myscript.py`
```
>>> command = 'cl run --- python myscript.py'
>>> lexer = shlex.shlex(command, posix=True, punctuation_chars=True)
>>> lexer.escapedquotes = '\'"'
>>> list(lexer)
['cl', 'run', '---', 'python', 'myscript.py']
```
**Usage from CLI will remain the same.**