### PR TITLE
Fix typo in worker

### DIFF
--- a/codalab/worker/worker.py
+++ b/codalab/worker/worker.py
@@ -286,7 +286,7 @@ class Worker:
                             self.terminate = True
                         if self.terminate:
                             break
-                        sleep(5)
+                        time.sleep(5)
         self.cleanup()
 
     def cleanup(self):


### PR DESCRIPTION
`s/sleep(5)/time.sleep(5)/`