### PR TITLE
CI: Save / upload logs on both success and failure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,10 +76,12 @@ jobs:
           TEST: ${{ matrix.test }}
           VERSION: ${{ github.head_ref || 'master' }}
       - name: Save logs
+        if: always()
         run: |
           mkdir /tmp/logs
           for c in $(docker ps -a --format="{{.Names}}"); do docker logs $c > /tmp/logs/$c.log 2> /tmp/logs/$c.err; done
       - name: Upload logs
+        if: always()
         uses: actions/upload-artifact@v1
         with:
           name: logs-test-${{ matrix.test }}
@@ -115,10 +117,12 @@ jobs:
           TEST: ${{ matrix.test }}
           VERSION: ${{ github.head_ref || 'master' }}
       - name: Save logs
+        if: always()
         run: |
           mkdir /tmp/logs
           for c in $(docker ps -a --format="{{.Names}}"); do docker logs $c > /tmp/logs/$c.log 2> /tmp/logs/$c.err; done
       - name: Upload logs
+        if: always()
         uses: actions/upload-artifact@v1
         with:
           name: logs-test-sharedfs-${{ matrix.test }}
@@ -165,10 +169,12 @@ jobs:
           name: screenshots-test-${{ matrix.test }}
           path: tests/ui
       - name: Save logs
+        if: always()
         run: |
           mkdir /tmp/logs
           for c in $(docker ps -a --format="{{.Names}}"); do docker logs $c > /tmp/logs/$c.log 2> /tmp/logs/$c.err; done
       - name: Upload logs
+        if: always()
         uses: actions/upload-artifact@v1
         with:
           name: logs-test-${{ matrix.test }}


### PR DESCRIPTION
Previously, by removing `if: failure()` from the logs steps, I unintentionally made GitHub Actions save / upload logs only on success, but not on job failures.

This change adds `if: always()`, so that jobs are saved / uploaded both on success and failure.