### PR TITLE
[rc0.5.23] Fix AwsBatchWorkerManager --job-filter 

### DIFF
--- a/codalab/worker_manager/aws_batch_worker_manager.py
+++ b/codalab/worker_manager/aws_batch_worker_manager.py
@@ -68,12 +68,13 @@ class AWSBatchWorkerManager(WorkerManager):
         jobs = []
         for status in ['SUBMITTED', 'PENDING', 'RUNNABLE', 'STARTING', 'RUNNING']:
             response = self.batch_client.list_jobs(jobQueue=self.args.job_queue, jobStatus=status)
-            # Only record jobs if a job regex filter isn't provided or if the job's name completely matches
-            # a provided job regex filter.
-            if not self.args.job_filter or re.fullmatch(
-                self.args.job_filter, response.get("jobName", "")
-            ):
-                jobs.extend(response['jobSummaryList'])
+            for jobSummary in response['jobSummaryList']:
+                # Only record jobs if a job regex filter isn't provided or if the job's name completely matches
+                # a provided job regex filter.
+                if not self.args.job_filter or re.fullmatch(
+                    self.args.job_filter, jobSummary.get("jobName", "")
+                ):
+                    jobs.append(jobSummary)
         logger.info(
             'Workers: {}'.format(
                 ' '.join(job['jobId'] + ':' + job['status'] for job in jobs) or '(none)'


### PR DESCRIPTION
### Reasons for making this change

Dupe of https://github.com/codalab/codalab-worksheets/pull/2944

This fixes the --job-filter flag to actually work, since it requires iterating into the returned jobSummaryList and breaking it apart.

To, e.g., filter to only jobs that you own, you can use:
--job-filter 'nfliu.*'
