### PR TITLE
Use docker BuildKit for building images

### DIFF
--- a/codalab_service.py
+++ b/codalab_service.py
@@ -584,7 +584,7 @@ class CodalabServiceManager(object):
             success = True
         else:
             try:
-                subprocess.check_call(command_string, shell=True, cwd=BASE_DIR)
+                subprocess.check_call(command_string, shell=True, cwd=BASE_DIR, env={"DOCKER_BUILDKIT": "1"})
                 success = True
             except subprocess.CalledProcessError as e:
                 success = False

--- a/codalab_service.py
+++ b/codalab_service.py
@@ -584,7 +584,9 @@ class CodalabServiceManager(object):
             success = True
         else:
             try:
-                subprocess.check_call(command_string, shell=True, cwd=BASE_DIR, env={"DOCKER_BUILDKIT": "1"})
+                subprocess.check_call(
+                    command_string, shell=True, cwd=BASE_DIR, env={"DOCKER_BUILDKIT": "1"}
+                )
                 success = True
             except subprocess.CalledProcessError as e:
                 success = False


### PR DESCRIPTION
Use [Docker BuildKit](https://docs.docker.com/develop/develop-images/build_enhancements/). Has a more interactive UI for development and is also faster to build images on CI.

BuildKit is only supported on Docker 18.09+, but with this change, people who are using older versions of Docker will still have the same experience as before.

For example, on the local development environment, we have a cleaner UI with time metrics:

![image](https://user-images.githubusercontent.com/1689183/85621280-0283c980-b633-11ea-9b35-0f8ede9a202b.png)

CI also gives us time metrics now:

![image](https://user-images.githubusercontent.com/1689183/85621332-20512e80-b633-11ea-8161-82fdde46c83b.png)