### PR TITLE
Re-add ace dependency

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -46,6 +46,7 @@
       })();
     </script>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/c3/0.6.12/c3.min.css" rel="stylesheet" type="text/css">
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.2.2/ace.js"></script>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/semantic-ui@2.4.2/dist/semantic.min.css" />


### PR DESCRIPTION
Turns out that we shouldn't have removed ace in #2498 -- this ended up breaking the "Edit Source" functionality, because it requires Ace to work. It would be great to re-add the edit worksheet frontend tests so we could have caught this (sorry @teetone).