### PR TITLE
Refactor scrolling on worksheets ui

### DIFF
--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -2,13 +2,7 @@ import * as React from 'react';
 import $ from 'jquery';
 import _ from 'underscore';
 import { withStyles } from '@material-ui/core/styles';
-import {
-    keepPosInView,
-    renderPermissions,
-    getAfterSortKey,
-    createAlertText,
-    getIds,
-} from '../../../util/worksheet_utils';
+import { renderPermissions, getAfterSortKey, createAlertText } from '../../../util/worksheet_utils';
 import * as Mousetrap from '../../../util/ws_mousetrap_fork';
 import WorksheetItemList from '../WorksheetItemList';
 import ReactDOM from 'react-dom';
@@ -95,6 +89,9 @@ class Worksheet extends React.Component {
         };
         this.copyCallbacks = [];
         this.bundleTableID = new Set();
+
+        // Throttle so that if keys are held down, we don't suffer a huge lag.
+        this.scrollToItem = _.throttle(this.__innerScrollToItem, 50).bind(this);
     }
 
     fetch(props) {
@@ -665,32 +662,13 @@ class Worksheet extends React.Component {
         }
     };
 
-    scrollToItem = (index, subIndex) => {
-        // scroll the window to keep the focused element in view if needed
-        var __innerScrollToItem = function(index, subIndex) {
-            // Compute the current position of the focused item.
-            var pos;
-            if (index === -1) {
-                pos = -1000000; // Scroll all the way to the top
-            } else {
-                var item = this.refs.list.refs['item' + index];
-                if (!item) {
-                    // Don't scroll to an item if it doesn't exist.
-                    return;
-                }
-                if (this._numTableRows(item.props.item)) {
-                    item = item.refs['row' + subIndex]; // Specifically, the row
-                }
-                var node = ReactDOM.findDOMNode(item);
-                pos = node.getBoundingClientRect().top;
-            }
-            keepPosInView(pos);
-        };
-
-        // Throttle so that if keys are held down, we don't suffer a huge lag.
-        if (this.throttledScrollToItem === undefined)
-            this.throttledScrollToItem = _.throttle(__innerScrollToItem, 50).bind(this);
-        this.throttledScrollToItem(index, subIndex);
+    __innerScrollToItem = (index, subIndex) => {
+        const node = subIndex
+            ? document.getElementById(`codalab-worksheet-item-${index}-subitem-${subIndex}`)
+            : document.getElementById(`codalab-worksheet-item-${index}`);
+        if (node) {
+            node.scrollIntoView({ block: 'center' });
+        }
     };
 
     componentDidMount() {

--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -1261,15 +1261,6 @@ class Worksheet extends React.Component {
         rawIndexAfterEditMode,
         { moveIndex = false, textDeleted = false } = {},
     ) => {
-        let itemHeights = {};
-        if (this.refs.list && this.refs.list.refs) {
-            for (let refName in this.refs.list.refs) {
-                itemHeights[refName] = ReactDOM.findDOMNode(
-                    this.refs.list.refs[refName],
-                ).clientHeight;
-            }
-        }
-        this.setState({ itemHeights });
         if (partialUpdateItems === undefined) {
             $('#update_progress').show();
             this.setState({ updating: true });
@@ -1610,7 +1601,6 @@ class Worksheet extends React.Component {
                 setDeleteItemCallback={this.setDeleteItemCallback}
                 addCopyBundleRowsCallback={this.addCopyBundleRowsCallback}
                 onAsyncItemLoad={this.onAsyncItemLoad}
-                itemHeights={this.state.itemHeights}
                 updateBundleBlockSchema={this.updateBundleBlockSchema}
                 updateSchemaItem={this.updateSchemaItem}
             />

--- a/frontend/src/components/worksheets/WorksheetItemList.js
+++ b/frontend/src/components/worksheets/WorksheetItemList.js
@@ -50,7 +50,7 @@ const addWorksheetItems = function(props, worksheet_items, prevItem, afterItem) 
         url = '/bundles/' + item.bundles_spec.bundle_infos[0].uuid;
     if (item.subworksheet_info) url = '/worksheets/' + item.subworksheet_info.uuid;
 
-    props.key = props.ref = 'item' + props.focusIndex;
+    props.key = props.id = 'codalab-worksheet-item-' + props.focusIndex;
     props.url = url;
     props.prevItem = prevItem;
     props.itemHeight = (props.itemHeights || {})[props.ref] || 100;
@@ -103,6 +103,7 @@ const addWorksheetItems = function(props, worksheet_items, prevItem, afterItem) 
             after_sort_key={props.after_sort_key}
             ids={props.ids}
             updateSchemaItem={props.updateSchemaItem}
+            id={props.id}
         >
             {elem}
         </ItemWrapper>,

--- a/frontend/src/components/worksheets/WorksheetItemList.js
+++ b/frontend/src/components/worksheets/WorksheetItemList.js
@@ -53,7 +53,6 @@ const addWorksheetItems = function(props, worksheet_items, prevItem, afterItem) 
     props.key = props.id = 'codalab-worksheet-item-' + props.focusIndex;
     props.url = url;
     props.prevItem = prevItem;
-    props.itemHeight = (props.itemHeights || {})[props.ref] || 100;
     props.after_sort_key = getAfterSortKey(
         props.item,
         props.item.mode === 'markup_block' ? undefined : props.subFocusIndex,
@@ -243,7 +242,6 @@ class WorksheetItemList extends React.Component {
                         updateBundleBlockSchema: this.props.updateBundleBlockSchema,
                         saveAndUpdateWorksheet: this.props.saveAndUpdateWorksheet,
                         onAsyncItemLoad: (item) => this.props.onAsyncItemLoad(index, item),
-                        itemHeights: this.props.itemHeights,
                         updateSchemaItem: this.props.updateSchemaItem,
                     };
                     addWorksheetItems(

--- a/frontend/src/components/worksheets/items/ItemWrapper.js
+++ b/frontend/src/components/worksheets/items/ItemWrapper.js
@@ -18,7 +18,7 @@ class ItemWrapper extends React.Component {
             after_sort_key,
             worksheetUUID,
             reloadWorksheet,
-            saveAndUpdateWorksheet,
+            id,
         } = this.props;
         const { showNewRun, showNewText } = this.props;
 
@@ -28,7 +28,7 @@ class ItemWrapper extends React.Component {
 
         const { isDummyItem } = item;
         return (
-            <div className={isDummyItem ? '' : classes.container}>
+            <div className={isDummyItem ? '' : classes.container} id={id}>
                 {!isDummyItem && <div className={classes.main}>{children}</div>}
                 {showNewRun && (
                     <div className={classes.insertBox}>

--- a/frontend/src/components/worksheets/items/RecordItem.js
+++ b/frontend/src/components/worksheets/items/RecordItem.js
@@ -68,14 +68,13 @@ class RecordItem extends React.Component {
         let k = header[0];
         let v = header[1];
         let items = item.rows.map(function(item, index) {
-            let ref = 'row' + index;
             let displayValue = JSON.stringify(item[v]); // stringify is needed to convert metadata objects
             if (displayValue) {
                 displayValue = displayValue.substr(1, displayValue.length - 2); // get rid of ""
             }
 
             return (
-                <tr ref={ref} key={index}>
+                <tr id={`codalab-worksheet-item-${focusIndex}-subitem-${index}`} key={index}>
                     <th>{item[k]}</th>
                     <td style={{ maxWidth: '500px', wordWrap: 'break-word' }}>{displayValue}</td>
                 </tr>
@@ -92,7 +91,6 @@ class RecordItem extends React.Component {
                 {this.state.showDetail && (
                     <BundleDetail
                         uuid={bundleInfo.uuid}
-                        ref='bundleDetail'
                         bundleMetadataChanged={reloadWorksheet}
                         onUpdate={this.receiveBundleInfoUpdates}
                         onClose={() => {

--- a/frontend/src/components/worksheets/items/TableItem/BundleRow.js
+++ b/frontend/src/components/worksheets/items/TableItem/BundleRow.js
@@ -261,7 +261,7 @@ class BundleRow extends Component {
             Mousetrap.unbind('i');
         }
         return (
-            <TableBody classes={{ root: classes.tableBody }}>
+            <TableBody classes={{ root: classes.tableBody }} id={this.props.id}>
                 {/** ---------------------------------------------------------------------------------------------------
                  *  Main Content
                  */}
@@ -294,7 +294,6 @@ class BundleRow extends Component {
                             <BundleDetail
                                 uuid={bundleInfo.uuid}
                                 bundleMetadataChanged={this.props.reloadWorksheet}
-                                ref='bundleDetail'
                                 onUpdate={this.receiveBundleInfoUpdates}
                                 onClose={() => {
                                     this.setState({

--- a/frontend/src/components/worksheets/items/TableItem/TableItem.js
+++ b/frontend/src/components/worksheets/items/TableItem/TableItem.js
@@ -167,7 +167,6 @@ class TableItem extends React.Component<{
         });
         let bodyRowsHtml = rowItems.map((rowItem, rowIndex) => {
             let bundleInfo = bundleInfos[rowIndex];
-            let rowRef = 'row' + rowIndex;
             let rowFocused = this.props.focused && rowIndex === this.props.subFocusIndex;
             let url = '/bundles/' + bundleInfo.uuid;
             let worksheet = bundleInfo.host_worksheet;
@@ -179,7 +178,7 @@ class TableItem extends React.Component<{
             return (
                 <BundleRow
                     key={rowIndex}
-                    ref={rowRef}
+                    id={`codalab-worksheet-item-${this.props.focusIndex}-subitem-${rowIndex}`}
                     worksheetUUID={worksheetUUID}
                     item={rowItem}
                     rowIndex={rowIndex}

--- a/frontend/src/components/worksheets/items/WorksheetItem.js
+++ b/frontend/src/components/worksheets/items/WorksheetItem.js
@@ -79,14 +79,15 @@ class WorksheetItem extends React.Component {
         var tableClassName = this.props.focused ? 'table focused' : 'table';
         var items = this._getItems();
 
+        const { focusIndex } = this.props;
+
         var body_rows_html = items.map(function(row_item, row_index) {
-            var row_ref = 'row' + row_index;
             var row_focused = self.props.focused && row_index === self.props.subFocusIndex;
             var url = '/worksheets/' + row_item.uuid;
             return (
                 <TableWorksheetRow
                     key={row_index}
-                    ref={row_ref}
+                    id={`codalab-worksheet-item-${focusIndex}-subitem-${row_index}`}
                     item={row_item}
                     rowIndex={row_index}
                     focused={row_focused}
@@ -140,7 +141,7 @@ class TableWorksheetRow extends React.Component {
         var item = this.props.item;
         var className = /*'type-worksheet' + */ this.props.focused ? ' focused' : '';
         return (
-            <tr className={className}>
+            <tr className={className} id={this.props.id}>
                 <td>
                     <div onClick={this.handleRowClick}>
                         <a href='#' onClick={this.handleTextClick}>

--- a/frontend/src/util/worksheet_utils.js
+++ b/frontend/src/util/worksheet_utils.js
@@ -155,25 +155,6 @@ export function shorten_uuid(uuid) {
     return uuid.slice(0, 8);
 }
 
-export function keepPosInView(pos) {
-    var navbarHeight = parseInt($('body').css('padding-top'));
-    const worksheetContainerEl = $('#worksheet_container');
-    var viewportHeight = Math.max(worksheetContainerEl.innerHeight() || 0);
-
-    // How far is the pos from top of viewport?
-    var distanceFromTopViewPort = pos - navbarHeight;
-
-    if (distanceFromTopViewPort < 100 || distanceFromTopViewPort > viewportHeight * 0.8) {
-        // If pos is off the top of the screen or it is more than 80% down the screen,
-        // then scroll so that it is at 50% down the screen.
-        // Where is the top of the element on the page and does it fit in the
-        // the upper half of the page?
-        var scrollTo =
-            worksheetContainerEl.scrollTop() + distanceFromTopViewPort - viewportHeight * 0.5;
-        worksheetContainerEl.stop(true).animate({ scrollTop: scrollTo }, 50);
-    }
-}
-
 // Whether an interpreted item changed - used in shouldComponentUpdate.
 export function worksheetItemPropsChanged(props, nextProps) {
     /*console.log('worksheetItemPropsChanged',


### PR DESCRIPTION
Refactor scrolling on worksheets ui.
- Rather than string refs, I directly get elements through their IDs. This is better than using string refs, which are deprecated and can be buggy.
- Don't use keepPosInView -- use [scrollIntoView()](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView) instead, which is simpler and faster.


Fixes #2685, related to #2712.