### PR TITLE
Sync RunStateMachine docker networks when re-initializing them

### DIFF
--- a/codalab/worker/worker.py
+++ b/codalab/worker/worker.py
@@ -407,6 +407,11 @@ class Worker:
         # We (re-)initialize the Docker networks here, in case they've been removed.
         # For any networks that exist, this is essentially a no-op.
         self.init_docker_networks(self.docker_network_prefix, verbose=False)
+        # In case the docker networks have changed, we also update them in the RunStateMachine
+        self.run_state_manager.worker_docker_network = self.worker_docker_network
+        self.run_state_manager.docker_network_external = self.docker_network_external
+        self.run_state_manager.docker_network_internal = self.docker_network_internal
+
         # 1. transition all runs
         for uuid in self.runs:
             run_state = self.runs[uuid]


### PR DESCRIPTION
The issue here is that if we prune a docker network and create a new one, the `RunStateMachine` still holds on to the docker network that existed when the `Worker` was first created, which leads to errors when it tries to use a network that no longer exists.

This PR fixes things such that when we reinitialize the docker networks, we also update the networks that the `RunStateMachine` stores.