### PR TITLE
Fix SlurmWorkerManager overlaunching

### DIFF
--- a/codalab/worker_manager/slurm_batch_worker_manager.py
+++ b/codalab/worker_manager/slurm_batch_worker_manager.py
@@ -129,13 +129,16 @@ class SlurmBatchWorkerManager(WorkerManager):
         jobs_to_remove = set()
         for job_id in self.submitted_jobs:
             job_acct = self.run_command(
-                [self.SACCT, '-j', job_id, '--format', 'state', '--noheader']
+                [self.SCONTROL, 'show', 'jobid', '-d', job_id, '--oneliner'], verbose=False
             )
-            if 'FAILED' in job_acct:
+            job_state = re.search(r'JobState=(.*) ', job_acct).group(1)
+            logger.info("Job ID {} has state {}".format(job_id, job_state))
+            if 'FAILED' in job_state:
                 jobs_to_remove.add(job_id)
                 logger.error("Failed to start job {}".format(job_id))
-            elif 'COMPLETING' in job_acct or 'COMPLETED' in job_acct or 'CANCELLED' in job_acct:
+            elif 'COMPLETED' in job_state or 'CANCELLED' in job_state:
                 jobs_to_remove.add(job_id)
+                logger.info("Removing job ID {}".format(job_id))
         self.submitted_jobs = self.submitted_jobs - jobs_to_remove
         logger.info("Submitted jobs: {}".format(self.submitted_jobs))
 
@@ -263,7 +266,7 @@ class SlurmBatchWorkerManager(WorkerManager):
 
         return command
 
-    def run_command(self, command):
+    def run_command(self, command, verbose=True):
         """
         Run a given shell command and return the result
         :param command: the input command as list
@@ -275,7 +278,8 @@ class SlurmBatchWorkerManager(WorkerManager):
             if output:
                 logger.info("Executed command: {}".format(' '.join(command)))
                 result = output.decode()
-                logger.info(result)
+                if verbose:
+                    logger.info(result)
                 return result
             if errors:
                 logger.error(


### PR DESCRIPTION
Merge #2368 before merging this

When a job gets pre-empted, Slurm puts it in to the `COMPLETING` stage before requeueing it.

Right now, since we remove jobs from the SlurmWorkerManager when it's in the `COMPLETING` state, we run the risk of over-launching jobs (since we think the jobs are done and should be removed, but they're actually be requeued).

Also adds some fixes to logging to make it more readable / usable.