### PR TITLE
fix migration

### DIFF
--- a/alembic/versions/2020060503_add_exit_after_number_of_runs__54e95ff2e718.py
+++ b/alembic/versions/2020060503_add_exit_after_number_of_runs__54e95ff2e718.py
@@ -15,7 +15,7 @@ import sqlalchemy as sa
 import sys
 
 def upgrade():
-    op.add_column('worker', sa.Column('exit_after_num_runs', sa.Integer(), nullable=False, server_default=sys.maxsize))
+    op.add_column('worker', sa.Column('exit_after_num_runs', sa.Integer(), nullable=False, server_default='999999999'))
 
 
 def downgrade():


### PR DESCRIPTION
`server_default` has to be a string, and `sys.maxsize` is too large.