### PR TITLE
Pass down max work dir size and delete workdir on exit to slurm workers

### DIFF
--- a/codalab/worker_manager/slurm_batch_worker_manager.py
+++ b/codalab/worker_manager/slurm_batch_worker_manager.py
@@ -258,6 +258,10 @@ class SlurmBatchWorkerManager(WorkerManager):
             command.extend(['--tag', self.args.worker_tag])
         if self.args.password_file:
             command.extend(['--password-file', self.args.password_file])
+        if self.args.worker_max_work_dir_size:
+            command.extend(['--max-work-dir-size', self.args.worker_max_work_dir_size])
+        if self.args.worker_delete_work_dir_on_exit:
+            command.extend(['--worker-delete-work-dir-on-exit'])
 
         return command
 

--- a/codalab/worker_manager/slurm_batch_worker_manager.py
+++ b/codalab/worker_manager/slurm_batch_worker_manager.py
@@ -261,7 +261,7 @@ class SlurmBatchWorkerManager(WorkerManager):
         if self.args.worker_max_work_dir_size:
             command.extend(['--max-work-dir-size', self.args.worker_max_work_dir_size])
         if self.args.worker_delete_work_dir_on_exit:
-            command.extend(['--worker-delete-work-dir-on-exit'])
+            command.extend(['--delete-work-dir-on-exit'])
 
         return command
 


### PR DESCRIPTION
These were added to the AWS batch worker, but not the slurm worker