### PR TITLE
Remove scrollbar in table

### DIFF
--- a/frontend/src/components/worksheets/items/TableItem/TableItem.js
+++ b/frontend/src/components/worksheets/items/TableItem/TableItem.js
@@ -145,15 +145,7 @@ class TableItem extends React.Component<{
                             [classes.tableHeader]: true,
                         }),
                     }}
-                    style={
-                        index === 0
-                            ? {
-                                  paddingLeft: editPermission ? '30px' : '40px',
-                                  paddingBottom: 0,
-                                  paddingTop: 0,
-                              }
-                            : {}
-                    }
+                    style={index === 0 ? { paddingLeft: editPermission ? '30px' : '70px' } : {}}
                 >
                     {editPermission && index === 0 && (
                         <Tooltip title={'Change the schemas of this table'}>
@@ -236,18 +228,14 @@ class TableItem extends React.Component<{
         });
         return (
             <div className='ws-item'>
-                <TableContainer
-                    style={{
-                        overflowX: 'auto',
-                        maxHeight: 500,
-                    }}
-                >
+                <TableContainer style={{ overflowX: 'auto' }}>
                     <Table className={tableClassName}>
                         <TableHead>
                             <TableRow
                                 style={{
                                     height: 32,
                                     borderTop: '0px solid #DEE2E6',
+                                    backgroundColor: '#F8F9FA',
                                 }}
                             >
                                 {headerHtml}
@@ -333,11 +321,6 @@ class _TableContainer extends React.Component {
 const styles = () => ({
     tableContainer: {
         position: 'relative',
-        '&::-webkit-scrollbar': {
-            display: 'none',
-        } /* Safari and Chrome */,
-        '-ms-overflow-style': 'none' /* Internet Explorer 10+ */,
-        'scrollbar-width': 'none' /* Firefox */,
     },
     tableHeader: {
         position: 'sticky',

--- a/frontend/src/components/worksheets/items/TableItem/TableItem.js
+++ b/frontend/src/components/worksheets/items/TableItem/TableItem.js
@@ -333,7 +333,11 @@ class _TableContainer extends React.Component {
 const styles = () => ({
     tableContainer: {
         position: 'relative',
-        overflow: 'hidden',
+        '&::-webkit-scrollbar': {
+            display: 'none',
+        } /* Safari and Chrome */,
+        '-ms-overflow-style': 'none' /* Internet Explorer 10+ */,
+        'scrollbar-width': 'none' /* Firefox */,
     },
     tableHeader: {
         position: 'sticky',

--- a/frontend/src/components/worksheets/items/TableItem/TableItem.js
+++ b/frontend/src/components/worksheets/items/TableItem/TableItem.js
@@ -236,7 +236,12 @@ class TableItem extends React.Component<{
         });
         return (
             <div className='ws-item'>
-                <TableContainer style={{ overflowX: 'auto', maxHeight: 500 }}>
+                <TableContainer
+                    style={{
+                        overflowX: 'auto',
+                        maxHeight: 500,
+                    }}
+                >
                     <Table className={tableClassName}>
                         <TableHead>
                             <TableRow
@@ -328,6 +333,11 @@ class _TableContainer extends React.Component {
 const styles = (theme) => ({
     tableContainer: {
         position: 'relative',
+        '&::-webkit-scrollbar': {
+            display: 'none',
+        } /* Safari and Chrome */,
+        '-ms-overflow-style': 'none' /* Internet Explorer 10+ */,
+        'scrollbar-width': 'none' /* Firefox */,
     },
     tableHeader: {
         position: 'sticky',

--- a/frontend/src/components/worksheets/items/TableItem/TableItem.js
+++ b/frontend/src/components/worksheets/items/TableItem/TableItem.js
@@ -330,14 +330,10 @@ class _TableContainer extends React.Component {
     }
 }
 
-const styles = (theme) => ({
+const styles = () => ({
     tableContainer: {
         position: 'relative',
-        '&::-webkit-scrollbar': {
-            display: 'none',
-        } /* Safari and Chrome */,
-        '-ms-overflow-style': 'none' /* Internet Explorer 10+ */,
-        'scrollbar-width': 'none' /* Firefox */,
+        overflow: 'hidden',
     },
     tableHeader: {
         position: 'sticky',


### PR DESCRIPTION
### Reasons for making this change

Remove the scrollbar in the table. The table cannot be scrolled anymore.

### Related issues

fixes #2875 ; reopens #2082

### Screenshots
No scroll bar: 
<img width="1470" alt="Screen Shot 2020-10-03 at 3 01 55 PM" src="https://user-images.githubusercontent.com/34461466/95002547-2b005580-058a-11eb-8741-5950ab176adf.png">

### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
