### PR TITLE
Make table header row has the same height as table body row

### DIFF
--- a/frontend/src/components/worksheets/items/TableItem/TableItem.js
+++ b/frontend/src/components/worksheets/items/TableItem/TableItem.js
@@ -145,7 +145,15 @@ class TableItem extends React.Component<{
                             [classes.tableHeader]: true,
                         }),
                     }}
-                    style={index === 0 ? { paddingLeft: editPermission ? '30px' : '70px' } : {}}
+                    style={
+                        index === 0
+                            ? {
+                                  paddingLeft: editPermission ? '30px' : '70px',
+                                  paddingBottom: 0,
+                                  paddingTop: 0,
+                              }
+                            : {}
+                    }
                 >
                     {editPermission && index === 0 && (
                         <Tooltip title={'Change the schemas of this table'}>


### PR DESCRIPTION
### Reasons for making this change

Previously, when I removed the effect of table scrolling, I removed the same-height feature of the table header as well. So I open this PR to recover the feature.

### Related issues

fixes #2397 

### Screenshots

<img width="756" alt="2397" src="https://user-images.githubusercontent.com/34461466/95017982-685bf600-0611-11eb-8604-698e62637381.png">


### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
