### PR TITLE
Prettier CLI Reference Doc

### DIFF
--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -354,22 +354,22 @@ class Commands(object):
                 """
         Usage: {inline_code}cl <command> <arguments>{inline_code}
 
-        {heading}Commands for bundles:
+        {heading}Commands for bundles
         {bundle_commands}
 
-        {heading}Commands for worksheets:
+        {heading}Commands for worksheets
         {worksheet_commands}
 
-        {heading}Commands for groups and permissions:
+        {heading}Commands for groups and permissions
         {group_and_permission_commands}
 
-        {heading}Commands for users:
+        {heading}Commands for users
         {user_commands}
 
-        {heading}Commands for managing server:
+        {heading}Commands for managing server
         {server_commands}
 
-        {heading}Other commands:
+        {heading}Other commands
         {other_commands}
         """
             )

--- a/docs/CLI-Reference.md
+++ b/docs/CLI-Reference.md
@@ -4,7 +4,7 @@ This file is auto-generated from the output of `cl help -v -m` and provides the 
 
 Usage: `cl <command> <arguments>`
 
-## Commands for bundles:
+## Commands for bundles
 ### upload (up):
     Create a bundle by uploading an existing file/directory.
       upload <path>            : Upload contents of file/directory <path> as a bundle.
@@ -294,7 +294,7 @@ Usage: `cl <command> <arguments>`
       -w, --worksheet-spec  Operate on this worksheet ([(<alias>|<address>)::](<uuid>|<name>)).
 
 
-## Commands for worksheets:
+## Commands for worksheets
 ### new:
     Create a new worksheet.
     Arguments:
@@ -375,7 +375,7 @@ Usage: `cl <command> <arguments>`
       -u, --uuid-only  Print only uuids.
 
 
-## Commands for groups and permissions:
+## Commands for groups and permissions
 ### gls:
     Show groups to which you belong.
     Arguments:
@@ -432,7 +432,7 @@ Usage: `cl <command> <arguments>`
       -w, --worksheet-spec  Operate on this worksheet ([(<alias>|<address>)::](<uuid>|<name>)).
 
 
-## Commands for users:
+## Commands for users
 ### uinfo:
     Show user information.
     Arguments:
@@ -459,7 +459,7 @@ Usage: `cl <command> <arguments>`
       user_spec  Username or id of user to delete.
 
 
-## Commands for managing server:
+## Commands for managing server
 ### workers:
     Display information about workers that you have connected to the CodaLab instance.
 
@@ -485,7 +485,7 @@ Usage: `cl <command> <arguments>`
       -r, --repair     When used with --force and --data-hash, repairs incorrect data_hash in existing bundles
 
 
-## Other commands:
+## Other commands
 ### help:
     Show usage information for commands.
       help           : Show brief description for all commands.


### PR DESCRIPTION
Just to make CLI Reference Doc prettier. Removed the end colon...
<img width="660" alt="Screen Shot 2020-06-19 at 11 11 36 AM" src="https://user-images.githubusercontent.com/1483372/85167455-b6451d80-b21d-11ea-90a8-6c81264fc5e5.png">
