### PR TITLE
Resolve crash of an null-valued bundle spec

### DIFF
--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -563,7 +563,7 @@ class BundleCLI(object):
         instance, worksheet_spec, bundle_spec, subpath = parse_target_spec(target_spec)
 
         if bundle_spec is None:
-            raise UsageError('bundle spec is not missing')
+            raise UsageError('bundle spec is missing')
 
         if instance is not None:
             if self.headless:

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -563,7 +563,7 @@ class BundleCLI(object):
         instance, worksheet_spec, bundle_spec, subpath = parse_target_spec(target_spec)
 
         if bundle_spec is None:
-            raise UsageError('bundle spec is missing')
+            raise UsageError('Bundle spec is missing')
 
         if instance is not None:
             if self.headless:

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -562,6 +562,9 @@ class BundleCLI(object):
         """
         instance, worksheet_spec, bundle_spec, subpath = parse_target_spec(target_spec)
 
+        if bundle_spec is None:
+            raise UsageError('bundle spec is not missing')
+
         if instance is not None:
             if self.headless:
                 raise UsageError('Cannot use alias on web CLI')

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -2366,6 +2366,12 @@ def test_nonexistent(ctx):
     _run_command([cl, 'work', 'nonexistent::'], expected_exit_code=1)
 
 
+@TestModule.register('rm_empty')
+def test_rm_empty(ctx):
+    result = _run_command([cl, 'rm', '""'], expected_exit_code=1)
+    check_equals(result, 'UsageError: bundle spec is missing')
+
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
         description='Runs the specified CodaLab worksheets unit and integration tests against the specified CodaLab instance (defaults to localhost)'

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -896,6 +896,8 @@ def test_rm(ctx):
     uuid = _run_command([cl, 'upload', test_path('a.txt')])
     _run_command([cl, 'add', 'bundle', uuid])  # Duplicate
     _run_command([cl, 'rm', uuid])  # Can delete even though it exists twice on the same worksheet
+    result = _run_command([cl, 'rm', ''], expected_exit_code=1)  # Empty parameter should give an Usage error
+    check_equals(result, '')
 
 
 @TestModule.register('make')
@@ -2364,12 +2366,6 @@ def test_edit(ctx):
 @TestModule.register('work')
 def test_nonexistent(ctx):
     _run_command([cl, 'work', 'nonexistent::'], expected_exit_code=1)
-
-
-@TestModule.register('rm_empty')
-def test_rm_empty(ctx):
-    result = _run_command([cl, 'rm', '""'], expected_exit_code=1)
-    check_equals(result, 'UsageError: bundle spec is missing')
 
 
 if __name__ == '__main__':

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -896,8 +896,7 @@ def test_rm(ctx):
     uuid = _run_command([cl, 'upload', test_path('a.txt')])
     _run_command([cl, 'add', 'bundle', uuid])  # Duplicate
     _run_command([cl, 'rm', uuid])  # Can delete even though it exists twice on the same worksheet
-    result = _run_command([cl, 'rm', ''], expected_exit_code=1)  # Empty parameter should give an Usage error
-    check_equals(result, '')
+    _run_command([cl, 'rm', ''], expected_exit_code=1)  # Empty parameter should give an Usage error
 
 
 @TestModule.register('make')


### PR DESCRIPTION
### Reasons for making this change
When the bundle_spec returned as None, there will be a crash of regex matching invalid type. Since bundle_spec is required, I'm checking if it's missing - if yes, then throw an UsageError
<!-- Add a reason for making this change here. -->

### Related issues
#2760 
<!-- Add a reference to issues resolved, if applicable (for example, "fixes #1"). -->

### Screenshots
![image](https://user-images.githubusercontent.com/18689351/97671209-08584400-1a45-11eb-83a6-b7ff235b63d0.png)

<!-- Add screenshots, if necessary -->

### Checklist

* [ ] I've added a screenshot of the changes, if this is a frontend change
* [ ] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [ ] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
