### PR TITLE
Add a flag to indicate the number of job allowed on worker. (design 1)

### DIFF
--- a/codalab/worker/main.py
+++ b/codalab/worker/main.py
@@ -113,13 +113,13 @@ def parse_args():
     parser.add_argument(
         '--exit-number-jobs',
         help='The worker will exit after this many jobs assigned and finished on this worker',
-        type=int,
+        type=check_positive_int,
         default=10000,
     )
     parser.add_argument(
         '--idle-seconds',
         help='Not running anything for this many seconds constitutes idle',
-        type=int,
+        type=check_positive_int,
         default=0,
     )
     parser.add_argument(
@@ -144,6 +144,18 @@ def parse_args():
     )
 
     return parser.parse_args()
+
+
+def check_positive_int(value):
+    """
+    Check if the CLI argument is a positive integer.
+    :param value: input value from CLI
+    :return:
+    """
+    value = int(value)
+    if value <= 0:
+        raise argparse.ArgumentTypeError('{} is an invalid positive int value'.format(value))
+    return value
 
 
 def connect_to_codalab_server(server, password_file):

--- a/codalab/worker/main.py
+++ b/codalab/worker/main.py
@@ -119,7 +119,7 @@ def parse_args():
     parser.add_argument(
         '--idle-seconds',
         help='Not running anything for this many seconds constitutes idle',
-        type=check_positive_int,
+        type=int,
         default=0,
     )
     parser.add_argument(
@@ -150,7 +150,7 @@ def check_positive_int(value):
     """
     Check if the CLI argument is a positive integer.
     :param value: input value from CLI
-    :return:
+    :return: a positive integer value
     """
     value = int(value)
     if value <= 0:

--- a/codalab/worker/main.py
+++ b/codalab/worker/main.py
@@ -111,10 +111,10 @@ def parse_args():
         help='If specified the worker quits if it finds itself with no jobs after a checkin',
     )
     parser.add_argument(
-        '--exit-number-jobs',
+        '--exit-after-num-runs',
         help='The worker will exit after this many jobs assigned and finished on this worker',
-        type=check_positive_int,
-        default=10000,
+        type=int,
+        default=sys.maxsize,
     )
     parser.add_argument(
         '--idle-seconds',
@@ -144,18 +144,6 @@ def parse_args():
     )
 
     return parser.parse_args()
-
-
-def check_positive_int(value):
-    """
-    Check if the CLI argument is a positive integer.
-    :param value: input value from CLI
-    :return: a positive integer value
-    """
-    value = int(value)
-    if value <= 0:
-        raise argparse.ArgumentTypeError('{} is an invalid positive int value'.format(value))
-    return value
 
 
 def connect_to_codalab_server(server, password_file):
@@ -239,7 +227,7 @@ def main():
         args.work_dir,
         local_bundles_dir,
         args.exit_when_idle,
-        args.exit_number_jobs,
+        args.exit_after_num_runs,
         args.idle_seconds,
         bundle_service,
         args.shared_file_system,

--- a/codalab/worker/main.py
+++ b/codalab/worker/main.py
@@ -136,7 +136,12 @@ def parse_args():
         action='store_true',
         help='Terminate the worker and kill all the existing running bundles.',
     )
-
+    parser.add_argument(
+        '--exit-number-jobs',
+        help='Not running anything for this many jobs assigned to this worker',
+        type=int,
+        default=10000,
+    )
     return parser.parse_args()
 
 
@@ -221,6 +226,7 @@ def main():
         args.work_dir,
         local_bundles_dir,
         args.exit_when_idle,
+        args.exit_number_jobs,
         args.idle_seconds,
         bundle_service,
         args.shared_file_system,

--- a/codalab/worker/main.py
+++ b/codalab/worker/main.py
@@ -111,6 +111,12 @@ def parse_args():
         help='If specified the worker quits if it finds itself with no jobs after a checkin',
     )
     parser.add_argument(
+        '--exit-number-jobs',
+        help='The worker will exit after this many jobs assigned and finished on this worker',
+        type=int,
+        default=10000,
+    )
+    parser.add_argument(
         '--idle-seconds',
         help='Not running anything for this many seconds constitutes idle',
         type=int,
@@ -136,12 +142,7 @@ def parse_args():
         action='store_true',
         help='Terminate the worker and kill all the existing running bundles.',
     )
-    parser.add_argument(
-        '--exit-number-jobs',
-        help='Not running anything for this many jobs assigned to this worker',
-        type=int,
-        default=10000,
-    )
+
     return parser.parse_args()
 
 

--- a/codalab/worker/worker.py
+++ b/codalab/worker/worker.py
@@ -448,7 +448,7 @@ class Worker:
         start_message = {'hostname': socket.gethostname(), 'start_time': int(now)}
         if self.exit_number_jobs == 0:
             print(
-                'Worker has finished assigning the number of jobs allowed to run on: {}. '
+                'Worker has finished starting the number of jobs allowed to run on: {}. '
                 'Stop starting further runs.'.format(self.exit_number_jobs),
                 file=sys.stdout,
             )

--- a/codalab/worker/worker.py
+++ b/codalab/worker/worker.py
@@ -454,7 +454,8 @@ class Worker:
             )
             return
 
