### PR TITLE
Make WorkerManager name subparser required

### DIFF
--- a/codalab/worker_manager/main.py
+++ b/codalab/worker_manager/main.py
@@ -86,6 +86,10 @@ def main():
         description='Which worker manager to run (AWS Batch etc.)',
         dest='worker_manager_name',
     )
+    # This is a workaround for setting a subparser as required for older
+    # versions of python (< 3.7) , necessary due to a bug in Python 3.x .
+    # https://bugs.python.org/issue9253#msg186387
+    subparsers.required = True
 
     # Each worker manager class defines its NAME, which is the subcommand the users use
     # to invoke that type of Worker Manager. We map those to their respective classes


### PR DESCRIPTION
Without this, you get an ugly error message:
```
$ cl-worker-manager --once
Traceback (most recent call last):
  File "/home/nfliu/miniconda3/envs/cl_dev/bin/cl-worker-manager", line 33, in <module>
    sys.exit(load_entry_point('codalab', 'console_scripts', 'cl-worker-manager')())
  File "/home/nfliu/git/codalab-worksheets/codalab/worker_manager/main.py", line 116, in main
    manager = worker_manager_types[args.worker_manager_name](args)
KeyError: None
```
After the fix:
```
$ cl-worker-manager --once
usage: cl-worker-manager [-h] [--server SERVER] [--min-workers MIN_WORKERS]
                         [--max-workers MAX_WORKERS]
                         [--search [SEARCH [SEARCH ...]]]
                         [--worker-tag WORKER_TAG]
                         [--worker-work-dir-prefix WORKER_WORK_DIR_PREFIX]
                         [--worker-max-work-dir-size WORKER_MAX_WORK_DIR_SIZE]
                         [--worker-delete-work-dir-on-exit] [--verbose]
                         [--sleep-time SLEEP_TIME] [--once]
                         [--worker-idle-seconds WORKER_IDLE_SECONDS]
                         [--min-seconds-between-workers MIN_SECONDS_BETWEEN_WORKERS]
                         [--worker-exit-after-num-runs WORKER_EXIT_AFTER_NUM_RUNS]
                         [--worker-pass-down-termination]
                         [--worker-exit-on-exception] [--worker-tag-exclusive]
                         [--worker-group WORKER_GROUP]
                         [--worker-executable WORKER_EXECUTABLE]
                         {aws-batch,slurm-batch} ...
cl-worker-manager: error: the following arguments are required: worker_manager_name
```