### PR TITLE
Worker telemetry with Sentry

### DIFF
--- a/codalab/lib/telemetry_util.py
+++ b/codalab/lib/telemetry_util.py
@@ -1,0 +1,58 @@
+import logging
+import os
+
+import sentry_sdk
+
+CODALAB_SENTRY_INGEST = os.getenv("CODALAB_SENTRY_INGEST_URL", None)
+logger = logging.getLogger(__name__)
+
+
+def run_if_sentry_ingest_provided(f):
+    def wrapper(*args, **kwargs):
+        if CODALAB_SENTRY_INGEST:
+            return f(*args, **kwargs)
+
+    return wrapper
+
+
+def run_once(f):
+    def wrapper(*args, **kwargs):
+        if not wrapper.has_run:
+            wrapper.has_run = True
+            return f(*args, **kwargs)
+
+    wrapper.has_run = False
+    return wrapper
+
+
+@run_if_sentry_ingest_provided
+def initialize_sentry():
+    """
+    Initialize the Sentry SDK if it hasn't already been initialized.
+    """
+    if sentry_sdk.Hub.current.client is None:
+        sentry_sdk.init(CODALAB_SENTRY_INGEST)
+        print_sentry_warning()
+
+
+@run_if_sentry_ingest_provided
+def load_sentry_data(username=None, **kwargs):
+    with sentry_sdk.configure_scope() as scope:
+        if username:
+            scope.user = {"username": username}
+        for kwarg, value in kwargs.items():
+            scope.set_tag(kwarg, value)
+
+
+@run_if_sentry_ingest_provided
+def capture_exception(exception=None):
+    sentry_sdk.capture_exception(exception)
+
+
+@run_if_sentry_ingest_provided
+@run_once
+def print_sentry_warning():
+    logger.info("@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@")
+    logger.info("@       ATTENTION: Reporting exceptions to the CodaLab team via Sentry.      @")
+    logger.info("@  This will log personally-identifying data (e.g., username, instance URL). @")
+    logger.info("@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@")

--- a/codalab/lib/telemetry_util.py
+++ b/codalab/lib/telemetry_util.py
@@ -7,14 +7,6 @@ CODALAB_SENTRY_INGEST = os.getenv("CODALAB_SENTRY_INGEST_URL", None)
 logger = logging.getLogger(__name__)
 
 
-def run_if_sentry_ingest_provided(f):
-    def wrapper(*args, **kwargs):
-        if CODALAB_SENTRY_INGEST:
-            return f(*args, **kwargs)
-
-    return wrapper
-
-
 def run_once(f):
     def wrapper(*args, **kwargs):
         if not wrapper.has_run:
@@ -25,7 +17,10 @@ def run_once(f):
     return wrapper
 
 
