### PR TITLE
Set timeouts for urlopen calls

### DIFF
--- a/codalab/common.py
+++ b/codalab/common.py
@@ -10,7 +10,7 @@ import http.client
 # http://semver.org/
 CODALAB_VERSION = '0.5.21'
 BINARY_PLACEHOLDER = '<binary>'
-URLOPEN_TIMEOUT = 30
+URLOPEN_TIMEOUT_SECONDS = 30
 
 
 class IntegrityError(ValueError):

--- a/codalab/common.py
+++ b/codalab/common.py
@@ -10,6 +10,7 @@ import http.client
 # http://semver.org/
 CODALAB_VERSION = '0.5.21'
 BINARY_PLACEHOLDER = '<binary>'
+URLOPEN_TIMEOUT = 30
 
 
 class IntegrityError(ValueError):

--- a/codalab/lib/file_util.py
+++ b/codalab/lib/file_util.py
@@ -8,6 +8,7 @@ import sys
 from . import formatting
 import urllib.request, urllib.error, urllib.parse
 import subprocess
+from codalab.common import URLOPEN_TIMEOUT
 
 
 def tracked(fileobj, progress_callback):
@@ -62,7 +63,7 @@ def download_url(source_url, target_path, print_status=False):
     """
     Download the file at |source_url| and write it to |target_path|.
     """
-    in_file = urllib.request.urlopen(source_url, timeout=30)
+    in_file = urllib.request.urlopen(source_url, timeout=URLOPEN_TIMEOUT)
     total_bytes = in_file.info().get('Content-Length')
     if total_bytes:
         total_bytes = int(total_bytes)

--- a/codalab/lib/file_util.py
+++ b/codalab/lib/file_util.py
@@ -62,7 +62,7 @@ def download_url(source_url, target_path, print_status=False):
     """
     Download the file at |source_url| and write it to |target_path|.
     """
-    in_file = urllib.request.urlopen(source_url)
+    in_file = urllib.request.urlopen(source_url, timeout=30)
     total_bytes = in_file.info().get('Content-Length')
     if total_bytes:
         total_bytes = int(total_bytes)

--- a/codalab/lib/file_util.py
+++ b/codalab/lib/file_util.py
@@ -8,7 +8,7 @@ import sys
 from . import formatting
 import urllib.request, urllib.error, urllib.parse
 import subprocess
-from codalab.common import URLOPEN_TIMEOUT
+from codalab.common import URLOPEN_TIMEOUT_SECONDS
 
 
 def tracked(fileobj, progress_callback):
@@ -63,7 +63,7 @@ def download_url(source_url, target_path, print_status=False):
     """
     Download the file at |source_url| and write it to |target_path|.
     """
-    in_file = urllib.request.urlopen(source_url, timeout=URLOPEN_TIMEOUT)
+    in_file = urllib.request.urlopen(source_url, timeout=URLOPEN_TIMEOUT_SECONDS)
     total_bytes = in_file.info().get('Content-Length')
     if total_bytes:
         total_bytes = int(total_bytes)

--- a/codalab/server/auth.py
+++ b/codalab/server/auth.py
@@ -58,7 +58,7 @@ class RestOAuthHandler(object):
             data=urllib.parse.urlencode(data).encode('utf-8'),
         )
         try:
-            response = urllib.request.urlopen(request)
+            response = urllib.request.urlopen(request, timeout=30)
             result = json.loads(response.read().decode())
             return result
         except urllib.error.HTTPError as e:

--- a/codalab/server/auth.py
+++ b/codalab/server/auth.py
@@ -5,7 +5,7 @@ import base64
 import json
 import threading
 import urllib.request, urllib.parse, urllib.error
-from codalab.common import URLOPEN_TIMEOUT
+from codalab.common import URLOPEN_TIMEOUT_SECONDS
 
 
 # TODO(sckoo): clean up auth logic across:
@@ -59,7 +59,7 @@ class RestOAuthHandler(object):
             data=urllib.parse.urlencode(data).encode('utf-8'),
         )
         try:
-            response = urllib.request.urlopen(request, timeout=URLOPEN_TIMEOUT)
+            response = urllib.request.urlopen(request, timeout=URLOPEN_TIMEOUT_SECONDS)
             result = json.loads(response.read().decode())
             return result
         except urllib.error.HTTPError as e:

--- a/codalab/server/auth.py
+++ b/codalab/server/auth.py
@@ -5,6 +5,7 @@ import base64
 import json
 import threading
 import urllib.request, urllib.parse, urllib.error
+from codalab.common import URLOPEN_TIMEOUT
 
 
 # TODO(sckoo): clean up auth logic across:
@@ -58,7 +59,7 @@ class RestOAuthHandler(object):
             data=urllib.parse.urlencode(data).encode('utf-8'),
         )
         try:
-            response = urllib.request.urlopen(request, timeout=30)
+            response = urllib.request.urlopen(request, timeout=URLOPEN_TIMEOUT)
             result = json.loads(response.read().decode())
             return result
         except urllib.error.HTTPError as e:

--- a/codalab/worker/bundle_service_client.py
+++ b/codalab/worker/bundle_service_client.py
@@ -102,7 +102,7 @@ class BundleServiceClient(RestClient):
             data=urllib.parse.urlencode(request_data).encode('utf-8'),
             headers=headers,
         )
-        with closing(urllib.request.urlopen(request)) as response:
+        with closing(urllib.request.urlopen(request, timeout=30)) as response:
             response_data = response.read().decode()
         try:
             token = json.loads(response_data)

--- a/codalab/worker/bundle_service_client.py
+++ b/codalab/worker/bundle_service_client.py
@@ -9,7 +9,7 @@ import urllib.request, urllib.parse, urllib.error
 
 from .rest_client import RestClient, RestClientException
 from .file_util import tar_gzip_directory
