### PR TITLE
Don't duplicate sort keys for the same bundle items

### DIFF
--- a/codalab/lib/worksheet_util.py
+++ b/codalab/lib/worksheet_util.py
@@ -921,11 +921,11 @@ def interpret_items(schemas, raw_items, db_model=None):
                 current_schema = None
 
             if item_type == TYPE_BUNDLE:
-                bundle_info["sort_key"] = sort_key
+                bundle_info = dict(bundle_info, sort_key=sort_key)
                 raw_to_block.append((len(blocks), len(bundle_infos)))
                 bundle_infos.append((raw_index, bundle_info))
             elif item_type == TYPE_WORKSHEET:
-                subworksheet_info["sort_key"] = sort_key
+                subworksheet_info = dict(subworksheet_info, sort_key=sort_key)
                 raw_to_block.append((len(blocks), len(worksheet_infos)))
                 worksheet_infos.append(subworksheet_info)
             elif item_type == TYPE_MARKUP:


### PR DESCRIPTION
Fixes #2232

The issue was that setting `bundle_info["key"]` was mutating the object, which was shared across multiple bundle items with the same uuid. This PR uses an immutable assignment instead.

It also does this for subworksheet_info (which is not relevant to #2232, but is good practice and consistent anyway).