### PR TITLE
Fix the bug of upload not releasing keyboard shortcuts

### DIFF
--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -1436,6 +1436,7 @@ class Worksheet extends React.Component {
 
         Mousetrap(form).bind(['enter'], function(e) {
             e.stopImmediatePropagation();
+            e.preventDefault();
             document.querySelector('label[for=' + e.target.firstElementChild.htmlFor + ']').click();
             Mousetrap(form).unbind(['enter']);
         });

--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -1435,8 +1435,9 @@ class Worksheet extends React.Component {
         let form = document.querySelector('#upload-menu');
 
         Mousetrap(form).bind(['enter'], function(e) {
-            e.stopPropagation();
+            e.stopImmediatePropagation();
             document.querySelector('label[for=' + e.target.firstElementChild.htmlFor + ']').click();
+            Mousetrap(form).unbind(['enter']);
         });
 
         this.setState({ uploadAnchor: e.currentTarget });


### PR DESCRIPTION
### Reasons for making this change

On a worksheet, hit 'a u' to trigger upload, select by press 'enter', but two upload menus will appear consecutively. 
The bug results from that `stopPropagation` allows other handlers on the same element to be executed, so another hidden upload menu will also be clicked when we press 'enter' later, and thus two menus appear consecutively, so I use `stopImmediatePropagation` instead, and it prevents every event from running.

### Related issues

fix #2364 

### Screenshots

![2364-upload](https://user-images.githubusercontent.com/34461466/93828920-42058600-fc21-11ea-8279-f5fa82e23be1.gif)
Works normally now.

### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