-from codalab.common import ensure_str, URLOPEN_TIMEOUT
+from codalab.common import ensure_str, URLOPEN_TIMEOUT_SECONDS
 
 
 def wrap_exception(message):
@@ -102,7 +102,7 @@ class BundleServiceClient(RestClient):
             data=urllib.parse.urlencode(request_data).encode('utf-8'),
             headers=headers,
         )
-        with closing(urllib.request.urlopen(request, timeout=URLOPEN_TIMEOUT)) as response:
+        with closing(urllib.request.urlopen(request, timeout=URLOPEN_TIMEOUT_SECONDS)) as response:
             response_data = response.read().decode()
         try:
             token = json.loads(response_data)

--- a/codalab/worker/bundle_service_client.py
+++ b/codalab/worker/bundle_service_client.py
@@ -9,7 +9,7 @@ import urllib.request, urllib.parse, urllib.error
 
 from .rest_client import RestClient, RestClientException
 from .file_util import tar_gzip_directory
-from codalab.common import ensure_str
+from codalab.common import ensure_str, URLOPEN_TIMEOUT
 
 
 def wrap_exception(message):
@@ -102,7 +102,7 @@ class BundleServiceClient(RestClient):
             data=urllib.parse.urlencode(request_data).encode('utf-8'),
             headers=headers,
         )
-        with closing(urllib.request.urlopen(request, timeout=30)) as response:
+        with closing(urllib.request.urlopen(request, timeout=URLOPEN_TIMEOUT)) as response:
             response_data = response.read().decode()
         try:
             token = json.loads(response_data)

--- a/codalab/worker/rest_client.py
+++ b/codalab/worker/rest_client.py
@@ -88,7 +88,7 @@ class RestClient(object):
             # Return a file-like object containing the contents of the response
             # body, transparently decoding gzip streams if indicated by the
             # Content-Encoding header.
-            response = urllib.request.urlopen(request)
+            response = urllib.request.urlopen(request, timeout=30)
             encoding = response.headers.get('Content-Encoding')
             if not encoding or encoding == 'identity':
                 return response
@@ -96,7 +96,7 @@ class RestClient(object):
                 return un_gzip_stream(response)
             else:
                 raise RestClientException('Unsupported Content-Encoding: ' + encoding, False)
-        with closing(urllib.request.urlopen(request)) as response:
+        with closing(urllib.request.urlopen(request, timeout=30)) as response:
             # If the response is a JSON document, as indicated by the
             # Content-Type header, try to deserialize it and return the result.
             # Otherwise, just ignore the response body and return None.

--- a/codalab/worker/rest_client.py
+++ b/codalab/worker/rest_client.py
@@ -6,7 +6,7 @@ import urllib.request, urllib.parse, urllib.error
 from typing import Dict, Any
 
 from .file_util import un_gzip_stream
-from codalab.common import URLOPEN_TIMEOUT
+from codalab.common import URLOPEN_TIMEOUT_SECONDS
 
 
 class RestClientException(Exception):
@@ -89,7 +89,7 @@ class RestClient(object):
             # Return a file-like object containing the contents of the response
             # body, transparently decoding gzip streams if indicated by the
             # Content-Encoding header.
-            response = urllib.request.urlopen(request, timeout=URLOPEN_TIMEOUT)
+            response = urllib.request.urlopen(request, timeout=URLOPEN_TIMEOUT_SECONDS)
             encoding = response.headers.get('Content-Encoding')
             if not encoding or encoding == 'identity':
                 return response
@@ -97,7 +97,7 @@ class RestClient(object):
                 return un_gzip_stream(response)
             else:
                 raise RestClientException('Unsupported Content-Encoding: ' + encoding, False)
-        with closing(urllib.request.urlopen(request, timeout=URLOPEN_TIMEOUT)) as response:
+        with closing(urllib.request.urlopen(request, timeout=URLOPEN_TIMEOUT_SECONDS)) as response:
             # If the response is a JSON document, as indicated by the
             # Content-Type header, try to deserialize it and return the result.
             # Otherwise, just ignore the response body and return None.

--- a/codalab/worker/rest_client.py
+++ b/codalab/worker/rest_client.py
@@ -6,6 +6,7 @@ import urllib.request, urllib.parse, urllib.error
 from typing import Dict, Any
 
 from .file_util import un_gzip_stream
+from codalab.common import URLOPEN_TIMEOUT
 
 
 class RestClientException(Exception):
@@ -88,7 +89,7 @@ class RestClient(object):
             # Return a file-like object containing the contents of the response
             # body, transparently decoding gzip streams if indicated by the
             # Content-Encoding header.
-            response = urllib.request.urlopen(request, timeout=30)
+            response = urllib.request.urlopen(request, timeout=URLOPEN_TIMEOUT)
             encoding = response.headers.get('Content-Encoding')
             if not encoding or encoding == 'identity':
                 return response
@@ -96,7 +97,7 @@ class RestClient(object):
                 return un_gzip_stream(response)
             else:
                 raise RestClientException('Unsupported Content-Encoding: ' + encoding, False)
-        with closing(urllib.request.urlopen(request, timeout=30)) as response:
+        with closing(urllib.request.urlopen(request, timeout=URLOPEN_TIMEOUT)) as response:
             # If the response is a JSON document, as indicated by the
             # Content-Type header, try to deserialize it and return the result.
             # Otherwise, just ignore the response body and return None.


### PR DESCRIPTION
It's possible that `urlopen` hangs indefinitely, so we add a timeout to prevent this case (since exceptions are usually caught anyway)