### PR TITLE
Regularize the column header name

### DIFF
--- a/frontend/src/components/worksheets/items/TableItem/TableItem.js
+++ b/frontend/src/components/worksheets/items/TableItem/TableItem.js
@@ -134,6 +134,8 @@ class TableItem extends React.Component<{
         let bundleInfos = item.bundles_spec.bundle_infos;
         let headerItems = item.header;
         let headerHtml = headerItems.map((item, index) => {
+            item = item === 'uuid[0:8]' ? 'uuid' : item;
+            item = item === 'summary[0:1024]' ? 'summary' : item;
             return (
                 <TableCell
                     onMouseEnter={(e) => this.setState({ hovered: true })}


### PR DESCRIPTION
### Reasons for making this change

Make sure the column header does not contain the truncate symbols.


### Screenshots

Before:
<img width="917" alt="Screen Shot 2020-10-14 at 2 24 55 PM" src="https://user-images.githubusercontent.com/34461466/96048698-cc5d9600-0e2b-11eb-9fde-695487618a0f.png">

After:
<img width="938" alt="Screen Shot 2020-10-14 at 2 38 39 PM" src="https://user-images.githubusercontent.com/34461466/96048564-a33d0580-0e2b-11eb-9723-87b4268820c9.png">



### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
