### PR TITLE
Run github actions on all PRs, even those that are not to master

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
 
 jobs:
   format:


### PR DESCRIPTION
This helps so that PRs that are based on other PRs, such as #2953, still have github actions run on them.