### PR TITLE
Show a dialog for schema deletion

### DIFF
--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -609,6 +609,13 @@ class Worksheet extends React.Component {
         this.autoHideOpenedMessagePopover();
     };
 
+    setDeleteSchemaItemCallback = (callback) => {
+        this.setState({
+            deleteItemCallback: callback,
+            openedDialog: DIALOG_TYPES.OPEN_DELETE_SCHEMA,
+        });
+    };
+
     autoHideOpenedMessagePopover() {
         const self = this;
         if (this.timer) {
@@ -1676,6 +1683,7 @@ class Worksheet extends React.Component {
                 onAsyncItemLoad={this.onAsyncItemLoad}
                 updateBundleBlockSchema={this.updateBundleBlockSchema}
                 updateSchemaItem={this.updateSchemaItem}
+                setDeleteSchemaItemCallback={this.setDeleteSchemaItemCallback}
             />
         );
 

--- a/frontend/src/components/worksheets/WorksheetDialogs.js
+++ b/frontend/src/components/worksheets/WorksheetDialogs.js
@@ -199,6 +199,40 @@ class WorksheetDialogs extends React.Component {
                         </DialogContentText>
                     </DialogContent>
                 </Dialog>
+                {/* Delete schema dialog */}
+                <Dialog
+                    open={this.props.openedDialog === DIALOG_TYPES.OPEN_DELETE_SCHEMA}
+                    onClose={this.props.closeDialog}
+                    aria-labelledby='delete-schema-confirmation-title'
+                    aria-describedby='delete-schema-confirmation-description'
+                >
+                    <DialogTitle id='delete-schema-confirmation-title' style={{ color: 'red' }}>
+                        Delete this schema permanently?
+                    </DialogTitle>
+                    <DialogContent>
+                        <DialogContentText
+                            id='alert-dialog-description'
+                            style={{ color: 'red', marginBottom: '20px' }}
+                        >
+                            {'Schema deletion cannot be undone.'}
+                        </DialogContentText>
+                        <DialogContentText id='alert-dialog-description' style={{ color: 'grey' }}>
+                            {'Note: Deleting a schema does not delete its bundles.'}
+                        </DialogContentText>
+                        <DialogActions>
+                            <Button color='primary' onClick={this.props.closeDialog}>
+                                CANCEL
+                            </Button>
+                            <Button
+                                color='primary'
+                                variant='contained'
+                                onClick={this.props.deleteItemCallback}
+                            >
+                                DELETE
+                            </Button>
+                        </DialogActions>
+                    </DialogContent>
+                </Dialog>
             </div>
         );
     }

--- a/frontend/src/components/worksheets/WorksheetItemList.js
+++ b/frontend/src/components/worksheets/WorksheetItemList.js
@@ -249,6 +249,7 @@ class WorksheetItemList extends React.Component {
                         saveAndUpdateWorksheet: this.props.saveAndUpdateWorksheet,
                         onAsyncItemLoad: (item) => this.props.onAsyncItemLoad(index, item),
                         updateSchemaItem: this.props.updateSchemaItem,
+                        setDeleteSchemaItemCallback: this.props.setDeleteSchemaItemCallback,
                     };
                     addWorksheetItems(
                         props,
@@ -306,6 +307,7 @@ class WorksheetItemList extends React.Component {
                             }}
                             create={true}
                             updateSchemaItem={this.props.updateSchemaItem}
+                            setDeleteSchemaItemCallback={this.props.setDeleteSchemaItemCallback}
                         />
                     )}
                     {worksheet_items}

--- a/frontend/src/components/worksheets/items/SchemaItem/SchemaItem.js
+++ b/frontend/src/components/worksheets/items/SchemaItem/SchemaItem.js
@@ -38,7 +38,6 @@ class SchemaItem extends React.Component<{
             rows: [...this.props.item.field_rows],
             curSchemaName: this.props.item.schema_name,
             newAddedRow: -1,
-            confirmingDeletion: false,
         };
     }
 
@@ -50,7 +49,6 @@ class SchemaItem extends React.Component<{
         }
         if (save) {
             this.saveSchema();
-            this.setState({ confirmingDeletion: false });
         }
     };
 
