### PR TITLE
Fix logging of active workers in SlurmWorkerManager

### DIFF
--- a/codalab/worker_manager/slurm_batch_worker_manager.py
+++ b/codalab/worker_manager/slurm_batch_worker_manager.py
@@ -132,11 +132,11 @@ class SlurmBatchWorkerManager(WorkerManager):
 
         # Get all the Slurm workers that are submitted by SlurmWorkerManager and owned by the current user.
         # Returning result will be in the following format:
-        # JOBID:STATE (header won't be included with "--noheader" option)
-        # 1478828,PENDING
-        # 1478830,PENDING
+        # JOBID (header won't be included with "--noheader" option)
+        # 1478828
+        # 1478830
         jobs = self.run_command(
-            [self.SQUEUE, '-u', self.username, '--format', '%A,%T', '--noheader']
+            [self.SQUEUE, '-u', self.username, '--format', '%A', '--noheader']
         )
         jobs = jobs.strip().split()
         logger.info(

--- a/codalab/worker_manager/slurm_batch_worker_manager.py
+++ b/codalab/worker_manager/slurm_batch_worker_manager.py
@@ -135,9 +135,7 @@ class SlurmBatchWorkerManager(WorkerManager):
         # JOBID (header won't be included with "--noheader" option)
         # 1478828
         # 1478830
-        jobs = self.run_command(
-            [self.SQUEUE, '-u', self.username, '--format', '%A', '--noheader']
-        )
+        jobs = self.run_command([self.SQUEUE, '-u', self.username, '--format', '%A', '--noheader'])
         jobs = jobs.strip().split()
         logger.info(
             'Workers: {}'.format(


### PR DESCRIPTION
this always prints `"(none)"` right now, because we're fetching both the run ID and the status, and then checking if the `runid,status` string is in `self.submitted_jobs`. It isn't (since the status is tacked on), so this removes the status from the output and consequently fixes the logging.