### PR TITLE
Put the hostname in the remote: field for workermanager-launched jobs

### DIFF
--- a/codalab/worker_manager/worker_manager.py
+++ b/codalab/worker_manager/worker_manager.py
@@ -94,7 +94,7 @@ class WorkerManager(object):
             '--work-dir',
             work_dir,
             '--id',
-            worker_id,
+            f'$(hostname -s)-{worker_id}',
             '--network-prefix',
             'cl_worker_{}_network'.format(worker_id),
         ]

--- a/tests/unit/worker_manager/slurm_batch_worker_manager_test.py
+++ b/tests/unit/worker_manager/slurm_batch_worker_manager_test.py
@@ -33,7 +33,7 @@ class SlurmBatchWorkerManagerTest(unittest.TestCase):
         expected_command_str = (
             "cl-worker --server some_server --verbose --exit-when-idle --idle-seconds 888 "
             "--work-dir /some/path/some_user-codalab-SlurmBatchWorkerManager-scratch/some_worker_id "
-            "--id some_worker_id --network-prefix cl_worker_some_worker_id_network --tag some_tag "
+            "--id $(hostname -s)-some_worker_id --network-prefix cl_worker_some_worker_id_network --tag some_tag "
             "--group some_group --exit-after-num-runs 8 --max-work-dir-size 88g --pass-down-termination"
         )
         self.assertEqual(' '.join(command), expected_command_str)


### PR DESCRIPTION
Right now, the workermanager launches jobs that have a remote: field of something like `nfliu-codalab-slurm-worker-443cb25d`. This is annoying if you want to figure out the hostname of the node that the job ran on.

This changes the `id` field to `{shorthostname}-{workerid}`, so the remote field would be something like `jagupard12-nfliu-codalab-slurm-worker-443cb25d`