### PR TITLE
Improve the UI message for PermissionError from log in

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,7 +80,7 @@ jobs:
     strategy:
       matrix:
         test:
-          - unittest gen-rest-docs gen-cli-docs gen-readthedocs basic auth status batch anonymous competition unicode rest1 upload1 upload2 upload3 upload4 download refs binary rm make worksheet_search worksheet_tags freeze detach perm search_time groups
+          - unittest gen-rest-docs gen-cli-docs gen-readthedocs basic auth status batch anonymous competition unicode rest1 upload1 upload2 upload3 upload4 download refs binary rm make worksheet_search worksheet_tags freeze detach perm search_time groups worker_manager
           - run
           - run2
           - search link read kill write mimic workers edit_user sharing_workers

--- a/codalab/common.py
+++ b/codalab/common.py
@@ -61,6 +61,12 @@ class PermissionError(UsageError):
     """
 
 
+class LoginPermissionError(PermissionError):
+    """
+    Raised when the login credentials are incorrect.
+    """
+
+
 # Listed in order of most specific to least specific.
 http_codes_and_exceptions = [
     (http.client.FORBIDDEN, PermissionError),

--- a/codalab/lib/codalab_manager.py
+++ b/codalab/lib/codalab_manager.py
@@ -38,7 +38,7 @@ import time
 from distutils.util import strtobool
 
 from codalab.client.json_api_client import JsonApiClient
-from codalab.common import CODALAB_VERSION, PermissionError, UsageError
+from codalab.common import CODALAB_VERSION, UsageError, LoginPermissionError
 from codalab.lib.bundle_store import MultiDiskBundleStore
 from codalab.lib.crypt_util import get_random_string
 from codalab.lib.download_manager import DownloadManager
@@ -49,16 +49,6 @@ from codalab.lib import formatting
 from codalab.model.worker_model import WorkerModel
 
 
-def exception_handler(exctype, value, traceback, debug_hook=sys.excepthook):
-    # All your trace are belong to us!
-    # your format
-    if exctype == PermissionError:
-        print("%s: %s" % (exctype.__name__, value))
-    else:
-        debug_hook(exctype, value, traceback)
-
-
-sys.excepthook = exception_handler
 MAIN_BUNDLE_SERVICE = 'https://worksheets.codalab.org'
 
 
@@ -511,7 +501,7 @@ class CodaLabManager(object):
 
         token_info = auth_handler.generate_token('credentials', username, password)
         if token_info is None:
-            raise PermissionError("Invalid username or password.")
+            raise LoginPermissionError("Invalid username or password.")
         return _cache_token(token_info, username)
 
     def get_current_worksheet_uuid(self):

--- a/codalab/lib/codalab_manager.py
+++ b/codalab/lib/codalab_manager.py
@@ -49,6 +49,16 @@ from codalab.lib import formatting
 from codalab.model.worker_model import WorkerModel
 
 
+def exception_handler(exctype, value, traceback, debug_hook=sys.excepthook):
+    # All your trace are belong to us!
+    # your format
+    if exctype == PermissionError:
+        print("%s: %s" % (exctype.__name__, value))
+    else:
+        debug_hook(exctype, value, traceback)
+
+
+sys.excepthook = exception_handler
 MAIN_BUNDLE_SERVICE = 'https://worksheets.codalab.org'
 
 

--- a/codalab/server/auth.py
+++ b/codalab/server/auth.py
@@ -67,5 +67,3 @@ class RestOAuthHandler(object):
             if e.code == 401:
                 return None
             raise e
-        except urllib.error.URLError:
-            print("Your login info is incorrect. Please try again.")

--- a/codalab/server/auth.py
+++ b/codalab/server/auth.py
@@ -68,4 +68,4 @@ class RestOAuthHandler(object):
                 return None
             raise e
         except urllib.error.URLError:
-            print("Your login info is incorrect. Please double check")
+            print("Your login info is incorrect. Please try again.")

--- a/codalab/server/auth.py
+++ b/codalab/server/auth.py
@@ -6,7 +6,7 @@ import json
 import urllib.request
 import urllib.parse
 import urllib.error
-from codalab.common import URLOPEN_TIMEOUT_SECONDS
+from codalab.common import URLOPEN_TIMEOUT_SECONDS, LoginPermissionError
 
 
 # TODO(sckoo): clean up auth logic across:

--- a/codalab/server/auth.py
+++ b/codalab/server/auth.py
@@ -66,4 +66,6 @@ class RestOAuthHandler(object):
         except urllib.error.HTTPError as e:
             if e.code == 401:
                 return None
-            raise
+            raise e
+        except urllib.error.URLError:
+            print("Your login info is incorrect. Please double check")

--- a/codalab/worker_manager/main.py
+++ b/codalab/worker_manager/main.py
@@ -4,6 +4,8 @@ Main entry point for the worker managers.
 
 import argparse
 import logging
+
+from codalab.common import LoginPermissionError
 from .aws_batch_worker_manager import AWSBatchWorkerManager
 from .azure_batch_worker_manager import AzureBatchWorkerManager
 from .slurm_batch_worker_manager import SlurmBatchWorkerManager
@@ -130,7 +132,10 @@ def main():
         )
 
     manager = worker_manager_types[args.worker_manager_name](args)
-    manager.run_loop()
+    try:
+        manager.run_loop()
+    except LoginPermissionError:
+        print('Login credentials are incorrect. Please double check')
 
 
 if __name__ == '__main__':

--- a/codalab/worker_manager/main.py
+++ b/codalab/worker_manager/main.py
@@ -5,7 +5,6 @@ Main entry point for the worker managers.
 import argparse
 import logging
 
-from codalab.common import LoginPermissionError
 from .aws_batch_worker_manager import AWSBatchWorkerManager
 from .azure_batch_worker_manager import AzureBatchWorkerManager
 from .slurm_batch_worker_manager import SlurmBatchWorkerManager
@@ -132,10 +131,7 @@ def main():
         )
 
     manager = worker_manager_types[args.worker_manager_name](args)
-    try:
-        manager.run_loop()
-    except LoginPermissionError:
-        print('All attempts have failed. Please double check your login credentials.')
+    manager.run_loop()
 
 
 if __name__ == '__main__':

--- a/codalab/worker_manager/main.py
+++ b/codalab/worker_manager/main.py
@@ -135,7 +135,7 @@ def main():
     try:
         manager.run_loop()
     except LoginPermissionError:
-        print('Login credentials are incorrect. Please double check')
+        print('All attempts have failed. Please double check your login credentials.')
 
 
 if __name__ == '__main__':

--- a/codalab/worker_manager/worker_manager.py
+++ b/codalab/worker_manager/worker_manager.py
@@ -12,7 +12,7 @@ from argparse import ArgumentParser
 from collections import namedtuple
 from typing import Dict, List, Union
 
-from codalab.common import NotFoundError
+from codalab.common import NotFoundError, LoginPermissionError
 from codalab.client.json_api_client import JsonApiException
 from codalab.lib.codalab_manager import CodaLabManager
 from codalab.lib.formatting import parse_size
@@ -154,18 +154,17 @@ class WorkerManager(object):
             except (
                 http.client.HTTPException,
                 socket.error,
-                NotFoundError,
+                urllib.error.URLError,
+                JsonApiException,
+                ssl.SSLError,
             ):
                 # Sometimes, network errors occur when running the WorkerManager . These are often
                 # transient exceptions, and retrying the command would lead to success---as a result,
                 # we ignore these network-based exceptions (rather than fatally exiting from the
                 # WorkerManager )
                 traceback.print_exc()
-            except (urllib.error.URLError, JsonApiException, ssl.SSLError) as e:
-                if "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed" in str(e):
-                    print("Your login info is incorrect. Please try again.")
-                else:
-                    traceback.print_exc()
+            except NotFoundError:
+                print("Your login info is incorrect. Please try again.")
 
             if self.args.once:
                 break

--- a/codalab/worker_manager/worker_manager.py
+++ b/codalab/worker_manager/worker_manager.py
@@ -169,7 +169,6 @@ class WorkerManager(object):
 
             if self.args.once:
                 break
-            print('Sleeping {} seconds'.format(self.args.sleep_time))
             logger.debug('Sleeping {} seconds'.format(self.args.sleep_time))
             time.sleep(self.args.sleep_time)
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -2367,6 +2367,32 @@ def test_nonexistent(ctx):
     _run_command([cl, 'work', 'nonexistent::'], expected_exit_code=1)
 
 
+@TestModule.register('worker_manager')
+def test_false_login(ctx):
+    username = os.getenv("CODALAB_USERNAME")
+    password = os.getenv("CODALAB_PASSWORD")
+    del os.environ["CODALAB_USERNAME"]
+    del os.environ["CODALAB_PASSWORD"]
+    _run_command([cl, 'logout'])
+    os.environ["CODALAB_USERNAME"] = username
+    os.environ["CODALAB_PASSWORD"] = "wrongpassword"
+    os.environ['USER'] = "some_user"
+    result = _run_command(
+        [
+            cl_worker_manager,
+            '--server=https://worksheets.codalab.org/',
+            'slurm-batch',
+            '--partition',
+            'foo',
+        ],
+        1,
+    )
+    print("result is " + str(result))
+    sys.stdout.flush()
+    os.environ["CODALAB_USERNAME"] = username
+    os.environ["CODALAB_PASSWORD"] = password
+
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
         description='Runs the specified CodaLab worksheets unit and integration tests against the specified CodaLab instance (defaults to localhost)'
@@ -2403,10 +2429,17 @@ if __name__ == '__main__':
         choices=list(TestModule.modules.keys()) + ['all', 'default'],
         help='Tests to run from: {%(choices)s}',
     )
+    parser.add_argument(
+        '--cl-worker-manager',
+        type=str,
+        help='Path to codalab worker manager CLI executable, defaults to "cl-worker-manager"',
+        default='cl-worker-manager',
+    )
 
     args = parser.parse_args()
     cl = args.cl_executable
     cl_version = args.cl_version
+    cl_worker_manager = args.cl_worker_manager
     success = TestModule.run(args.tests, args.instance, args.second_instance)
     if not success:
         sys.exit(1)


### PR DESCRIPTION
### Reasons for making this change
Suppress extra stack traces for errors occurring when login credentials are incorrect
<!-- Add a reason for making this change here. -->

### Related issues
#2316 
<!-- Add a reference to issues resolved, if applicable (for example, "fixes #1"). -->

### Screenshots

<!-- Add screenshots, if necessary -->
![image](https://user-images.githubusercontent.com/18689351/96933892-2b4b8c80-1476-11eb-8bd0-53ddc384b135.png)
afer commit 4:
![image](https://user-images.githubusercontent.com/18689351/97265570-1a877780-17e4-11eb-8090-8b27ee723327.png)


### Checklist

* [ ] I've added a screenshot of the changes, if this is a frontend change
* [ ] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [ ] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
