### PR TITLE
Enable customizing the cl-worker executable used in the WorkerManager

### DIFF
--- a/codalab/worker_manager/aws_batch_worker_manager.py
+++ b/codalab/worker_manager/aws_batch_worker_manager.py
@@ -78,7 +78,7 @@ class AWSBatchWorkerManager(WorkerManager):
         work_dir = os.path.join(work_dir_prefix, 'cl_worker_{}_work_dir'.format(worker_id))
         worker_network_prefix = 'cl_worker_{}_network'.format(worker_id)
         command = [
-            'cl-worker',
+            self.args.worker_executable,
             '--server',
             self.args.server,
             '--verbose',

--- a/codalab/worker_manager/main.py
+++ b/codalab/worker_manager/main.py
@@ -68,6 +68,9 @@ def main():
         action='store_true',
         help="If set, the CodaLab worker will exit if it encounters an exception (rather than sleeping).",
     )
+    parser.add_argument(
+        '--worker-executable', default="cl-worker", help="The CodaLab worker executable to run."
+    )
     subparsers = parser.add_subparsers(
         title='Worker Manager to run',
         description='Which worker manager to run (AWS Batch etc.)',

--- a/codalab/worker_manager/slurm_batch_worker_manager.py
+++ b/codalab/worker_manager/slurm_batch_worker_manager.py
@@ -240,7 +240,7 @@ class SlurmBatchWorkerManager(WorkerManager):
         worker_work_dir = work_dir_prefix.joinpath(Path('slurm-codalab-worker-scratch', worker_id))
 
         command = [
-            'cl-worker',
+            self.args.worker_executable,
             '--server',
             self.args.server,
             '--verbose',


### PR DESCRIPTION
Sometimes, it's not ideal to use the `cl-worker` that is found first in the $PATH , but you'd rather provide an explicit path to an executable.