### PR TITLE
Release candidate 0.5.20

### DIFF
--- a/codalab/common.py
+++ b/codalab/common.py
@@ -8,7 +8,7 @@ import http.client
 
 # Increment this on master when ready to cut a release.
 # http://semver.org/
-CODALAB_VERSION = '0.5.19'
+CODALAB_VERSION = '0.5.20'
 BINARY_PLACEHOLDER = '<binary>'
 
 

--- a/codalab/worker/main.py
+++ b/codalab/worker/main.py
@@ -10,7 +10,6 @@ import logging
 import signal
 import socket
 import stat
-import subprocess
 import sys
 import psutil
 
@@ -308,21 +307,8 @@ def parse_gpuset_args(arg):
         return set()
 
     try:
-        # We run nvidia-smi on the host directly, in order to respect
-        # environment variables like CUDA_VISIBLE_DEVICES or other restrictions
-        # that, for instance, might be placed by Slurm or a similar resource
-        # allocation system. Running nvidia-smi in Docker ignores these
-        # restrictions, hence why we don't just simply use
-        # docker_utils.get_nvidia_devices()
-        nvidia_command = ['nvidia-smi', '--query-gpu=index,uuid', '--format=csv,noheader']
-        output = subprocess.run(
-            nvidia_command, stdout=subprocess.PIPE, check=True, universal_newlines=True
-        ).stdout
-        print(output.split('\n')[:-1])
-        all_gpus = {
-            gpu.split(',')[0].strip(): gpu.split(',')[1].strip() for gpu in output.split('\n')[:-1]
-        }
-    except (subprocess.CalledProcessError, FileNotFoundError):
+        all_gpus = docker_utils.get_nvidia_devices()  # Dict[GPU index: GPU UUID]
+    except docker_utils.DockerException:
         all_gpus = {}
 
     if arg == 'ALL':

--- a/docs/REST-API-Reference.md
+++ b/docs/REST-API-Reference.md
@@ -1,6 +1,6 @@
 # REST API Reference
 
-_version 0.5.19_
+_version 0.5.20_
 
 This reference and the REST API itself is still under heavy development and is
 subject to change at any time. Feedback through our GitHub issues is appreciated!

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -1,5 +1,5 @@
 // Should match codalab/common.py#CODALAB_VERSION
-export const CODALAB_VERSION = '0.5.19';
+export const CODALAB_VERSION = '0.5.20';
 
 export const NAVBAR_HEIGHT = 60;
 

--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -17,5 +17,5 @@ nose==1.3.7
 # Server-specific
 alembic==1.0.0
 gunicorn==20.0.4
-oauthlib==3.1.0
+oauthlib==2.1.0
 mysqlclient==1.4.1

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import sys
 
 
 # should match codalab/common.py#CODALAB_VERSION
-CODALAB_VERSION = "0.5.19"
+CODALAB_VERSION = "0.5.20"
 
 
 class Install(install):


### PR DESCRIPTION
### Reasons for making this change

Renaming the branch from #2652 to match our release guidelines

