### PR TITLE
Remove SlurmWorkerManager jobs when they timeout

### DIFF
--- a/codalab/worker_manager/slurm_batch_worker_manager.py
+++ b/codalab/worker_manager/slurm_batch_worker_manager.py
@@ -137,7 +137,7 @@ class SlurmBatchWorkerManager(WorkerManager):
             if 'FAILED' in job_state:
                 jobs_to_remove.add(job_id)
                 logger.error("Failed to start job {}".format(job_id))
-            elif 'COMPLETED' in job_state or 'CANCELLED' in job_state:
+            elif 'COMPLETED' in job_state or 'CANCELLED' in job_state or "TIMEOUT" in job_state:
                 jobs_to_remove.add(job_id)
                 logger.info("Removing job ID {}".format(job_id))
         self.submitted_jobs = self.submitted_jobs - jobs_to_remove


### PR DESCRIPTION
When a batch job reaches its allotted time (e.g., 10 days is our default), the slurm job terminates and is given the state `TIMEOUT`. This PR edits the code such that these `TIMEOUT` jobs are removed from the SlurmWorkerManager's internal state.