### PR TITLE
Don't fail WorkerManager if a network exception is encountered

### DIFF
--- a/codalab/worker_manager/worker_manager.py
+++ b/codalab/worker_manager/worker_manager.py
@@ -1,5 +1,6 @@
 import logging
 import time
+import traceback
 from codalab.lib.codalab_manager import CodaLabManager
 from codalab.worker.bundle_state import State
 from collections import namedtuple
@@ -75,7 +76,10 @@ class WorkerManager(object):
 
     def run_loop(self):
         while True:
-            self.run_one_iteration()
+            try:
+                self.run_one_iteration()
+            except Exception:
+                traceback.print_exc()
             if self.args.once:
                 break
             logger.debug('Sleeping {} seconds'.format(self.args.sleep_time))

--- a/codalab/worker_manager/worker_manager.py
+++ b/codalab/worker_manager/worker_manager.py
@@ -85,6 +85,10 @@ class WorkerManager(object):
             try:
                 self.run_one_iteration()
             except (urllib.error.URLError, http.client.HTTPException, socket.error, NotFoundError):
+                # Sometimes, network errors occur when running the WorkerManager . These are often
+                # transient exceptions, and retrying the command would lead to success---as a result,
+                # we ignore these network-based exceptions (rather than fatally exiting from the
+                # WorkerManager )
                 traceback.print_exc()
             if self.args.once:
                 break

--- a/codalab/worker_manager/worker_manager.py
+++ b/codalab/worker_manager/worker_manager.py
@@ -1,9 +1,15 @@
+from collections import namedtuple
+import http
 import logging
+import socket
 import time
 import traceback
+import urllib
+
+from codalab.common import NotFoundError
 from codalab.lib.codalab_manager import CodaLabManager
 from codalab.worker.bundle_state import State
-from collections import namedtuple
+
 
 logger = logging.getLogger(__name__)
 
@@ -78,7 +84,7 @@ class WorkerManager(object):
         while True:
             try:
                 self.run_one_iteration()
-            except Exception:
+            except (urllib.error.URLError, http.client.HTTPException, socket.error, NotFoundError):
                 traceback.print_exc()
             if self.args.once:
                 break


### PR DESCRIPTION
Sometimes there are slight blips in connectivity to the codalab server which means that the following lines might fail:

https://github.com/codalab/codalab-worksheets/blob/master/codalab/worker_manager/worker_manager.py#L89-L91

This makes it such that the workermanager can recover and keep operating, versus fatally exiting.