### PR TITLE
Set default value of exit_after_num_runs to maxint in rest API call

### DIFF
--- a/alembic/versions/2020060503_add_exit_after_number_of_runs__54e95ff2e718.py
+++ b/alembic/versions/2020060503_add_exit_after_number_of_runs__54e95ff2e718.py
@@ -12,7 +12,7 @@ down_revision = '9d0f1ffb18e9'
 
 from alembic import op
 import sqlalchemy as sa
-import sys
+
 
 def upgrade():
     op.add_column('worker', sa.Column('exit_after_num_runs', sa.Integer(), nullable=False, server_default='999999999'))

--- a/codalab/rest/workers.py
+++ b/codalab/rest/workers.py
@@ -4,6 +4,7 @@ from __future__ import (
 from contextlib import closing
 import http.client
 import json
+import sys
 from datetime import datetime
 
 from bottle import abort, get, local, post, put, request, response
@@ -35,7 +36,7 @@ def checkin(worker_id):
         request.json["dependencies"],
         request.json.get("shared_file_system", False),
         request.json.get("tag_exclusive", False),
-        request.json.get("exit_after_num_runs"),
+        request.json.get("exit_after_num_runs", sys.maxsize),
     )
 
     for run in request.json["runs"]:

--- a/codalab/rest/workers.py
+++ b/codalab/rest/workers.py
@@ -4,7 +4,6 @@ from __future__ import (
 from contextlib import closing
 import http.client
 import json
-import sys
 from datetime import datetime
 
 from bottle import abort, get, local, post, put, request, response
@@ -13,6 +12,7 @@ from codalab.lib import spec_util
 from codalab.objects.permission import check_bundle_have_run_permission
 from codalab.server.authenticated_plugin import AuthenticatedPlugin
 from codalab.worker.bundle_state import BundleCheckinState
+from codalab.worker.main import DEFAULT_EXIT_AFTER_NUM_RUNS
 
 
 @post("/workers/<worker_id>/checkin", name="worker_checkin", apply=AuthenticatedPlugin())
@@ -36,7 +36,7 @@ def checkin(worker_id):
         request.json["dependencies"],
         request.json.get("shared_file_system", False),
         request.json.get("tag_exclusive", False),
-        request.json.get("exit_after_num_runs", sys.maxsize),
+        request.json.get("exit_after_num_runs", DEFAULT_EXIT_AFTER_NUM_RUNS),
     )
 
     for run in request.json["runs"]:

--- a/codalab/worker/main.py
+++ b/codalab/worker/main.py
@@ -23,6 +23,9 @@ from codalab.worker.docker_image_manager import DockerImageManager
 logger = logging.getLogger(__name__)
 
 
+DEFAULT_EXIT_AFTER_NUM_RUNS = 999999999
+
+
 def parse_args():
     parser = argparse.ArgumentParser(description='CodaLab worker.')
     parser.add_argument('--tag', help='Tag that allows for scheduling runs on specific workers.')
@@ -144,7 +147,7 @@ def parse_args():
     parser.add_argument(
         '--exit-after-num-runs',
         type=int,
-        default=sys.maxsize,
+        default=DEFAULT_EXIT_AFTER_NUM_RUNS,
         help='The worker quits after this many jobs assigned to this worker',
     )
     parser.add_argument(


### PR DESCRIPTION
This PR sets the default value of `exit_after_num_runs` to max int in rest call to avoid potential failures.