### PR TITLE
Enable workers to exit on exceptions, instead of sleeping

### DIFF
--- a/codalab/worker/main.py
+++ b/codalab/worker/main.py
@@ -147,6 +147,11 @@ def parse_args():
         default=sys.maxsize,
         help='The worker quits after this many jobs assigned to this worker',
     )
+    parser.add_argument(
+        '--exit-on-exception',
+        action='store_true',
+        help="Exit the worker if it encounters an exception (rather than sleeping).",
+    )
     return parser.parse_args()
 
 

--- a/codalab/worker/worker.py
+++ b/codalab/worker/worker.py
@@ -68,6 +68,8 @@ class Worker:
         pass_down_termination=False,  # type: bool
         # A flag indicating if the work_dir will be deleted when the worker exits.
         delete_work_dir_on_exit=False,  # type: bool
+        # A flag indicating if the worker will exit if it encounters an exception
+        exit_on_exception=False,  # type: bool
     ):
         self.image_manager = image_manager
         self.dependency_manager = dependency_manager
@@ -101,6 +103,7 @@ class Worker:
         self.terminate = False
         self.terminate_and_restage = False
         self.pass_down_termination = pass_down_termination
+        self.exit_on_exception = exit_on_exception
 
         self.last_checkin_successful = False
         self.last_time_ran = None  # type: Optional[bool]
@@ -206,9 +209,13 @@ class Worker:
             except Exception:
                 self.last_checkin_successful = False
                 traceback.print_exc()
-                # Sleep for a long time so we don't keep on failing.
-                logger.error('Sleeping for 1 hour due to exception...please help me!')
-                time.sleep(1 * 60 * 60)
+                if self.exit_on_exception:
+                    logger.error('Encountered exception, terminating the worker...')
+                    self.terminate = True
+                else:
+                    # Sleep for a long time so we don't keep on failing.
+                    logger.error('Sleeping for 1 hour due to exception...please help me!')
+                    time.sleep(1 * 60 * 60)
         self.cleanup()
 
     def cleanup(self):

--- a/codalab/worker_manager/aws_batch_worker_manager.py
+++ b/codalab/worker_manager/aws_batch_worker_manager.py
@@ -100,6 +100,8 @@ class AWSBatchWorkerManager(WorkerManager):
             command.extend(['--worker-delete-work-dir-on-exit'])
         if self.args.worker_exit_after_num_runs and self.args.worker_exit_after_num_runs > 0:
             command.extend(['--exit-after-num-runs', str(self.args.worker_exit_after_num_runs)])
+        if self.args.worker_exit_on_exception:
+            command.extend(['--exit-on-exception'])
 
         # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-batch-jobdefinition.html
         # Need to mount:

--- a/codalab/worker_manager/main.py
+++ b/codalab/worker_manager/main.py
@@ -58,6 +58,11 @@ def main():
         type=int,
         help='If specified, the CodaLab worker will exit after finishing this many of runs',
     )
+    parser.add_argument(
+        '--worker-exit-on-exception',
+        action='store_true',
+        help="If set, the CodaLab worker will exit if it encounters an exception (rather than sleeping).",
+    )
     subparsers = parser.add_subparsers(
         title='Worker Manager to run',
         description='Which worker manager to run (AWS Batch etc.)',

--- a/codalab/worker_manager/slurm_batch_worker_manager.py
+++ b/codalab/worker_manager/slurm_batch_worker_manager.py
@@ -265,6 +265,8 @@ class SlurmBatchWorkerManager(WorkerManager):
             command.extend(['--max-work-dir-size', self.args.worker_max_work_dir_size])
         if self.args.worker_delete_work_dir_on_exit:
             command.extend(['--delete-work-dir-on-exit'])
+        if self.args.worker_exit_on_exception:
+            command.extend(['--exit-on-exception'])
 
         return command
 


### PR DESCRIPTION
Fixes #2441 

This is important especially when workers on running on batch compute, since some errors are irrecoverable (e.g., #2442 ). In this case, it's easier / more-efficient to just exit the worker and restart, but this isn't currently possible because workers cannot exit on Exceptions.