### PR TITLE
Downgrade react-bootstrap to fix keyboard shortcuts modal

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1672,6 +1672,27 @@
         "regenerator-runtime": "^0.12.0"
       }
     },
+    "@babel/runtime-corejs2": {
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.11.0.tgz",
+      "integrity": "sha512-vFaGjzMzlDF4FUWvYBHGM/+nLwIzyf9mFfsU+1KcCGmS6S5/bVENENZ3Kq6BEJnbeMZut9qq72wuNhTvIQoNiA==",
+      "requires": {
+        "core-js": "^2.6.5",
+        "regenerator-runtime": "^0.13.4"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.11",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+          "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
+        },
+        "regenerator-runtime": {
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+        }
+      }
+    },
     "@babel/runtime-corejs3": {
       "version": "7.9.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.9.2.tgz",
@@ -2267,25 +2288,6 @@
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
       "dev": true
     },
-    "@popperjs/core": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.4.4.tgz",
-      "integrity": "sha512-1oO6+dN5kdIA3sKPZhRGJTfGVP4SWV6KqlMOwry4J3HfyD68sl/3KmG7DeYUzvN+RbhXDnv/D8vNNB8168tAMg=="
-    },
-    "@restart/context": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@restart/context/-/context-2.1.4.tgz",
-      "integrity": "sha512-INJYZQJP7g+IoDUh/475NlGiTeMfwTXUEr3tmRneckHIxNolGOW9CTq83S8cxq0CgJwwcMzMJFchxvlwe7Rk8Q=="
-    },
-    "@restart/hooks": {
-      "version": "0.3.25",
-      "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.3.25.tgz",
-      "integrity": "sha512-m2v3N5pxTsIiSH74/sb1yW8D9RxkJidGW+5Mfwn/lHb2QzhZNlaU1su7abSyT9EGf0xS/0waLjrf7/XxQHUk7w==",
-      "requires": {
-        "lodash": "^4.17.15",
-        "lodash-es": "^4.17.15"
-      }
-    },
     "@semantic-ui-react/event-stack": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@semantic-ui-react/event-stack/-/event-stack-3.1.1.tgz",
@@ -2580,11 +2582,6 @@
         }
       }
     },
-    "@types/classnames": {
-      "version": "2.2.10",
-      "resolved": "https://registry.npmjs.org/@types/classnames/-/classnames-2.2.10.tgz",
-      "integrity": "sha512-1UzDldn9GfYYEsWWnn/P4wkTlkZDH7lDb0wBMGbtIQc9zXEQq7FlKBdZUn6OBqD8sKZZ2RQO2mAjGpXiDGoRmQ=="
-    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
@@ -2636,11 +2633,6 @@
           }
         }
       }
-    },
-    "@types/invariant": {
-      "version": "2.2.33",
-      "resolved": "https://registry.npmjs.org/@types/invariant/-/invariant-2.2.33.tgz",
-      "integrity": "sha512-/jUNmS8d4bCKdqslfxW6dg/9Gksfzxz67IYfqApHn+HvHlMVXwYv2zpTDnS/yaK9BB0i0GlBTaYci0EFE62Hmw=="
     },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.1",
@@ -2750,11 +2742,6 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
       "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
       "dev": true
-    },
-    "@types/warning": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.0.tgz",
-      "integrity": "sha1-DSUBJorY+ZYrdA04fEZU9fjiPlI="
     },
     "@types/yargs": {
       "version": "13.0.8",
@@ -11002,6 +10989,11 @@
       "resolved": "https://registry.npmjs.org/keyboard-key/-/keyboard-key-1.1.0.tgz",
       "integrity": "sha512-qkBzPTi3rlAKvX7k0/ub44sqOfXeLc/jcnGGmj5c7BJpU8eDrEVPyhCvNYAaoubbsLm9uGWwQJO1ytQK1a9/dQ=="
     },
+    "keycode": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.2.0.tgz",
+      "integrity": "sha1-PQr1bce4uOXLqNCpfxByBO7CKwQ="
+    },
     "killable": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/killable/-/killable-1.0.1.tgz",
@@ -11511,11 +11503,6 @@
       "version": "4.17.19",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
       "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
-    },
-    "lodash-es": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.15.tgz",
-      "integrity": "sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ=="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
@@ -14551,109 +14538,28 @@
       }
     },
     "react-bootstrap": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-1.3.0.tgz",
