### PR TITLE
Handle simultaneous image deletion in DockerImageManager

### DIFF
--- a/codalab/worker/docker_image_manager.py
+++ b/codalab/worker/docker_image_manager.py
@@ -171,7 +171,18 @@ class DockerImageManager:
                     tag_label, timestamp = tag.split(":")
                     # remove any other timestamp but not the current one
                     if tag_label == self.CACHE_TAG and timestamp != new_timestamp:
-                        self._docker.images.remove(tag)
+                        try:
+                            self._docker.images.remove(tag)
+                        except docker.errors.ImageNotFound as err:
+                            # It's possible that we get a 404 not found error here when removing the image,
+                            # since another worker on the same system has already done so. We just
+                            # ignore this 404, since any extraneous tags will be removed during the next iteration.
+                            logger.error(
+                                "Attempted to remove image %s from cache, but image was not found: %s",
+                                image_tag,
+                                err,
+                            )
+
                 return ImageAvailabilityState(
                     digest=digest, stage=DependencyStage.READY, message=success_message
                 )


### PR DESCRIPTION
Fixes #2442 

Sometimes, Docker downloads fail with an error message that it was downloaded successfully, but cannot be found locally due to an unhandled client error:
```
81348:2020-06-16 18:21:30,684 http://localhost:None "DELETE /v1.35/images/codalab-image-cache/last-used:1592356889.1950865?force=False&noprune=False HTTP/1.1" 404 78
81349:2020-06-16 18:21:30,685 Failed to download Docker image: Image codalab/default-cpu:latest was downloaded successfully, but it cannot be found locally due to unhandled error 404 Client Error: Not Found ("No such image: codalab-image-cache/last-used:1592356889.1950865")
```

If you look at the preceding line, docker is trying to DELETE an image, but it fails because it can't find it (404). Investigating the logs of other workers, I found this line in the logs of a different worker:

```
564853:2020-06-16 18:21:30,684 http://localhost:None "DELETE /v1.35/images/codalab-image-cache/last-used:1592356889.1950865?force=False&noprune=False HTTP/1.1" 200 66
```

This indicates that this particular different worker **was** able to delete the image, before the first worker got to it (the timestamp is the exact same, probably because the workers started at the same time on the same node, and finished the download at the same time). Thus, the first worker wasn't able to delete the image, and threw a 404 on deletion.

This PR simply circumvents the issue by catching a 404 on deletion.