### PR TITLE
Re-create missing docker networks before launching containers

### DIFF
--- a/codalab/worker/worker.py
+++ b/codalab/worker/worker.py
@@ -143,9 +143,15 @@ class Worker:
 
         # Right now the suffix to the general worker network is hardcoded to manually match the suffix
         # in the docker-compose file, so make sure any changes here are synced to there.
-        self.worker_docker_network = create_or_get_network(docker_network_prefix + "_general", internal=True, verbose=verbose)
-        self.docker_network_external = create_or_get_network(docker_network_prefix + "_ext", internal=False, verbose=verbose)
-        self.docker_network_internal = create_or_get_network(docker_network_prefix + "_int", internal=True, verbose=verbose)
+        self.worker_docker_network = create_or_get_network(
+            docker_network_prefix + "_general", internal=True, verbose=verbose
+        )
+        self.docker_network_external = create_or_get_network(
+            docker_network_prefix + "_ext", internal=False, verbose=verbose
+        )
+        self.docker_network_internal = create_or_get_network(
+            docker_network_prefix + "_int", internal=True, verbose=verbose
+        )
 
     def save_state(self):
         # Remove complex container objects from state before serializing, these can be retrieved

--- a/codalab/worker/worker.py
+++ b/codalab/worker/worker.py
@@ -109,6 +109,7 @@ class Worker:
         self.last_time_ran = None  # type: Optional[bool]
 
         self.runs = {}  # type: Dict[str, RunState]
+        self.docker_network_prefix = docker_network_prefix
         self.init_docker_networks(docker_network_prefix)
         self.run_state_manager = RunStateMachine(
             docker_image_manager=self.image_manager,
@@ -366,6 +367,9 @@ class Worker:
 
     def process_runs(self):
         """ Transition each run then filter out finished runs """
+        # We (re-)initialize the Docker networks here, in case they've been removed.
+        # For any networks that exist, this is essentially a no-op.
+        self.init_docker_networks(self.docker_network_prefix)
         # 1. transition all runs
         for uuid in self.runs:
             run_state = self.runs[uuid]


### PR DESCRIPTION
Fixes #2439 

Docker networks are getting weirdly removed from hosts—these are usually networks that haven't been used in awhile, so maybe something on the host is auto-pruning them? This makes the worker more robust to these changes in the docker network(s) by re-creating them (if they don't exist) before launching containers.