### PR TITLE
Better style of bundle table header

### DIFF
--- a/frontend/src/components/worksheets/items/TableItem/TableItem.js
+++ b/frontend/src/components/worksheets/items/TableItem/TableItem.js
@@ -148,12 +148,20 @@ class TableItem extends React.Component<{
                                   top: 0,
                                   backgroundColor: '#F8F9FA',
                                   zIndex: 1,
+                                  color: '#000000',
+                                  paddingBottom: 0,
+                                  paddingTop: 0,
+                                  height: 26,
                               }
                             : {
                                   position: 'sticky',
                                   top: 0,
                                   backgroundColor: '#F8F9FA',
                                   zIndex: 1,
+                                  color: '#000000',
+                                  paddingBottom: 0,
+                                  paddingTop: 0,
+                                  height: 26,
                               }
                     }
                 >
@@ -161,7 +169,7 @@ class TableItem extends React.Component<{
                         <Tooltip title={'Change the schemas of this table'}>
                             <IconButton>
                                 <ViewListIcon
-                                    style={{ padding: '0px' }}
+                                    style={{ padding: '0px', height: 15 }}
                                     onClick={() => {
                                         this.setState({
                                             openSchemaTextBox: !this.state.openSchemaTextBox,
@@ -243,7 +251,7 @@ class TableItem extends React.Component<{
                         <TableHead>
                             <TableRow
                                 style={{
-                                    height: 36,
+                                    height: 32,
                                     borderTop: '0px solid #DEE2E6',
                                 }}
                             >

--- a/frontend/src/components/worksheets/items/TableItem/TableItem.js
+++ b/frontend/src/components/worksheets/items/TableItem/TableItem.js
@@ -15,6 +15,7 @@ import SaveIcon from '@material-ui/icons/Save';
 import RestoreIcon from '@material-ui/icons/Restore';
 import TextField from '@material-ui/core/TextField';
 import Tooltip from '@material-ui/core/Tooltip';
+import classNames from 'classnames';
 
 class TableItem extends React.Component<{
     worksheetUUID: string,
@@ -125,8 +126,7 @@ class TableItem extends React.Component<{
     };
 
     render() {
-        const { worksheetUUID, setFocus, editPermission } = this.props;
-
+        const { classes, worksheetUUID, setFocus, editPermission } = this.props;
         // Provide copy data callback
         this.props.addCopyBundleRowsCallback(this.props.itemID, this.copyCheckedBundleRows);
         let tableClassName = this.props.focused ? 'table focused' : 'table';
@@ -140,29 +140,19 @@ class TableItem extends React.Component<{
                     onMouseLeave={(e) => this.setState({ hovered: false })}
                     component='th'
                     key={index}
+                    classes={{
+                        root: classNames({
+                            [classes.tableHeader]: true,
+                        }),
+                    }}
                     style={
                         index === 0
                             ? {
-                                  paddingLeft: editPermission ? '30px' : '70px',
-                                  position: 'sticky',
-                                  top: 0,
-                                  backgroundColor: '#F8F9FA',
-                                  zIndex: 1,
-                                  color: '#000000',
+                                  paddingLeft: editPermission ? '30px' : '40px',
                                   paddingBottom: 0,
                                   paddingTop: 0,
-                                  height: 26,
                               }
-                            : {
-                                  position: 'sticky',
-                                  top: 0,
-                                  backgroundColor: '#F8F9FA',
-                                  zIndex: 1,
-                                  color: '#000000',
-                                  paddingBottom: 0,
-                                  paddingTop: 0,
-                                  height: 26,
-                              }
+                            : {}
                     }
                 >
                     {editPermission && index === 0 && (
@@ -339,6 +329,14 @@ const styles = (theme) => ({
     tableContainer: {
         position: 'relative',
     },
+    tableHeader: {
+        position: 'sticky',
+        top: 0,
+        backgroundColor: '#F8F9FA',
+        zIndex: 1,
+        color: '#000000',
+        height: 26,
+    },
 });
 
 const TableContainer = withStyles(styles)(_TableContainer);
@@ -372,4 +370,5 @@ const TableWrapper = (props) => {
     return <TableItem {...props} />;
 };
 
-export default TableWrapper;
+export { TableWrapper };
+export default withStyles(styles)(TableItem);


### PR DESCRIPTION
### Reasons for making this change

Make the header in black color and the same height as regular rows.

### Related issues

fix #2397 

### Screenshots

<img width="1072" alt="2397-table-header-style" src="https://user-images.githubusercontent.com/34461466/93957183-99325600-fd08-11ea-9d09-e528823d05c2.png">


### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
