### PR TITLE
remove canEdit in worksheet.js

### DIFF
--- a/frontend/src/components/FileBrowser/FileBrowser.js
+++ b/frontend/src/components/FileBrowser/FileBrowser.js
@@ -18,7 +18,6 @@ export class FileBrowser extends React.Component<
         buildPayload: (string) => {},
         method: string,
         url: string,
-        canEdit?: boolean,
         onChange?: () => void,
     },
     {
@@ -34,7 +33,6 @@ export class FileBrowser extends React.Component<
     /** Prop default values. */
     static defaultProps = {
         method: 'POST',
-        canEdit: true,
     };
 
     constructor(props) {

--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -665,7 +665,7 @@ class Worksheet extends React.Component {
         });
     }
 
-    canEdit() {
+    hasEditPermission() {
         var info = this.state.ws.info;
         return info && info.edit_permission;
     }
@@ -985,7 +985,7 @@ class Worksheet extends React.Component {
 
         if (!editMode) {
             // Going out of raw mode - save the worksheet.
-            if (this.canEdit()) {
+            if (this.hasEditPermission()) {
                 var editor = ace.edit('worksheet-editor');
                 if (saveChanges) {
                     this.state.ws.info.source = editor.getValue().split('\n');
@@ -1104,7 +1104,7 @@ class Worksheet extends React.Component {
             editor.session.setMode('ace/mode/markdown', function() {
                 editor.session.$mode.blockComment = { start: '//', end: '' };
             });
-            if (!this.canEdit()) {
+            if (!this.hasEditPermission()) {
                 editor.setOptions({
                     readOnly: true,
                     highlightActiveLine: false,
@@ -1414,16 +1414,15 @@ class Worksheet extends React.Component {
         const { anchorEl, uploadAnchor } = this.state;
 
         this.setupEventHandlers();
-        var info = this.state.ws.info;
-        var rawWorksheet = info && info.source.join('\n');
-        var editPermission = info && info.edit_permission;
-        var canEdit = this.canEdit() && this.state.editMode;
+        let info = this.state.ws.info;
+        let rawWorksheet = info && info.source.join('\n');
+        const editPermission = this.hasEditPermission();
 
-        var searchClassName = this.state.showTerminal ? '' : 'search-hidden';
-        var editableClassName = canEdit ? 'editable' : '';
-        var disableWorksheetEditing = this.canEdit() ? '' : 'disabled';
-        var sourceStr = editPermission ? 'Edit Source' : 'View Source';
-        var editFeatures = (
+        let searchClassName = this.state.showTerminal ? '' : 'search-hidden';
+        let editableClassName = editPermission && this.state.editMode ? 'editable' : '';
+        let disableWorksheetEditing = editPermission ? '' : 'disabled';
+        let sourceStr = editPermission ? 'Edit Source' : 'View Source';
+        let editFeatures = (
             <div style={{ display: 'inline-block' }}>
                 <Button
                     onClick={this.editMode}
@@ -1540,7 +1539,6 @@ class Worksheet extends React.Component {
                 active={this.state.activeComponent === 'list'}
                 ws={this.state.ws}
                 version={this.state.version}
-                canEdit={canEdit}
                 focusIndex={this.state.focusIndex}
                 subFocusIndex={this.state.subFocusIndex}
                 setFocus={this.setFocus}
@@ -1595,7 +1593,7 @@ class Worksheet extends React.Component {
             <React.Fragment>
                 <WorksheetHeader
                     showTerminal={this.state.showTerminal}
-                    canEdit={this.canEdit()}
+                    editPermission={editPermission}
                     info={info}
                     classes={classes}
                     renderPermissions={renderPermissions}

--- a/frontend/src/components/worksheets/Worksheet/WorksheetHeader.js
+++ b/frontend/src/components/worksheets/Worksheet/WorksheetHeader.js
@@ -26,7 +26,7 @@ export default ({
     showUploadMenu,
     closeUploadMenu,
     uploadAnchor,
-    canEdit,
+    editPermission,
     info,
     classes,
     renderPermissions,
@@ -58,8 +58,8 @@ export default ({
                         <h5 className='worksheet-title'>
                             {/*TODO: use html contenteditable*/}
                             <WorksheetEditableField
-                                key={'title' + canEdit}
-                                canEdit={canEdit}
+                                key={'title' + editPermission}
+                                canEdit={editPermission}
                                 fieldName='title'
                                 value={info ? info.title : 'Loading...'}
                                 uuid={info && info.uuid}
@@ -71,7 +71,7 @@ export default ({
                             {info && (
                                 <React.Fragment>
                                     <WorksheetEditableField
-                                        canEdit={canEdit}
+                                        canEdit={editPermission}
                                         fieldName='name'
                                         value={info && info.name}
                                         uuid={info && info.uuid}
@@ -117,7 +117,7 @@ export default ({
                                     &nbsp;tags:&nbsp;
                                     <div style={{ display: 'inline-block' }}>
                                         <WorksheetEditableField
-                                            canEdit={canEdit}
+                                            canEdit={editPermission}
                                             dataType='list'
                                             fieldName='tags'
                                             value={info.tags.join(' ')}

--- a/frontend/src/components/worksheets/WorksheetItemList.js
+++ b/frontend/src/components/worksheets/WorksheetItemList.js
@@ -32,7 +32,7 @@ export const BLOCK_TO_COMPONENT = {
 // - item: information about the table to display
 // - index: integer representing the index in the list of items
 // - focused: whether this item has the focus
-// - canEdit: whether we're allowed to edit this item
+// - editPermission: whether we have permission to edit this item
 // - setFocus: call back to select this item
 // - updateWorksheetSubFocusIndex: call back to notify parent of which row is selected (for tables)
 const addWorksheetItems = function(props, worksheet_items, prevItem, afterItem) {
@@ -215,7 +215,6 @@ class WorksheetItemList extends React.Component {
                         version: this.props.version,
                         active: this.props.active,
                         focused,
-                        canEdit: this.props.canEdit,
                         focusIndex: index,
                         subFocusIndex: this.props.subFocusIndex,
                         setFocus: this.props.setFocus,

--- a/frontend/src/components/worksheets/items/TableItem/TableItem.js
+++ b/frontend/src/components/worksheets/items/TableItem/TableItem.js
@@ -107,7 +107,6 @@ class TableItem extends React.Component<{
         this.props.addCopyBundleRowsCallback(this.props.itemID, this.copyCheckedBundleRows);
         var tableClassName = this.props.focused ? 'table focused' : 'table';
         var item = this.props.item;
-        var canEdit = this.props.canEdit;
         var bundleInfos = item.bundles_spec.bundle_infos;
         var headerItems = item.header;
         var headerHtml = headerItems.map((item, index) => {
@@ -155,7 +154,6 @@ class TableItem extends React.Component<{
                     bundleInfo={bundleInfo}
                     uuid={bundleInfo.uuid}
                     headerItems={headerItems}
-                    canEdit={canEdit}
                     updateRowIndex={this.updateRowIndex}
                     columnWithHyperlinks={columnWithHyperlinks}
                     reloadWorksheet={this.props.reloadWorksheet}

--- a/frontend/src/components/worksheets/items/WorksheetItem.js
+++ b/frontend/src/components/worksheets/items/WorksheetItem.js
@@ -77,7 +77,6 @@ class WorksheetItem extends React.Component {
 
         var self = this;
         var tableClassName = this.props.focused ? 'table focused' : 'table';
-        var canEdit = this.props.canEdit;
         var items = this._getItems();
 
         var body_rows_html = items.map(function(row_item, row_index) {
@@ -93,7 +92,6 @@ class WorksheetItem extends React.Component {
                     focused={row_focused}
                     url={url}
                     uuid={row_item.uuid}
-                    canEdit={canEdit}
                     updateRowIndex={self.updateRowIndex}
                 />
             );


### PR DESCRIPTION
### Reasons for making this change

canEdit had two reference in Worksheet.js, including a variable name and a function name.
The variable is actually not used anywhere, and the function collides with the editPermission variable in rendering.
There is also a canEdit field in editableFieldBase which is used for text.
The PR removes the canEdit variable in Worksheet.JS and renames canEdit function to hasEditPermission to remove redundancy and make it clearer what the function is doing.
The canEdit field in now only kept in editableFieldBase

### Related issues

part of #2619 
