### PR TITLE
Keep all other fields intact and clear only the password field when the user fails in the sign up process

### DIFF
--- a/frontend/src/components/SignUp.js
+++ b/frontend/src/components/SignUp.js
@@ -43,6 +43,28 @@ export class SignUp extends React.Component {
         );
     };
 
+    componentDidMount() {
+        const { error } = queryString.parse(this.props.location.search);
+        if (!error) {
+            return;
+        }
+        // Retrieve previous user input from the Http Request
+        const { email, username, first_name, last_name, affiliation } = queryString.parse(
+            this.props.location.search,
+        );
+        this.setState(
+            Immutable({
+                form: {
+                    email: email,
+                    username: username,
+                    first_name: first_name,
+                    last_name: last_name,
+                    affiliation: affiliation,
+                },
+            }),
+        );
+    }
+
     render() {
         const { error } = queryString.parse(this.props.location.search);
         return (


### PR DESCRIPTION
### Reasons for making this change

Enable the users not to re-type everything when they're trying to sign up. Clear the password field since it contains secure information.

### Related issues

fixes #2404 

### Screenshots

![ezgif com-gif-maker](https://user-images.githubusercontent.com/34461466/97141894-dbdaba00-171c-11eb-99a5-8700fc75ac89.gif)


### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
