### PR TITLE
Ignore 'reference does not exist' when removing docker tags

### DIFF
--- a/codalab/worker/docker_image_manager.py
+++ b/codalab/worker/docker_image_manager.py
@@ -173,7 +173,7 @@ class DockerImageManager:
                     if tag_label == self.CACHE_TAG and timestamp != new_timestamp:
                         try:
                             self._docker.images.remove(tag)
-                        except docker.errors.ImageNotFound as err:
+                        except (docker.errors.ImageNotFound, docker.errors.NotFound) as err:
                             # It's possible that we get a 404 not found error here when removing the image,
                             # since another worker on the same system has already done so. We just
                             # ignore this 404, since any extraneous tags will be removed during the next iteration.

--- a/codalab/worker/docker_image_manager.py
+++ b/codalab/worker/docker_image_manager.py
@@ -173,7 +173,7 @@ class DockerImageManager:
                     if tag_label == self.CACHE_TAG and timestamp != new_timestamp:
                         try:
                             self._docker.images.remove(tag)
-                        except (docker.errors.ImageNotFound, docker.errors.NotFound) as err:
+                        except docker.errors.NotFound as err:
                             # It's possible that we get a 404 not found error here when removing the image,
                             # since another worker on the same system has already done so. We just
                             # ignore this 404, since any extraneous tags will be removed during the next iteration.


### PR DESCRIPTION
Fixes #2757 , here's a sentry log that shows the issue: https://sentry.io/organizations/codalab/issues/1842669967/?project=5383515&query=is%3Aunresolved


Sometimes, when docker can't find the image, it'll throw an error with "reference does not exist". In this case, docker-py raises a `NotFound` error instead of an `ImageNotFound` https://github.com/docker/docker-py/blob/master/docker/errors.py#L30 . So, we catch `NotFound` instead (since `ImageNotFound` is a subclass of it).