### PR TITLE
More resource allocation options for AWS Batch Worker Manager

### DIFF
--- a/codalab/worker_manager/aws_batch_worker_manager.py
+++ b/codalab/worker_manager/aws_batch_worker_manager.py
@@ -28,6 +28,9 @@ class AWSBatchWorkerManager(WorkerManager):
             '--cpus', type=int, default=1, help='Default number of CPUs for each worker'
         )
         subparser.add_argument(
+            '--gpus', type=int, default=0, help='Default number of GPUs to request for each worker'
+        )
+        subparser.add_argument(
             '--memory-mb', type=int, default=2048, help='Default memory (in MB) for each worker'
         )
         subparser.add_argument(
@@ -120,6 +123,8 @@ class AWSBatchWorkerManager(WorkerManager):
             },
             'retryStrategy': {'attempts': 1},
         }
+        if self.args.gpus:
+            job_definition["containerProperties"]["resourceRequirements"] = [{"value": str(self.args.gpus), "type": "GPU"}]
 
         # Allow worker to directly mount a directory.  Note that the worker
         # needs to be set up a priori with this shared filesystem.

--- a/codalab/worker_manager/aws_batch_worker_manager.py
+++ b/codalab/worker_manager/aws_batch_worker_manager.py
@@ -88,6 +88,8 @@ class AWSBatchWorkerManager(WorkerManager):
         ]
         if self.args.worker_tag:
             command.extend(['--tag', self.args.worker_tag])
+        if self.args.worker_max_work_dir_size:
+            command.extend(['--max-work-dir-size', self.args.worker_max_work_dir_size])
 
         # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-batch-jobdefinition.html
         # Need to mount:

--- a/codalab/worker_manager/aws_batch_worker_manager.py
+++ b/codalab/worker_manager/aws_batch_worker_manager.py
@@ -124,7 +124,9 @@ class AWSBatchWorkerManager(WorkerManager):
             'retryStrategy': {'attempts': 1},
         }
         if self.args.gpus:
-            job_definition["containerProperties"]["resourceRequirements"] = [{"value": str(self.args.gpus), "type": "GPU"}]
+            job_definition["containerProperties"]["resourceRequirements"] = [
+                {"value": str(self.args.gpus), "type": "GPU"}
+            ]
 
         # Allow worker to directly mount a directory.  Note that the worker
         # needs to be set up a priori with this shared filesystem.

--- a/codalab/worker_manager/main.py
+++ b/codalab/worker_manager/main.py
@@ -18,7 +18,9 @@ def main():
         '--search', nargs='*', help='Monitor only runs that satisfy these criteria', default=[]
     )
     parser.add_argument('--worker-tag', help='Tag to look for and put on workers')
-    parser.add_argument('--worker-max-work-dir-size', help='Maximum size of the temporary bundle data')
+    parser.add_argument(
+        '--worker-max-work-dir-size', help='Maximum size of the temporary bundle data'
+    )
     parser.add_argument(
         '--verbose', action='store_true', help='Whether to print out extra information'
     )

--- a/codalab/worker_manager/main.py
+++ b/codalab/worker_manager/main.py
@@ -18,6 +18,7 @@ def main():
         '--search', nargs='*', help='Monitor only runs that satisfy these criteria', default=[]
     )
     parser.add_argument('--worker-tag', help='Tag to look for and put on workers')
+    parser.add_argument('--worker-max-work-dir-size', help='Maximum size of the temporary bundle data')
     parser.add_argument(
         '--verbose', action='store_true', help='Whether to print out extra information'
     )


### PR DESCRIPTION
We have heterogeneous AWS compute environments with multiples families of nodes (e.g., p2, g4dn, p3). Sometimes, it's useful to specify to specify the number of gpus your job needs because it makes resource allocation more efficient. E.g., if I want 1 GPU, but 100GB of memory, I'd rather my job land on a g4dn.8xlarge (128 GB RAM, 1 GPU), than a p2.8xlarge (8 GPUs, 488 GB of RAM).

This also adds a flag to control each worker's `--max-work-dir-size`

see: https://docs.aws.amazon.com/batch/latest/userguide/job_definition_parameters.html (`resourceRequirements`)