### PR TITLE
Make sure run container names are random

### DIFF
--- a/codalab/worker/docker_utils.py
+++ b/codalab/worker/docker_utils.py
@@ -13,6 +13,7 @@ from dateutil import parser, tz
 import datetime
 import re
 import requests
+import secrets
 
 
 MIN_API_VERSION = '1.17'
@@ -172,7 +173,7 @@ def start_bundle_container(
         environment['NVIDIA_VISIBLE_DEVICES'] = ','.join(gpuset) if gpuset else 'all'
 
     # Name the container with the UUID for readability
-    container_name = 'codalab_run_%s' % uuid
+    container_name = f"codalab_run_{uuid}_{secrets.token_hex(5)}"
     container = client.containers.run(
         image=docker_image,
         command=docker_command,


### PR DESCRIPTION
### Reasons for making this change

Fixes #2111. That issue happens whenever there's a problem with starting the Docker container, it isn't removed, and a new container with the same name (for the same run) is attempted to start. This wasn't a problem until #1437 was merged, because before #1437 was merged, all run containers would have been assigned random names.

This PR keeps the UUID in the container name, but adds some randomness to the names so that names cannot clash.