### PR TITLE
CI: Remove some parallelism

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,8 +59,7 @@ jobs:
           - search read kill write mimic workers
           - resources
           - memoize
-          - copy netcat
-          - netcurl
+          - copy netcat netcurl
     steps:
       - name: Clear free space
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
     needs: [build]
     strategy:
       matrix:
-        test: [unittest gen-rest-docs gen-cli-docs gen-readthedocs basic status batch anonymous competition unicode rest1 upload1 upload2 upload3 upload4 download refs binary rm make worksheet_search worksheet_tags freeze detach perm search_time groups,run,run2,search read kill write,mimic workers,resources,copy,memoize,netcat,netcurl]
+        test: [unittest gen-rest-docs gen-cli-docs gen-readthedocs basic status batch anonymous competition unicode rest1 upload1 upload2 upload3 upload4 download refs binary rm make worksheet_search worksheet_tags freeze detach perm search_time groups,run,run2,search read kill write mimic workers,resources,memoize,copy netcat,netcurl]
     steps:
       - name: Clear free space
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,15 @@ jobs:
     needs: [build]
     strategy:
       matrix:
-        test: [unittest gen-rest-docs gen-cli-docs gen-readthedocs basic status batch anonymous competition unicode rest1 upload1 upload2 upload3 upload4 download refs binary rm make worksheet_search worksheet_tags freeze detach perm search_time groups,run,run2,search read kill write mimic workers,resources,memoize,copy netcat,netcurl]
+        test:
+          - unittest gen-rest-docs gen-cli-docs gen-readthedocs basic status batch anonymous competition unicode rest1 upload1 upload2 upload3 upload4 download refs binary rm make worksheet_search worksheet_tags freeze detach perm search_time groups
+          - run
+          - run2
+          - search read kill write mimic workers
+          - resources
+          - memoize
+          - copy netcat
+          - netcurl
     steps:
       - name: Clear free space
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
     needs: [build]
     strategy:
       matrix:
-        test: [unittest gen-rest-docs gen-cli-docs gen-readthedocs basic status batch anonymous competition unicode rest1 upload1 upload2 upload3 upload4 download refs binary rm make worksheet_search worksheet_tags freeze detach perm search_time groups,search,run,run2,read,kill,write,mimic workers,resources,copy memoize,netcat,netcurl]
+        test: [unittest gen-rest-docs gen-cli-docs gen-readthedocs basic status batch anonymous competition unicode rest1 upload1 upload2 upload3 upload4 download refs binary rm make worksheet_search worksheet_tags freeze detach perm search_time groups,run,run2,search read kill write,mimic workers,resources,copy,memoize,netcat,netcurl]
     steps:
       - name: Clear free space
         run: |
@@ -132,7 +132,7 @@ jobs:
     needs: [build]
     strategy:
       matrix:
-        test: [run,run2,read,write kill resources]
+        test: [run,run2,read write kill resources]
     steps:
       - name: Clear free space
         run: |


### PR DESCRIPTION
Remove some unnecessary parallelism in github actions, so that we require less parallel workers per job.

The build still takes ~10 mins to complete, but it now requires only 16 parallel jobs instead of 22.