### PR TITLE
Added --worker-group to WorkerManager

### DIFF
--- a/codalab/worker_manager/aws_batch_worker_manager.py
+++ b/codalab/worker_manager/aws_batch_worker_manager.py
@@ -89,36 +89,10 @@ class AWSBatchWorkerManager(WorkerManager):
         )
         # This needs to be a unique directory since Batch jobs may share a host
         work_dir = os.path.join(work_dir_prefix, 'cl_worker_{}_work_dir'.format(worker_id))
-        worker_network_prefix = 'cl_worker_{}_network'.format(worker_id)
-        command = [
-            self.args.worker_executable,
-            '--server',
-            self.args.server,
-            '--verbose',
-            '--exit-when-idle',
-            '--idle-seconds',
-            str(self.args.worker_idle_seconds),
-            '--work-dir',
-            work_dir,
-            '--id',
-            worker_id,
-            '--network-prefix',
-            worker_network_prefix,
-        ]
-        if self.args.worker_tag:
-            command.extend(['--tag', self.args.worker_tag])
-        if self.args.worker_max_work_dir_size:
-            command.extend(['--max-work-dir-size', self.args.worker_max_work_dir_size])
-        if self.args.worker_delete_work_dir_on_exit:
-            command.extend(['--worker-delete-work-dir-on-exit'])
-        if self.args.worker_exit_after_num_runs and self.args.worker_exit_after_num_runs > 0:
-            command.extend(['--exit-after-num-runs', str(self.args.worker_exit_after_num_runs)])
-        if self.args.worker_exit_on_exception:
-            command.extend(['--exit-on-exception'])
+        command = self.build_command(worker_id, work_dir)
+
         if self.args.worker_pass_down_termination:
-            command.extend(['--pass-down-termination'])
-        if self.args.worker_tag_exclusive:
-            command.extend(['--tag-exclusive'])
+            command.append('--pass-down-termination')
 
         # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-batch-jobdefinition.html
         # Need to mount:

--- a/codalab/worker_manager/aws_batch_worker_manager.py
+++ b/codalab/worker_manager/aws_batch_worker_manager.py
@@ -91,9 +91,6 @@ class AWSBatchWorkerManager(WorkerManager):
         work_dir = os.path.join(work_dir_prefix, 'cl_worker_{}_work_dir'.format(worker_id))
         command = self.build_command(worker_id, work_dir)
 
-        if self.args.worker_pass_down_termination:
-            command.append('--pass-down-termination')
-
         # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-batch-jobdefinition.html
         # Need to mount:
         # - docker.sock to enable us to start docker in docker

--- a/codalab/worker_manager/main.py
+++ b/codalab/worker_manager/main.py
@@ -74,6 +74,11 @@ def main():
         help="If set, the CodaLab worker will only run bundles that match the worker\'s tag.",
     )
     parser.add_argument(
+        '--worker-group',
+        type=str,
+        help="If set, the CodaLab worker will only run bundles for that group.",
+    )
+    parser.add_argument(
         '--worker-executable', default="cl-worker", help="The CodaLab worker executable to run."
     )
     subparsers = parser.add_subparsers(

--- a/codalab/worker_manager/worker_manager.py
+++ b/codalab/worker_manager/worker_manager.py
@@ -82,6 +82,41 @@ class WorkerManager(object):
         """Start a new `WorkerJob`."""
         raise NotImplementedError
 
+    def build_command(self, worker_id, work_dir):
+        command = [
+            self.args.worker_executable,
+            '--server',
+            self.args.server,
+            '--verbose',
+            '--exit-when-idle',
+            '--idle-seconds',
+            str(self.args.worker_idle_seconds),
+            '--work-dir',
+            work_dir,
+            '--id',
+            worker_id,
+            '--network-prefix',
+            'cl_worker_{}_network'.format(worker_id),
+        ]
+
+        # Additional optional arguments
+        if self.args.worker_tag:
+            command.extend(['--tag', self.args.worker_tag])
+        if self.args.worker_group:
+            command.extend(['--group', self.args.worker_group])
+        if self.args.worker_exit_after_num_runs and self.args.worker_exit_after_num_runs > 0:
+            command.extend(['--exit-after-num-runs', str(self.args.worker_exit_after_num_runs)])
+        if self.args.worker_max_work_dir_size:
+            command.extend(['--max-work-dir-size', self.args.worker_max_work_dir_size])
+        if self.args.worker_delete_work_dir_on_exit:
+            command.extend(['--delete-work-dir-on-exit'])
+        if self.args.worker_exit_on_exception:
+            command.extend(['--exit-on-exception'])
+        if self.args.worker_tag_exclusive:
+            command.extend(['--tag-exclusive'])
+
+        return command
+
     def run_loop(self):
         while True:
             try:

--- a/codalab/worker_manager/worker_manager.py
+++ b/codalab/worker_manager/worker_manager.py
@@ -114,6 +114,8 @@ class WorkerManager(object):
             command.extend(['--exit-on-exception'])
         if self.args.worker_tag_exclusive:
             command.extend(['--tag-exclusive'])
+        if self.args.worker_pass_down_termination:
+            command.extend(['--pass-down-termination'])
 
         return command
 

--- a/tests/unit/worker_manager/slurm_batch_worker_manager_test.py
+++ b/tests/unit/worker_manager/slurm_batch_worker_manager_test.py
@@ -20,6 +20,7 @@ class SlurmBatchWorkerManagerTest(unittest.TestCase):
             worker_delete_work_dir_on_exit=False,
             worker_exit_on_exception=False,
             worker_tag_exclusive=False,
+            worker_pass_down_termination=False,
             password_file=None,
         )
 

--- a/tests/unit/worker_manager/slurm_batch_worker_manager_test.py
+++ b/tests/unit/worker_manager/slurm_batch_worker_manager_test.py
@@ -1,0 +1,38 @@
+import unittest
+from types import SimpleNamespace
+
+from codalab.worker_manager.slurm_batch_worker_manager import SlurmBatchWorkerManager
+
+
+class SlurmBatchWorkerManagerTest(unittest.TestCase):
+    def test_base_command(self):
+        args = SimpleNamespace(
+            server="some_server",
+            user="some_user",
+            partition="some_partition",
+            worker_executable="cl-worker",
+            worker_idle_seconds="888",
+            worker_tag="some_tag",
+            worker_group="some_group",
+            worker_exit_after_num_runs=8,
+            worker_max_work_dir_size="88g",
+            worker_work_dir_prefix="/some/path",
+            worker_delete_work_dir_on_exit=False,
+            worker_exit_on_exception=False,
+            worker_tag_exclusive=False,
+            password_file=None,
+        )
+
+        worker_manager = SlurmBatchWorkerManager(args)
+        command = worker_manager.setup_codalab_worker("some_worker_id")
+
+        # --pass-down-termination should always be set for Slurm worker managers
+        self.assertTrue('--pass-down-termination' in command)
+
+        expected_command_str = (
+            "cl-worker --server some_server --verbose --exit-when-idle --idle-seconds 888 "
+            "--work-dir /some/path/some_user-codalab-SlurmBatchWorkerManager-scratch/some_worker_id "
+            "--id some_worker_id --network-prefix cl_worker_some_worker_id_network --tag some_tag "
+            "--group some_group --exit-after-num-runs 8 --max-work-dir-size 88g --pass-down-termination"
+        )
+        self.assertEqual(' '.join(command), expected_command_str)


### PR DESCRIPTION
### Reasons for making this change

- Added `--worker-group` to WorkerManager to share workers among group members
- Some minor code refactor

### Related issues

Resolves #2859, #2607, #2509 

### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
