### PR TITLE
Fix bug of insertion after pasting bundles; Fix bug for `Add Schema` action button

### DIFF
--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -471,6 +471,10 @@ class Worksheet extends React.Component {
         let actualData = { items };
         if (after_sort_key) {
             actualData['after_sort_key'] = after_sort_key;
+        } else {
+            // If no location for the insertion is specified,
+            // insert the new item at the top of the worksheet in default.
+            actualData['after_sort_key'] = -1;
         }
         actualData['item_type'] = 'bundle';
         $.ajax({

--- a/frontend/src/components/worksheets/items/SchemaItem/SchemaItem.js
+++ b/frontend/src/components/worksheets/items/SchemaItem/SchemaItem.js
@@ -106,7 +106,9 @@ class SchemaItem extends React.Component<{
         this.props.updateSchemaItem(
             updatedSchema,
             ids,
-            getAfterSortKey(this.props.item) - 1,
+            getAfterSortKey(this.props.item) - 1 >= 0
+                ? getAfterSortKey(this.props.item) - 1
+                : this.props.after_sort_key,
             this.props.create,
             false,
         );
@@ -218,7 +220,6 @@ class SchemaItem extends React.Component<{
         const schemaItem = item;
         const schemaHeaders = schemaItem.header;
         const schemaName = schemaItem.schema_name;
-        // console.log("Schema:", item.ids, item.sort_keys, this.props.after_sort_key)
         let headerHtml, bodyRowsHtml;
         const explanations = {
             field: 'Column name that is displayed.',

--- a/frontend/src/components/worksheets/items/TableItem/BundleRow.js
+++ b/frontend/src/components/worksheets/items/TableItem/BundleRow.js
@@ -15,6 +15,7 @@ import NewRun from '../../NewRun';
 import * as Mousetrap from '../../../../util/ws_mousetrap_fork';
 import BundleDetail from '../../BundleDetail';
 import TextEditorItem from '../TextEditorItem';
+import SchemaItem from '../SchemaItem';
 
 // The approach taken in this design is to hack the HTML `Table` element by using one `TableBody` for each `BundleRow`.
 // We need the various columns to be aligned for all `BundleRow` within a `Table`, therefore using `div` is not an
@@ -378,6 +379,36 @@ class BundleRow extends Component {
                                     closeEditor={() => {
                                         this.props.onHideNewText();
                                     }}
+                                />
+                            </div>
+                        </TableCell>
+                    </TableRow>
+                )}
+                {this.props.showNewSchema && (
+                    <TableRow>
+                        <TableCell colSpan='100%' classes={{ root: classes.insertPanel }}>
+                            <div className={classes.insertBox}>
+                                <SchemaItem
+                                    after_sort_key={this.props.after_sort_key}
+                                    ws={this.props.ws}
+                                    onSubmit={() => this.props.onHideNewSchema()}
+                                    reloadWorksheet={reloadWorksheet}
+                                    editPermission={true}
+                                    item={{
+                                        field_rows: [
+                                            {
+                                                field: '',
+                                                'generalized-path': '',
+                                                'post-processor': null,
+                                                from_schema_name: '',
+                                            },
+                                        ],
+                                        header: ['field', 'generalized-path', 'post-processor'],
+                                        schema_name: '',
+                                        sort_keys: [-1],
+                                    }}
+                                    create={true}
+                                    updateSchemaItem={this.props.updateSchemaItem}
                                 />
                             </div>
                         </TableCell>

--- a/frontend/src/components/worksheets/items/TableItem/TableItem.js
+++ b/frontend/src/components/worksheets/items/TableItem/TableItem.js
@@ -228,8 +228,15 @@ class TableItem extends React.Component<{
                         this.props.showNewText &&
                         rowFocused
                     }
+                    showNewSchema={
+                        this.props.showNewButtonsAfterEachBundleRow &&
+                        this.props.showNewSchema &&
+                        rowFocused
+                    }
                     onHideNewRun={this.props.onHideNewRun}
                     onHideNewText={this.props.onHideNewText}
+                    onHideNewSchema={this.props.onHideNewSchema}
+                    updateSchemaItem={this.props.updateSchemaItem}
                     ids={this.props.ids}
                 />
             );


### PR DESCRIPTION
### Reasons for making this change

**Fix bug of insertion after pasting bundles**
Previously, if we 

1. create a new worksheet
2. paste bundles
3. click `Add Text` or `Add schema` button

The new items will be added to the wrong place. Ther bug is due to when we paste bundles to a worksheet, the sort keys for the bundles are `None`, so when we want to add things after them, the new items will always be added to the top of the worksheet.
**Solution**
Assign a sort key for the pasting bundles.

 **Fix bug for `Add Schema` action button**
Previously, when we focus on a bundle, we cannot add new schemas, and that's the reason why the `Add Schema` button does not work sometimes.  
**Solution**
Enable the user to add schemas when focusing on a bundle.

### Related issues

fixes #2949 

### Screenshots
**Fix bug of insertion after pasting bundles**
![paste](https://user-images.githubusercontent.com/34461466/97388304-0fd8eb00-1895-11eb-8f0f-f6a43902a5ff.gif)


 **Fix bug for `Add Schema` action button**
![schema](https://user-images.githubusercontent.com/34461466/97388312-14050880-1895-11eb-961c-246dba5fb72a.gif)


### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
