### PR TITLE
Add --worker-tag-exclusive to WorkerManager

### DIFF
--- a/codalab/worker_manager/aws_batch_worker_manager.py
+++ b/codalab/worker_manager/aws_batch_worker_manager.py
@@ -104,6 +104,8 @@ class AWSBatchWorkerManager(WorkerManager):
             command.extend(['--exit-on-exception'])
         if self.args.worker_pass_down_termination:
             command.extend(['--pass-down-termination'])
+        if self.args.worker_tag_exclusive:
+            command.extend(['--tag-exclusive'])
 
         # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-batch-jobdefinition.html
         # Need to mount:

--- a/codalab/worker_manager/main.py
+++ b/codalab/worker_manager/main.py
@@ -69,6 +69,11 @@ def main():
         help="If set, the CodaLab worker will exit if it encounters an exception (rather than sleeping).",
     )
     parser.add_argument(
+        '--worker-tag-exclusive',
+        action='store_true',
+        help="If set, the CodaLab worker will only run bundles that match the worker\'s tag.",
+    )
+    parser.add_argument(
         '--worker-executable', default="cl-worker", help="The CodaLab worker executable to run."
     )
     subparsers = parser.add_subparsers(

--- a/codalab/worker_manager/slurm_batch_worker_manager.py
+++ b/codalab/worker_manager/slurm_batch_worker_manager.py
@@ -268,6 +268,8 @@ class SlurmBatchWorkerManager(WorkerManager):
             command.extend(['--delete-work-dir-on-exit'])
         if self.args.worker_exit_on_exception:
             command.extend(['--exit-on-exception'])
+        if self.args.worker_tag_exclusive:
+            command.extend(['--tag-exclusive'])
 
         return command
 

--- a/codalab/worker_manager/worker_manager.py
+++ b/codalab/worker_manager/worker_manager.py
@@ -111,6 +111,9 @@ class WorkerManager(object):
         # want to see their staged bundles.
         if os.environ.get('CODALAB_USERNAME') != "codalab":
             keywords += [".mine"]
+        if args.worker_tag_exclusive and args.worker_tag:
+            keywords += ["request_queue=" + args.worker_tag]
+
         bundles = self.codalab_client.fetch(
             'bundles', params={'worksheet': None, 'keywords': keywords, 'include': ['owner']}
         )


### PR DESCRIPTION
Is it better to do search for `request_queue=<X>` or `request_queue=tag=<X>`?