### PR TITLE
Add boto3 to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 bottle==0.12.9
+boto3==1.13.19
 docker==3.7.0
 marshmallow-jsonapi==0.15.1
 marshmallow==2.15.1


### PR DESCRIPTION
Otherwise, `pip install -e .` on a freshly cloned repo, followed by `cl-worker-manager -h` yields:
```
Traceback (most recent call last):
  File "/juice/scr/nfliu/miniconda3/envs/cl_dev/bin/cl-worker-manager", line 11, in <module>
    load_entry_point('codalab', 'console_scripts', 'cl-worker-manager')()
  File "/juice/scr/nfliu/miniconda3/envs/cl_dev/lib/python3.6/site-packages/pkg_resources/__init__.py"
, line 490, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/juice/scr/nfliu/miniconda3/envs/cl_dev/lib/python3.6/site-packages/pkg_resources/__init__.py"
, line 2853, in load_entry_point
    return ep.load()
  File "/juice/scr/nfliu/miniconda3/envs/cl_dev/lib/python3.6/site-packages/pkg_resources/__init__.py"
, line 2453, in load
    return self.resolve()
  File "/juice/scr/nfliu/miniconda3/envs/cl_dev/lib/python3.6/site-packages/pkg_resources/__init__.py"
, line 2459, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/juice/scr/nfliu/git/codalab-worksheets/codalab/worker_manager/main.py", line 7, in <module>
    from .aws_batch_worker_manager import AWSBatchWorkerManager
  File "/juice/scr/nfliu/git/codalab-worksheets/codalab/worker_manager/aws_batch_worker_manager.py", l
ine 2, in <module>
    import boto3
ModuleNotFoundError: No module named 'boto3'
```