### PR TITLE
Bump to version 0.5.23

### DIFF
--- a/codalab/common.py
+++ b/codalab/common.py
@@ -8,7 +8,7 @@ import http.client
 
 # Increment this on master when ready to cut a release.
 # http://semver.org/
-CODALAB_VERSION = '0.5.22'
+CODALAB_VERSION = '0.5.23'
 BINARY_PLACEHOLDER = '<binary>'
 URLOPEN_TIMEOUT_SECONDS = 30
 

--- a/codalab/worker_manager/aws_batch_worker_manager.py
+++ b/codalab/worker_manager/aws_batch_worker_manager.py
@@ -68,12 +68,13 @@ class AWSBatchWorkerManager(WorkerManager):
         jobs = []
         for status in ['SUBMITTED', 'PENDING', 'RUNNABLE', 'STARTING', 'RUNNING']:
             response = self.batch_client.list_jobs(jobQueue=self.args.job_queue, jobStatus=status)
-            # Only record jobs if a job regex filter isn't provided or if the job's name completely matches
-            # a provided job regex filter.
-            if not self.args.job_filter or re.fullmatch(
-                self.args.job_filter, response.get("jobName", "")
-            ):
-                jobs.extend(response['jobSummaryList'])
+            for jobSummary in response['jobSummaryList']:
+                # Only record jobs if a job regex filter isn't provided or if the job's name completely matches
+                # a provided job regex filter.
+                if not self.args.job_filter or re.fullmatch(
+                    self.args.job_filter, jobSummary.get("jobName", "")
+                ):
+                    jobs.append(jobSummary)
         logger.info(
             'Workers: {}'.format(
                 ' '.join(job['jobId'] + ':' + job['status'] for job in jobs) or '(none)'

--- a/docs/REST-API-Reference.md
+++ b/docs/REST-API-Reference.md
@@ -1,6 +1,6 @@
 # REST API Reference
 
-_version 0.5.22_
+_version 0.5.23_
 
 This reference and the REST API itself is still under heavy development and is
 subject to change at any time. Feedback through our GitHub issues is appreciated!

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -1,5 +1,5 @@
 // Should match codalab/common.py#CODALAB_VERSION
-export const CODALAB_VERSION = '0.5.22';
+export const CODALAB_VERSION = '0.5.23';
 
 // Name Regex to match the backend in spec_utils.py
 export const NAME_REGEX = /^[a-zA-Z_][a-zA-Z0-9_.-]*$/i;

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import sys
 
 
 # should match codalab/common.py#CODALAB_VERSION
-CODALAB_VERSION = "0.5.22"
+CODALAB_VERSION = "0.5.23"
 
 
 class Install(install):


### PR DESCRIPTION
### Reasons for making this change

Bump new version

Full diff: [0.5.22...rc0.5.23](https://github.com/codalab/codalab-worksheets/compare/0.5.22...rc0.5.23)

# Draft release notes

## Frontend
- Fix the bug of Command + click on a worksheet link opening up two tabs (#2834)
- Validate new worksheet name on the frontend (#2735) 
- Add staged_status to bundle details page (#2850)
- Switch shift-enter and enter in New Run logic change (#2762)
- Create an indicator for when the cursor is "above" all bundles (#2733)
- Fix the bug of upload not releasing keyboard shortcuts (#2867)
- Remove componentWillMount and componentWillReceiveProps in FileBrowser (#2866)
- Move the jump-to-end button to the front (#2876) 
- Fix bug of 'g g' not scrolling to top (#2877) 
- Make file browser have less vertical spacing (#2883)
- Better style of bundle table header (#2879)
- Add schema button and delete schema button (#2686)
- Fix frontend npm build warnings (#2912)
- Reset the state rows when opening the schema detail (#2697)



## Backend
- Share workers among group members (#2463) 
- Better handle nonexistent files in codalab.worker.file_utils.get_path_size (#2855)
- Run negative priority bundles behind those with unspecified priority (#2858)
- Added --worker-group to WorkerManager (#2860)
- Remove "CREATED" docker containers when they've failed to start (#2766)
- Optionally enable sentry on AWS batch workermanager-launched workers (#2889)
- Make WorkerManager name subparser required (#2895)
- Put the hostname in the remote: field for workermanager-launched jobs (#2894)
- Resolve flake8 errors in tests directory and config flake8 property (#2837)
- Resolve flake8 errors in alembic directory (#2839)
- Delete prefixing f (#2865)
- Resolve flake8 errors in scripts directory (#2838)
- Resolve flake8 errors in tests directory (#2841)
- Resolve flake8 errors in root directory (#2840)
- Fix AwsBatchWorkerManager --job-filter (#2945)



## Dev / docs / CI
- Fix stress test path (#2836)
- Improve monitor logging (#2901)



## Dependency upgrades
- Bump sentry-sdk from 0.17.3 to 0.17.4 (#2820)
- Bump @testing-library/react from 10.4.8 to 11.0.2 in /frontend (#2827)
- Bump freezegun from 0.3.15 to 1.0.0 (#2826）
- Bump dompurify from 2.0.14 to 2.0.15 in /frontend (#2828)
- Bump alembic from 1.4.2 to 1.4.3 (#2830)
- Bump coverage from 5.2.1 to 5.3 (#2831)
- Bump sentry-sdk from 0.17.4 to 0.17.5 (#2845)
- Bump sentry-sdk from 0.17.5 to 0.17.6 (#2848)
- Bump sentry-sdk from 0.17.6 to 0.17.7 (#2880) 
- Bump sentry-sdk from 0.17.7 to 0.17.8 (#2887)
- Bump mkdocs-material from 5.5.12 to 5.5.14 (#2886)
- Bump boto3 from 1.14.57 to 1.15.5 (#2893)
- Bump boto3 from 1.15.5 to 1.15.7 (#2908)
- Bump mkdocs-material from 5.5.14 to 6.0.1 (#2905)
- Bump argcomplete from 1.12.0 to 1.12.1 (#2906) 
- Bump sentry-sdk from 0.17.8 to 0.18.0 (#2927) 