### PR TITLE
Capture exceptions from the DockerImageManager

### DIFF
--- a/codalab/worker/docker_image_manager.py
+++ b/codalab/worker/docker_image_manager.py
@@ -5,6 +5,7 @@ import traceback
 import logging
 
 import docker
+from codalab.lib.telemetry_util import capture_exception, using_sentry
 import codalab.worker.docker_utils as docker_utils
 
 from codalab.worker.fsm import DependencyStage
@@ -187,6 +188,8 @@ class DockerImageManager:
                     digest=digest, stage=DependencyStage.READY, message=success_message
                 )
             except Exception as ex:
+                if using_sentry():
+                    capture_exception()
                 return ImageAvailabilityState(
                     digest=None, stage=DependencyStage.FAILED, message=failure_message % ex
                 )


### PR DESCRIPTION
This would enable us to get more details about what happened, instead of just seeing the error message log at the end.