### PR TITLE
Enable filtering jobs in the AWSBatchWorkerManager

### DIFF
--- a/codalab/worker_manager/aws_batch_worker_manager.py
+++ b/codalab/worker_manager/aws_batch_worker_manager.py
@@ -50,8 +50,8 @@ class AWSBatchWorkerManager(WorkerManager):
             '--job-filter',
             type=str,
             help=(
-                'Ignore jobs on the job queue if their job name does not '
-                'completely match provided regex filter.'
+                'Only consider jobs on the job queue with job names that '
+                'completely match this regex filter.'
             ),
         )
 

--- a/codalab/worker_manager/aws_batch_worker_manager.py
+++ b/codalab/worker_manager/aws_batch_worker_manager.py
@@ -46,6 +46,14 @@ class AWSBatchWorkerManager(WorkerManager):
             default='codalab-batch-cpu',
             help='Name of the AWS Batch job queue to use',
         )
+        subparser.add_argument(
+            '--job-filter',
+            type=str,
+            help=(
+                'Ignore jobs on the job queue if their job name does not '
+                'completely match provided regex filter.'
+            ),
+        )
 
     def __init__(self, args):
         super().__init__(args)
@@ -53,12 +61,16 @@ class AWSBatchWorkerManager(WorkerManager):
 
     def get_worker_jobs(self):
         """Return list of workers."""
-        # Get all jobs that are not SUCCEEDED or FAILED.  Assume these
-        # represent workers we launched (no one is sharing this queue).
+        # Get all jobs that are not SUCCEEDED or FAILED.
         jobs = []
         for status in ['SUBMITTED', 'PENDING', 'RUNNABLE', 'STARTING', 'RUNNING']:
             response = self.batch_client.list_jobs(jobQueue=self.args.job_queue, jobStatus=status)
-            jobs.extend(response['jobSummaryList'])
+            # Only record jobs if a job regex filter isn't provided or if the job's name completely matches
+            # a provided job regex filter.
+            if not args.job_filter or (
+                args.job_filter and re.fullmatch(args.job_filter, response.get("jobName", ""))
+            ):
+                jobs.extend(response['jobSummaryList'])
         logger.info(
             'Workers: {}'.format(
                 ' '.join(job['jobId'] + ':' + job['status'] for job in jobs) or '(none)'

--- a/codalab/worker_manager/aws_batch_worker_manager.py
+++ b/codalab/worker_manager/aws_batch_worker_manager.py
@@ -67,9 +67,7 @@ class AWSBatchWorkerManager(WorkerManager):
             response = self.batch_client.list_jobs(jobQueue=self.args.job_queue, jobStatus=status)
             # Only record jobs if a job regex filter isn't provided or if the job's name completely matches
             # a provided job regex filter.
-            if not args.job_filter or (
-                args.job_filter and re.fullmatch(args.job_filter, response.get("jobName", ""))
-            ):
+            if not args.job_filter or re.fullmatch(args.job_filter, response.get("jobName", "")):
                 jobs.extend(response['jobSummaryList'])
         logger.info(
             'Workers: {}'.format(


### PR DESCRIPTION
Currently, the AWSBatchWorkerManager treats _all jobs_ on the provided job queue as cl-worker jobs. However, this isn't a valid assumption in many cases (namely, when the queue is shared, like in the Stanford NLP AWS account).

This PR adds an argument that enables filtering the workermanager jobs with a regex. The default behavior should not be changed.