### PR TITLE
Add --worker-work-dir-prefix to WorkerManager

### DIFF
--- a/codalab/worker_manager/aws_batch_worker_manager.py
+++ b/codalab/worker_manager/aws_batch_worker_manager.py
@@ -67,9 +67,11 @@ class AWSBatchWorkerManager(WorkerManager):
         image = 'codalab/worker:' + os.environ.get('CODALAB_VERSION', 'latest')
         worker_id = uuid.uuid4().hex
         logger.debug('Starting worker %s with image %s', worker_id, image)
-        work_dir = '/tmp/cl_worker_{}_work_dir'.format(
-            worker_id
-        )  # This needs to be a unique directory since Batch jobs may share a host
+        work_dir_prefix = (
+            self.args.worker_work_dir_prefix if self.args.worker_work_dir_prefix else "/tmp/"
+        )
+        # This needs to be a unique directory since Batch jobs may share a host
+        work_dir = os.path.join(work_dir_prefix, 'cl_worker_{}_work_dir'.format(worker_id))
         worker_network_prefix = 'cl_worker_{}_network'.format(worker_id)
         command = [
             'cl-worker',

--- a/codalab/worker_manager/main.py
+++ b/codalab/worker_manager/main.py
@@ -19,6 +19,9 @@ def main():
     )
     parser.add_argument('--worker-tag', help='Tag to look for and put on workers')
     parser.add_argument(
+        '--worker-work-dir-prefix', help="Prefix to use for each worker's working directory."
+    )
+    parser.add_argument(
         '--worker-max-work-dir-size', help='Maximum size of the temporary bundle data'
     )
     parser.add_argument(


### PR DESCRIPTION
Allows a user to specify where workers should write their working files.

ref: https://github.com/codalab/codalab-worksheets/pull/2279#discussion_r431369118