### PR TITLE
Fix indentation when updating workers' exit_after_num_runs in BundleManager

### DIFF
--- a/codalab/server/bundle_manager.py
+++ b/codalab/server/bundle_manager.py
@@ -381,7 +381,6 @@ class BundleManager(object):
             workers.user_owned_workers(self._model.root_user_id), running_bundles_info
         )
 
-        workers_list = []
         # Dispatch bundles
         for bundle, bundle_resources in staged_bundles_to_run:
             if user_parallel_run_quota_left[bundle.owner_id] > 0:
@@ -409,20 +408,20 @@ class BundleManager(object):
                     worker['exit_after_num_runs'] -= 1
                     break
 
-        # To avoid the potential race condition between bundle manager's dispatch frequency and
-        # worker's checkin frequency, update the column "exit_after_num_runs" in worker table
-        # before bundle manager's next scheduling loop
-        for worker in workers_list:
-            # Update workers that have "exit_after_num_runs" manually set from CLI.
-            if (
-                worker['exit_after_num_runs']
-                < workers._workers[worker['worker_id']]['exit_after_num_runs']
-            ):
-                self._worker_model.update_workers(
-                    worker["user_id"],
-                    worker['worker_id'],
-                    {'exit_after_num_runs': worker['exit_after_num_runs']},
-                )
+            # To avoid the potential race condition between bundle manager's dispatch frequency and
+            # worker's checkin frequency, update the column "exit_after_num_runs" in worker table
+            # before bundle manager's next scheduling loop
+            for worker in workers_list:
+                # Update workers that have "exit_after_num_runs" manually set from CLI.
+                if (
+                    worker['exit_after_num_runs']
+                    < workers._workers[worker['worker_id']]['exit_after_num_runs']
+                ):
+                    self._worker_model.update_workers(
+                        worker["user_id"],
+                        worker['worker_id'],
+                        {'exit_after_num_runs': worker['exit_after_num_runs']},
+                    )
 
     def _deduct_worker_resources(self, workers_list, running_bundles_info):
         """


### PR DESCRIPTION
Right now, the BundleManager only updates `exit_after_num_runs` for workers that are eligible to run the _last_ bundle , since `workers_list` is shadowed in the loop and recreated. I'm pretty sure this is not the intended behavior / a bug.

I'm pretty sure we want to be running this after every bundle dispatch instead, ref: https://github.com/codalab/codalab-worksheets/pull/2424#discussion_r447828225