### PR TITLE
Fix accessing worker information from WorkerInfoAccessor

### DIFF
--- a/codalab/server/bundle_manager.py
+++ b/codalab/server/bundle_manager.py
@@ -414,7 +414,10 @@ class BundleManager(object):
         # before bundle manager's next scheduling loop
         for worker in workers_list:
             # Update workers that have "exit_after_num_runs" manually set from CLI.
-            if worker['exit_after_num_runs'] < workers._workers[worker['worker_id']]['exit_after_num_runs']:
+            if (
+                worker['exit_after_num_runs']
+                < workers._workers[worker['worker_id']]['exit_after_num_runs']
+            ):
                 self._worker_model.update_workers(
                     worker["user_id"],
                     worker['worker_id'],

--- a/codalab/server/bundle_manager.py
+++ b/codalab/server/bundle_manager.py
@@ -414,7 +414,7 @@ class BundleManager(object):
         # before bundle manager's next scheduling loop
         for worker in workers_list:
             # Update workers that have "exit_after_num_runs" manually set from CLI.
-            if worker['exit_after_num_runs'] < workers[worker['worker_id']]['exit_after_num_runs']:
+            if worker['exit_after_num_runs'] < workers._workers[worker['worker_id']]['exit_after_num_runs']:
                 self._worker_model.update_workers(
                     worker["user_id"],
                     worker['worker_id'],


### PR DESCRIPTION
Before this diff:
```
Traceback (most recent call last):
  File "/opt/codalab-worksheets/codalab/server/bundle_manager.py", line 80, in run
    self._run_iteration()
  File "/opt/codalab-worksheets/codalab/server/bundle_manager.py", line 100, in _run_iteration
    self._schedule_run_bundles()
  File "/opt/codalab-worksheets/codalab/server/bundle_manager.py", line 714, in _schedule_run_bundles
    self._schedule_run_bundles_on_workers(workers, staged_bundles_to_run, user_info_cache)
  File "/opt/codalab-worksheets/codalab/server/bundle_manager.py", line 417, in _schedule_run_bundles_on_workers
    if worker['exit_after_num_runs'] < workers[worker['worker_id']]['exit_after_num_runs']:
TypeError: 'WorkerInfoAccessor' object is not subscriptable
```