### PR TITLE
Skip frontend production build on dev mode

### DIFF
--- a/codalab_service.py
+++ b/codalab_service.py
@@ -564,10 +564,15 @@ class CodalabServiceManager(object):
         else:
             cache_args = ''
 
+        if self.args.dev:
+            build_args = ' --build-arg dev=true'
+        else:
+            build_args = ''
+
         # Build the image using the cache
         self._run_docker_cmd(
-            'build%s -t %s -f docker/dockerfiles/Dockerfile.%s .'
-            % (cache_args, docker_image, image)
+            'build%s %s -t %s -f docker/dockerfiles/Dockerfile.%s .'
+            % (cache_args, build_args, docker_image, image)
         )
 
     def push_image(self, image):

--- a/docker/dockerfiles/Dockerfile.frontend
+++ b/docker/dockerfiles/Dockerfile.frontend
@@ -2,6 +2,8 @@ FROM node:14
 
 ENV NPM_CONFIG_LOGLEVEL warn
 
+ARG dev=false
+
 RUN npm install -g serve
 
 WORKDIR /opt/frontend
@@ -14,7 +16,7 @@ RUN npm ci
 # Overridden in dev mode
 COPY frontend .
 
-# Build static files
-RUN npm run build --production
+# Build static files (skipped in dev mode)
+RUN if [ "$dev" = "false" ] ; then npm run build --production; fi
 
 EXPOSE 2700


### PR DESCRIPTION
### Reasons for making this change

Fixes #2602. Uses build args to conditionally run the production build based on whether codalab service has been started with the `-d` flag.

To test, run:

```
python3 codalab_service.py -bds frontend # should skip production build
python3 codalab_service.py -bs frontend # should perform production build
```