### PR TITLE
Load jobs by partition in SlurmWorkerManager

### DIFF
--- a/codalab/worker_manager/slurm_batch_worker_manager.py
+++ b/codalab/worker_manager/slurm_batch_worker_manager.py
@@ -100,7 +100,16 @@ class SlurmBatchWorkerManager(WorkerManager):
         # 1478830,john-job-5234492
         submitted_jobs = set()
         jobs = self.run_command(
-            [self.SQUEUE, '-u', self.username, '--format', '%A,%j', '--noheader']
+            [
+                self.SQUEUE,
+                '-u',
+                self.username,
+                '-p',
+                self.args.partition,
+                '--format',
+                '%A,%j',
+                '--noheader',
+            ]
         )
         for job in jobs.strip().split():
             job_id, job_name = job.split(',')


### PR DESCRIPTION
This way, if you have two `slurmworkermanager` with otherwise identical arguments except for the partition (e.g., one is on `jag-lo`, another is on `jag-standard`), the worker can correctly load existing jobs for each.