### PR TITLE
Optionally enable sentry on AWS batch workermanager-launched workers

### DIFF
--- a/codalab/worker_manager/aws_batch_worker_manager.py
+++ b/codalab/worker_manager/aws_batch_worker_manager.py
@@ -11,6 +11,8 @@ import re
 import uuid
 from .worker_manager import WorkerManager, WorkerJob
 
+from codalab.lib.telemetry_util import CODALAB_SENTRY_INGEST, using_sentry
+
 logger = logging.getLogger(__name__)
 
 
@@ -169,6 +171,11 @@ class AWSBatchWorkerManager(WorkerManager):
             )
             job_definition['containerProperties']['mountPoints'].append(
                 {'sourceVolume': 'shared_dir', 'containerPath': bundle_mount, 'readOnly': False}
+            )
+
+        if using_sentry:
+            job_definition["containerProperties"]["environment"].append(
+                {'name': 'CODALAB_SENTRY_INGEST_URL', 'value': CODALAB_SENTRY_INGEST}
             )
 
         # Create a job definition

--- a/codalab/worker_manager/aws_batch_worker_manager.py
+++ b/codalab/worker_manager/aws_batch_worker_manager.py
@@ -173,7 +173,7 @@ class AWSBatchWorkerManager(WorkerManager):
                 {'sourceVolume': 'shared_dir', 'containerPath': bundle_mount, 'readOnly': False}
             )
 
-        if using_sentry:
+        if using_sentry():
             job_definition["containerProperties"]["environment"].append(
                 {'name': 'CODALAB_SENTRY_INGEST_URL', 'value': CODALAB_SENTRY_INGEST}
             )


### PR DESCRIPTION
This just exports the right environment variable in the container, if we're using sentry on the host that's running the WorkerManager.