### PR TITLE
Disable cut button/shortcut when no edit permission

### DIFF
--- a/frontend/src/components/worksheets/BundleBulkActionMenu.js
+++ b/frontend/src/components/worksheets/BundleBulkActionMenu.js
@@ -71,6 +71,7 @@ class BundleBulkActionMenu extends React.Component {
                     size='small'
                     color='inherit'
                     aria-label='Cut'
+                    disabled={!this.props.editPermission}
                     onClick={this.props.toggleCmdDialog('cut')}
                 >
                     <FileCopyOutlinedIcon className={classes.buttonIcon} />

--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -978,12 +978,6 @@ class Worksheet extends React.Component {
                 }
                 this.toggleCmdDialogNoEvent('copy');
             });
-            Mousetrap.bind(['a z'], () => {
-                if (this.state.openDetach || this.state.openDelete || this.state.openKill) {
-                    return;
-                }
-                this.toggleCmdDialogNoEvent('cut');
-            });
             if (this.state.ws.info.edit_permission) {
                 Mousetrap.bind(['backspace', 'del'], () => {
                     if (this.state.openDetach || this.state.openKill) {
@@ -1002,6 +996,12 @@ class Worksheet extends React.Component {
                         return;
                     }
                     this.toggleCmdDialogNoEvent('kill');
+                });
+                Mousetrap.bind(['a z'], () => {
+                    if (this.state.openDetach || this.state.openDelete || this.state.openKill) {
+                        return;
+                    }
+                    this.toggleCmdDialogNoEvent('cut');
                 });
 
                 // Confirm bulk bundle operation


### PR DESCRIPTION
Shouldn't be able to perform cut when a user doesn't have edit permission (copy is fine)