### PR TITLE
Handle sort key is 0 condition on frontend and use correct sort key for new runs

### DIFF
--- a/frontend/src/components/worksheets/NewRun/NewRun.jsx
+++ b/frontend/src/components/worksheets/NewRun/NewRun.jsx
@@ -234,7 +234,7 @@ class NewRun extends React.Component<{
 
         let args = ['run'];
 
-        if (after_sort_key) args.push(`-a ${ after_sort_key }`);
+        if (after_sort_key !== null || after_sort_key !== undefined) args.push(`-a ${ after_sort_key }`);
         if (name) args.push(`--name=${name}`);
         if (description) args.push(`--description=${description}`);
         if (tags) args.push(`--tags=${tags.map((tag) => `'${tag}'`).join(",")}`);

--- a/frontend/src/components/worksheets/NewRun/NewRun.jsx
+++ b/frontend/src/components/worksheets/NewRun/NewRun.jsx
@@ -234,7 +234,7 @@ class NewRun extends React.Component<{
 
         let args = ['run'];
 
-        if (after_sort_key !== null || after_sort_key !== undefined) args.push(`-a ${ after_sort_key }`);
+        if (after_sort_key || after_sort_key === 0) args.push(`-a ${ after_sort_key }`);
         if (name) args.push(`--name=${name}`);
         if (description) args.push(`--description=${description}`);
         if (tags) args.push(`--tags=${tags.map((tag) => `'${tag}'`).join(",")}`);

--- a/frontend/src/components/worksheets/items/TableItem/BundleRow.js
+++ b/frontend/src/components/worksheets/items/TableItem/BundleRow.js
@@ -325,7 +325,7 @@ class BundleRow extends Component {
                                         this.setState({ showNewRun: 0, showDetail: false });
                                         onHideNewRerun();
                                     }}
-                                    after_sort_key={bundleInfo.sort_key}
+                                    after_sort_key={this.props.after_sort_key}
                                     reloadWorksheet={reloadWorksheet}
                                     defaultRun={runProp}
                                 />
@@ -338,7 +338,7 @@ class BundleRow extends Component {
                         <TableCell colSpan='100%' classes={{ root: classes.insertPanel }}>
                             <div className={classes.insertBox}>
                                 <NewRun
-                                    after_sort_key={bundleInfo.sort_key}
+                                    after_sort_key={this.props.after_sort_key}
                                     ws={this.props.ws}
                                     onSubmit={() => this.props.onHideNewRun()}
                                     reloadWorksheet={reloadWorksheet}
@@ -354,7 +354,7 @@ class BundleRow extends Component {
                                 <TextEditorItem
                                     ids={this.props.ids}
                                     mode='create'
-                                    after_sort_key={bundleInfo.sort_key}
+                                    after_sort_key={this.props.after_sort_key}
                                     worksheetUUID={this.props.worksheetUUID}
                                     reloadWorksheet={reloadWorksheet}
                                     closeEditor={() => {

--- a/frontend/src/components/worksheets/items/TableItem/BundleRow.js
+++ b/frontend/src/components/worksheets/items/TableItem/BundleRow.js
@@ -338,7 +338,7 @@ class BundleRow extends Component {
                         <TableCell colSpan='100%' classes={{ root: classes.insertPanel }}>
                             <div className={classes.insertBox}>
                                 <NewRun
-                                    after_sort_key={this.props.after_sort_key}
+                                    after_sort_key={bundleInfo.sort_key}
                                     ws={this.props.ws}
                                     onSubmit={() => this.props.onHideNewRun()}
                                     reloadWorksheet={reloadWorksheet}
@@ -354,7 +354,7 @@ class BundleRow extends Component {
                                 <TextEditorItem
                                     ids={this.props.ids}
                                     mode='create'
-                                    after_sort_key={this.props.after_sort_key}
+                                    after_sort_key={bundleInfo.sort_key}
                                     worksheetUUID={this.props.worksheetUUID}
                                     reloadWorksheet={reloadWorksheet}
                                     closeEditor={() => {

--- a/frontend/src/components/worksheets/items/TextEditorItem/TextEditorItem.js
+++ b/frontend/src/components/worksheets/items/TextEditorItem/TextEditorItem.js
@@ -79,7 +79,7 @@ class TextEditorItem extends React.Component<{
 
         const data = { items };
 
-        if (after_sort_key) {
+        if (after_sort_key !== null || after_sort_key !== undefined) {
             data['after_sort_key'] = after_sort_key;
         }
 

--- a/frontend/src/components/worksheets/items/TextEditorItem/TextEditorItem.js
+++ b/frontend/src/components/worksheets/items/TextEditorItem/TextEditorItem.js
@@ -79,7 +79,7 @@ class TextEditorItem extends React.Component<{
 
         const data = { items };
 
-        if (after_sort_key !== null || after_sort_key !== undefined) {
+        if (after_sort_key || after_sort_key === 0) {
             data['after_sort_key'] = after_sort_key;
         }
 

--- a/frontend/src/util/worksheet_utils.js
+++ b/frontend/src/util/worksheet_utils.js
@@ -309,7 +309,7 @@ export function getAfterSortKey(item, subFocusIndex) {
     if (!item) return 0;
     const sort_keys = item.sort_keys || [];
     if (sort_keys[subFocusIndex] || sort_keys[subFocusIndex] === 0) {
-        return 0;
+        return sort_keys[subFocusIndex];
     }
     return Math.max(...sort_keys);
 }

--- a/frontend/src/util/worksheet_utils.js
+++ b/frontend/src/util/worksheet_utils.js
@@ -308,7 +308,10 @@ export function createHandleRedirectFn(worksheetUuid) {
 export function getAfterSortKey(item, subFocusIndex) {
     if (!item) return 0;
     const sort_keys = item.sort_keys || [];
-    return sort_keys[subFocusIndex] || Math.max(...sort_keys);
+    if (sort_keys[subFocusIndex] || sort_keys[subFocusIndex] === 0) {
+        return 0;
+    }
+    return Math.max(...sort_keys);
 }
 
 export function getIds(item) {


### PR DESCRIPTION
fix #2401 should also fix #2396  

To reproduce the problem, open an empty worksheet, add a new run, focus and add another new run. Focus on the first bundle, add new text or new run, it appends to the end