### PR TITLE
Add staged_status to bundle details page

### DIFF
--- a/frontend/src/components/Bundle/Bundle.js
+++ b/frontend/src/components/Bundle/Bundle.js
@@ -420,21 +420,7 @@ function renderHeader(bundleInfo, bundleMetadataChanged) {
             <span className={bundleStateClass}>{bundleInfo.state}</span>,
         ),
     );
-    if (
-        bundleInfo.bundle_type === 'run' &&
-        !typeof bundleInfo.metadata.staged_status === 'undefined'
-    ) {
-        rows.push(
-            createRow(
-                bundleInfo,
-                bundleMetadataChanged,
-                'staged_status',
-                bundleInfo.metadata.staged_status,
-            ),
-        );
-    }
     let bundleHeader;
-    console.log(bundleInfo);
     // TODO: don't use the fact that there is a bundle-content element in lgoic
     if (document.getElementById('bundle-content')) {
         let bundle_name = <h3 className='bundle-name'>{bundleInfo.metadata.name}</h3>;

--- a/frontend/src/components/Bundle/Bundle.js
+++ b/frontend/src/components/Bundle/Bundle.js
@@ -420,7 +420,21 @@ function renderHeader(bundleInfo, bundleMetadataChanged) {
             <span className={bundleStateClass}>{bundleInfo.state}</span>,
         ),
     );
+    if (
+        bundleInfo.bundle_type === 'run' &&
+        !typeof bundleInfo.metadata.staged_status === 'undefined'
+    ) {
+        rows.push(
+            createRow(
+                bundleInfo,
+                bundleMetadataChanged,
+                'staged_status',
+                bundleInfo.metadata.staged_status,
+            ),
+        );
+    }
     let bundleHeader;
+    console.log(bundleInfo);
     // TODO: don't use the fact that there is a bundle-content element in lgoic
     if (document.getElementById('bundle-content')) {
         let bundle_name = <h3 className='bundle-name'>{bundleInfo.metadata.name}</h3>;

--- a/frontend/src/components/worksheets/BundleDetail/BundleDetailSideBar.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/BundleDetailSideBar.jsx
@@ -128,6 +128,10 @@ class BundleDetailSideBar extends React.Component<
                     <span className={ `${ classes.stateBox } ${ classes[stateSpecClass] }`} style={{ display: 'inline' }}>
                         <Typography inline color='inherit'>{bundleState}</Typography>
                     </span>
+                    {(bundleInfo.bundle_type === 'run'
+                        && typeof bundleInfo.metadata.staged_status !== 'undefined')
+                        ? bundleInfo.metadata.staged_status
+                        : null}
                     {metadata.failure_message  
                         &&  <div className={classes.wrappableText} style={{ color: 'red', display: 'inline'}}>      
                                 ({metadata.failure_message})


### PR DESCRIPTION
### Reasons for making this change

To make staged_status show up more prominently 

### Related issues

fixes #2623 

### Screenshots

<img width="1026" alt="2623-staeged-status" src="https://user-images.githubusercontent.com/34461466/93380591-45110880-f814-11ea-98f1-81fff51b0b8c.png">

### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
