### PR TITLE
Add required CI check for when all CI tasks are complete

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -339,3 +339,10 @@ jobs:
         with:
           name: logs-test-${{ matrix.test }}
           path: /tmp/logs
+
+  ci:
+    name: All CI tasks complete
+    runs-on: ubuntu-latest
+    needs: [format, test_frontend, build, test_backend, test_backend_on_worker_restart, test_backend_sharedfs, test_backend_protected_mode, test_ui]
+    steps:
+      - run: echo Done


### PR DESCRIPTION
Fixes #2544 by making a "ci" job that depends on all other CI jobs. Once this is merged, we can make this single "ci" job the only required job for all PRs to be merged.