### PR TITLE
Remove extant output directories when force-downloading bundles

### DIFF
--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -1361,7 +1361,7 @@ class BundleCLI(object):
         )
         with progress, closing(contents):
             if target_info['type'] == 'directory':
-                un_tar_directory(contents, final_path, 'gz')
+                un_tar_directory(contents, final_path, 'gz', force=args.force)
             elif target_info['type'] == 'file':
                 with open(final_path, 'wb') as out:
                     shutil.copyfileobj(contents, out)

--- a/codalab/worker/file_util.py
+++ b/codalab/worker/file_util.py
@@ -73,10 +73,12 @@ def tar_gzip_directory(
         raise IOError(e.output)
 
 
-def un_tar_directory(fileobj, directory_path, compression=''):
+def un_tar_directory(fileobj, directory_path, compression='', force=False):
     """
     Extracts the given file-like object containing a tar archive into the given
-    directory, which will be created and should not already exist.
+    directory, which will be created and should not already exist. If it already exists,
+    and `force` is `False`, an error is raised. If it already exists, and `force` is `True`,
+    the directory is removed and recreated.
 
     compression specifies the compression scheme and can be one of '', 'gz' or
     'bz2'.
@@ -84,6 +86,8 @@ def un_tar_directory(fileobj, directory_path, compression=''):
     Raises tarfile.TarError if the archive is not valid.
     """
     directory_path = os.path.realpath(directory_path)
+    if force:
+        shutil.rmtree(directory_path)
     os.mkdir(directory_path)
     with tarfile.open(fileobj=fileobj, mode='r|' + compression) as tar:
         for member in tar:

--- a/codalab/worker/file_util.py
+++ b/codalab/worker/file_util.py
@@ -87,7 +87,7 @@ def un_tar_directory(fileobj, directory_path, compression='', force=False):
     """
     directory_path = os.path.realpath(directory_path)
     if force:
-        shutil.rmtree(directory_path)
+        remove_path(directory_path)
     os.mkdir(directory_path)
     with tarfile.open(fileobj=fileobj, mode='r|' + compression) as tar:
         for member in tar:


### PR DESCRIPTION
Currently, if you try to download a bundle to a path that already exists, the following error is raised:

```
Downloading fusionnet_no_features_synthetic_cloze_worddropout.10000_sampled_hyperparameters(0x652a46bde3854fe08086d55f5f73c888)/ => /tmp/fusionnet_no_features_synthetic_cloze_worddropout.10000_sampled_hyperparameters

Received 0.00MiB [0.82MiB/sec]
Traceback (most recent call last):
  File "/juice/scr/nfliu/miniconda3/envs/cl_dev/bin/cl", line 11, in <module>
    load_entry_point('codalab', 'console_scripts', 'cl')()
  File "/juice/scr/nfliu/git/codalab-worksheets/codalab/bin/cl.py", line 10, in main
    cli.do_command(sys.argv[1:])
  File "/juice/scr/nfliu/git/codalab-worksheets/codalab/lib/bundle_cli.py", line 875, in do_command
    structured_result = command_fn()
  File "/juice/scr/nfliu/git/codalab-worksheets/codalab/lib/bundle_cli.py", line 869, in <lambda>
    command_fn = lambda: args.function(self, args)
  File "/juice/scr/nfliu/git/codalab-worksheets/codalab/lib/bundle_cli.py", line 1364, in do_download_command
    un_tar_directory(contents, final_path, 'gz')
  File "/juice/scr/nfliu/git/codalab-worksheets/codalab/worker/file_util.py", line 87, in un_tar_directory
    os.mkdir(directory_path)
FileExistsError: [Errno 17] File exists: '/tmp/fusionnet_no_features_synthetic_cloze_worddropout.10000_sampled_hyperparameters'
```

This can happen when a download is interrupted or fails—the directory is left behind, but the contents aren't completely in there.

This PR makes it such that, if the `--force` flag is provided to `cl down`, the directory that already exists is removed.