### PR TITLE
Bump to Version 0.5.25

### DIFF
--- a/codalab/common.py
+++ b/codalab/common.py
@@ -8,7 +8,7 @@ import http.client
 
 # Increment this on master when ready to cut a release.
 # http://semver.org/
-CODALAB_VERSION = '0.5.23'
+CODALAB_VERSION = '0.5.25'
 BINARY_PLACEHOLDER = '<binary>'
 URLOPEN_TIMEOUT_SECONDS = 30
 

--- a/docs/REST-API-Reference.md
+++ b/docs/REST-API-Reference.md
@@ -1,6 +1,6 @@
 # REST API Reference
 
-_version 0.5.23_
+_version 0.5.25_
 
 This reference and the REST API itself is still under heavy development and is
 subject to change at any time. Feedback through our GitHub issues is appreciated!

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -1,5 +1,5 @@
 // Should match codalab/common.py#CODALAB_VERSION
-export const CODALAB_VERSION = '0.5.23';
+export const CODALAB_VERSION = '0.5.25';
 
 // Name Regex to match the backend in spec_utils.py
 export const NAME_REGEX = /^[a-zA-Z_][a-zA-Z0-9_.-]*$/i;

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -1,7 +1,6 @@
 // Should match codalab/common.py#CODALAB_VERSION
 export const CODALAB_VERSION = '0.5.25';
 
-
 // Name Regex to match the backend in spec_utils.py
 export const NAME_REGEX = /^[a-zA-Z_][a-zA-Z0-9_.-]*$/i;
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import sys
 
 
 # should match codalab/common.py#CODALAB_VERSION
-CODALAB_VERSION = "0.5.23"
+CODALAB_VERSION = "0.5.25"
 
 
 class Install(install):


### PR DESCRIPTION
Full diff: https://github.com/codalab/codalab-worksheets/compare/rc0.5.24...rc0.5.25

## Frontend
- Better style of the schema blocks (#2941)

## Backend
- `uls` search for user stats (#2389)
- Better handle EC2 spot interruptions in AWS Batch WorkerManager (#2977)

## Dev / docs / CI
- Add flake8 check to pre-commit.sh (#2864)
- Fix More Flake8 Violations (#2975)
- Resolve following flake8 violations (#2965)
- Fix flake8 errors in codalab/ (#2844)