### PR TITLE
Improve monitor logging

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -91,8 +91,8 @@ def get_public_workers():
 
 # message is a list
 def send_email(subject, message):
-    print(
-        'send_email to %s from %s@%s; subject: %s; message contains %d lines'
+    log(
+        'Sending an email to %s from %s@%s; subject: %s; message contains %d lines'
         % (admin_email, sender_username, sender_host, subject, len(message))
     )
     sys.stdout.flush()
@@ -117,17 +117,9 @@ def send_email(subject, message):
     s.quit()
 
 
-def get_date():
-    # Only save a backup for every month to save space
-    return datetime.datetime.utcnow().strftime('%Y-%m')
-
-
-def log(line, newline=True):
-    line = '[%s] %s' % (get_date(), line)
-    if newline:
-        print(line)
-    else:
-        print(line)
+def log(line):
+    current_datetime = datetime.datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S')
+    line = '[%s] %s' % (current_datetime, line)
     sys.stdout.flush()
     report.append(line)
     out = open(args.log_path, 'a')
@@ -229,7 +221,6 @@ def email_time():
 
 def backup_db():
     log('Backup DB (note that errors are not detected due to shell pipes)')
-    date = get_date()
     mysql_conf_path = os.path.join(args.codalab_home, 'monitor-mysql.cnf')
     with open(mysql_conf_path, 'w') as f:
         print('[client]', file=f)
@@ -237,7 +228,10 @@ def backup_db():
         print('port="%s"' % bundles_port, file=f)
         print('user="%s"' % bundles_username, file=f)
         print('password="%s"' % bundles_password, file=f)
-    path = '%s/%s-%s.mysqldump.gz' % (args.backup_path, bundles_database, date)
+
+    # Only save a backup for every month to save space
+    month = datetime.datetime.utcnow().strftime('%Y-%m')
+    path = '%s/%s-%s.mysqldump.gz' % (args.backup_path, bundles_database, month)
     run_command(
         [
             'bash',

--- a/monitor.py
+++ b/monitor.py
@@ -95,7 +95,7 @@ def send_email(subject, message):
         'Sending an email to %s from %s@%s; subject: %s; message contains %d lines'
         % (admin_email, sender_username, sender_host, subject, len(message))
     )
-    sys.stdout.flush()
+
     if not admin_email:
         return
 
@@ -120,6 +120,7 @@ def send_email(subject, message):
 def log(line):
     current_datetime = datetime.datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S')
     line = '[%s] %s' % (current_datetime, line)
+    print(line)
     sys.stdout.flush()
     report.append(line)
     out = open(args.log_path, 'a')


### PR DESCRIPTION
### Reasons for making this change

The previous datetime format `%Y-%m` for logging makes it hard to debug issues. This is just a quick fix to improve the monitor logging.

### Related issues

Resolves #2898 

### Screenshots

Before:

![94250500-2676d580-fed6-11ea-89ff-9c54a6b3047d](https://user-images.githubusercontent.com/16793796/94352794-5cbf6c80-001e-11eb-8a6c-e8b9689a6e26.png)

After:

![Screen Shot 2020-09-26 at 5 33 01 PM](https://user-images.githubusercontent.com/16793796/94352796-6052f380-001e-11eb-8f64-2d50303b07b6.png)


### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [ ] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
