### PR TITLE
Disable auto-rebase for dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,20 +2,24 @@ version: 2
 updates:
   - package-ecosystem: "pip"
     directory: "/"
+    rebase-strategy: "disabled"
     schedule:
       interval: "daily"
 
   - package-ecosystem: "npm"
     directory: "frontend"
+    rebase-strategy: "disabled"
     schedule:
       interval: "daily"
 
   - package-ecosystem: "docker"
     directory: "docker/dockerfiles"
+    rebase-strategy: "disabled"
     schedule:
       interval: "daily"
       
   - package-ecosystem: "github-actions"
     directory: ".github/workflows"
+    rebase-strategy: "disabled"
     schedule:
       interval: "daily"


### PR DESCRIPTION
### Reasons for making this change

Fixes #2662 by disabling auto-rebase for dependabot PRs. See https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#rebase-strategy for more information on the parameter added.