### PR TITLE
Move jump-to-end button to front

### DIFF
--- a/frontend/src/__tests__/__snapshots__/Worksheet.test.js.snap
+++ b/frontend/src/__tests__/__snapshots__/Worksheet.test.js.snap
@@ -658,7 +658,7 @@ Object {
               </div>
               <button
                 class="MuiButtonBase-root-141 MuiButton-root-115 MuiButton-contained-126 MuiButton-containedPrimary-127 MuiButton-raised-129 MuiButton-raisedPrimary-130"
-                style="border-radius: 400px; position: fixed; bottom: 50px; right: 30px;"
+                style="border-radius: 400px; position: fixed; bottom: 50px; right: 30px; z-index: 10;"
                 tabindex="0"
                 type="button"
               >
@@ -1420,7 +1420,7 @@ Object {
             </div>
             <button
               class="MuiButtonBase-root-141 MuiButton-root-115 MuiButton-contained-126 MuiButton-containedPrimary-127 MuiButton-raised-129 MuiButton-raisedPrimary-130"
-              style="border-radius: 400px; position: fixed; bottom: 50px; right: 30px;"
+              style="border-radius: 400px; position: fixed; bottom: 50px; right: 30px; z-index: 10;"
               tabindex="0"
               type="button"
             >

--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -1693,6 +1693,7 @@ class Worksheet extends React.Component {
                                         bottom: '50px',
                                         right: '30px',
                                         backgroundColor: '00BFFF',
+                                        zIndex: 10,
                                     }}
                                 >
                                     <ExpandMoreIcon size='medium' />


### PR DESCRIPTION
### Reasons for making this change

Fix bug to move the jump-to-end button to the front

### Related issues

fix #2872 

### Screenshots

<img width="1647" alt="2872-jump-to-end-button" src="https://user-images.githubusercontent.com/34461466/93880555-8846fd80-fc92-11ea-94c9-2765511ffc9f.png">


### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
