### PR TITLE
Don't limit WorkerManager staged bundle search by provided tags

### DIFF
--- a/codalab/worker_manager/worker_manager.py
+++ b/codalab/worker_manager/worker_manager.py
@@ -98,8 +98,6 @@ class WorkerManager(object):
     def run_one_iteration(self):
         # Get staged bundles for the current user.
         keywords = ['state=' + State.STAGED] + [".mine"] + self.args.search
-        if self.args.worker_tag:
-            keywords.append('request_queue=tag=' + self.args.worker_tag)
         bundles = self.codalab_client.fetch(
             'bundles', params={'worksheet': None, 'keywords': keywords, 'include': ['owner']}
         )


### PR DESCRIPTION
It's nice to be able to specify tags for workers, but still leave them to run untagged bundles. The current behavior is that more workers won't be launched if there are staged bundles that match all other criteria except the tag.