### PR TITLE
Rename actionbar => terminal

### DIFF
--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -510,6 +510,7 @@ class Worksheet extends React.Component {
                 checkedBundles: {},
                 showBundleOperationButtons: false,
                 updating: false,
+                forceDelete: false,
             },
             clear_callback,
         );

--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -694,7 +694,7 @@ class Worksheet extends React.Component {
             .animate({ scrollTop: 0 }, 250);
     };
     handleTerminalBlur = (event) => {
-        // explicitly close terminal because we're leaving the action bar
+        // explicitly close terminal because we're leaving the terminal
         // $('#command_line').terminal().focus(false);
         this.setState({ activeComponent: 'list' });
         $('#command_line').data('resizing', null);
@@ -727,7 +727,7 @@ class Worksheet extends React.Component {
         }.bind(this);
 
         if (this.state.activeComponent === 'action') {
-            // no need for other keys, we have the action bar focused
+            // no need for other keys, we have the terminal focused
             return;
         }
 
@@ -752,7 +752,7 @@ class Worksheet extends React.Component {
                 }.bind(this),
             );
 
-            // Show/hide web terminal (action bar)
+            // Show/hide web terminal
             Mousetrap.bind(
                 ['shift+c'],
                 function(e) {
@@ -760,7 +760,7 @@ class Worksheet extends React.Component {
                 }.bind(this),
             );
 
-            // Focus on web terminal (action bar)
+            // Focus on web terminal
             Mousetrap.bind(
                 ['c c'],
                 function(e) {
@@ -1188,7 +1188,7 @@ class Worksheet extends React.Component {
         if (prevState.showTerminal !== this.state.showTerminal) {
             // Hack to make sure that the <Sticky> component in WorksheetHeader.js updates.
             // This is needed because otherwise the header doesn't move up or down as needed
-            // when the action bar is shown / hidden.
+            // when the terminal is shown / hidden.
             window.scrollTo(window.scrollX, window.scrollY + 1);
         }
     }
@@ -1366,7 +1366,7 @@ class Worksheet extends React.Component {
             },
         });
 
-        // Note: this is redundant if we're doing 'cl work' from the action bar,
+        // Note: this is redundant if we're doing 'cl work' from the terminal,
         // but is necessary if triggered in other ways.
         this.reloadWorksheet();
 

--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -22,7 +22,7 @@ import {
     LOCAL_STORAGE_WORKSHEET_WIDTH,
     DIALOG_TYPES,
 } from '../../../constants';
-import WorksheetActionBar from '../WorksheetActionBar';
+import WorksheetTerminal from '../WorksheetTerminal';
 import Loading from '../../Loading';
 import Button from '@material-ui/core/Button';
 import EditIcon from '@material-ui/icons/EditOutlined';
@@ -66,7 +66,7 @@ class Worksheet extends React.Component {
             activeComponent: 'list', // Where the focus is (action, list, or side_panel)
             editMode: false, // Whether we're editing the worksheet
             editorEnabled: false, // Whether the editor is actually showing (sometimes lags behind editMode)
-            showActionBar: false, // Whether the action bar is shown
+            showTerminal: false, // Whether the action bar is shown
             focusIndex: -1, // Which worksheet items to be on (-1 is none)
             subFocusIndex: 0, // For tables, which row in the table
             numOfBundles: -1, // Number of bundles in this worksheet (-1 is just the initial value)
@@ -684,7 +684,7 @@ class Worksheet extends React.Component {
     editMode = () => {
         this.toggleEditMode(true);
     };
-    handleActionBarFocus = (event) => {
+    handleTerminalFocus = (event) => {
         this.setState({ activeComponent: 'action' });
         // just scroll to the top of the page.
         // Add the stop() to keep animation events from building up in the queue
@@ -693,7 +693,7 @@ class Worksheet extends React.Component {
             .stop(true)
             .animate({ scrollTop: 0 }, 250);
     };
-    handleActionBarBlur = (event) => {
+    handleTerminalBlur = (event) => {
         // explicitly close terminal because we're leaving the action bar
         // $('#command_line').terminal().focus(false);
         this.setState({ activeComponent: 'list' });
@@ -756,7 +756,7 @@ class Worksheet extends React.Component {
             Mousetrap.bind(
                 ['shift+c'],
                 function(e) {
-                    this.toggleActionBar();
+                    this.toggleTerminal();
                 }.bind(this),
             );
 
@@ -764,7 +764,7 @@ class Worksheet extends React.Component {
             Mousetrap.bind(
                 ['c c'],
                 function(e) {
-                    this.focusActionBar();
+                    this.focusTerminal();
                 }.bind(this),
             );
 
@@ -1185,7 +1185,7 @@ class Worksheet extends React.Component {
                 editor.renderer.scrollToRow(rawIndex);
             }
         }
-        if (prevState.showActionBar !== this.state.showActionBar) {
+        if (prevState.showTerminal !== this.state.showTerminal) {
             // Hack to make sure that the <Sticky> component in WorksheetHeader.js updates.
             // This is needed because otherwise the header doesn't move up or down as needed
             // when the action bar is shown / hidden.
@@ -1193,13 +1193,13 @@ class Worksheet extends React.Component {
         }
     }
 
-    toggleActionBar() {
-        this.setState({ showActionBar: !this.state.showActionBar });
+    toggleTerminal() {
+        this.setState({ showTerminal: !this.state.showTerminal });
     }
 
-    focusActionBar() {
+    focusTerminal() {
         this.setState({ activeComponent: 'action' });
-        this.setState({ showActionBar: true });
+        this.setState({ showTerminal: true });
         $('#command_line')
             .terminal()
             .focus();
@@ -1436,7 +1436,7 @@ class Worksheet extends React.Component {
         var editPermission = info && info.edit_permission;
         var canEdit = this.canEdit() && this.state.editMode;
 
-        var searchClassName = this.state.showActionBar ? '' : 'search-hidden';
+        var searchClassName = this.state.showTerminal ? '' : 'search-hidden';
         var editableClassName = canEdit ? 'editable' : '';
         var disableWorksheetEditing = this.canEdit() ? '' : 'disabled';
         var sourceStr = editPermission ? 'Edit Source' : 'View Source';
@@ -1453,19 +1453,19 @@ class Worksheet extends React.Component {
                     {sourceStr}
                 </Button>
                 <Button
-                    onClick={(e) => this.toggleActionBar()}
+                    onClick={(e) => this.toggleTerminal()}
                     size='small'
                     color='inherit'
                     aria-label='Expand CLI'
                     id='terminal-button'
                     disabled={!info}
                 >
-                    {this.state.showActionBar ? (
+                    {this.state.showTerminal ? (
                         <ContractIcon className={classes.buttonIcon} />
                     ) : (
                         <ExpandIcon className={classes.buttonIcon} />
                     )}
-                    {this.state.showActionBar ? 'HIDE TERMINAL' : 'SHOW TERMINAL'}
+                    {this.state.showTerminal ? 'HIDE TERMINAL' : 'SHOW TERMINAL'}
                 </Button>
                 <Button
                     onClick={(e) =>
@@ -1536,17 +1536,17 @@ class Worksheet extends React.Component {
         );
 
         var action_bar_display = (
-            <WorksheetActionBar
+            <WorksheetTerminal
                 ref={'action'}
                 ws={this.state.ws}
-                handleFocus={this.handleActionBarFocus}
-                handleBlur={this.handleActionBarBlur}
+                handleFocus={this.handleTerminalFocus}
+                handleBlur={this.handleTerminalBlur}
                 active={this.state.activeComponent === 'action'}
                 reloadWorksheet={this.reloadWorksheet}
                 openWorksheet={this.openWorksheet}
                 editMode={this.editMode}
                 setFocus={this.setFocus}
-                hidden={!this.state.showActionBar}
+                hidden={!this.state.showTerminal}
             />
         );
 
@@ -1563,7 +1563,7 @@ class Worksheet extends React.Component {
                 reloadWorksheet={this.reloadWorksheet}
                 saveAndUpdateWorksheet={this.saveAndUpdateWorksheet}
                 openWorksheet={this.openWorksheet}
-                focusActionBar={this.focusActionBar}
+                focusTerminal={this.focusTerminal}
                 ensureIsArray={this.ensureIsArray}
                 showNewRun={this.state.showNewRun}
                 showNewText={this.state.showNewText}
@@ -1610,7 +1610,7 @@ class Worksheet extends React.Component {
         return (
             <React.Fragment>
                 <WorksheetHeader
-                    showActionBar={this.state.showActionBar}
+                    showTerminal={this.state.showTerminal}
                     canEdit={this.canEdit()}
                     info={info}
                     classes={classes}

--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -66,7 +66,7 @@ class Worksheet extends React.Component {
             activeComponent: 'list', // Where the focus is (action, list, or side_panel)
             editMode: false, // Whether we're editing the worksheet
             editorEnabled: false, // Whether the editor is actually showing (sometimes lags behind editMode)
-            showTerminal: false, // Whether the action bar is shown
+            showTerminal: false, // Whether the terminal is shown
             focusIndex: -1, // Which worksheet items to be on (-1 is none)
             subFocusIndex: 0, // For tables, which row in the table
             numOfBundles: -1, // Number of bundles in this worksheet (-1 is just the initial value)

--- a/frontend/src/components/worksheets/WorksheetItemList.js
+++ b/frontend/src/components/worksheets/WorksheetItemList.js
@@ -225,7 +225,7 @@ class WorksheetItemList extends React.Component {
                         focusIndex: index,
                         subFocusIndex: this.props.subFocusIndex,
                         setFocus: this.props.setFocus,
-                        focusActionBar: this.props.focusActionBar,
+                        focusTerminal: this.props.focusTerminal,
                         openWorksheet: this.props.openWorksheet,
                         reloadWorksheet: this.props.reloadWorksheet,
                         ws: this.props.ws,

--- a/frontend/src/components/worksheets/WorksheetTerminal.js
+++ b/frontend/src/components/worksheets/WorksheetTerminal.js
@@ -4,9 +4,9 @@ import $ from 'jquery';
 import _ from 'underscore';
 import 'jquery.terminal';
 
-const ACTIONBAR_MINIMIZE_HEIGHT = 30;
-let ACTIONBAR_DRAGHEIGHT = 350;
-class WorksheetActionBar extends React.Component {
+const TERMINAL_MINIMIZE_HEIGHT = 30;
+let TERMINAL_DRAGHEIGHT = 350;
+class WorksheetTerminal extends React.Component {
     /** Constructor. */
 
     constructor(props) {
@@ -65,7 +65,7 @@ class WorksheetActionBar extends React.Component {
                 greetings:
                     "Click here to enter commands (e.g., help, run '<bash command>', rm <bundle>, kill <bundle>, etc.).",
                 name: 'command_line',
-                height: ACTIONBAR_MINIMIZE_HEIGHT,
+                height: TERMINAL_MINIMIZE_HEIGHT,
                 prompt: 'CodaLab> ',
                 history: true,
                 keydown: function(event, terminal) {
@@ -87,13 +87,13 @@ class WorksheetActionBar extends React.Component {
                         return false;
                     }
                     if (term.enabled()) {
-                        term.resize(term.width(), ACTIONBAR_MINIMIZE_HEIGHT);
+                        term.resize(term.width(), TERMINAL_MINIMIZE_HEIGHT);
                         self.props.handleBlur();
                     }
                 },
                 onFocus: function(term) {
                     if (!term.data('resizing')) {
-                        term.resize(term.width(), ACTIONBAR_DRAGHEIGHT);
+                        term.resize(term.width(), TERMINAL_DRAGHEIGHT);
                     }
                     self.props.handleFocus();
                 },
@@ -217,20 +217,20 @@ class WorksheetActionBar extends React.Component {
     componentWillUnmount() {}
     componentDidUpdate() {}
     resizePanel(e) {
-        var actionbar = $('#ws_search');
-        var topOffset = actionbar.offset().top;
+        var terminal = $('#ws_search');
+        var topOffset = terminal.offset().top;
         var worksheetHeight = $('#worksheet').height();
         var commandLine = $('#command_line');
         $(document).mousemove(function(e) {
             e.preventDefault();
             $('#command_line').data('resizing', 'true');
-            var actionbarHeight = e.pageY - topOffset;
-            var actionbarHeightPercentage = (actionbarHeight / worksheetHeight) * 100;
-            if (65 < actionbarHeight && actionbarHeightPercentage < 90) {
+            var terminalHeight = e.pageY - topOffset;
+            var terminalHeightPercentage = (terminalHeight / worksheetHeight) * 100;
+            if (65 < terminalHeight && terminalHeightPercentage < 90) {
                 // minimum height: 65px; maximum height: 90% of worksheet height
-                actionbar.css('height', actionbarHeight);
-                ACTIONBAR_DRAGHEIGHT = actionbarHeight - 20;
-                commandLine.terminal().resize(commandLine.width(), ACTIONBAR_DRAGHEIGHT);
+                terminal.css('height', terminalHeight);
+                TERMINAL_DRAGHEIGHT = terminalHeight - 20;
+                commandLine.terminal().resize(commandLine.width(), TERMINAL_DRAGHEIGHT);
             }
         });
     }
@@ -246,4 +246,4 @@ class WorksheetActionBar extends React.Component {
     }
 }
 
-export default WorksheetActionBar;
+export default WorksheetTerminal;

--- a/frontend/src/components/worksheets/items/WorksheetItem.js
+++ b/frontend/src/components/worksheets/items/WorksheetItem.js
@@ -39,7 +39,7 @@ class WorksheetItem extends React.Component {
                 $('#command_line')
                     .terminal()
                     .insert(uuid + ' ');
-                //this.props.focusActionBar();
+                //this.props.focusTerminal();
             }.bind(this),
             'keydown',
         );

--- a/frontend/src/components/worksheets/items/WorksheetItem.js
+++ b/frontend/src/components/worksheets/items/WorksheetItem.js
@@ -39,7 +39,6 @@ class WorksheetItem extends React.Component {
                 $('#command_line')
                     .terminal()
                     .insert(uuid + ' ');
-                //this.props.focusTerminal();
             }.bind(this),
             'keydown',
         );


### PR DESCRIPTION
fix #2431 

Not sure why it was called actionbar in the first place, but it terminal would make finding the component easier..