### PR TITLE
Log hostname when executing slurm jobs

### DIFF
--- a/codalab/worker_manager/slurm_batch_worker_manager.py
+++ b/codalab/worker_manager/slurm_batch_worker_manager.py
@@ -323,6 +323,17 @@ class SlurmBatchWorkerManager(WorkerManager):
             for key in sorted(slurm_args.keys())
         ]
 
+        # Log the hostname of the node that the SlurmWorkerManager
+        # is running a worker on.
+        log_hostname = textwrap.dedent(
+            '''
+            echo "Worker is executing on host: $(hostname)" || true
+            '''
+            + '\n\n'
+            if not self.args.password_file
+            else ''
+        )
+
         # Check the existence of environment variables CODALAB_USERNAME and
         # CODALAB_PASSWORD when password_file is not given.
         worker_authentication = textwrap.dedent(
@@ -367,6 +378,7 @@ class SlurmBatchWorkerManager(WorkerManager):
             '#!/usr/bin/env bash\n\n'
             + '\n'.join(sbatch_args)
             + '\n\n'
+            + log_hostname
             + worker_authentication
             + gpu_isolation
             + ' '.join(srun_args)

--- a/codalab/worker_manager/slurm_batch_worker_manager.py
+++ b/codalab/worker_manager/slurm_batch_worker_manager.py
@@ -330,8 +330,6 @@ class SlurmBatchWorkerManager(WorkerManager):
             echo "Worker is executing on host: $(hostname)" || true
             '''
             + '\n\n'
-            if not self.args.password_file
-            else ''
         )
 
         # Check the existence of environment variables CODALAB_USERNAME and


### PR DESCRIPTION
Right now, the SlurmWorkerManager creates job names like `name-codalab-slurm-worker-d79260eb`. It's hard to trace this back to the actual host that was being used (and we can't access this hostname ahead of time, since we don't know which node the job will land on).

As a result, this adds a logging statement that prints out what the hostname is .