### PR TITLE
Fix github actions on forks by not calling --push

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/setup-python@v1
         with:
           python-version: 3.6
-      - run: python3 codalab_service.py build --pull --version ${VERSION} --push -s ${SERVICE}
+      - run: python3 codalab_service.py build --pull --version ${VERSION} -s ${SERVICE} $([ -z "${CODALAB_DOCKER_USERNAME}" ] || echo "--push")
         env:
           CODALAB_DOCKER_USERNAME: ${{ secrets.CODALAB_DOCKER_USERNAME }}
           CODALAB_DOCKER_PASSWORD: ${{ secrets.CODALAB_DOCKER_PASSWORD }}


### PR DESCRIPTION
This conditional expression was in the old `.travis.yml`, but it isn't there in the new github actions workflow. This PR adds that expression so that `--push` is not called from forks.

Fixes #2456