### PR TITLE
2212: Test that bundles are ready after performing wadd across instances

### DIFF
--- a/test_cli.py
+++ b/test_cli.py
@@ -19,6 +19,7 @@ Things not tested:
 from collections import namedtuple, OrderedDict
 from contextlib import contextmanager
 from codalab.worker.download_util import BundleTarget
+from codalab.worker.bundle_state import State
 from scripts.create_sample_worksheet import SampleWorksheet
 from scripts.test_util import Colorizer, run_command
 
@@ -119,7 +120,7 @@ def wait_until_state(uuid, expected_state, timeout_seconds=100):
         # Return when the bundle is in the expected state or one of the final states
         if current_state == expected_state:
             return
-        elif current_state in {'running', 'ready', 'failed', 'killed'}:
+        elif current_state in State.FINAL_STATES:
             assert current_state == expected_state, "waiting for '()' state, but got '{}'".format(
                 expected_state, current_state
             )

--- a/test_cli.py
+++ b/test_cli.py
@@ -1381,8 +1381,6 @@ def test(ctx):
     def assert_bundles_ready(worksheet):
         _run_command([cl, 'work', worksheet])
         bundles = _run_command([cl, 'ls', '--uuid-only'])
-        # TODO: remove this -tony
-        print('Tony - worksheet: {}, bundles: {}'.format(worksheet, bundles))
         for uuid in bundles.split('\n'):
             wait_until_state(uuid, 'ready')
 


### PR DESCRIPTION
Resolves #2212 

Modified existing `copy` test to ensure that bundles are in `ready` states after performing `wadd`  across instances.