### PR TITLE
Fix frontend npm build warnings

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+    "extends": "react-app",
+    "rules": {
+    }
+}

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,5 +1,0 @@
-{
-    "extends": "react-app",
-    "rules": {
-    }
-}

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,9 +1,5 @@
 {
     "extends": "react-app",
     "rules": {
-        "no-loop-func": "off",
-        "jsx-a11y/anchor-is-valid": "off",
-        "no-shadow-restricted-names": "off",
-        "react/no-direct-mutation-state": "off"
     }
 }

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,7 +1,6 @@
 {
     "extends": "react-app",
     "rules": {
-        "no-unused-vars": "off",
         "no-loop-func": "off",
         "jsx-a11y/anchor-is-valid": "off",
         "no-shadow-restricted-names": "off",

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,5 +1,13 @@
 {
     "extends": "react-app",
-    "rules": {
-    }
+    "rules": {},
+    "overrides": [
+        {
+            "files": ["./src/util/ws_mousetrap_fork.js"],
+            "rules": {
+                // Override the rule check for ws_mousetrap_fork.js since it is external code
+                "no-shadow-restricted-names": "off"
+            }
+        }
+    ]
 }

--- a/frontend/src/CodalabApp.js
+++ b/frontend/src/CodalabApp.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Router, Route, Link, Redirect, withRouter, Switch } from 'react-router-dom';
-import { CookiesProvider, withCookies } from 'react-cookie';
+import { Router, Route, Redirect, Switch } from 'react-router-dom';
+import { CookiesProvider } from 'react-cookie';
 
 import { MuiThemeProvider } from '@material-ui/core/styles';
 import CodalabTheme from './theme';

--- a/frontend/src/__tests__/Worksheet.test.js
+++ b/frontend/src/__tests__/Worksheet.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import nock from 'nock';
-import { render, fireEvent, waitFor, screen } from '../utils/test-utils';
+import { render, waitFor, screen } from '../utils/test-utils';
 import Worksheet from '../components/worksheets/Worksheet/Worksheet';
 
 describe('render simple worksheet', () => {

--- a/frontend/src/components/Button.js
+++ b/frontend/src/components/Button.js
@@ -16,7 +16,7 @@ class Button extends React.Component {
             classname = classname + ' ' + this.props.className;
         }
         return (
-            <a
+            <button
                 style={buttonStyle}
                 className={classname}
                 id={this.props.id}
@@ -24,7 +24,7 @@ class Button extends React.Component {
                 onClick={this.props.handleClick}
             >
                 {this.props.text}
-            </a>
+            </button>
         );
     }
 }

--- a/frontend/src/components/FileBrowser/FileBrowser.js
+++ b/frontend/src/components/FileBrowser/FileBrowser.js
@@ -334,9 +334,9 @@ export class FileBrowserItem extends React.Component<{
                     onClick={() => this.props.updateFileBrowser(file_location)}
                 >
                     <span className='glyphicon-folder-open glyphicon' alt='More' />
-                    <a target='_blank' rel='noopener noreferrer'>
+                    <button class='link' target='_blank' rel='noopener noreferrer'>
                         {this.props.index}
-                    </a>
+                    </button>
                     <span className='pull-right'>{size}</span>
                 </span>
             );
@@ -421,9 +421,9 @@ class FileBrowserItemLite extends React.Component<{
                     <TableCell>
                         <div style={rowCenter}>
                             <FolderIcon style={iconStyle} />
-                            <a target='_blank' rel='noopener noreferrer'>
+                            <button class='link' target='_blank' rel='noopener noreferrer'>
                                 {this.props.index}
-                            </a>
+                            </button>
                         </div>
                     </TableCell>
                     <TableCell align='right'>{size}</TableCell>

--- a/frontend/src/components/FileBrowser/FileBrowser.js
+++ b/frontend/src/components/FileBrowser/FileBrowser.js
@@ -263,11 +263,12 @@ export class FileBrowserBreadCrumbs extends React.Component<{
         for (let i = 0; i < splitDirs.length; i++) {
             if (i > 0) currentDirectory += '/';
             currentDirectory += splitDirs[i];
+            const fixedCurrentDirectory = currentDirectory;
             links.push(
                 <span
                     key={splitDirs[i]}
                     index={splitDirs[i]}
-                    onClick={() => this.props.updateFileBrowser(currentDirectory)}
+                    onClick={() => this.props.updateFileBrowser(fixedCurrentDirectory)}
                 >
                     {' '}
                     / {splitDirs[i]}

--- a/frontend/src/components/Login.js
+++ b/frontend/src/components/Login.js
@@ -87,8 +87,8 @@ class Login extends React.Component {
                     <p>
                         <NavLink to='/account/reset'>Forgot your password?</NavLink>
                     </p>
-                    <a
-                        href='#'
+                    <button
+                        class='link'
                         onClick={(event) => {
                             alert(
                                 'Please log in and navigate to your dashboard to resend confirmation email.',
@@ -97,7 +97,7 @@ class Login extends React.Component {
                         }}
                     >
                         Resend confirmation email
-                    </a>
+                    </button>
                 </ContentWrapper>
             </React.Fragment>
         );

--- a/frontend/src/components/Login.js
+++ b/frontend/src/components/Login.js
@@ -33,7 +33,7 @@ class Login extends React.Component {
     };
 
     render() {
-        const { next, error } = queryString.parse(this.props.location.search);
+        const { error } = queryString.parse(this.props.location.search);
         const pathname = this.props.location.pathname;
 
         let { redirectToReferrer, from } = this.state;

--- a/frontend/src/components/UserInfo.js
+++ b/frontend/src/components/UserInfo.js
@@ -248,8 +248,7 @@ class UserInfo extends React.Component {
 }
 
 class AccountNotificationsCheckbox extends React.Component {
-    handleClick = (cb) => {
-        var notifications = this.props.user.attributes['notifications'];
+    handleClick = () => {
         this.props.onChange('notifications', parseInt(this.props.fieldKey));
     };
 

--- a/frontend/src/components/worksheets/BundleBulkActionMenu.js
+++ b/frontend/src/components/worksheets/BundleBulkActionMenu.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { withStyles } from '@material-ui/core';
 import Typography from '@material-ui/core/Typography';
-import ExitToAppIcon from '@material-ui/icons/ExitToApp';
 import DeleteForeverIcon from '@material-ui/icons/DeleteForever';
 import HighlightOffIcon from '@material-ui/icons/HighlightOff';
 import FileCopyOutlinedIcon from '@material-ui/icons/FileCopyOutlined';

--- a/frontend/src/components/worksheets/ErrorMessage.js
+++ b/frontend/src/components/worksheets/ErrorMessage.js
@@ -1,8 +1,5 @@
 import * as React from 'react';
-import { Link } from 'react-router-dom';
-import Button from '@material-ui/core/Button';
 import Grid from '@material-ui/core/Grid';
-import Typography from '@material-ui/core/Typography';
 
 class ErrorMessage extends React.Component {
     render() {

--- a/frontend/src/components/worksheets/NewWorksheet.js
+++ b/frontend/src/components/worksheets/NewWorksheet.js
@@ -7,13 +7,6 @@ import { NAME_REGEX } from '../../constants';
 
 var SAMPLE_WORKSHEET_TEXT = '-worksheetname';
 
-type Props = {
-    clickAction: 'DEFAULT' | 'SIGN_IN_REDIRECT' | 'DISABLED',
-    ws: {},
-    userInfo?: {},
-    escCount: number,
-};
-
 class NewWorksheet extends React.Component {
     /** Constructor. */
     constructor(props) {

--- a/frontend/src/components/worksheets/RunBundleBuilder.js
+++ b/frontend/src/components/worksheets/RunBundleBuilder.js
@@ -3,7 +3,6 @@ import Immutable from 'seamless-immutable';
 import $ from 'jquery';
 import Button from '../Button';
 import {
-    depEqual,
     shorten_uuid,
     buildTerminalCommand,
     createHandleRedirectFn,
@@ -61,14 +60,6 @@ class RunBundleBuilder extends React.Component<Props> {
     };
 
     createRunBundle = () => {
-        var clCommand = this.getClCommand(
-            this.state.selectedDependencies,
-            this.state.dependencyKeyList,
-            this.state.command,
-        );
-        var response = $('#command_line')
-            .terminal()
-            .exec(clCommand);
         this.toggleBuilder();
     };
 

--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -5,7 +5,6 @@ import { withStyles } from '@material-ui/core/styles';
 import { renderPermissions, getAfterSortKey, createAlertText } from '../../../util/worksheet_utils';
 import * as Mousetrap from '../../../util/ws_mousetrap_fork';
 import WorksheetItemList from '../WorksheetItemList';
-import ReactDOM from 'react-dom';
 import InformationModal from '../InformationModal/InformationModal';
 import WorksheetHeader from './WorksheetHeader';
 import {
@@ -354,7 +353,6 @@ class Worksheet extends React.Component {
             this.setState({ openedDialog: DIALOG_TYPES.OPEN_KILL });
         } else if (cmd_type === 'copy' || cmd_type === 'cut') {
             let validBundles = [];
-            let cutBundleIds = [];
             let actualCopiedCounts = 0;
             let tableIDs = Object.keys(this.copyCallbacks).sort();
             tableIDs.forEach((tableID) => {
@@ -447,14 +445,11 @@ class Worksheet extends React.Component {
     pasteBundlesToWorksheet = () => {
         // Unchecks all bundles after pasting
         const data = JSON.parse(window.localStorage.getItem('CopiedBundles'));
-        let bundleString = '';
         let items = [];
         data.forEach((bundle) => {
-            bundleString += '[]{' + bundle.uuid + '}\n';
             items.push(bundle.uuid);
         });
         // remove the last new line character
-        bundleString = bundleString.substr(0, bundleString.length - 1);
         let worksheetUUID = this.state.ws.uuid;
         let after_sort_key;
         if (this.state.focusIndex !== -1 && this.state.focusIndex !== undefined) {

--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -215,6 +215,7 @@ class Worksheet extends React.Component {
         // TODO: This function should be cleaner, after my logic refactoring, the identifier
         //      shouldn't be necessary. However, if we want more control on what happens after
         //      bulk operation, this might be useful
+        let bundlesCount = this.state.uuidBundlesCheckedCount;
         if (check) {
             //A bundle is checked
             if (
@@ -223,7 +224,6 @@ class Worksheet extends React.Component {
             ) {
                 return;
             }
-            let bundlesCount = this.state.uuidBundlesCheckedCount;
             if (!(uuid in bundlesCount)) {
                 bundlesCount[uuid] = 0;
             }
@@ -253,7 +253,10 @@ class Worksheet extends React.Component {
                 delete this.state.uuidBundlesCheckedCount[uuid];
                 delete this.state.checkedBundles[uuid];
             } else {
-                this.state.uuidBundlesCheckedCount[uuid] -= 1;
+                bundlesCount[uuid] -= 1;
+                this.setState({
+                    uuidBundlesCheckedCount: bundlesCount,
+                });
                 delete this.state.checkedBundles[uuid][identifier];
             }
             if (Object.keys(this.state.uuidBundlesCheckedCount).length === 0) {
@@ -1034,7 +1037,15 @@ class Worksheet extends React.Component {
             if (this.hasEditPermission()) {
                 var editor = ace.edit('worksheet-editor');
                 if (saveChanges) {
-                    this.state.ws.info.source = editor.getValue().split('\n');
+                    this.setState({
+                        ws: {
+                            ...this.state.ws,
+                            info: {
+                                ...this.state.ws.info,
+                                source: editor.getValue().split('\n'),
+                            },
+                        },
+                    });
                 }
                 var rawIndex = editor.getCursorPosition().row;
                 this.setState({

--- a/frontend/src/components/worksheets/items/ContentsItem.js
+++ b/frontend/src/components/worksheets/items/ContentsItem.js
@@ -23,7 +23,6 @@ class ContentsItem extends React.Component {
             return <div />;
         }
         var contents = this.props.item.lines.join('');
-        var bundleInfo = this.props.item.bundles_spec.bundle_infos[0];
         return (
             <div className='ws-item' onClick={this.handleClick}>
                 <div className={className} ref={this.props.item.ref}>

--- a/frontend/src/components/worksheets/items/GraphItem.js
+++ b/frontend/src/components/worksheets/items/GraphItem.js
@@ -50,7 +50,6 @@ class GraphItem extends React.Component {
         // columns, one for x and y.
         var ytox = {}; // Maps the names of the y columns to x columns
         var columns = [];
-        var totalNumPoints = 0;
         for (var i = 0; i < item.trajectories.length; i++) {
             // For each trajectory
             var info = item.trajectories[i];
@@ -71,7 +70,6 @@ class GraphItem extends React.Component {
             }
             columns.push(xcol);
             columns.push(ycol);
-            totalNumPoints += points.length;
         }
 
         return {

--- a/frontend/src/components/worksheets/items/MarkdownItem.js
+++ b/frontend/src/components/worksheets/items/MarkdownItem.js
@@ -101,7 +101,7 @@ class MarkdownItem extends React.Component {
     };
 
     deleteItem = () => {
-        const { reloadWorksheet, item, worksheetUUID, setFocus, focused, focusIndex } = this.props;
+        const { reloadWorksheet, item, worksheetUUID } = this.props;
         const url = `/rest/worksheets/${worksheetUUID}/add-items`;
         $.ajax({
             url,

--- a/frontend/src/components/worksheets/items/SchemaItem/SchemaItem.js
+++ b/frontend/src/components/worksheets/items/SchemaItem/SchemaItem.js
@@ -136,11 +136,13 @@ class SchemaItem extends React.Component<{
         const headerKeys = this.props.item.header;
         let textFieldChanged = false;
         for (let ind = 0; ind < originalRows.length; ind++) {
+            let candTextFieldChanged = false;
             headerKeys.forEach((key) => {
                 if (originalRows[ind][key] !== this.state.rows[ind][key]) {
-                    textFieldChanged = true;
+                    candTextFieldChanged = true;
                 }
             });
+            textFieldChanged = candTextFieldChanged;
         }
         return textFieldChanged;
     };

--- a/frontend/src/components/worksheets/items/SchemaItem/SchemaItem.js
+++ b/frontend/src/components/worksheets/items/SchemaItem/SchemaItem.js
@@ -59,7 +59,7 @@ class SchemaItem extends React.Component<{
     };
 
     saveSchema = () => {
-        const { schema_name, field_rows, ids } = this.props.item;
+        const { schema_name, ids } = this.props.item;
         let updatedSchema = ['schema ' + this.state.curSchemaName];
         let fromAddSchema = false;
         // Note: When using the add-item end point,

--- a/frontend/src/components/worksheets/items/TextEditorItem/TextEditorItem.js
+++ b/frontend/src/components/worksheets/items/TextEditorItem/TextEditorItem.js
@@ -61,8 +61,6 @@ class TextEditorItem extends React.Component<{
         const {
             ids,
             mode,
-            showDefault,
-            defaultValue,
             worksheetUUID,
             after_sort_key,
             reloadWorksheet,
@@ -106,7 +104,7 @@ class TextEditorItem extends React.Component<{
     };
 
     render() {
-        const { classes, defaultValue, showDefault } = this.props;
+        const { classes, defaultValue } = this.props;
         Mousetrap.bindGlobal(['ctrl+enter'], () => {
             this.saveText();
             Mousetrap.unbindGlobal(['ctrl+enter']);

--- a/frontend/src/components/worksheets/items/WorksheetItem.js
+++ b/frontend/src/components/worksheets/items/WorksheetItem.js
@@ -144,7 +144,9 @@ class TableWorksheetRow extends React.Component {
             <tr className={className} id={this.props.id}>
                 <td>
                     <div onClick={this.handleRowClick}>
-                        <a onClick={this.handleTextClick}>{`${item.title + ' '}[${item.name}]`}</a>
+                        <button class='link' onClick={this.handleTextClick}>{`${item.title + ' '}[${
+                            item.name
+                        }]`}</button>
                     </div>
                 </td>
             </tr>

--- a/frontend/src/css/imports.scss
+++ b/frontend/src/css/imports.scss
@@ -493,10 +493,14 @@ button.link {
   border: none;
   cursor: pointer;
   outline:none;
+  display: inline;
 }
 button.link:hover{
   text-decoration: underline;
   color: #1a4b75;
+}
+.link-button:focus {
+  text-decoration: none;
 }
 
 .context-menu {

--- a/frontend/src/css/imports.scss
+++ b/frontend/src/css/imports.scss
@@ -482,7 +482,7 @@ a.button-disabled {
   color: #b4b4b4;
 }
 
-// Make <button> looks like <a>
+// Make <button> look like <a>
 button.link {
   font-size: 1em;
   text-align: left;

--- a/frontend/src/css/imports.scss
+++ b/frontend/src/css/imports.scss
@@ -481,6 +481,24 @@ a.button-disabled {
   background-color: #e6e6e6;
   color: #b4b4b4;
 }
+
+// Make <button> looks like <a>
+button.link {
+  font-size: 1em;
+  text-align: left;
+  color:  #4479b2;
+  background: none;
+  margin: 0;
+  padding: 0;
+  border: none;
+  cursor: pointer;
+  outline:none;
+}
+button.link:hover{
+  text-decoration: underline;
+  color: #1a4b75;
+}
+
 .context-menu {
   font-size: 14px;
   background-color: white;

--- a/frontend/src/util/worksheet_utils.js
+++ b/frontend/src/util/worksheet_utils.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import $ from 'jquery';
 import _ from 'underscore';
 
 // See codalab.lib.formatting in codalab-worksheets

--- a/frontend/src/util/ws_mousetrap_fork.js
+++ b/frontend/src/util/ws_mousetrap_fork.js
@@ -20,7 +20,7 @@
  * @version 1.6.3
  * @url craig.is/killing/mice
  */
-(function(window, document) {
+(function(window, document, undefined) {
     // Check if mousetrap is used inside browser, if not, return
     if (!window) {
         return;

--- a/frontend/src/util/ws_mousetrap_fork.js
+++ b/frontend/src/util/ws_mousetrap_fork.js
@@ -20,7 +20,7 @@
  * @version 1.6.3
  * @url craig.is/killing/mice
  */
-(function(window, document, undefined) {
+(function(window, document) {
     // Check if mousetrap is used inside browser, if not, return
     if (!window) {
         return;

--- a/tests/ui/ui_tester.py
+++ b/tests/ui/ui_tester.py
@@ -317,13 +317,13 @@ class WorksheetTest(UITester):
         self.login()
         self.wait_until_worksheet_content_loads()
         # wait for small worksheet to be resolved from place holder item
-        by = By.LINK_TEXT
-        selector = "Small Worksheet [cl_small_worksheet]"
+        by = By.XPATH
+        selector = '//button[text()="Small Worksheet [cl_small_worksheet]"]'
         timeout_message = 'Timed out while waiting for {}: {}.'.format(by, selector)
         WebDriverWait(self.browser, 10).until(
             EC.presence_of_element_located((by, selector)), message=timeout_message
         )
-        self.click(By.LINK_TEXT, 'Small Worksheet [cl_small_worksheet]')
+        self.click(by, selector)
         self.switch_to_new_tab()
         self.wait_until_worksheet_content_loads()
         self.output_images('worksheet_container')


### PR DESCRIPTION
### Reasons for making this change

Fix all existing frontend npm build warnings.
Warnings include:
- unused vars
- direct mutation of state
- shadowing of global property `undefined`
- unsafe references in Function declared in a loop 
- fake links that should really just be buttons

### Related issues

fixes #1094 

### Screenshots

No more npm warning when running `pre-commit.sh`:

<img width="835" alt="1094-var" src="https://user-images.githubusercontent.com/34461466/94745696-0a3cc380-0330-11eb-9771-310b28511230.png">

Use `<button>` to replace `<a>`:

![1094-button](https://user-images.githubusercontent.com/34461466/94756005-2d28a100-034b-11eb-8f75-2e46d478c5db.gif)


### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