@@ -59,7 +57,6 @@ class SchemaItem extends React.Component<{
             rows: [...this.props.item.field_rows],
             curSchemaName: this.props.item.schema_name,
             newAddedRow: -1,
-            confirmingDeletion: false,
         });
     };
 
@@ -199,7 +196,7 @@ class SchemaItem extends React.Component<{
     };
 
     deleteThisSchema = () => {
-        this.setState({ showSchemaDetail: false, confirmingDeletion: false });
+        this.setState({ showSchemaDetail: false });
         this.props.updateSchemaItem([], this.props.item.ids, null, false, true);
     };
 
@@ -313,10 +310,8 @@ class SchemaItem extends React.Component<{
                                         this.props.onSubmit();
                                         return;
                                     }
-                                    this.setState({ confirmingDeletion: true });
                                     this.props.setDeleteItemCallback(this.deleteThisSchema);
                                 }}
-                                disabled={this.state.confirmingDeletion}
                             >
                                 <DeleteForeverIcon fontSize='small' />
                             </IconButton>

--- a/frontend/src/components/worksheets/items/SchemaItem/SchemaItem.js
+++ b/frontend/src/components/worksheets/items/SchemaItem/SchemaItem.js
@@ -24,10 +24,7 @@ import Tooltip from '@material-ui/core/Tooltip';
 import HelpOutlineOutlinedIcon from '@material-ui/icons/HelpOutlineOutlined';
 import { getAfterSortKey } from '../../../../util/worksheet_utils';
 import DeleteForeverIcon from '@material-ui/icons/DeleteForever';
-import WarningIcon from '@material-ui/icons/Warning';
-import CancelIcon from '@material-ui/icons/Cancel';
 import Grid from '@material-ui/core/Grid';
-import Typography from '@material-ui/core/Typography';
 
 class SchemaItem extends React.Component<{
     worksheetUUID: string,
@@ -317,6 +314,7 @@ class SchemaItem extends React.Component<{
                                         return;
                                     }
                                     this.setState({ confirmingDeletion: true });
+                                    this.props.setDeleteItemCallback(this.deleteThisSchema);
                                 }}
                                 disabled={this.state.confirmingDeletion}
                             >
@@ -524,25 +522,6 @@ class SchemaItem extends React.Component<{
                             onChange={this.changeSchemaName}
                         />
                     )}
-                    <Grid item xs={2} spacing={0}>
-                        {(showSchemaDetail || this.props.create) && this.state.confirmingDeletion && (
-                            <Tooltip title={'This action is not revertable'}>
-                                <IconButton onClick={this.deleteThisSchema}>
-                                    <WarningIcon outlined fontSize='small' color='error' />
-                                    <Typography color='error'>Confirm</Typography>
-                                </IconButton>
-                            </Tooltip>
-                        )}
-                        {(showSchemaDetail || this.props.create) && this.state.confirmingDeletion && (
-                            <IconButton
-                                outlined
-                                onClick={() => this.setState({ confirmingDeletion: false })}
-                            >
-                                <CancelIcon fontSize='small' />
-                                <Typography>Cancel</Typography>
-                            </IconButton>
-                        )}
-                    </Grid>
                 </Grid>
                 {schemaTable}
             </div>

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -20,6 +20,7 @@ export const DIALOG_TYPES = {
     OPEN_DELETE_MARKDOWN: 'delete_markdown_block',
     OPEN_DELETE_WORKSHEET: 'delete_whole_worksheet',
     OPEN_ERROR_DIALOG: 'error_dialog',
+    OPEN_DELETE_SCHEMA: 'delete_schema',
 };
 
 // Bundle fetch status values; corresponds with FetchStatusCodes in backend


### PR DESCRIPTION
### Reasons for making this change

Instead of showing inline buttons, provide a dialog for schema deletion, so that it is more consistent with other delete actions.
Inline buttons:
![94928056-155b3500-0491-11eb-9508-70e97beace51](https://user-images.githubusercontent.com/34461466/97235269-be9aff80-179f-11eb-83ae-1aa36dcb7329.png)

### Related issues

fixes #2917 

### Screenshots

![2917](https://user-images.githubusercontent.com/34461466/97235348-e7bb9000-179f-11eb-95ba-4da2eac3277f.gif)

### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
