### PR TITLE
Make worker id match output directory and job name

### DIFF
--- a/codalab/worker_manager/slurm_batch_worker_manager.py
+++ b/codalab/worker_manager/slurm_batch_worker_manager.py
@@ -171,7 +171,7 @@ class SlurmBatchWorkerManager(WorkerManager):
         """
         Start a CodaLab Slurm worker by submitting a batch job to Slurm
         """
-        worker_id = uuid.uuid4().hex
+        worker_id = self.username + "-" + self.args.job_name + '-' + uuid.uuid4().hex[:8]
 
         # Set up the Slurm worker directory
         slurm_work_dir = self.setup_slurm_work_directory(worker_id)
@@ -204,7 +204,7 @@ class SlurmBatchWorkerManager(WorkerManager):
     def setup_slurm_work_directory(self, worker_id):
         """
         Set up the work directory for Slurm Batch Worker Manager
-        :param worker_id: a string in the format of 32 hex characters
+        :param worker_id: a string representing the worker id
         :return: slurm work directory
         """
         # Set up the Slurm worker directory
@@ -222,7 +222,7 @@ class SlurmBatchWorkerManager(WorkerManager):
     def setup_codalab_worker(self, worker_id):
         """
         Set up the configuration for the codalab worker that will run on the Slurm worker
-        :param worker_id: a string of worker id in 32 hex characters
+        :param worker_id: a string representing the worker id
         :return: the command to run on
         """
         # This needs to be a unique directory since Batch jobs may share a host
@@ -234,7 +234,7 @@ class SlurmBatchWorkerManager(WorkerManager):
             work_dir_prefix = Path()
 
         worker_work_dir = work_dir_prefix.joinpath(
-            Path('slurm-codalab-worker-scratch', self.username + '-' + worker_id)
+            Path('slurm-codalab-worker-scratch', worker_id)
         )
 
         command = [
@@ -354,7 +354,7 @@ class SlurmBatchWorkerManager(WorkerManager):
         slurm_args['partition'] = self.args.partition
         slurm_args['gres'] = "gpu:" + str(self.args.gpus)
         # job-name is unique
-        slurm_args['job-name'] = self.username + "-" + self.args.job_name + '-' + worker_id[:8]
+        slurm_args['job-name'] = worker_id
         slurm_args['cpus-per-task'] = str(self.args.cpus)
         slurm_args['ntasks-per-node'] = 1
         slurm_args['time'] = self.args.time

--- a/codalab/worker_manager/slurm_batch_worker_manager.py
+++ b/codalab/worker_manager/slurm_batch_worker_manager.py
@@ -233,9 +233,7 @@ class SlurmBatchWorkerManager(WorkerManager):
         else:
             work_dir_prefix = Path()
 
-        worker_work_dir = work_dir_prefix.joinpath(
-            Path('slurm-codalab-worker-scratch', worker_id)
-        )
+        worker_work_dir = work_dir_prefix.joinpath(Path('slurm-codalab-worker-scratch', worker_id))
 
         command = [
             'cl-worker',


### PR DESCRIPTION
Right now, when running the SlurmWorkerManager, it generates jobs with (for example):
- worker id: 53f9bcfd24ec4c648e1fafc6364b8d4b
- slurm job name: nfliu-codalab-slurm-worker-53f9bcfd
- output path: `/some/prefix/53f9bcfd24ec4c648e1fafc6364b8d4b` with files `nfliu-codalab-slurm-worker-53f9bcfd.out` and `nfliu-codalab-slurm-worker-53f9bcfd.slurm`.

This is a bit annoying because, given a run on codalab, you can't just necessarily look at the remote and know which slurm job it is. I've changed it such that it's easier to map between worker id <-> job name <-> output path, by making them all the same. So now (for the example above):

- worker id: nfliu-codalab-slurm-worker-53f9bcfd
- slurm job name: nfliu-codalab-slurm-worker-53f9bcfd
- output path: `some/prefix/nfliu-codalab-slurm-worker-53f9bcfd` with files `nfliu-codalab-slurm-worker-53f9bcfd.out` and `nfliu-codalab-slurm-worker-53f9bcfd.slurm`.