### PR TITLE
Add CUDA / nvidia-smi to worker Docker image

### DIFF
--- a/docker/dockerfiles/Dockerfile.worker
+++ b/docker/dockerfiles/Dockerfile.worker
@@ -7,7 +7,7 @@ RUN go get -u github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/dock
 WORKDIR /root/go/src/github.com/awslabs/amazon-ecr-credential-helper
 RUN make
 
-FROM ubuntu:16.04
+FROM nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04
 MAINTAINER CodaLab Worksheets <codalab.worksheets@gmail.com>
 
 ENV DEBIAN_FRONTEND noninteractive


### PR DESCRIPTION
The worker docker image doesn't have `nvidia-smi`, so it isn't able to detect any GPUs in the case that the worker is containerized.

This adds `nvidia-smi` to the worker docker image.