### PR TITLE
Enable excluding patterns in run bundle uploaded output

### DIFF
--- a/codalab/bundles/run_bundle.py
+++ b/codalab/bundles/run_bundle.py
@@ -32,6 +32,7 @@ class RunBundle(DerivedBundle):
     METADATA_SPECS.append(MetadataSpec('request_queue', str, 'Submit run to this job queue.', hide_when_anonymous=True, default=None))
     METADATA_SPECS.append(MetadataSpec('request_priority', int, 'Job priority (higher is more important).', default=None))
     METADATA_SPECS.append(MetadataSpec('request_network', bool, 'Whether to allow network access.', default=False))
+    METADATA_SPECS.append(MetadataSpec('upload_exclude_patterns', str, 'Exclude these file patterns when uploading run output.', default=None))
 
     METADATA_SPECS.append(MetadataSpec('actions', list, 'Actions (e.g., kill) that were performed on this run.', generated=True))
 

--- a/codalab/bundles/run_bundle.py
+++ b/codalab/bundles/run_bundle.py
@@ -32,7 +32,7 @@ class RunBundle(DerivedBundle):
     METADATA_SPECS.append(MetadataSpec('request_queue', str, 'Submit run to this job queue.', hide_when_anonymous=True, default=None))
     METADATA_SPECS.append(MetadataSpec('request_priority', int, 'Job priority (higher is more important).', default=None))
     METADATA_SPECS.append(MetadataSpec('request_network', bool, 'Whether to allow network access.', default=False))
-    METADATA_SPECS.append(MetadataSpec('upload_exclude_patterns', str, 'Exclude these file patterns when uploading run output.', default=None))
+    METADATA_SPECS.append(MetadataSpec('exclude_patterns', str, 'Exclude these file patterns when uploading run output.', default=None))
 
     METADATA_SPECS.append(MetadataSpec('actions', list, 'Actions (e.g., kill) that were performed on this run.', generated=True))
 

--- a/codalab/bundles/run_bundle.py
+++ b/codalab/bundles/run_bundle.py
@@ -32,7 +32,7 @@ class RunBundle(DerivedBundle):
     METADATA_SPECS.append(MetadataSpec('request_queue', str, 'Submit run to this job queue.', hide_when_anonymous=True, default=None))
     METADATA_SPECS.append(MetadataSpec('request_priority', int, 'Job priority (higher is more important).', default=None))
     METADATA_SPECS.append(MetadataSpec('request_network', bool, 'Whether to allow network access.', default=False))
-    METADATA_SPECS.append(MetadataSpec('exclude_patterns', list, 'Exclude these file patterns when uploading run output.', generated=True))
+    METADATA_SPECS.append(MetadataSpec('exclude_patterns', list, 'Exclude these file patterns when uploading run output.', default=[]))
 
     METADATA_SPECS.append(MetadataSpec('actions', list, 'Actions (e.g., kill) that were performed on this run.', generated=True))
 

--- a/codalab/bundles/run_bundle.py
+++ b/codalab/bundles/run_bundle.py
@@ -32,7 +32,7 @@ class RunBundle(DerivedBundle):
     METADATA_SPECS.append(MetadataSpec('request_queue', str, 'Submit run to this job queue.', hide_when_anonymous=True, default=None))
     METADATA_SPECS.append(MetadataSpec('request_priority', int, 'Job priority (higher is more important).', default=None))
     METADATA_SPECS.append(MetadataSpec('request_network', bool, 'Whether to allow network access.', default=False))
-    METADATA_SPECS.append(MetadataSpec('exclude_patterns', str, 'Exclude these file patterns when uploading run output.', default=None))
+    METADATA_SPECS.append(MetadataSpec('exclude_patterns', list, 'Exclude these file patterns when uploading run output.', generated=True))
 
     METADATA_SPECS.append(MetadataSpec('actions', list, 'Actions (e.g., kill) that were performed on this run.', generated=True))
 

--- a/codalab/bundles/run_bundle.py
+++ b/codalab/bundles/run_bundle.py
@@ -32,7 +32,7 @@ class RunBundle(DerivedBundle):
     METADATA_SPECS.append(MetadataSpec('request_queue', str, 'Submit run to this job queue.', hide_when_anonymous=True, default=None))
     METADATA_SPECS.append(MetadataSpec('request_priority', int, 'Job priority (higher is more important).', default=None))
     METADATA_SPECS.append(MetadataSpec('request_network', bool, 'Whether to allow network access.', default=False))
