### PR TITLE
Fix scontrol state parsing regex in SlurmWorkerManager

### DIFF
--- a/codalab/worker_manager/slurm_batch_worker_manager.py
+++ b/codalab/worker_manager/slurm_batch_worker_manager.py
@@ -131,7 +131,8 @@ class SlurmBatchWorkerManager(WorkerManager):
             job_acct = self.run_command(
                 [self.SCONTROL, 'show', 'jobid', '-d', job_id, '--oneliner'], verbose=False
             )
-            job_state = re.search(r'JobState=(.*) ', job_acct).group(1)
+            # Extract out the JobState from the full scontrol output.
+            job_state = re.search(r'JobState=(.*)\sReason', job_acct).group(1)
             logger.info("Job ID {} has state {}".format(job_id, job_state))
             if 'FAILED' in job_state:
                 jobs_to_remove.add(job_id)


### PR DESCRIPTION
Sample scontrol output:

```
'JobId=1539172 JobName=nfliu-codalab-slurm-worker-main-standard-708acee8 UserId=nfliu(19658) GroupId=users(100) MCS_label=N/A Priority=4294777008 Nice=0 Account=sail QOS=normal JobState=RUNNING Reason=None Dependency=(null) Requeue=1 Restarts=0 BatchFlag=1 Reboot=0 ExitCode=0:0 DerivedExitCode=0:0 RunTime=1-14:04:26 TimeLimit=10-00:00:00 TimeMin=N/A SubmitTime=2020-06-20T20:39:11 EligibleTime=2020-06-20T20:39:11 StartTime=2020-06-20T20:49:42 EndTime=2020-06-30T20:49:42 Deadline=N/A PreemptTime=None SuspendTime=None SecsPreSuspend=0 LastSchedEval=2020-06-20T20:49:42 Partition=jag-standard AllocNode:Sid=codalab:22480 ReqNodeList= ExcNodeList=(null) NodeList=jagupard12 BatchHost=jagupard12 NumNodes=1 NumCPUs=4 NumTasks=1 CPUs/Task=4 ReqB:S:C:T=0:0:*:* TRES=cpu=4,mem=32000M,node=1,billing=4,gres/gpu=1 Socks/Node=* NtasksPerN:B:S:C=1:0:*:* CoreSpec=*   Nodes=jagupard12 CPU_IDs=4-7 Mem=32000 GRES_IDX=gpu(IDX:2) MinCPUsNode=4 MinMemoryNode=32000M MinTmpDiskNode=0 Features=(null) DelayBoot=00:00:00 Gres=gpu:1 Reservation=(null) OverSubscribe=OK Contiguous=0 Licenses=(null) Network=(null) Command=/sailhome/nfliu/scr/slurm_output/nfliu-codalab-slurm-worker-main-standard-708acee8/nfliu-codalab-slurm-worker-main-standard-708acee8.slurm WorkDir=/sailhome/nfliu StdErr=/sailhome/nfliu/scr/slurm_output/nfliu-codalab-slurm-worker-main-standard-708acee8/nfliu-codalab-slurm-worker-main-standard-708acee8.out StdIn=/dev/null StdOut=/sailhome/nfliu/scr/slurm_output/nfliu-codalab-slurm-worker-main-standard-708acee8/nfliu-codalab-slurm-worker-main-standard-708acee8.out Power=\n'
```

Before this change, it extracted:

```
'RUNNING Reason=None Dependency=(null) Requeue=1 Restarts=0 BatchFlag=1 Reboot=0 ExitCode=0:0 DerivedExitCode=0:0 RunTime=1-14:04:54 TimeLimit=10-00:00:00 TimeMin=N/A SubmitTime=2020-06-20T20:39:11 EligibleTime=2020-06-20T20:39:11 StartTime=2020-06-20T20:49:42 EndTime=2020-06-30T20:49:42 Deadline=N/A PreemptTime=None SuspendTime=None SecsPreSuspend=0 LastSchedEval=2020-06-20T20:49:42 Partition=jag-standard AllocNode:Sid=codalab:22480 ReqNodeList= ExcNodeList=(null) NodeList=jagupard12 BatchHost=jagupard12 NumNodes=1 NumCPUs=4 NumTasks=1 CPUs/Task=4 ReqB:S:C:T=0:0:*:* TRES=cpu=4,mem=32000M,node=1,billing=4,gres/gpu=1 Socks/Node=* NtasksPerN:B:S:C=1:0:*:* CoreSpec=*   Nodes=jagupard12 CPU_IDs=4-7 Mem=32000 GRES_IDX=gpu(IDX:2) MinCPUsNode=4 MinMemoryNode=32000M MinTmpDiskNode=0 Features=(null) DelayBoot=00:00:00 Gres=gpu:1 Reservation=(null) OverSubscribe=OK Contiguous=0 Licenses=(null) Network=(null) Command=/sailhome/nfliu/scr/slurm_output/nfliu-codalab-slurm-worker-main-standard-708acee8/nfliu-codalab-slurm-worker-main-standard-708acee8.slurm WorkDir=/sailhome/nfliu StdErr=/sailhome/nfliu/scr/slurm_output/nfliu-codalab-slurm-worker-main-standard-708acee8/nfliu-codalab-slurm-worker-main-standard-708acee8.out StdIn=/dev/null StdOut=/sailhome/nfliu/scr/slurm_output/nfliu-codalab-slurm-worker-main-standard-708acee8/nfliu-codalab-slurm-worker-main-standard-708acee8.out'
```

After the change, we correctly get:

```
'RUNNING'
```