### PR TITLE
order search results by user's own worksheets

### DIFF
--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -3230,6 +3230,7 @@ class BundleCLI(object):
         aliases=('wsearch', 'ws'),
         help=[
             'List worksheets on the current instance matching the given keywords (returns 10 results by default).',
+            'Searcher\'s own worksheets are prioritized',
             '  wls tag=paper           : List worksheets tagged as "paper".',
             '  wls group=<group_spec>  : List worksheets shared with the group identfied by group_spec.',
             '  wls .mine               : List my worksheets.',

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -3230,7 +3230,7 @@ class BundleCLI(object):
         aliases=('wsearch', 'ws'),
         help=[
             'List worksheets on the current instance matching the given keywords (returns 10 results by default).',
-            'Searcher\'s own worksheets are prioritized',
+            'Searcher\'s own worksheets are prioritized.',
             '  wls tag=paper           : List worksheets tagged as "paper".',
             '  wls group=<group_spec>  : List worksheets shared with the group identfied by group_spec.',
             '  wls .mine               : List my worksheets.',

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -1497,7 +1497,14 @@ class BundleModel(object):
             cl_worksheet.c.frozen,
             cl_worksheet.c.owner_id,
         ]
-        query = select(cols_to_select).distinct().where(clause).offset(offset).order_by(desc(cl_worksheet.c.owner_id == user_id)).limit(limit)
+        query = (
+            select(cols_to_select)
+            .distinct()
+            .where(clause)
+            .offset(offset)
+            .order_by(desc(cl_worksheet.c.owner_id == user_id))
+            .limit(limit)
+        )
 
         # Sort
         if sort_key[0] is not None:

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -1497,7 +1497,7 @@ class BundleModel(object):
             cl_worksheet.c.frozen,
             cl_worksheet.c.owner_id,
         ]
-        query = select(cols_to_select).distinct().where(clause).offset(offset).limit(limit)
+        query = select(cols_to_select).distinct().where(clause).offset(offset).order_by(desc(cl_worksheet.c.owner_id == user_id)).limit(limit)
 
         # Sort
         if sort_key[0] is not None:

--- a/docs/CLI-Reference.md
+++ b/docs/CLI-Reference.md
@@ -344,6 +344,7 @@ Usage: `cl <command> <arguments>`
 
 ### wls (wsearch, ws)
     List worksheets on the current instance matching the given keywords (returns 10 results by default).
+    Searcher's own worksheets are prioritized.
       wls tag=paper           : List worksheets tagged as "paper".
       wls group=<group_spec>  : List worksheets shared with the group identfied by group_spec.
       wls .mine               : List my worksheets.


### PR DESCRIPTION
### Reasons for making this change

Solve #2487

### Related issues

### Screenshots

![Screen Shot 2020-10-09 at 1 59 51 PM](https://user-images.githubusercontent.com/13169407/95631016-bde03a80-0a37-11eb-91cf-fdd64b5a4a59.png)

### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [ ] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed


