### PR TITLE
Use yaml.safe_load instead of yaml.load

### DIFF
--- a/codalab_service.py
+++ b/codalab_service.py
@@ -539,7 +539,7 @@ class CodalabServiceManager(object):
             # so we can't just use regular interpolation with environment variables. Instead,
             # we create a temporary file with the modified docker-compose.yml and use that file instead.
             with open(os.path.join(self.compose_cwd, 'docker-compose.yml')) as f:
-                compose_options = yaml.load(f)
+                compose_options = yaml.safe_load(f)
             for mount_path in self.args.link_mounts.split(","):
                 mount_path = os.path.abspath(mount_path)
                 compose_options["x-codalab-server"]["volumes"].append(


### PR DESCRIPTION
Fixes error shown on CI:

```
codalab_service.py:542: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
```