### PR TITLE
Better handle EC2 spot interruptions in AWS Batch WorkerManager

### DIFF
--- a/codalab/worker_manager/aws_batch_worker_manager.py
+++ b/codalab/worker_manager/aws_batch_worker_manager.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import re
+from shlex import quote
 import uuid
 from .worker_manager import WorkerManager, WorkerJob
 
@@ -110,7 +111,12 @@ class AWSBatchWorkerManager(WorkerManager):
                 'image': image,
                 'vcpus': self.args.cpus,
                 'memory': self.args.memory_mb,
-                'command': command,
+                'command': [
+                    "/bin/bash",
+                    "-c",
+                    "/opt/scripts/detect-ec2-spot-preemption.sh & "
+                    + " ".join(quote(arg) for arg in command),
+                ],
                 'environment': [
                     {'name': 'CODALAB_USERNAME', 'value': os.environ.get('CODALAB_USERNAME')},
                     {'name': 'CODALAB_PASSWORD', 'value': os.environ.get('CODALAB_PASSWORD')},

--- a/docker/dockerfiles/Dockerfile.worker
+++ b/docker/dockerfiles/Dockerfile.worker
@@ -14,7 +14,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 
 RUN apt-get update && \
-  apt-get install -y --no-install-recommends software-properties-common && \
+  apt-get install -y --no-install-recommends software-properties-common curl && \
   add-apt-repository ppa:deadsnakes/ppa && \
   apt-get update && \
   apt-get install -y --no-install-recommends \
@@ -34,6 +34,7 @@ RUN echo "{\"credsStore\": \"ecr-login\"}" >> ~/.docker/config.json
 
 WORKDIR /opt
 RUN mkdir ${WORKDIR}/codalab
+RUN mkdir ${WORKDIR}/scripts
 
 # Install dependencies
 COPY requirements.txt requirements.txt
@@ -44,6 +45,7 @@ RUN python3.6 -m pip install --user --no-cache-dir --upgrade pip; \
 COPY codalab/lib codalab/lib
 COPY codalab/worker codalab/worker
 COPY codalab/common.py codalab/common.py
+COPY scripts/detect-ec2-spot-preemption.sh scripts/detect-ec2-spot-preemption.sh
 COPY setup.py setup.py
 
 RUN python3 -m pip install --no-cache-dir -e .

--- a/scripts/detect-ec2-spot-preemption.sh
+++ b/scripts/detect-ec2-spot-preemption.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+while true
+do
+    # This IP address comes from:
+    # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-interruptions.html#spot-instance-termination-notices
+    # It's a special endpoint set up by AWS whereby AWS instances can view metadata about themselves.
+    # One such piece of metadata is the termination time, which is only set when the spot instance is to be
+    # pre-empted (you get a 404 otherwise).
+    # This script was partially taken from https://stackoverflow.com/q/32613600/14089059 .
+    if [ -z $(curl -Is http://169.254.169.254/latest/meta-data/spot/termination-time | head -1 | grep 404 | cut -d \  -f 2) ]
+    then
+        echo "EC2 spot instance scheduled for shutdown."
+        echo "Sending SIGTERM to CodaLab workers"
+        # Kill all cl-workers in the EC2 instance.
+        pgrep -f "cl-worker" | xargs kill
+    else
+        # Instance not yet marked for termination, so sleep and check again in 5 seconds.
+        sleep 5
+    fi
+done

--- a/scripts/detect-ec2-spot-preemption.sh
+++ b/scripts/detect-ec2-spot-preemption.sh
@@ -14,6 +14,7 @@ do
         echo "Sending SIGTERM to CodaLab workers"
         # Kill all cl-workers in the EC2 instance.
         pgrep -f "cl-worker" | xargs kill
+        sleep 5
     else
         # Instance not yet marked for termination, so sleep and check again in 5 seconds.
         sleep 5

--- a/scripts/detect-ec2-spot-preemption.sh
+++ b/scripts/detect-ec2-spot-preemption.sh
@@ -18,4 +18,4 @@ echo "EC2 spot instance scheduled for shutdown."
 echo "Sending SIGTERM to CodaLab workers"
 # Kill all cl-workers in the EC2 instance.
 pgrep -f "cl-worker" | xargs kill
-echo "Sendt SIGTERM to CodaLab workers"
+echo "Sent SIGTERM to CodaLab workers"

--- a/scripts/detect-ec2-spot-preemption.sh
+++ b/scripts/detect-ec2-spot-preemption.sh
@@ -7,16 +7,17 @@ do
     # It's a special endpoint set up by AWS whereby AWS instances can view metadata about themselves.
     # One such piece of metadata is the termination time, which is only set when the spot instance is to be
     # pre-empted (you get a 404 otherwise).
-    # This script was partially taken from https://stackoverflow.com/q/32613600/14089059 .
-    if [ -z $(curl -Is http://169.254.169.254/latest/meta-data/spot/termination-time | head -1 | grep 404 | cut -d \  -f 2) ]
+    # This script was partially taken from:
+    # https://github.com/AmazonWebServices-Projects/ec2-spot-labs/blob/master/ec2-spot-interruption-handler/wait_x_seconds_before_interruption.sh
+    if [ -n "$(curl -s http://169.254.169.254/latest/meta-data/spot/instance-action | grep 404)" ];
     then
+        # Instance not yet marked for termination, so sleep and check again in 5 seconds.
+        sleep 5
+    else
         echo "EC2 spot instance scheduled for shutdown."
         echo "Sending SIGTERM to CodaLab workers"
         # Kill all cl-workers in the EC2 instance.
         pgrep -f "cl-worker" | xargs kill
-        sleep 5
-    else
-        # Instance not yet marked for termination, so sleep and check again in 5 seconds.
         sleep 5
     fi
 done

--- a/scripts/detect-ec2-spot-preemption.sh
+++ b/scripts/detect-ec2-spot-preemption.sh
@@ -1,23 +1,21 @@
 #!/usr/bin/env bash
 
-while true
-do
-    # This IP address comes from:
-    # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-interruptions.html#spot-instance-termination-notices
-    # It's a special endpoint set up by AWS whereby AWS instances can view metadata about themselves.
-    # One such piece of metadata is the termination time, which is only set when the spot instance is to be
-    # pre-empted (you get a 404 otherwise).
-    # This script was partially taken from:
+# This script was partially taken from:
     # https://github.com/AmazonWebServices-Projects/ec2-spot-labs/blob/master/ec2-spot-interruption-handler/wait_x_seconds_before_interruption.sh
-    if [ -n "$(curl -s http://169.254.169.254/latest/meta-data/spot/instance-action | grep 404)" ];
-    then
-        # Instance not yet marked for termination, so sleep and check again in 5 seconds.
-        sleep 5
-    else
-        echo "EC2 spot instance scheduled for shutdown."
-        echo "Sending SIGTERM to CodaLab workers"
-        # Kill all cl-workers in the EC2 instance.
-        pgrep -f "cl-worker" | xargs kill
-        sleep 5
-    fi
+
+# This IP address comes from:
+# https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-interruptions.html#spot-instance-termination-notices
+# It's a special endpoint set up by AWS whereby AWS instances can view metadata about themselves.
+# One such piece of metadata is the termination action + time, which is only set when the spot instance is to be
+# pre-empted (you get a 404 otherwise).
+while [ -n "$(curl -s http://169.254.169.254/latest/meta-data/spot/instance-action | grep 404)" ];
+do
+   sleep 5
 done
+
+
+echo "EC2 spot instance scheduled for shutdown."
+echo "Sending SIGTERM to CodaLab workers"
+# Kill all cl-workers in the EC2 instance.
+pgrep -f "cl-worker" | xargs kill
+echo "Sendt SIGTERM to CodaLab workers"


### PR DESCRIPTION
(Continuation of #2976 , opening from a branch on codalab/codalab-worksheets so the tag is pushed to docker hub)

### Reasons for making this change

When EC2 spot instances are preempted, they're given 2 minutes to clean up. These cleanup signals are sent via an AWS web endpoint (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-interruptions.html#spot-instance-termination-notices). Then, the container terminates.

Right now, we don't catch these interruption notices, so jobs running on AWS workers will go into `worker_offline` state instead of being restaged. This PR adds a script to (1) catch the EC2 preemption notices and (2) send a SIGTERM to all CodaLab workers when it sees one. When the CodaLab worker gets a SIGTERM, it should restage its jobs (if applicable) / clean up and prepare for a graceful exit.