-        start_message = {'hostname': socket.gethostname(), 'start_time': int(time.time())}
+        now = time.time()
+        start_message = {'hostname': socket.gethostname(), 'start_time': int(now)}
         if self.bundle_service.start_bundle(self.id, bundle['uuid'], start_message):
             bundle = BundleInfo.from_dict(bundle)
             resources = RunResources.from_dict(resources)

--- a/codalab/worker/worker.py
+++ b/codalab/worker/worker.py
@@ -302,7 +302,7 @@ class Worker:
                 time.sleep(self.CHECKIN_COOLDOWN)
             self.last_checkin_successful = False
             response = None
-
+        print("exit_number_jobs = {}".format(self.exit_number_jobs))
         if not response:
             return
         action_type = response['type']
@@ -446,9 +446,11 @@ class Worker:
         """
         now = time.time()
         start_message = {'hostname': socket.gethostname(), 'start_time': int(now)}
-        if self.exit_number_jobs <= 0:
+        if self.exit_number_jobs == 0:
             print(
-                'exit_number_jobs is not enough {}'.format(self.exit_number_jobs), file=sys.stdout
+                'Worker has finished assigning the number of jobs allowed to run on: {}. '
+                'Stop starting further runs.'.format(self.exit_number_jobs),
+                file=sys.stdout,
             )
             return
 

--- a/codalab/worker/worker.py
+++ b/codalab/worker/worker.py
@@ -440,8 +440,10 @@ class Worker:
 
     def run(self, bundle, resources):
         """
-        First, checks in with the bundle service and sees if the bundle
-        is still assigned to this worker. If not, returns immediately.
+        First, checks if the worker has already finished receiving/starting the number of jobs allowed to run.
+        If not, returns immediately.
+        Then, checks in with the bundle service and sees if the bundle is still assigned to this worker.
+        If not, returns immediately.
         Otherwise, tell RunManager to create the run.
         """
         if self.exit_number_jobs == 0:

--- a/codalab/worker/worker.py
+++ b/codalab/worker/worker.py
@@ -302,7 +302,6 @@ class Worker:
                 time.sleep(self.CHECKIN_COOLDOWN)
             self.last_checkin_successful = False
             response = None
-        print("exit_number_jobs = {}".format(self.exit_number_jobs))
         if not response:
             return
         action_type = response['type']

--- a/codalab/worker/worker.py
+++ b/codalab/worker/worker.py
@@ -179,7 +179,7 @@ class Worker:
         Checks whether the worker has finished the number of job allowed to run.
 
         :return: True if the number of jobs allowed to run is 0 and all those runs are finished.
-                 False if any of the above conditions does not meet.
+                 False if neither of the two conditions are met.
         """
         return self.exit_number_jobs == 0 and len(self.runs) == 0
 

--- a/codalab/worker/worker.py
+++ b/codalab/worker/worker.py
@@ -444,8 +444,6 @@ class Worker:
         is still assigned to this worker. If not, returns immediately.
         Otherwise, tell RunManager to create the run.
         """
-        now = time.time()
-        start_message = {'hostname': socket.gethostname(), 'start_time': int(now)}
         if self.exit_number_jobs == 0:
             print(
                 'Worker has finished starting the number of jobs allowed to run on: {}. '
@@ -454,6 +452,7 @@ class Worker:
             )
             return
 
+        start_message = {'hostname': socket.gethostname(), 'start_time': int(time.time())}
         if self.bundle_service.start_bundle(self.id, bundle['uuid'], start_message):
             bundle = BundleInfo.from_dict(bundle)
             resources = RunResources.from_dict(resources)

--- a/codalab/worker/worker.py
+++ b/codalab/worker/worker.py
@@ -303,7 +303,6 @@ class Worker:
             self.last_checkin_successful = False
             response = None
 
-        print("##### exit_number_jobs = {}".format(self.exit_number_jobs))
         if not response:
             return
         action_type = response['type']


### PR DESCRIPTION
This is a partial feature request #1019 . More details are documented at #2287.

### Overview
There are two potential implementations here:
1. Option 1 is to let the worker passively handle the job counting itself and not to bother the bundle-manager. This is implemented in this PR. 
    a. Pros: less code modification 
    b. Cons: some jobs may get stuck in the `starting` state for a while before moved back to the `staged` state. See the following link:
https://github.com/codalab/codalab-worksheets/blob/a65ad040aa9de2cb2fcdf3e09ec3fbcd3889fbc9/codalab/server/bundle_manager.py#L264-L271
1. Option 2 is to let the bundle-manager assign the number of jobs that the worker can take (there is no logic change in worker side expect the additional flag). This is implemented in #2289
    a. Pros: jobs won't get stuck in the `starting` state. (No frequent intermediate state transitions any more) 
    b. Cons: more code modification and a redundant extra column will be generated in the worker table. It's not quite useful in most of the cases...



### Question 
1. Do we consider reduce the timeout period from 5 minutes to something shorter for a smoother state transition?
1. Not exactly sure if the name of the new flag is acceptable. Please feel free to suggest.
1. Need to decide which option to use? Or maybe there are other solutions that are better than proposed ones. 