### PR TITLE
Fix uploading files on frontend by adding optional key to MetadataSpec

### DIFF
--- a/codalab/bundles/uploaded_bundle.py
+++ b/codalab/bundles/uploaded_bundle.py
@@ -20,11 +20,11 @@ class UploadedBundle(NamedBundle):
     )
 
     METADATA_SPECS.append(
-        MetadataSpec('link_url', str, 'Link URL of bundle.')
+        MetadataSpec('link_url', str, 'Link URL of bundle.', optional=True)
     )
     METADATA_SPECS.append(
         MetadataSpec('link_format', str, 'Link format of bundle. Can be equal to'
-            '"raw" or "zip" (only "raw" is supported as of now).')
+            '"raw" or "zip" (only "raw" is supported as of now).', optional=True)
     )
     # fmt: on
 

--- a/codalab/objects/metadata.py
+++ b/codalab/objects/metadata.py
@@ -46,7 +46,7 @@ class Metadata(object):
                         'Metadata value for %s should be of type %s, was %s (type %s)'
                         % (spec.key, spec.type.__name__, value, type(value).__name__)
                     )
-            elif not spec.generated:
+            elif not spec.generated and not spec.optional:
                 raise UsageError('Missing metadata key: %s' % (spec.key,))
 
     def set_metadata_key(self, key, value):

--- a/codalab/objects/metadata_spec.py
+++ b/codalab/objects/metadata_spec.py
@@ -38,6 +38,7 @@ class MetadataSpec(object):
         formatting=None,
         completer=None,
         hide_when_anonymous=False,
+        optional=False,
     ):
         self.key = key
         self.type = type
@@ -49,6 +50,7 @@ class MetadataSpec(object):
         self.formatting = formatting
         self.completer = completer
         self.hide_when_anonymous = hide_when_anonymous
+        self.optional = optional
 
     def get_constructor(self):
         # Convert from string to type


### PR DESCRIPTION
### Reasons for making this change

Fixes #2687. Adds an `optional` key to MetadataSpec and sets link_url and link_format to be optional, so that they are not required when uploading a new file from the web UI.