-    METADATA_SPECS.append(MetadataSpec('exclude_patterns', list, 'Exclude these file patterns when uploading run output.', default=[]))
+    METADATA_SPECS.append(MetadataSpec('exclude_patterns', list, 'Exclude these file patterns from being saved into the bundle contents.', default=[]))
 
     METADATA_SPECS.append(MetadataSpec('actions', list, 'Actions (e.g., kill) that were performed on this run.', generated=True))
 

--- a/codalab/worker/bundle_service_client.py
+++ b/codalab/worker/bundle_service_client.py
@@ -149,8 +149,8 @@ class BundleServiceClient(RestClient):
         )
 
     @wrap_exception('Unable to update bundle contents in bundle service')
-    def update_bundle_contents(self, worker_id, uuid, path, progress_callback):
-        with closing(tar_gzip_directory(path)) as fileobj:
+    def update_bundle_contents(self, worker_id, uuid, path, exclude_patterns, progress_callback):
+        with closing(tar_gzip_directory(path, exclude_patterns=exclude_patterns)) as fileobj:
             self._upload_with_chunked_encoding(
                 'PUT',
                 '/bundles/' + uuid + '/contents/blob/',

--- a/codalab/worker/file_util.py
+++ b/codalab/worker/file_util.py
@@ -321,7 +321,7 @@ def path_is_parent(parent_path, child_path):
     """
     Given a parent_path and a child_path, determine if the child path
     is a strict subpath of the parent_path. In the case that the resolved
-    parent_path is equivalent to the resolved child_path, this funciton returns
+    parent_path is equivalent to the resolved child_path, this function returns
     False.
 
     Note that this function does not dereference symbolic links.

--- a/codalab/worker/file_util.py
+++ b/codalab/worker/file_util.py
@@ -315,3 +315,27 @@ def remove_path(path):
             shutil.rmtree(path)
         else:
             os.remove(path)
+
+
+def path_is_parent(parent_path, child_path):
+    """
+    Given a parent_path and a child_path, determine if the child path
+    is a strict subpath of the parent_path. In the case that the resolved
+    parent_path is equivalent to the resolved child_path, this funciton returns
+    False.
+
+    Note that this function does not dereference symbolic links.
+    """
+    # Remove relative path references.
+    parent_path = os.path.abspath(parent_path)
+    child_path = os.path.abspath(child_path)
+
+    # Explicitly handle the case where the parent_path equals the child_path
+    if parent_path == child_path:
+        return False
+
+    # Compare the common path of the parent and child path with the common
+    # path of just the parent path. Using the commonpath method on just
+    # the parent path will regularize the path name in the same way as the
+    # comparison that deals with both paths, removing any trailing path separator.
+    return os.path.commonpath([parent_path]) == os.path.commonpath([parent_path, child_path])

--- a/codalab/worker/worker.py
+++ b/codalab/worker/worker.py
@@ -598,10 +598,10 @@ class Worker:
 
         threading.Thread(target=write_fn).start()
 
-    def upload_bundle_contents(self, bundle_uuid, bundle_path, update_status):
+    def upload_bundle_contents(self, bundle_uuid, bundle_path, exclude_patterns, update_status):
         self.execute_bundle_service_command_with_retry(
             lambda: self.bundle_service.update_bundle_contents(
-                self.id, bundle_uuid, bundle_path, update_status
+                self.id, bundle_uuid, bundle_path, exclude_patterns, update_status
             )
         )
 

--- a/codalab/worker/worker_run_state.py
+++ b/codalab/worker/worker_run_state.py
@@ -507,7 +507,7 @@ class RunStateMachine(StateTransitioner):
                 self.upload_bundle_callback(
                     run_state.bundle.uuid,
                     run_state.bundle_path,
-                    run_state.bundle.metadata["upload_exclude_patterns"],
+                    run_state.bundle.metadata["exclude_patterns"],
                     progress_callback,
                 )
                 self.uploading[run_state.bundle.uuid]['success'] = True

--- a/codalab/worker/worker_run_state.py
+++ b/codalab/worker/worker_run_state.py
@@ -505,7 +505,10 @@ class RunStateMachine(StateTransitioner):
                     return True
 
                 self.upload_bundle_callback(
-                    run_state.bundle.uuid, run_state.bundle_path, progress_callback
+                    run_state.bundle.uuid,
+                    run_state.bundle_path,
+                    run_state.bundle.metadata["upload_exclude_patterns"],
+                    progress_callback,
                 )
                 self.uploading[run_state.bundle.uuid]['success'] = True
             except Exception as e:

--- a/docs/CLI-Reference.md
+++ b/docs/CLI-Reference.md
@@ -63,6 +63,7 @@ Usage: `cl <command> <arguments>`
       --request-queue              Submit run to this job queue.
       --request-priority           Job priority (higher is more important).
       --request-network            Whether to allow network access.
+      --upload-exclude-patterns    Exclude these file patterns when uploading run output.
       -e, --edit                   Show an editor to allow editing of the bundle metadata.
       -W, --wait                   Wait until run finishes.
       -t, --tail                   Wait until run finishes, displaying stdout/stderr.
@@ -87,6 +88,7 @@ Usage: `cl <command> <arguments>`
       --request-queue              Submit run to this job queue.
       --request-priority           Job priority (higher is more important).
       --request-network            Whether to allow network access.
+      --upload-exclude-patterns    Exclude these file patterns when uploading run output.
       -e, --edit                   Show an editor to allow editing of the bundle metadata.
       -W, --wait                   Wait until run finishes.
       -t, --tail                   Wait until run finishes, displaying stdout/stderr.
@@ -221,6 +223,7 @@ Usage: `cl <command> <arguments>`
       --request-queue              Submit run to this job queue. (for runs)
       --request-priority           Job priority (higher is more important). (for runs)
       --request-network            Whether to allow network access. (for runs)
+      --upload-exclude-patterns    Exclude these file patterns when uploading run output. (for runs)
       --depth                      Number of parents to look back from the old output in search of the old input.
       -s, --shadow                 Add the newly created bundles right after the old bundles that are being mimicked.
       -i, --dry-run                Perform a dry run (just show what will be done without doing it)
@@ -249,6 +252,7 @@ Usage: `cl <command> <arguments>`
       --request-queue              Submit run to this job queue. (for runs)
       --request-priority           Job priority (higher is more important). (for runs)
       --request-network            Whether to allow network access. (for runs)
+      --upload-exclude-patterns    Exclude these file patterns when uploading run output. (for runs)
       --depth                      Number of parents to look back from the old output in search of the old input.
       -s, --shadow                 Add the newly created bundles right after the old bundles that are being mimicked.
       -i, --dry-run                Perform a dry run (just show what will be done without doing it)

--- a/docs/CLI-Reference.md
+++ b/docs/CLI-Reference.md
@@ -63,7 +63,7 @@ Usage: `cl <command> <arguments>`
       --request-queue              Submit run to this job queue.
       --request-priority           Job priority (higher is more important).
       --request-network            Whether to allow network access.
-      --upload-exclude-patterns    Exclude these file patterns when uploading run output.
+      --exclude-patterns           Exclude these file patterns when uploading run output.
       -e, --edit                   Show an editor to allow editing of the bundle metadata.
       -W, --wait                   Wait until run finishes.
       -t, --tail                   Wait until run finishes, displaying stdout/stderr.
@@ -88,7 +88,7 @@ Usage: `cl <command> <arguments>`
       --request-queue              Submit run to this job queue.
       --request-priority           Job priority (higher is more important).
       --request-network            Whether to allow network access.
-      --upload-exclude-patterns    Exclude these file patterns when uploading run output.
+      --exclude-patterns           Exclude these file patterns when uploading run output.
       -e, --edit                   Show an editor to allow editing of the bundle metadata.
       -W, --wait                   Wait until run finishes.
       -t, --tail                   Wait until run finishes, displaying stdout/stderr.
@@ -223,7 +223,7 @@ Usage: `cl <command> <arguments>`
       --request-queue              Submit run to this job queue. (for runs)
       --request-priority           Job priority (higher is more important). (for runs)
       --request-network            Whether to allow network access. (for runs)
-      --upload-exclude-patterns    Exclude these file patterns when uploading run output. (for runs)
+      --exclude-patterns           Exclude these file patterns when uploading run output. (for runs)
       --depth                      Number of parents to look back from the old output in search of the old input.
       -s, --shadow                 Add the newly created bundles right after the old bundles that are being mimicked.
       -i, --dry-run                Perform a dry run (just show what will be done without doing it)
@@ -252,7 +252,7 @@ Usage: `cl <command> <arguments>`
       --request-queue              Submit run to this job queue. (for runs)
       --request-priority           Job priority (higher is more important). (for runs)
       --request-network            Whether to allow network access. (for runs)
-      --upload-exclude-patterns    Exclude these file patterns when uploading run output. (for runs)
+      --exclude-patterns           Exclude these file patterns when uploading run output. (for runs)
       --depth                      Number of parents to look back from the old output in search of the old input.
       -s, --shadow                 Add the newly created bundles right after the old bundles that are being mimicked.
       -i, --dry-run                Perform a dry run (just show what will be done without doing it)

--- a/docs/CLI-Reference.md
+++ b/docs/CLI-Reference.md
@@ -63,7 +63,7 @@ Usage: `cl <command> <arguments>`
       --request-queue              Submit run to this job queue.
       --request-priority           Job priority (higher is more important).
       --request-network            Whether to allow network access.
-      --exclude-patterns           Exclude these file patterns when uploading run output.
+      --exclude-patterns           Exclude these file patterns from being saved into the bundle contents.
       -e, --edit                   Show an editor to allow editing of the bundle metadata.
       -W, --wait                   Wait until run finishes.
       -t, --tail                   Wait until run finishes, displaying stdout/stderr.
@@ -88,7 +88,7 @@ Usage: `cl <command> <arguments>`
       --request-queue              Submit run to this job queue.
       --request-priority           Job priority (higher is more important).
       --request-network            Whether to allow network access.
-      --exclude-patterns           Exclude these file patterns when uploading run output.
+      --exclude-patterns           Exclude these file patterns from being saved into the bundle contents.
       -e, --edit                   Show an editor to allow editing of the bundle metadata.
       -W, --wait                   Wait until run finishes.
       -t, --tail                   Wait until run finishes, displaying stdout/stderr.
@@ -223,7 +223,7 @@ Usage: `cl <command> <arguments>`
       --request-queue              Submit run to this job queue. (for runs)
       --request-priority           Job priority (higher is more important). (for runs)
       --request-network            Whether to allow network access. (for runs)
-      --exclude-patterns           Exclude these file patterns when uploading run output. (for runs)
+      --exclude-patterns           Exclude these file patterns from being saved into the bundle contents. (for runs)
       --depth                      Number of parents to look back from the old output in search of the old input.
       -s, --shadow                 Add the newly created bundles right after the old bundles that are being mimicked.
       -i, --dry-run                Perform a dry run (just show what will be done without doing it)
@@ -252,7 +252,7 @@ Usage: `cl <command> <arguments>`
       --request-queue              Submit run to this job queue. (for runs)
       --request-priority           Job priority (higher is more important). (for runs)
       --request-network            Whether to allow network access. (for runs)
-      --exclude-patterns           Exclude these file patterns when uploading run output. (for runs)
+      --exclude-patterns           Exclude these file patterns from being saved into the bundle contents. (for runs)
       --depth                      Number of parents to look back from the old output in search of the old input.
       -s, --shadow                 Add the newly created bundles right after the old bundles that are being mimicked.
       -i, --dry-run                Perform a dry run (just show what will be done without doing it)

--- a/test_cli.py
+++ b/test_cli.py
@@ -1104,9 +1104,25 @@ def test(ctx):
         [
             cl,
             'run',
-            'echo "hi" > hi.txt ; echo "bye" > bye.txt; echo "goodbye" > goodbye.txt;',
+            'echo "hi" > hi.txt ; echo "bye" > bye.txt; echo "goodbye" > goodbye.txt',
             '--exclude-patterns',
             '*bye*.txt',
+        ]
+    )
+    check_num_lines(
+        2 + 1, _run_command([cl, 'cat', remote_uuid])
+    )  # 2 header lines, 1 item at bundle target root
+
+    # Test multiple exclude_patterns
+    remote_uuid = _run_command(
+        [
+            cl,
+            'run',
+            'echo "hi" > hi.txt ; echo "bye" > bye.txt; echo "goodbye" > goodbye.txt',
+            '--exclude-patterns',
+            'bye.txt',
+            '--exclude-patterns',
+            'goodbye.txt',
         ]
     )
     check_num_lines(

--- a/test_cli.py
+++ b/test_cli.py
@@ -1106,7 +1106,7 @@ def test(ctx):
             'run',
             'echo "hi" > hi.txt ; echo "bye" > bye.txt; echo "goodbye" > goodbye.txt',
             '--exclude-patterns',
-            '*bye*.txt',
+            "'*bye*.txt'",
         ]
     )
     check_num_lines(
@@ -1120,9 +1120,9 @@ def test(ctx):
             'run',
             'echo "hi" > hi.txt ; echo "bye" > bye.txt; echo "goodbye" > goodbye.txt',
             '--exclude-patterns',
-            'bye.txt',
+            "'bye.txt'",
             '--exclude-patterns',
-            'goodbye.txt',
+            "'goodbye.txt'",
         ]
     )
     check_num_lines(

--- a/test_cli.py
+++ b/test_cli.py
@@ -1099,6 +1099,20 @@ def test(ctx):
     check_equals('hello', _run_command([cl, 'cat', multi_alias_uuid + '/foo1/stdout']))
     check_equals('hello', _run_command([cl, 'cat', multi_alias_uuid + '/foo2/stdout']))
 
+    # Test exclude_patterns
+    remote_uuid = _run_command(
+        [
+            cl,
+            'run',
+            'echo "hi" > hi.txt ; echo "bye" > bye.txt; echo "goodbye" > goodbye.txt;',
+            '--exclude-patterns',
+            '*bye*.txt',
+        ]
+    )
+    check_num_lines(
+        2 + 1, _run_command([cl, 'cat', remote_uuid])
+    )  # 2 header lines, 1 item at bundle target root
+
 
 @TestModule.register('read')
 def test(ctx):

--- a/test_cli.py
+++ b/test_cli.py
@@ -1106,12 +1106,12 @@ def test(ctx):
             'run',
             'echo "hi" > hi.txt ; echo "bye" > bye.txt; echo "goodbye" > goodbye.txt',
             '--exclude-patterns',
-            "'*bye*.txt'",
+            '*bye*.txt',
         ]
     )
     wait(remote_uuid)
     check_num_lines(
-        2 + 1, _run_command([cl, 'cat', remote_uuid])
+        2 + 2 + 1, _run_command([cl, 'cat', remote_uuid])
     )  # 2 header lines, 1 item at bundle target root
 
     # Test multiple exclude_patterns
@@ -1121,14 +1121,14 @@ def test(ctx):
             'run',
             'echo "hi" > hi.txt ; echo "bye" > bye.txt; echo "goodbye" > goodbye.txt',
             '--exclude-patterns',
-            "'bye.txt'",
+            'bye.txt',
             '--exclude-patterns',
-            "'goodbye.txt'",
+            'goodbye.txt',
         ]
     )
     wait(remote_uuid)
     check_num_lines(
-        2 + 1, _run_command([cl, 'cat', remote_uuid])
+        2 + 2 + 1, _run_command([cl, 'cat', remote_uuid])
     )  # 2 header lines, 1 item at bundle target root
 
 

--- a/test_cli.py
+++ b/test_cli.py
@@ -1112,7 +1112,7 @@ def test(ctx):
     wait(remote_uuid)
     check_num_lines(
         2 + 2 + 1, _run_command([cl, 'cat', remote_uuid])
-    )  # 2 header lines, 1 item at bundle target root
+    )  # 2 header lines, 1 stdout file, 1 stderr file, 1 item at bundle target root
 
     # Test multiple exclude_patterns
     remote_uuid = _run_command(
@@ -1128,7 +1128,7 @@ def test(ctx):
     wait(remote_uuid)
     check_num_lines(
         2 + 2 + 1, _run_command([cl, 'cat', remote_uuid])
-    )  # 2 header lines, 1 item at bundle target root
+    )  # 2 header lines, 1 stdout file, 1 stderr file, 1 item at bundle target root
 
 
 @TestModule.register('read')

--- a/test_cli.py
+++ b/test_cli.py
@@ -1109,6 +1109,7 @@ def test(ctx):
             "'*bye*.txt'",
         ]
     )
+    wait(remote_uuid)
     check_num_lines(
         2 + 1, _run_command([cl, 'cat', remote_uuid])
     )  # 2 header lines, 1 item at bundle target root
@@ -1125,6 +1126,7 @@ def test(ctx):
             "'goodbye.txt'",
         ]
     )
+    wait(remote_uuid)
     check_num_lines(
         2 + 1, _run_command([cl, 'cat', remote_uuid])
     )  # 2 header lines, 1 item at bundle target root

--- a/test_cli.py
+++ b/test_cli.py
@@ -1122,7 +1122,6 @@ def test(ctx):
             'echo "hi" > hi.txt ; echo "bye" > bye.txt; echo "goodbye" > goodbye.txt',
             '--exclude-patterns',
             'bye.txt',
-            '--exclude-patterns',
             'goodbye.txt',
         ]
     )

--- a/test_cli.py
+++ b/test_cli.py
@@ -1110,9 +1110,16 @@ def test(ctx):
         ]
     )
     wait(remote_uuid)
-    check_num_lines(
-        2 + 2 + 1, _run_command([cl, 'cat', remote_uuid])
-    )  # 2 header lines, 1 stdout file, 1 stderr file, 1 item at bundle target root
+    # Since shared file system workers don't upload, exclude_patterns do not apply.
+    # Verify that all files are kept if the worker is using a shared file system.
+    if os.environ.get("CODALAB_SHARED_FILE_SYSTEM"):
+        check_num_lines(
+            2 + 2 + 3, _run_command([cl, 'cat', remote_uuid])
+        )  # 2 header lines, 1 stdout file, 1 stderr file, 3 items at bundle target root
+    else:
+        check_num_lines(
+            2 + 2 + 1, _run_command([cl, 'cat', remote_uuid])
+        )  # 2 header lines, 1 stdout file, 1 stderr file, 1 item at bundle target root
 
     # Test multiple exclude_patterns
     remote_uuid = _run_command(
@@ -1126,10 +1133,16 @@ def test(ctx):
         ]
     )
     wait(remote_uuid)
-    check_num_lines(
-        2 + 2 + 1, _run_command([cl, 'cat', remote_uuid])
-    )  # 2 header lines, 1 stdout file, 1 stderr file, 1 item at bundle target root
-
+    # Since shared file system workers don't upload, exclude_patterns do not apply.
+    # Verify that all files are kept if the worker is using a shared file system.
+    if os.environ.get("CODALAB_SHARED_FILE_SYSTEM"):
+        check_num_lines(
+            2 + 2 + 3, _run_command([cl, 'cat', remote_uuid])
+        )  # 2 header lines, 1 stdout file, 1 stderr file, 3 items at bundle target root
+    else:
+        check_num_lines(
+            2 + 2 + 1, _run_command([cl, 'cat', remote_uuid])
+        )  # 2 header lines, 1 stdout file, 1 stderr file, 1 item at bundle target root
 
 @TestModule.register('read')
 def test(ctx):

--- a/test_cli.py
+++ b/test_cli.py
@@ -1144,6 +1144,7 @@ def test(ctx):
             2 + 2 + 1, _run_command([cl, 'cat', remote_uuid])
         )  # 2 header lines, 1 stdout file, 1 stderr file, 1 item at bundle target root
 
+
 @TestModule.register('read')
 def test(ctx):
     dep_uuid = _run_command([cl, 'upload', test_path('')])


### PR DESCRIPTION
Fixes #2338 

Adds a new bundle metadata field `upload_exclude_patterns`, which are applied when `tar`ing the file for upload.

~~I haven't actually tested this, but I'm assuming that `bundle_service_client#update_bundle_contents()` will update the paths in the bundle according to the `tar`'d archive that's uploaded, and the `data_size` will be computed accordingly?~~
update: added tests