### PR TITLE
Fix issue 2617 by removing redundant href

### DIFF
--- a/frontend/src/components/worksheets/items/WorksheetItem.js
+++ b/frontend/src/components/worksheets/items/WorksheetItem.js
@@ -144,9 +144,7 @@ class TableWorksheetRow extends React.Component {
             <tr className={className} id={this.props.id}>
                 <td>
                     <div onClick={this.handleRowClick}>
-                        <a href='#' onClick={this.handleTextClick}>
-                            {`${item.title + ' '}[${item.name}]`}
-                        </a>
+                        <a onClick={this.handleTextClick}>{`${item.title + ' '}[${item.name}]`}</a>
                     </div>
                 </td>
             </tr>


### PR DESCRIPTION
### Reasons for making this change

Fix the bug of Command + click on a worksheet link opening up two tabs. 

### Related issues

fixes #2617 

### Screenshots

![2617-fix-popup](https://user-images.githubusercontent.com/34461466/93142221-71a11500-f69a-11ea-81dd-c63aa95103e8.gif)



