### PR TITLE
Improve monitor script when sending worker offline alert

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -73,7 +73,7 @@ if not os.path.exists(args.backup_path):
     os.mkdir(args.backup_path)
 
 # Comma-separated list of worker ids to monitor. Example: vm-clws-prod-worker-0,vm-clws-prod-worker-1
-public_workers = set(os.environ['CODALAB_PUBLIC_WORKERS'].split(','))
+public_workers = set([worker.strip() for worker in os.environ['CODALAB_PUBLIC_WORKERS'].split(',')])
 
 report = []  # Build up the current report to send in an email
 
@@ -260,6 +260,7 @@ def poll_online_workers():
         error_logs(
             'worker check failed', 'Missing value for environment variable CODALAB_PUBLIC_WORKERS.'
         )
+        return
     lines = run_command(['cl', 'workers']).split('\n')
     workers_info = lines[2:]
     online_workers = set()


### PR DESCRIPTION
This PR improves monitoring script when sending worker offline alert. 

When there are no workers defined in `CODALAB_PUBLIC_WORKERS`, we avoid sending any alert email to the monitoring channel. Plus, I added string parsing logic to be more robust.