### PR TITLE
Resolve potential file not found error

### DIFF
--- a/tests/worker/state_committer_test.py
+++ b/tests/worker/state_committer_test.py
@@ -30,6 +30,7 @@ class JsonStateCommitterTest(unittest.TestCase):
         self.committer.commit(test_state)
         with open(self.state_path) as f:
             self.assertEqual(test_state_json_str, f.read())
+        self.assertFalse(os.path.exists(self.committer.temp_file))
 
     def test_load(self):
         """ Make sure load loads the state file if it exists """


### PR DESCRIPTION
### Reasons for making this change
Sometimes temp file created could be deleted and thus a FileNotFoundError occurs and the gpu worker is down. This commit applies a change suggested by [discussion forum](https://bugs.python.org/issue29573)
<!-- Add a reason for making this change here. -->

### Related issues
#2745
<!-- Add a reference to issues resolved, if applicable (for example, "fixes #1"). -->

### Screenshots

<!-- Add screenshots, if necessary -->

### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
