### PR TITLE
Add --worker-pass-down-termination flag to WorkerManager

### DIFF
--- a/codalab/worker_manager/aws_batch_worker_manager.py
+++ b/codalab/worker_manager/aws_batch_worker_manager.py
@@ -102,6 +102,8 @@ class AWSBatchWorkerManager(WorkerManager):
             command.extend(['--exit-after-num-runs', str(self.args.worker_exit_after_num_runs)])
         if self.args.worker_exit_on_exception:
             command.extend(['--exit-on-exception'])
+        if self.args.worker_pass_down_termination:
+            command.extend(['--pass-down-termination'])
 
         # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-batch-jobdefinition.html
         # Need to mount:

--- a/codalab/worker_manager/main.py
+++ b/codalab/worker_manager/main.py
@@ -59,6 +59,11 @@ def main():
         help='If specified, the CodaLab worker will exit after finishing this many of runs',
     )
     parser.add_argument(
+        '--worker-pass-down-termination',
+        action='store_true',
+        help="If set, the CodaLab worker will kill and restage all existing running bundles when terminated.",
+    )
+    parser.add_argument(
         '--worker-exit-on-exception',
         action='store_true',
         help="If set, the CodaLab worker will exit if it encounters an exception (rather than sleeping).",


### PR DESCRIPTION
This enables use in the AWSBatchWorkerManager as well, useful for when spot instances get pre-empted.