### PR TITLE
Make file browser have less vertical spacing

### DIFF
--- a/frontend/src/components/FileBrowser/FileBrowser.js
+++ b/frontend/src/components/FileBrowser/FileBrowser.js
@@ -386,6 +386,10 @@ const iconStyle = {
     marginRight: 4,
 };
 
+const fileBrowserItemLiteTableRowStyle = {
+    height: 26,
+};
+
 class FileBrowserItemLite extends React.Component<{
     bundle_uuid: string,
     updateFileBrowser: (string) => void,
@@ -409,7 +413,10 @@ class FileBrowserItemLite extends React.Component<{
         let item;
         if (this.props.type === 'directory' || this.props.type === '..') {
             item = (
-                <TableRow onClick={() => this.props.updateFileBrowser(file_location)}>
+                <TableRow
+                    onClick={() => this.props.updateFileBrowser(file_location)}
+                    style={fileBrowserItemLiteTableRowStyle}
+                >
                     <TableCell>
                         <div style={rowCenter}>
                             <FolderIcon style={iconStyle} />
@@ -426,7 +433,7 @@ class FileBrowserItemLite extends React.Component<{
                 this.props.bundle_uuid
             }/contents/blob/${encodeBundleContentsPath(file_location)}`;
             item = (
-                <TableRow>
+                <TableRow style={fileBrowserItemLiteTableRowStyle}>
                     <TableCell>
                         <div style={rowCenter}>
                             <FileIcon style={iconStyle} />
@@ -440,7 +447,7 @@ class FileBrowserItemLite extends React.Component<{
             );
         } else if (this.props.type === 'link') {
             item = (
-                <TableRow>
+                <TableRow style={fileBrowserItemLiteTableRowStyle}>
                     <TableCell>
                         <div style={rowCenter}>
                             <LinkIcon style={iconStyle} />


### PR DESCRIPTION
### Reasons for making this change

Reduce the spacing to make view bundles with lots of files inside easier.

### Related issues

fixes #2134 

### Screenshots
previous:
<img width="1463" alt="Screen Shot 2020-09-23 at 6 07 13 PM" src="https://user-images.githubusercontent.com/34461466/94089301-b2e6a280-fdc7-11ea-9941-559d672f2c2c.png">


after:
<img width="1191" alt="2134-less-vertical-spacing" src="https://user-images.githubusercontent.com/34461466/93984882-3b6a3200-fd39-11ea-82de-f0f2561d0083.png">


### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
