### PR TITLE
Redistribute space for MainContent and Sidebar of the bundle details

### DIFF
--- a/frontend/src/components/worksheets/ConfigPanel/ConfigPanel.jsx
+++ b/frontend/src/components/worksheets/ConfigPanel/ConfigPanel.jsx
@@ -64,19 +64,22 @@ const styles = (theme) => ({
     container: {
         flexGrow: 1,
         height: '100%',
-        maxWidth: 1080,
+        maxWidth: '100%',
     },
     content: {
         backgroundColor: 'white',
         padding: theme.spacing.larger,
         maxHeight: '100%',
         overflow: 'auto',
+        flexGrow: 1,
+        maxWidth: '90%',
     },
     sidebar: {
         backgroundColor: theme.color.grey.lighter,
         padding: theme.spacing.larger,
         maxHeight: '100%',
         overflow: 'auto',
+        maxWidth: 250,
     },
     buttons: {
         '& button': {


### PR DESCRIPTION
### Reasons for making this change

Previously, there's a bunch of unused empty space to the right of the side panel in expanded mode. 
Now, assign a fixed width to the sidebar, and enable the main content to take up the majority of the space, scaling with the width.


### Related issues

fixes #2668 

### Screenshots

Before:
![88625105-fb4e4200-d05c-11ea-92f2-a4550d1de36f](https://user-images.githubusercontent.com/34461466/97158003-1c92fd00-1736-11eb-8f97-b1806bcdaf89.png)

After:
![2668](https://user-images.githubusercontent.com/34461466/97158033-274d9200-1736-11eb-8cac-648ed5c2b7b4.gif)


### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
