### PR TITLE
Run negative priority bundles behind those with unspecified priority

### DIFF
--- a/codalab/bundles/run_bundle.py
+++ b/codalab/bundles/run_bundle.py
@@ -32,7 +32,7 @@ class RunBundle(DerivedBundle):
     METADATA_SPECS.append(MetadataSpec('request_cpus', int, 'Number of CPUs allowed for this run.', default=1))
     METADATA_SPECS.append(MetadataSpec('request_gpus', int, 'Number of GPUs allowed for this run.', default=0))
     METADATA_SPECS.append(MetadataSpec('request_queue', str, 'Submit run to this job queue.', hide_when_anonymous=True, default=None))
-    METADATA_SPECS.append(MetadataSpec('request_priority', int, 'Job priority (higher is more important). Negative priority bundles are queued behind bundles with no specified priority. ', default=None))
+    METADATA_SPECS.append(MetadataSpec('request_priority', int, 'Job priority (higher is more important). Negative priority bundles are queued behind bundles with no specified priority.', default=None))
     METADATA_SPECS.append(MetadataSpec('request_network', bool, 'Whether to allow network access.', default=False))
     METADATA_SPECS.append(MetadataSpec('exclude_patterns', list, 'Exclude these file patterns from being saved into the bundle contents.', default=[]))
 

--- a/codalab/bundles/run_bundle.py
+++ b/codalab/bundles/run_bundle.py
@@ -32,7 +32,7 @@ class RunBundle(DerivedBundle):
     METADATA_SPECS.append(MetadataSpec('request_cpus', int, 'Number of CPUs allowed for this run.', default=1))
     METADATA_SPECS.append(MetadataSpec('request_gpus', int, 'Number of GPUs allowed for this run.', default=0))
     METADATA_SPECS.append(MetadataSpec('request_queue', str, 'Submit run to this job queue.', hide_when_anonymous=True, default=None))
-    METADATA_SPECS.append(MetadataSpec('request_priority', int, 'Job priority (higher is more important).', default=None))
+    METADATA_SPECS.append(MetadataSpec('request_priority', int, 'Job priority (higher is more important). Negative priority bundles are queued behind bundles with no specified priority. ', default=None))
     METADATA_SPECS.append(MetadataSpec('request_network', bool, 'Whether to allow network access.', default=False))
     METADATA_SPECS.append(MetadataSpec('exclude_patterns', list, 'Exclude these file patterns from being saved into the bundle contents.', default=[]))
 

--- a/codalab/server/bundle_manager.py
+++ b/codalab/server/bundle_manager.py
@@ -355,14 +355,17 @@ class BundleManager(object):
             user_staged_bundles = [
                 staged_bundles_to_run[queue_position] for queue_position in queue_positions
             ]
-            # Sort the staged bundles for this user, according to
-            # (1) their priority (larger values indicate higher priority) and
-            # (2) whether it requested to run on a specific worker (bundles with a specified
-            # worker have higher priority).
+            # Sort the staged bundles for this user, according to (1) their
+            # priority. Larger values indicate higher priority (i.e., at the
+            # start of the sorted list). Negative priority bundles should be
+            # queued behind bundles with no specified priority (None priority)
+            # and (2) whether it requested to run on a specific worker (bundles
+            # with a specified worker have higher priority).
             sorted_user_staged_bundles = sorted(
                 user_staged_bundles,
                 key=lambda b: (
-                    b[0].metadata.request_priority is not None,
+                    b[0].metadata.request_priority is not None and b[0].metadata.request_priority >= 0,
+                    b[0].metadata.request_priority is None,
                     b[0].metadata.request_priority,
                     b[0].metadata.request_queue is not None,
                 ),

--- a/codalab/server/bundle_manager.py
+++ b/codalab/server/bundle_manager.py
@@ -364,7 +364,8 @@ class BundleManager(object):
             sorted_user_staged_bundles = sorted(
                 user_staged_bundles,
                 key=lambda b: (
-                    b[0].metadata.request_priority is not None and b[0].metadata.request_priority >= 0,
+                    b[0].metadata.request_priority is not None
+                    and b[0].metadata.request_priority >= 0,
                     b[0].metadata.request_priority is None,
                     b[0].metadata.request_priority,
                     b[0].metadata.request_queue is not None,

--- a/docs/CLI-Reference.md
+++ b/docs/CLI-Reference.md
@@ -65,7 +65,7 @@ Usage: `cl <command> <arguments>`
       --request-cpus               Number of CPUs allowed for this run.
       --request-gpus               Number of GPUs allowed for this run.
       --request-queue              Submit run to this job queue.
-      --request-priority           Job priority (higher is more important).
+      --request-priority           Job priority (higher is more important). Negative priority bundles are queued behind bundles with no specified priority.
       --request-network            Whether to allow network access.
       --exclude-patterns           Exclude these file patterns from being saved into the bundle contents.
       -e, --edit                   Show an editor to allow editing of the bundle metadata.
@@ -201,7 +201,7 @@ Usage: `cl <command> <arguments>`
       --request-cpus               Number of CPUs allowed for this run. (for runs)
       --request-gpus               Number of GPUs allowed for this run. (for runs)
       --request-queue              Submit run to this job queue. (for runs)
-      --request-priority           Job priority (higher is more important). (for runs)
+      --request-priority           Job priority (higher is more important). Negative priority bundles are queued behind bundles with no specified priority. (for runs)
       --request-network            Whether to allow network access. (for runs)
       --exclude-patterns           Exclude these file patterns from being saved into the bundle contents. (for runs)
       --depth                      Number of parents to look back from the old output in search of the old input.
@@ -230,7 +230,7 @@ Usage: `cl <command> <arguments>`
       --request-cpus               Number of CPUs allowed for this run. (for runs)
       --request-gpus               Number of GPUs allowed for this run. (for runs)
       --request-queue              Submit run to this job queue. (for runs)
-      --request-priority           Job priority (higher is more important). (for runs)
+      --request-priority           Job priority (higher is more important). Negative priority bundles are queued behind bundles with no specified priority. (for runs)
       --request-network            Whether to allow network access. (for runs)
       --exclude-patterns           Exclude these file patterns from being saved into the bundle contents. (for runs)
       --depth                      Number of parents to look back from the old output in search of the old input.


### PR DESCRIPTION
Before this change, the sorting of bundles would place bundles with any `int` value of priority before bundles with no priority set (their priority is `None`). This fix makes it such that the ordering is:

1. Bundles with priority >= 0
2. Bundles with none priority
3. Bundles with negative priority.

The use case here is if you want to mark some bundles are unessential---you don't want to delete them, but they should be run _dead last_ among all currently staged bundles. In this case, you'd set the priority to some negative value.