### PR TITLE
Fix some frontend build warnings

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -2,19 +2,9 @@
     "extends": "react-app",
     "rules": {
         "no-unused-vars": "off",
-        "react/jsx-no-target-blank": "off",
         "no-loop-func": "off",
         "jsx-a11y/anchor-is-valid": "off",
         "no-shadow-restricted-names": "off",
-        "no-useless-escape": "off",
-        "jsx-a11y/alt-text": "off",
-        "no-redeclare": "off",
-        "react/no-direct-mutation-state": "off",
-        "no-script-url": "off",
-        "no-throw-literal": "off",
-        "no-dupe-keys": "off",
-        "no-control-regex": "off",
-        "no-dupe-class-members": "off",
-        "no-template-curly-in-string": "off"
+        "react/no-direct-mutation-state": "off"
     }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -68,8 +68,8 @@
     "test": "react-scripts test",
     "flow": "flow",
     "eject": "react-scripts eject",
-    "check-ci": "eslint src && prettier --config ./.prettierrc --check 'src/**/*.js'",
-    "format": "eslint src --fix && prettier --config ./.prettierrc --check 'src/**/*.js' --write"
+    "check-ci": "CI=true eslint src && prettier --config ./.prettierrc --check 'src/**/*.js'",
+    "format": "CI=true eslint src --fix && prettier --config ./.prettierrc --check 'src/**/*.js' --write"
   },
   "husky": {
     "hooks": {

--- a/frontend/src/components/Bundle/Bundle.js
+++ b/frontend/src/components/Bundle/Bundle.js
@@ -189,8 +189,8 @@ class Bundle extends React.Component<
             // Still loading
             return (
                 <div id='bundle-message' className='bundle-detail'>
-                    <img src={`${process.env.PUBLIC_URL}/img/Preloader_Small.gif`} /> Loading
-                    bundle...
+                    <img alt='Loading' src={`${process.env.PUBLIC_URL}/img/Preloader_Small.gif`} />{' '}
+                    Loading bundle...
                 </div>
             );
         }
@@ -476,7 +476,7 @@ function renderContents(bundleInfo, fileContents, stdout, stderr) {
         stdoutHtml = (
             <div>
                 <span>
-                    <a href={stdoutUrl} target='_blank'>
+                    <a href={stdoutUrl} target='_blank' rel='noopener noreferrer'>
                         stdout
                     </a>
                 </span>
@@ -495,7 +495,7 @@ function renderContents(bundleInfo, fileContents, stdout, stderr) {
         stderrHtml = (
             <div>
                 <span>
-                    <a href={stderrUrl} target='_blank'>
+                    <a href={stderrUrl} target='_blank' rel='noopener noreferrer'>
                         stderr
                     </a>
                 </span>

--- a/frontend/src/components/EditableField.js
+++ b/frontend/src/components/EditableField.js
@@ -7,7 +7,7 @@ import { renderFormat, serializeFormat } from '../util/worksheet_utils';
 const KEYCODE_ESC = 27;
 
 function isAscii(str) {
-    return /^[\x00-\x7F]*$/.test(str);
+    return /^[\x20-\x7F]*$/.test(str);
 }
 
 class EditableFieldBase extends React.Component<{

--- a/frontend/src/components/FileBrowser/FileBrowser.js
+++ b/frontend/src/components/FileBrowser/FileBrowser.js
@@ -219,7 +219,7 @@ export class FileBrowser extends React.Component<
             );
             header = (
                 <div className='collapsible-header inline-block'>
-                    <a href={url} target='_blank'>
+                    <a href={url} target='_blank' rel='noopener noreferrer'>
                         {this.props.bundle_name}({short_uuid})
                     </a>
                     &nbsp;{arrow}
@@ -334,7 +334,9 @@ export class FileBrowserItem extends React.Component<{
                     onClick={() => this.props.updateFileBrowser(file_location)}
                 >
                     <span className='glyphicon-folder-open glyphicon' alt='More' />
-                    <a target='_blank'>{this.props.index}</a>
+                    <a target='_blank' rel='noopener noreferrer'>
+                        {this.props.index}
+                    </a>
                     <span className='pull-right'>{size}</span>
                 </span>
             );
@@ -347,7 +349,7 @@ export class FileBrowserItem extends React.Component<{
             item = (
                 <span className={this.props.type}>
                     <span className='glyphicon-file glyphicon' alt='More' />
-                    <a href={file_link} target='_blank'>
+                    <a href={file_link} target='_blank' rel='noopener noreferrer'>
                         {this.props.index}
                     </a>
                     <span className='pull-right'>{size}</span>
@@ -412,7 +414,9 @@ class FileBrowserItemLite extends React.Component<{
                     <TableCell>
                         <div style={rowCenter}>
                             <FolderIcon style={iconStyle} />
-                            <a target='_blank'>{this.props.index}</a>
+                            <a target='_blank' rel='noopener noreferrer'>
+                                {this.props.index}
+                            </a>
                         </div>
                     </TableCell>
                     <TableCell align='right'>{size}</TableCell>
@@ -427,7 +431,7 @@ class FileBrowserItemLite extends React.Component<{
                     <TableCell>
                         <div style={rowCenter}>
                             <FileIcon style={iconStyle} />
-                            <a href={file_link} target='_blank'>
+                            <a href={file_link} target='_blank' rel='noopener noreferrer'>
                                 {this.props.index}
                             </a>
                         </div>

--- a/frontend/src/components/Footer.js
+++ b/frontend/src/components/Footer.js
@@ -19,6 +19,7 @@ class Footer extends React.Component {
                             <a
                                 href='https://codalab-worksheets.readthedocs.io/en/latest/About'
                                 target='_blank'
+                                rel='noopener noreferrer'
                             >
                                 About
                             </a>
@@ -27,6 +28,7 @@ class Footer extends React.Component {
                             <a
                                 href='https://codalab-worksheets.readthedocs.io/en/latest/Privacy'
                                 target='_blank'
+                                rel='noopener noreferrer'
                             >
                                 Privacy and Terms
                             </a>
@@ -35,6 +37,7 @@ class Footer extends React.Component {
                             <a
                                 href='https://github.com/codalab/codalab-worksheets/releases'
                                 target='_blank'
+                                rel='noopener noreferrer'
                             >
                                 v{CODALAB_VERSION}
                             </a>

--- a/frontend/src/components/Loading.js
+++ b/frontend/src/components/Loading.js
@@ -7,6 +7,6 @@ export default () => (
             left: '50%',
         }}
     >
-        <img src={`${process.env.PUBLIC_URL}/img/Preloader_Small.gif`} />
+        <img alt='Loading' src={`${process.env.PUBLIC_URL}/img/Preloader_Small.gif`} />
     </div>
 );

--- a/frontend/src/components/Login.js
+++ b/frontend/src/components/Login.js
@@ -88,7 +88,7 @@ class Login extends React.Component {
                         <NavLink to='/account/reset'>Forgot your password?</NavLink>
                     </p>
                     <a
-                        href=''
+                        href='#'
                         onClick={(event) => {
                             alert(
                                 'Please log in and navigate to your dashboard to resend confirmation email.',

--- a/frontend/src/components/NavBar.js
+++ b/frontend/src/components/NavBar.js
@@ -369,6 +369,7 @@ class NavBar extends React.Component<{
                             <IconButton
                                 href='https://github.com/codalab/codalab-worksheets/issues'
                                 target='_blank'
+                                rel='noopener noreferrer'
                             >
                                 <ContactIcon />
                             </IconButton>

--- a/frontend/src/components/worksheets/BundleDetail/BundleDetail.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/BundleDetail.jsx
@@ -179,7 +179,7 @@ class BundleDetail extends React.Component<
             }
         }).fail(function(xhr, status, err) {
             // 404 Not Found errors are normal if contents aren't available yet, so ignore them
-            if (xhr.status != 404) {
+            if (xhr.status !== 404) {
                 this.setState({
                     bundleInfo: null,
                     fileContents: null,

--- a/frontend/src/components/worksheets/InformationModal/InformationModal.js
+++ b/frontend/src/components/worksheets/InformationModal/InformationModal.js
@@ -187,7 +187,11 @@ const KeyboardShortcutModal = ({ show, toggle }) => (
             </table>
             <div>
                 For terminal keyboard shortcuts, see{' '}
-                <a href='http://terminal.jcubic.pl/api_reference.php#shortcuts' target='_blank'>
+                <a
+                    href='http://terminal.jcubic.pl/api_reference.php#shortcuts'
+                    target='_blank'
+                    rel='noopener noreferrer'
+                >
                     here
                 </a>{' '}
             </div>
@@ -198,7 +202,7 @@ const KeyboardShortcutModal = ({ show, toggle }) => (
 let InformationModal = ({ showInformationModal, toggleInformationModal }) => (
     <React.Fragment>
         <div id='update_progress' className='progress-message'>
-            <img src='/img/Preloader_Small.gif' /> Updating...
+            <img alt='Updating' src='/img/Preloader_Small.gif' /> Updating...
         </div>
         <KeyboardShortcutModal show={showInformationModal} toggle={toggleInformationModal} />
     </React.Fragment>

--- a/frontend/src/components/worksheets/NewUpload/NewUpload.jsx
+++ b/frontend/src/components/worksheets/NewUpload/NewUpload.jsx
@@ -174,7 +174,7 @@ class NewUpload extends React.Component<{
         const { name, description } = this.state;
         const folderNamePos = files[0].webkitRelativePath.indexOf("/");
         let folderName = "";
-        if (folderNamePos != -1) {
+        if (folderNamePos !== -1) {
             folderName = files[0].webkitRelativePath.slice(0, folderNamePos)
         }
 

--- a/frontend/src/components/worksheets/NewWorksheet.js
+++ b/frontend/src/components/worksheets/NewWorksheet.js
@@ -5,7 +5,7 @@ import Button from '../Button';
 import { createHandleRedirectFn, buildTerminalCommand } from '../../util/worksheet_utils';
 
 var SAMPLE_WORKSHEET_TEXT = '-worksheetname';
-var NAME_REGEX = /^[a-zA-Z_][a-zA-Z0-9_\.\-]*$/i;
+var NAME_REGEX = /^[a-zA-Z_][a-zA-Z0-9_.-]*$/i;
 
 type Props = {
     clickAction: 'DEFAULT' | 'SIGN_IN_REDIRECT' | 'DISABLED',

--- a/frontend/src/components/worksheets/RunBundleBuilder.js
+++ b/frontend/src/components/worksheets/RunBundleBuilder.js
@@ -305,7 +305,7 @@ class BundleBrowser extends React.Component {
                                                     '',
                                                 )}
                                             />
-                                            <a href={url} target='_blank'>
+                                            <a href={url} target='_blank' rel='noopener noreferrer'>
                                                 {b.metadata.name}({short_uuid})
                                             </a>
                                         </td>

--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -570,7 +570,7 @@ class Worksheet extends React.Component {
             // focusedBundleUuidList is a list of uuids of all bundles after the selected bundle (itself included)
             // Say the selected bundle has focusIndex 1 and subFocusIndex 2, then focusedBundleUuidList will include the uuids of
             // all the bundles that have focusIndex 1 and subFocusIndex >= 2, and also all the bundles that have focusIndex > 1
-            for (var i = index; i < info.blocks.length; i++) {
+            for (let i = index; i < info.blocks.length; i++) {
                 if (info.blocks[i].bundles_spec) {
                     var j = i === index ? subIndex : 0;
                     for (; j < (this._numTableRows(info.blocks[i]) || 1); j++) {
@@ -1511,6 +1511,7 @@ class Worksheet extends React.Component {
                 Press ctrl-enter to save. See{' '}
                 <a
                     target='_blank'
+                    rel='noopener noreferrer'
                     href='https://codalab-worksheets.readthedocs.io/en/latest/Worksheet-Markdown'
                 >
                     markdown syntax

--- a/frontend/src/components/worksheets/WorksheetTerminal.js
+++ b/frontend/src/components/worksheets/WorksheetTerminal.js
@@ -120,7 +120,11 @@ class WorksheetTerminal extends React.Component {
                         var link = '/' + hyperlink_info['type'] + 's/' + hyperlink_info['uuid'];
                         return html.replace(
                             key,
-                            '<a href=' + link + " target='_blank'>" + key + '</a>',
+                            '<a href=' +
+                                link +
+                                " target='_blank' rel='noopener noreferrer'>" +
+                                key +
+                                '</a>',
                         );
                     } else {
                         console.warn(

--- a/frontend/src/components/worksheets/items/ImageItem.js
+++ b/frontend/src/components/worksheets/items/ImageItem.js
@@ -52,7 +52,7 @@ class ImageItem extends React.Component {
         return (
             <div className='ws-item'>
                 <div className={className} ref={this.props.item.ref} onClick={this.handleClick}>
-                    <img style={styles} src={src} />
+                    <img alt='Worksheet item' style={styles} src={src} />
                 </div>
                 {this.state.showDetail && (
                     <BundleDetail

--- a/frontend/src/components/worksheets/items/TableItem/BundleRow.js
+++ b/frontend/src/components/worksheets/items/TableItem/BundleRow.js
@@ -173,6 +173,7 @@ class BundleRow extends Component {
                         href={url}
                         className='bundle-link'
                         target='_blank'
+                        rel='noopener noreferrer'
                         style={{ display: 'inline-block', width: 60 }}
                     >
                         {rowContent}

--- a/frontend/src/components/worksheets/items/WorksheetItem.js
+++ b/frontend/src/components/worksheets/items/WorksheetItem.js
@@ -64,7 +64,7 @@ class WorksheetItem extends React.Component {
         if (item.mode === 'subworksheets_block') {
             return item.subworksheet_infos;
         } else {
-            throw 'Invalid: ' + item.mode;
+            throw new Error('Invalid: ' + item.mode);
         }
     }
 
@@ -145,7 +145,7 @@ class TableWorksheetRow extends React.Component {
             <tr className={className}>
                 <td>
                     <div onClick={this.handleRowClick}>
-                        <a href='javascript:void(0)' onClick={this.handleTextClick}>
+                        <a href='#' onClick={this.handleTextClick}>
                             {`${item.title + ' '}[${item.name}]`}
                         </a>
                     </div>

--- a/frontend/src/routes/HomePage.js
+++ b/frontend/src/routes/HomePage.js
@@ -50,7 +50,7 @@ class HomePage extends React.Component<{
         return (
             <TableRow style={{ height: 0 }}>
                 <TableCell>
-                    <a target='_blank' href={href}>
+                    <a target='_blank' rel='noopener noreferrer' href={href}>
                         {title}
                     </a>
                 </TableCell>
@@ -137,6 +137,7 @@ class HomePage extends React.Component<{
                         </Grid>
                         <Grid item xs={12} sm={7} className={classes.textBox}>
                             <img
+                                alt='Upload'
                                 src={`${process.env.PUBLIC_URL}/img/summary1.png`}
                                 className={classes.summaryImg}
                             />
@@ -164,6 +165,7 @@ class HomePage extends React.Component<{
                         </Grid>
                         <Grid item xs={12} sm={7} className={classes.textBox}>
                             <img
+                                alt='Experiment'
                                 src={`${process.env.PUBLIC_URL}/img/summary2.png`}
                                 className={classes.summaryImg}
                             />
@@ -192,6 +194,7 @@ class HomePage extends React.Component<{
                         </Grid>
                         <Grid item xs={12} sm={7} className={classes.textBox}>
                             <img
+                                alt='Publish'
                                 src={`${process.env.PUBLIC_URL}/img/summary3.png`}
                                 className={classes.summaryImg}
                             />
@@ -222,6 +225,7 @@ class HomePage extends React.Component<{
                                     color='primary'
                                     href='https://github.com/codalab/worksheets-examples'
                                     target='_blank'
+                                    rel='noopener noreferrer'
                                 >
                                     Go To Repo
                                 </Button>
@@ -299,12 +303,14 @@ class HomePage extends React.Component<{
 
                             <Grid item className={classes.textBox}>
                                 <img
+                                    alt='Stanford'
                                     src={`${process.env.PUBLIC_URL}/img/users/stanford.png`}
                                     className={classes.userLogo}
                                 />
                             </Grid>
                             <Grid item className={classes.textBox}>
                                 <img
+                                    alt='Microsoft'
                                     src={`${process.env.PUBLIC_URL}/img/users/microsoft.png`}
                                     className={classes.userLogo}
                                 />

--- a/frontend/src/util/worksheet_utils.js
+++ b/frontend/src/util/worksheet_utils.js
@@ -195,7 +195,7 @@ export function worksheetItemPropsChanged(props, nextProps) {
 export function buildTerminalCommand(args) {
     var ret = [];
     args.forEach(function(s) {
-        if (/[^A-Za-z0-9_\/:=-]/.test(s)) {
+        if (/[^A-Za-z0-9_s/:=-]/.test(s)) {
             s = "'" + s.replace(/'/g, "'\\''") + "'";
             s = s
                 .replace(/^(?:'')+/g, '') // unduplicate single-quote at the beginning
@@ -219,7 +219,7 @@ export function createAlertText(requestURL, responseText, solution) {
 
 // the five functions below are used for uplading files on the web. Some of them are the same as some functions on the CLI.
 export const ARCHIVE_EXTS = ['.tar.gz', '.tgz', '.tar.bz2', '.zip', '.gz'];
-export const NOT_NAME_CHAR_REGEX = /[^a-zA-Z0-9_\.\-]/gi;
+export const NOT_NAME_CHAR_REGEX = /[^a-zA-Z0-9_.-]/gi;
 export const BEGIN_NAME_REGEX = /[a-zA-Z_]/gi;
 
 // same as shorten_name in /lib/spec_util.py
@@ -264,7 +264,7 @@ export function getArchiveExt(name) {
 export function createDefaultBundleName(name) {
     name = stripArchiveExt(name);
     name = name.replace(NOT_NAME_CHAR_REGEX, '-');
-    name = name.replace(/\-+/gi, '-'); // Collapse '---' => '-'
+    name = name.replace(/-+/gi, '-'); // Collapse '---' => '-'
     var beginChar = name.charAt(0);
     if (!beginChar.match(BEGIN_NAME_REGEX)) {
         name = '_' + name;


### PR DESCRIPTION
Part of #1094.

Removed exceptions for the following rules:

```
        "react/jsx-no-target-blank": "off",
        "no-useless-escape": "off",
        "jsx-a11y/alt-text": "off",
        "no-redeclare": "off",
        "no-script-url": "off",
        "no-throw-literal": "off",
        "no-dupe-keys": "off",
        "no-control-regex": "off",
        "no-dupe-class-members": "off",
        "no-template-curly-in-string": "off"
```

Also updated package.json to make sure that eslint errors are caught by CI.