### PR TITLE
Provide sticky header for result tables

### DIFF
--- a/frontend/src/components/worksheets/items/TableItem/TableItem.js
+++ b/frontend/src/components/worksheets/items/TableItem/TableItem.js
@@ -140,7 +140,21 @@ class TableItem extends React.Component<{
                     onMouseLeave={(e) => this.setState({ hovered: false })}
                     component='th'
                     key={index}
-                    style={index === 0 ? { paddingLeft: editPermission ? '30px' : '70px' } : {}}
+                    style={
+                        index === 0
+                            ? {
+                                  paddingLeft: editPermission ? '30px' : '70px',
+                                  position: 'sticky',
+                                  top: 0,
+                                  backgroundColor: '#F8F9FA',
+                                  zIndex: 1,
+                              }
+                            : {
+                                  position: 'sticky',
+                                  top: 0,
+                                  backgroundColor: '#F8F9FA',
+                              }
+                    }
                 >
                     {editPermission && index === 0 && (
                         <Tooltip title={'Change the schemas of this table'}>
@@ -223,13 +237,13 @@ class TableItem extends React.Component<{
         });
         return (
             <div className='ws-item'>
-                <TableContainer style={{ overflowX: 'auto' }}>
+                <TableContainer style={{ overflowX: 'auto', maxHeight: 500 }}>
                     <Table className={tableClassName}>
                         <TableHead>
                             <TableRow
                                 style={{
                                     height: 36,
-                                    borderTop: '2px solid #DEE2E6',
+                                    borderTop: '0px solid #DEE2E6',
                                     backgroundColor: '#F8F9FA',
                                 }}
                             >
@@ -294,6 +308,7 @@ class TableItem extends React.Component<{
                                 </TableCell>
                             </TableRow>
                         )}
+
                         {bodyRowsHtml}
                     </Table>
                 </TableContainer>

--- a/frontend/src/components/worksheets/items/TableItem/TableItem.js
+++ b/frontend/src/components/worksheets/items/TableItem/TableItem.js
@@ -307,7 +307,6 @@ class TableItem extends React.Component<{
                                 </TableCell>
                             </TableRow>
                         )}
-
                         {bodyRowsHtml}
                     </Table>
                 </TableContainer>

--- a/frontend/src/components/worksheets/items/TableItem/TableItem.js
+++ b/frontend/src/components/worksheets/items/TableItem/TableItem.js
@@ -244,7 +244,6 @@ class TableItem extends React.Component<{
                                 style={{
                                     height: 36,
                                     borderTop: '0px solid #DEE2E6',
-                                    backgroundColor: '#F8F9FA',
                                 }}
                             >
                                 {headerHtml}

--- a/frontend/src/components/worksheets/items/TableItem/TableItem.js
+++ b/frontend/src/components/worksheets/items/TableItem/TableItem.js
@@ -153,6 +153,7 @@ class TableItem extends React.Component<{
                                   position: 'sticky',
                                   top: 0,
                                   backgroundColor: '#F8F9FA',
+                                  zIndex: 1,
                               }
                     }
                 >


### PR DESCRIPTION
### Reasons for making this change

Enable users to understand which number corresponds to without scrolling up and down to see the column names.
Lock the column names row when scrolling by using the 'sticky' position.

### Related issues

Address #2082 

### Screenshots

![2082-sticky-header-result-table](https://user-images.githubusercontent.com/34461466/93146452-b54c4c80-f6a3-11ea-9460-58b47a93af81.gif)

### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