-@run_if_sentry_ingest_provided
+def using_sentry():
+    return CODALAB_SENTRY_INGEST is not None
+
+
 def initialize_sentry():
     """
     Initialize the Sentry SDK if it hasn't already been initialized.
@@ -35,7 +30,6 @@ def initialize_sentry():
         print_sentry_warning()
 
 
-@run_if_sentry_ingest_provided
 def load_sentry_data(username=None, **kwargs):
     with sentry_sdk.configure_scope() as scope:
         if username:
@@ -44,12 +38,10 @@ def load_sentry_data(username=None, **kwargs):
             scope.set_tag(kwarg, value)
 
 
-@run_if_sentry_ingest_provided
 def capture_exception(exception=None):
     sentry_sdk.capture_exception(exception)
 
 
-@run_if_sentry_ingest_provided
 @run_once
 def print_sentry_warning():
     logger.info("@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@")

--- a/codalab/worker/main.py
+++ b/codalab/worker/main.py
@@ -14,7 +14,7 @@ import sys
 import psutil
 
 from codalab.lib.formatting import parse_size
-from codalab.lib.telemetry_util import initialize_sentry, load_sentry_data
+from codalab.lib.telemetry_util import initialize_sentry, load_sentry_data, using_sentry
 from .bundle_service_client import BundleServiceClient, BundleAuthException
 from . import docker_utils
 from .worker import Worker
@@ -200,16 +200,16 @@ def main():
         format='%(asctime)s %(message)s', level=(logging.DEBUG if args.verbose else logging.INFO)
     )
 
-    # Initialize sentry logging (this is a null-op if
-    # the CODALAB_SENTRY_INGEST_URL env var is not set).
-    initialize_sentry()
+    # Initialize sentry logging
+    if using_sentry():
+        initialize_sentry()
 
     # This quits if connection unsuccessful
     bundle_service = connect_to_codalab_server(args.server, args.password_file)
 
-    # Load some data into sentry (this is a null-op if
-    # the CODALAB_SENTRY_INGEST_URL env var is not set).
-    load_sentry_data(username=bundle_service._username, **vars(args))
+    # Load some data into sentry
+    if using_sentry():
+        load_sentry_data(username=bundle_service._username, **vars(args))
 
     if args.shared_file_system:
         # No need to store bundles locally if filesystems are shared

--- a/codalab/worker/main.py
+++ b/codalab/worker/main.py
@@ -14,6 +14,7 @@ import sys
 import psutil
 
 from codalab.lib.formatting import parse_size
+from codalab.lib.telemetry_util import initialize_sentry, load_sentry_data
 from .bundle_service_client import BundleServiceClient, BundleAuthException
 from . import docker_utils
 from .worker import Worker
@@ -193,12 +194,23 @@ def connect_to_codalab_server(server, password_file):
 
 def main():
     args = parse_args()
-    # This quits if connection unsuccessful
-    bundle_service = connect_to_codalab_server(args.server, args.password_file)
+
     # Configure logging
     logging.basicConfig(
         format='%(asctime)s %(message)s', level=(logging.DEBUG if args.verbose else logging.INFO)
     )
+
+    # Initialize sentry logging (this is a null-op if
+    # the CODALAB_SENTRY_INGEST_URL env var is not set).
+    initialize_sentry()
+
+    # This quits if connection unsuccessful
+    bundle_service = connect_to_codalab_server(args.server, args.password_file)
+
+    # Load some data into sentry (this is a null-op if
+    # the CODALAB_SENTRY_INGEST_URL env var is not set).
+    load_sentry_data(username=bundle_service._username, **vars(args))
+
     if args.shared_file_system:
         # No need to store bundles locally if filesystems are shared
         local_bundles_dir = None

--- a/codalab/worker/worker.py
+++ b/codalab/worker/worker.py
@@ -13,6 +13,7 @@ from typing import Optional, Set, Dict
 import psutil
 
 import docker
+from codalab.lib.telemetry_util import capture_exception, initialize_sentry, load_sentry_data
 import codalab.worker.docker_utils as docker_utils
 import requests
 
@@ -108,6 +109,11 @@ class Worker:
         self.terminate_and_restage = False
         self.pass_down_termination = pass_down_termination
         self.exit_on_exception = exit_on_exception
+
+        # Initialize sentry logging (this is a null-op if
+        # the CODALAB_SENTRY_INGEST_URL env var is not set).
+        initialize_sentry()
+        load_sentry_data(username=bundle_service._username)
 
         self.last_checkin_successful = False
         self.last_time_ran = None  # type: Optional[bool]
@@ -259,13 +265,18 @@ class Worker:
                     self.terminate = True
             except Exception:
                 self.last_checkin_successful = False
+                capture_exception()
                 traceback.print_exc()
                 if self.exit_on_exception:
-                    logger.error('Encountered exception, terminating the worker...')
+                    logger.error(
+                        'Encountered exception, terminating the worker after sleeping for 5 minutes...'
+                    )
                     self.terminate = True
+                    # Sleep for 5 minutes
+                    time.sleep(5 * 60)
                 else:
                     # Sleep for a long time so we don't keep on failing.
-                    # We sleep in 5-second increments, itermittently checking
+                    # We sleep in 5-second increments to check
                     # if the worker needs to terminate (say, if it's received
                     # a SIGTERM signal).
                     logger.error('Sleeping for 1 hour due to exception...please help me!')

--- a/codalab_service.py
+++ b/codalab_service.py
@@ -239,6 +239,13 @@ CODALAB_ARGUMENTS = [
     CodalabArg(name='use_ssl', help='Use HTTPS instead of HTTP', type=bool, default=False),
     CodalabArg(name='ssl_cert_file', help='Path to the cert file for SSL'),
     CodalabArg(name='ssl_key_file', help='Path to the key file for SSL'),
+    ### Sentry
+    CodalabArg(
+        name='sentry_ingest_url',
+        help=(
+            'Ingest URL for logging exceptions with Sentry. If not provided, Sentry is not used.'
+        ),
+    ),
     ### Worker manager
     CodalabArg(
         name='worker_manager_type',

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ python-dateutil==2.8.1
 diffimg==0.2.3
 selenium==3.141.0
 requests==2.24.0
+sentry-sdk==0.16.3


### PR DESCRIPTION
### Reasons for making this change

Fixes https://github.com/codalab/codalab-worksheets/issues/2720

This PR adds support for doing some telemetry with [Sentry](https://sentry.io/). When I sat down to fix the issue above, I realized that (1) email is a bit annoying, since you have to configure this per-server and possibly even per-user (i.e., we can't just use codalab sendgrid here, and different servers might have different postfix configurations / use different ports, etc etc), and (2) people have already built robust tooling for this sort of stuff (e.g., Sentry).

So, I decided to explore it a bit and it turns out to be more featureful and easy to use than I expected. In short, Sentry will:

- Log any unhandled exceptions that cause the application to crash
- Log handled exceptions in the `Worker` before we sleep for an hour or exit.

One primary concern I had was to make it **exceedingly clear** when user data is getting logged and sent to remote servers by Sentry (and that this is False by default everywhere). When Sentry is initialized, a glaring error message is printed:

```
2020-08-09 19:31:45,947 @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
2020-08-09 19:31:45,948 @       ATTENTION: Reporting exceptions to the CodaLab team via Sentry.      @
2020-08-09 19:31:45,948 @  This will log personally-identifying data (e.g., username, instance URL). @
2020-08-09 19:31:45,948 @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
```