### PR TITLE
Remove componentWillMount and componentWillReceiveProps in FileBrowser

### DIFF
--- a/frontend/src/components/FileBrowser/FileBrowser.js
+++ b/frontend/src/components/FileBrowser/FileBrowser.js
@@ -50,16 +50,18 @@ export class FileBrowser extends React.Component<
         }
     }
 
-    componentWillReceiveProps(nextProps) {
-        if (nextProps.isRunBundleUIVisible === false && this.state.isVisible) {
-            this.setState({ isVisible: false });
-            this.getDOMNode()
-                .getElementsByClassName('file-browser-arrow')[0]
-                .click();
+    static getDerivedStateFromProps(nextProps, prevState) {
+        if (nextProps.isRunBundleUIVisible === false && prevState.isVisible) {
+            return { isVisible: false };
         }
     }
 
     componentDidUpdate(prevProps, prevState) {
+        if (this.props.isRunBundleUIVisible === false && prevState.isVisible) {
+            this.getDOMNode()
+                .getElementsByClassName('file-browser-arrow')[0]
+                .click();
+        }
         if (prevProps.uuid !== this.props.uuid) {
             // Reset and fire off an asynchronous fetch for new data
             this.setState({ fileBrowserData: {} });

--- a/frontend/src/components/FileBrowser/FileBrowser.js
+++ b/frontend/src/components/FileBrowser/FileBrowser.js
@@ -40,8 +40,14 @@ export class FileBrowser extends React.Component<
         this.state = {
             currentWorkingDirectory: '',
             fileBrowserData: {},
-            isVisible: false,
+            isVisible: !this.props.startCollapsed,
         };
+    }
+
+    componentDidMount() {
+        if (!this.props.startCollapsed) {
+            this.updateFileBrowser('');
+        }
     }
 
     componentWillReceiveProps(nextProps) {
@@ -57,13 +63,6 @@ export class FileBrowser extends React.Component<
         if (prevProps.uuid !== this.props.uuid) {
             // Reset and fire off an asynchronous fetch for new data
             this.setState({ fileBrowserData: {} });
-            this.updateFileBrowser('');
-        }
-    }
-
-    componentWillMount() {
-        if (!this.props.startCollapsed) {
-            this.setState({ isVisible: true });
             this.updateFileBrowser('');
         }
     }
@@ -470,6 +469,7 @@ export class FileBrowserLite extends React.Component<
         this.state = {
             currentWorkingDirectory: '',
             fileBrowserData: {},
+            isVisible: !this.props.startCollapsed,
         };
     }
 
@@ -482,6 +482,10 @@ export class FileBrowserLite extends React.Component<
     }
 
     componentDidMount() {
+        if (!this.props.startCollapsed) {
+            this.updateFileBrowser('');
+        }
+
         if (this.props.isRunningBundle) {
             this.timer = setInterval(() => {
                 if (!this.props.isRunningBundle) {
@@ -491,13 +495,6 @@ export class FileBrowserLite extends React.Component<
                 }
                 this.updateFileBrowser('');
             }, 4000);
-        }
-    }
-
-    componentWillMount() {
-        if (!this.props.startCollapsed) {
-            this.setState({ isVisible: true });
-            this.updateFileBrowser('');
         }
     }
 

--- a/frontend/src/components/FileBrowser/FileBrowser.js
+++ b/frontend/src/components/FileBrowser/FileBrowser.js
@@ -461,7 +461,6 @@ export class FileBrowserLite extends React.Component<
     {
         currentDirectory: string,
         fileBrowserData: {},
-        isVisible: boolean,
     },
 > {
     constructor(props) {
@@ -469,7 +468,6 @@ export class FileBrowserLite extends React.Component<
         this.state = {
             currentWorkingDirectory: '',
             fileBrowserData: {},
-            isVisible: !this.props.startCollapsed,
         };
     }
 


### PR DESCRIPTION
### Reasons for making this change

componentWillMount is deprecated in React, and we only used componentWillMount in FileBrowser. I moved the original code in `componentWillMount` to `componentDidMount` and `constructor`.

### Related issues

fix #2616 

### Screenshots

![2616-willMount](https://user-images.githubusercontent.com/34461466/93828267-c9ea9080-fc1f-11ea-94e5-413aa5ce2620.gif)
Everything works well.

### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