-      "integrity": "sha512-GYj0c6FO9mx7DaO8Xyz2zs0IcQ6CGCtM3O6/feIoCaG4N8B0+l4eqL7stlMcLpqO4d8NG2PoMO/AbUOD+MO7mg==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-0.33.1.tgz",
+      "integrity": "sha512-qWTRravSds87P8WC82tETy2yIso8qDqlIm0czsrduCaYAFtHuyLu0XDbUlfLXeRzqgwm5sRk2wRaTNoiVkk/YQ==",
       "requires": {
-        "@babel/runtime": "^7.4.2",
-        "@restart/context": "^2.1.4",
-        "@restart/hooks": "^0.3.21",
-        "@types/classnames": "^2.2.10",
-        "@types/invariant": "^2.2.33",
-        "@types/prop-types": "^15.7.3",
-        "@types/react": "^16.9.35",
-        "@types/react-transition-group": "^4.4.0",
-        "@types/warning": "^3.0.0",
-        "classnames": "^2.2.6",
-        "dom-helpers": "^5.1.2",
+        "@babel/runtime-corejs2": "^7.0.0",
+        "classnames": "^2.2.5",
+        "dom-helpers": "^3.2.0",
         "invariant": "^2.2.4",
-        "prop-types": "^15.7.2",
-        "prop-types-extra": "^1.1.0",
-        "react-overlays": "^4.1.0",
-        "react-transition-group": "^4.4.1",
-        "uncontrollable": "^7.0.0",
-        "warning": "^4.0.3"
+        "keycode": "^2.2.0",
+        "prop-types": "^15.6.1",
+        "prop-types-extra": "^1.0.1",
+        "react-overlays": "^0.9.0",
+        "react-prop-types": "^0.4.0",
+        "react-transition-group": "^2.0.0",
+        "uncontrollable": "^7.0.2",
+        "warning": "^3.0.0"
       },
       "dependencies": {
-        "@babel/runtime": {
-          "version": "7.11.0",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.0.tgz",
-          "integrity": "sha512-qArkXsjJq7H+T86WrIFV0Fnu/tNOkZ4cgXmjkzAu3b/58D5mFIO8JH/y77t7C9q0OdDRdh9s7Ue5GasYssxtXw==",
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        },
-        "@types/prop-types": {
-          "version": "15.7.3",
-          "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
-          "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
-        },
-        "@types/react": {
-          "version": "16.9.44",
-          "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.44.tgz",
-          "integrity": "sha512-BtLoJrXdW8DVZauKP+bY4Kmiq7ubcJq+H/aCpRfvPF7RAT3RwR73Sg8szdc2YasbAlWBDrQ6Q+AFM0KwtQY+WQ==",
-          "requires": {
-            "@types/prop-types": "*",
-            "csstype": "^3.0.2"
-          }
-        },
-        "@types/react-transition-group": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.0.tgz",
-          "integrity": "sha512-/QfLHGpu+2fQOqQaXh8MG9q03bFENooTb/it4jr5kKaZlDQfWvjqWZg48AwzPVMBHlRuTRAY7hRHCEOXz5kV6w==",
-          "requires": {
-            "@types/react": "*"
-          }
-        },
-        "csstype": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.2.tgz",
-          "integrity": "sha512-ofovWglpqoqbfLNOTBNZLSbMuGrblAf1efvvArGKOZMBrIoJeu5UsAipQolkijtyQx5MtAzT/J9IHj/CEY1mJw=="
-        },
-        "dom-helpers": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.0.tgz",
-          "integrity": "sha512-Ru5o9+V8CpunKnz5LGgWXkmrH/20cGKwcHwS4m73zIvs54CN9epEmT/HLqFJW3kXpakAFkEdzgy1hzlJe3E4OQ==",
-          "requires": {
-            "@babel/runtime": "^7.8.7",
-            "csstype": "^3.0.2"
-          }
-        },
-        "prop-types": {
-          "version": "15.7.2",
-          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-          "requires": {
-            "loose-envify": "^1.4.0",
-            "object-assign": "^4.1.1",
-            "react-is": "^16.8.1"
-          }
-        },
-        "react-is": {
-          "version": "16.13.1",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-        },
-        "react-transition-group": {
-          "version": "4.4.1",
-          "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.1.tgz",
-          "integrity": "sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==",
-          "requires": {
-            "@babel/runtime": "^7.5.5",
-            "dom-helpers": "^5.0.1",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "regenerator-runtime": {
-          "version": "0.13.7",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-        },
         "warning": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-          "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
+          "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
           "requires": {
             "loose-envify": "^1.0.0"
           }
@@ -15082,66 +14988,22 @@
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "react-overlays": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-4.1.0.tgz",
-      "integrity": "sha512-vdRpnKe0ckWOOD9uWdqykLUPHLPndIiUV7XfEKsi5008xiyHCfL8bxsx4LbMrfnxW1LzRthLyfy50XYRFNQqqw==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-0.9.1.tgz",
+      "integrity": "sha512-b0asy/zHtRd0i2+2/uNxe3YVprF3bRT1guyr791DORjCzE/HSBMog+ul83CdtKQ1kZ+pLnxWCu5W3BMysFhHdQ==",
       "requires": {
-        "@babel/runtime": "^7.4.5",
-        "@popperjs/core": "^2.0.0",
-        "@restart/hooks": "^0.3.12",
-        "@types/warning": "^3.0.0",
-        "dom-helpers": "^5.1.0",
-        "prop-types": "^15.7.2",
-        "uncontrollable": "^7.0.0",
-        "warning": "^4.0.3"
+        "classnames": "^2.2.5",
+        "dom-helpers": "^3.2.1",
+        "prop-types": "^15.5.10",
+        "prop-types-extra": "^1.0.1",
+        "react-transition-group": "^2.2.1",
+        "warning": "^3.0.0"
       },
       "dependencies": {
-        "@babel/runtime": {
-          "version": "7.11.0",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.0.tgz",
-          "integrity": "sha512-qArkXsjJq7H+T86WrIFV0Fnu/tNOkZ4cgXmjkzAu3b/58D5mFIO8JH/y77t7C9q0OdDRdh9s7Ue5GasYssxtXw==",
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        },
-        "csstype": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.2.tgz",
-          "integrity": "sha512-ofovWglpqoqbfLNOTBNZLSbMuGrblAf1efvvArGKOZMBrIoJeu5UsAipQolkijtyQx5MtAzT/J9IHj/CEY1mJw=="
-        },
-        "dom-helpers": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.0.tgz",
-          "integrity": "sha512-Ru5o9+V8CpunKnz5LGgWXkmrH/20cGKwcHwS4m73zIvs54CN9epEmT/HLqFJW3kXpakAFkEdzgy1hzlJe3E4OQ==",
-          "requires": {
-            "@babel/runtime": "^7.8.7",
-            "csstype": "^3.0.2"
-          }
-        },
-        "prop-types": {
-          "version": "15.7.2",
-          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-          "requires": {
-            "loose-envify": "^1.4.0",
-            "object-assign": "^4.1.1",
-            "react-is": "^16.8.1"
-          }
-        },
-        "react-is": {
-          "version": "16.13.1",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-        },
-        "regenerator-runtime": {
-          "version": "0.13.7",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-        },
         "warning": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-          "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
+          "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
           "requires": {
             "loose-envify": "^1.0.0"
           }
@@ -15173,6 +15035,24 @@
             "object-is": "^1.0.1",
             "object-keys": "^1.1.1",
             "regexp.prototype.flags": "^1.2.0"
+          }
+        }
+      }
+    },
+    "react-prop-types": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/react-prop-types/-/react-prop-types-0.4.0.tgz",
+      "integrity": "sha1-+ZsL+0AGkpya8gUefBQUpcdbk9A=",
+      "requires": {
+        "warning": "^3.0.0"
+      },
+      "dependencies": {
+        "warning": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
+          "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
+          "requires": {
+            "loose-envify": "^1.0.0"
           }
         }
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,7 +26,7 @@
     "material-ui-chip-input": "^1.1.0",
     "query-string": "^6.13.1",
     "react": "^16.13.1",
-    "react-bootstrap": "^1.3.0",
+    "react-bootstrap": "^0.33.1",
     "react-circular-progressbar": "^2.0.3",
     "react-cookie": "^4.0.3",
     "react-copy-to-clipboard": "^5.0.2",


### PR DESCRIPTION
### Reasons for making this change

It turns out, when I was making PR #2497 (to add react-bootstrap as an explicit rather than implicit dependency), I accidentally added react-bootstrap v1.x (which is for Bootstrap 4) instead of react-bootstrap v0.x (for Bootstrap 3). This PR fixes that by making sure react-bootstrap is back to its normal version.

### Related issues

Fixes #2653.