### PR TITLE
Actually fix builds from forks by building docker images when needed

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Setup tests
         run: |
           sudo service mysql stop
-          python3 codalab_service.py pull --version ${VERSION}
+          python3 codalab_service.py build services --version ${VERSION} --pull
         env:
           VERSION: ${{ github.head_ref || 'master' }}
       - name: Run tests
@@ -104,7 +104,7 @@ jobs:
       - name: Setup tests
         run: |
           sudo service mysql stop
-          python3 codalab_service.py pull --version ${VERSION}
+          python3 codalab_service.py build services --version ${VERSION} --pull
         env:
           VERSION: ${{ github.head_ref || 'master' }}
       - name: Run shared filesystem tests
@@ -145,7 +145,7 @@ jobs:
           sudo ./scripts/test-setup.sh
           export PATH=$PATH:$PWD/geckodriver
           sudo service mysql stop
-          python3 codalab_service.py pull --version ${VERSION}
+          python3 codalab_service.py build services --version ${VERSION} --pull
           pip install --upgrade diffimg==0.2.3
           pip install --upgrade selenium==3.141.0
         env:


### PR DESCRIPTION
Actually fix builds from forks by building docker images when needed.

Note that this makes builds from forks take much longer on github actions because 1) the original docker image build steps can't be reused (since they can't be pushed / pulled to be reused in subsequent steps) and 2) each test suite job will end up building all images from scratch.

This will fix builds for now (and it'll probably still be faster than travis), but would appreciate some suggestions as to how to improve this workflow (@nelson-liu )