### PR TITLE
Convert some logger.error s into logger.warning s

### DIFF
--- a/codalab/worker/docker_image_manager.py
+++ b/codalab/worker/docker_image_manager.py
@@ -137,7 +137,7 @@ class DockerImageManager:
                         # trying to remove images in 1st case. Since we can't do much for images in 1st case, we
                         # just continue with our lives, hoping it will get deleted once it's no longer in use and
                         # the cache becomes full again
-                        logger.error(
+                        logger.warning(
                             "Cannot forcibly remove image %s from cache: %s", image_tag, err
                         )
             logger.debug("Stopping docker image manager cleanup")
@@ -177,7 +177,7 @@ class DockerImageManager:
                             # It's possible that we get a 404 not found error here when removing the image,
                             # since another worker on the same system has already done so. We just
                             # ignore this 404, since any extraneous tags will be removed during the next iteration.
-                            logger.error(
+                            logger.warning(
                                 "Attempted to remove image %s from cache, but image was not found: %s",
                                 tag,
                                 err,

--- a/codalab/worker/docker_utils.py
+++ b/codalab/worker/docker_utils.py
@@ -95,7 +95,7 @@ def get_available_runtime():
             raise DockerException("nvidia-docker runtime available but no NVIDIA devices detected")
         return NVIDIA_RUNTIME
     except DockerException as e:
-        logger.error("Cannot initialize NVIDIA runtime, no GPU support: %s", e)
+        logger.warning("Cannot initialize NVIDIA runtime, no GPU support: %s", e)
         return DEFAULT_RUNTIME
 
 


### PR DESCRIPTION
These aren't really errors, but more warnings for the user. I'm mostly making this change because sentry records every `logger.error`, and these are rather innocuous statements.