### PR TITLE
Switch INT id PK to BIGINT id PK, retaining auto-increment

### DIFF
--- a/alembic/versions/2020110220_change_id_primary_keys_from__fcb22a612d2a.py
+++ b/alembic/versions/2020110220_change_id_primary_keys_from__fcb22a612d2a.py
@@ -1,0 +1,54 @@
+"""Change id primary keys from Integer to BigInteger, retaining auto-increment
+
+Revision ID: fcb22a612d2a
+Revises: 9d3ab0b9d304
+Create Date: 2020-11-02 20:57:08.361251
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'fcb22a612d2a'
+down_revision = '9d3ab0b9d304'
+
+
+def upgrade():
+    op.alter_column("bundle", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.Integer(), nullable=False)
+    op.alter_column("bundle_metadata", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.Integer(), nullable=False)
+    op.alter_column("bundle_dependency", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.Integer(), nullable=False)
+    op.alter_column("worksheet", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.Integer(), nullable=False)
+    op.alter_column("worksheet_item", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.Integer(), nullable=False)
+    op.alter_column("worksheet_tag", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.Integer(), nullable=False)
+    op.alter_column("group", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.Integer(), nullable=False)
+    op.alter_column("user_group", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.Integer(), nullable=False)
+    op.alter_column("group_bundle_permission", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.Integer(), nullable=False)
+    op.alter_column("group_object_permission", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.Integer(), nullable=False)
+    op.alter_column("user", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.Integer(), nullable=False)
+    op.alter_column("user_verification", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.Integer(), nullable=False)
+    op.alter_column("user_reset_code", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.Integer(), nullable=False)
+    op.alter_column("oauth2_client", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.Integer(), nullable=False)
+    op.alter_column("oauth2_token", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.Integer(), nullable=False)
+    op.alter_column("oauth2_auth_code", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.Integer(), nullable=False)
+    op.alter_column("chat", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.Integer(), nullable=False)
+
+
+def downgrade():
+    op.alter_column("bundle", 'id', type_=sa.Integer(), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False)
+    op.alter_column("bundle_metadata", 'id', type_=sa.Integer(), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False)
+    op.alter_column("bundle_dependency", 'id', type_=sa.Integer(), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False)
+    op.alter_column("worksheet", 'id', type_=sa.Integer(), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False)
+    op.alter_column("worksheet_item", 'id', type_=sa.Integer(), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False)
+    op.alter_column("worksheet_tag", 'id', type_=sa.Integer(), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False)
+    op.alter_column("group", 'id', type_=sa.Integer(), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False)
+    op.alter_column("user_group", 'id', type_=sa.Integer(), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False)
+    op.alter_column("group_bundle_permission", 'id', type_=sa.Integer(), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False)
+    op.alter_column("group_object_permission", 'id', type_=sa.Integer(), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False)
+    op.alter_column("user", 'id', type_=sa.Integer(), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False)
+    op.alter_column("user_verification", 'id', type_=sa.Integer(), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False)
+    op.alter_column("user_reset_code", 'id', type_=sa.Integer(), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False)
+    op.alter_column("oauth2_client", 'id', type_=sa.Integer(), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False)
+    op.alter_column("oauth2_token", 'id', type_=sa.Integer(), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False)
+    op.alter_column("oauth2_auth_code", 'id', type_=sa.Integer(), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False)
+    op.alter_column("chat", 'id', type_=sa.Integer(), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False)

--- a/codalab/model/tables.py
+++ b/codalab/model/tables.py
@@ -25,7 +25,7 @@ db_metadata = MetaData()
 bundle = Table(
     'bundle',
     db_metadata,
-    Column('id', Integer, primary_key=True, nullable=False),
+    Column('id', BigInteger().with_variant(Integer, "sqlite"), primary_key=True, nullable=False),
     Column('uuid', String(63), nullable=False),
     Column('bundle_type', String(63), nullable=False),
     # The command will be NULL except for run bundles.
@@ -44,7 +44,7 @@ bundle = Table(
 bundle_metadata = Table(
     'bundle_metadata',
     db_metadata,
-    Column('id', Integer, primary_key=True, nullable=False),
+    Column('id', BigInteger().with_variant(Integer, "sqlite"), primary_key=True, nullable=False),
     Column('bundle_uuid', String(63), ForeignKey(bundle.c.uuid), nullable=False),
     Column('metadata_key', String(63), nullable=False),
     Column('metadata_value', Text, nullable=False),
@@ -55,7 +55,7 @@ bundle_metadata = Table(
 bundle_dependency = Table(
     'bundle_dependency',
     db_metadata,
-    Column('id', Integer, primary_key=True, nullable=False),
+    Column('id', BigInteger().with_variant(Integer, "sqlite"), primary_key=True, nullable=False),
     Column('child_uuid', String(63), ForeignKey(bundle.c.uuid), nullable=False),
     Column('child_path', Text, nullable=False),
     # Deliberately omit ForeignKey(bundle.c.uuid), because bundles can have
@@ -69,7 +69,7 @@ bundle_dependency = Table(
 worksheet = Table(
     'worksheet',
     db_metadata,
-    Column('id', Integer, primary_key=True, nullable=False),
+    Column('id', BigInteger().with_variant(Integer, "sqlite"), primary_key=True, nullable=False),
     Column('uuid', String(63), nullable=False),
     Column('name', String(255), nullable=False),
     Column('owner_id', String(255), nullable=True),
@@ -88,7 +88,7 @@ worksheet = Table(
 worksheet_item = Table(
     'worksheet_item',
     db_metadata,
-    Column('id', Integer, primary_key=True, nullable=False),
+    Column('id', BigInteger().with_variant(Integer, "sqlite"), primary_key=True, nullable=False),
     Column('worksheet_uuid', String(63), ForeignKey(worksheet.c.uuid), nullable=False),
     # A worksheet item is either:
     # - type = bundle (bundle_uuid != null)
@@ -111,7 +111,7 @@ worksheet_item = Table(
 worksheet_tag = Table(
     'worksheet_tag',
     db_metadata,
-    Column('id', Integer, primary_key=True, nullable=False),
+    Column('id', BigInteger().with_variant(Integer, "sqlite"), primary_key=True, nullable=False),
     Column('worksheet_uuid', String(63), ForeignKey(worksheet.c.uuid), nullable=False),
     Column('tag', String(63), nullable=False),
     Index('worksheet_tag_worksheet_uuid_index', 'worksheet_uuid'),
@@ -121,7 +121,7 @@ worksheet_tag = Table(
 group = Table(
     'group',
     db_metadata,
-    Column('id', Integer, primary_key=True, nullable=False),
+    Column('id', BigInteger().with_variant(Integer, "sqlite"), primary_key=True, nullable=False),
     Column('uuid', String(63), nullable=False),
     Column('name', String(255), nullable=False),
     Column('user_defined', Boolean),
@@ -134,7 +134,7 @@ group = Table(
 user_group = Table(
     'user_group',
     db_metadata,
-    Column('id', Integer, primary_key=True, nullable=False),
+    Column('id', BigInteger().with_variant(Integer, "sqlite"), primary_key=True, nullable=False),
     Column('group_uuid', String(63), ForeignKey(group.c.uuid), nullable=False),
     Column('user_id', String(63), ForeignKey("user.user_id"), nullable=False),
     # Whether a user is able to modify this group.
@@ -147,7 +147,7 @@ user_group = Table(
 group_bundle_permission = Table(
     'group_bundle_permission',
     db_metadata,
-    Column('id', Integer, primary_key=True, nullable=False),
+    Column('id', BigInteger().with_variant(Integer, "sqlite"), primary_key=True, nullable=False),
     Column('group_uuid', String(63), ForeignKey(group.c.uuid), nullable=False),
     # Reference to a bundle
     Column('object_uuid', String(63), ForeignKey(bundle.c.uuid), nullable=False),
@@ -159,7 +159,7 @@ group_bundle_permission = Table(
 group_object_permission = Table(
     'group_object_permission',
     db_metadata,
-    Column('id', Integer, primary_key=True, nullable=False),
+    Column('id', BigInteger().with_variant(Integer, "sqlite"), primary_key=True, nullable=False),
     Column('group_uuid', String(63), ForeignKey(group.c.uuid), nullable=False),
     # Reference to a worksheet object
     Column('object_uuid', String(63), ForeignKey(worksheet.c.uuid), nullable=False),
@@ -181,7 +181,7 @@ NOTIFICATIONS_GENERAL = 0x02  # Receive general notifications (new features)
 user = Table(
     'user',
     db_metadata,
-    Column('id', Integer, primary_key=True, nullable=False),
+    Column('id', BigInteger().with_variant(Integer, "sqlite"), primary_key=True, nullable=False),
     # Basic information
     Column('user_id', String(63), nullable=False),
     Column('user_name', String(63), nullable=False, unique=True),
@@ -220,7 +220,7 @@ user = Table(
 user_verification = Table(
     'user_verification',
     db_metadata,
-    Column('id', Integer, primary_key=True, nullable=False),
+    Column('id', BigInteger().with_variant(Integer, "sqlite"), primary_key=True, nullable=False),
     Column('user_id', String(63), ForeignKey(user.c.user_id), nullable=False),
     Column('date_created', DateTime, nullable=False),
     Column('date_sent', DateTime, nullable=True),
@@ -231,7 +231,7 @@ user_verification = Table(
 user_reset_code = Table(
     'user_reset_code',
     db_metadata,
-    Column('id', Integer, primary_key=True, nullable=False),
+    Column('id', BigInteger().with_variant(Integer, "sqlite"), primary_key=True, nullable=False),
     Column('user_id', String(63), ForeignKey(user.c.user_id), nullable=False),
     Column('date_created', DateTime, nullable=False),
     Column('code', String(64), nullable=False),
@@ -242,7 +242,7 @@ user_reset_code = Table(
 oauth2_client = Table(
     'oauth2_client',
     db_metadata,
-    Column('id', Integer, primary_key=True, nullable=False),
+    Column('id', BigInteger().with_variant(Integer, "sqlite"), primary_key=True, nullable=False),
     Column('client_id', String(63), nullable=False),
     Column('name', String(63), nullable=True),
     Column('secret', String(255), nullable=True),
@@ -261,7 +261,7 @@ oauth2_client = Table(
 oauth2_token = Table(
     'oauth2_token',
     db_metadata,
-    Column('id', Integer, primary_key=True, nullable=False),
+    Column('id', BigInteger().with_variant(Integer, "sqlite"), primary_key=True, nullable=False),
     Column('client_id', String(63), ForeignKey(oauth2_client.c.client_id), nullable=False),
     Column('user_id', String(63), ForeignKey(user.c.user_id), nullable=False),
     Column('scopes', Text, nullable=False),
@@ -273,7 +273,7 @@ oauth2_token = Table(
 oauth2_auth_code = Table(
     'oauth2_auth_code',
     db_metadata,
-    Column('id', Integer, primary_key=True, nullable=False),
+    Column('id', BigInteger().with_variant(Integer, "sqlite"), primary_key=True, nullable=False),
     Column('client_id', String(63), ForeignKey(oauth2_client.c.client_id), nullable=False),
     Column('user_id', String(63), ForeignKey(user.c.user_id), nullable=False),
     Column('scopes', Text, nullable=False),
@@ -286,7 +286,9 @@ oauth2_auth_code = Table(
 chat = Table(
     'chat',
     db_metadata,
-    Column('id', Integer, primary_key=True, nullable=False),  # Primary key
+    Column(
+        'id', BigInteger().with_variant(Integer, "sqlite"), primary_key=True, nullable=False
+    ),  # Primary key
     Column('time', DateTime, nullable=False),  # When did the user send this query?
     Column('sender_user_id', String(63), nullable=True),  # Who sent it?
     Column('recipient_user_id', String(63), nullable=True),  # Who received it?


### PR DESCRIPTION
# Reasons for making this change

codalab.stanford.edu is broken because the primary key on the bundle_metadata table exceeds the INT range. This is what I see server-side when I try to upload:

```
sqlalchemy.exc.IntegrityError: (MySQLdb._exceptions.IntegrityError) (1062, "Duplicate entry '2147483647' for key 'PRIMARY'")
[SQL: INSERT INTO bundle_metadata (bundle_uuid, metadata_key, metadata_value) VALUES (%s, %s, %s), (%s, %s, %s), (%s, %s, %s), (%s, %s, %s), (%s, %s, %s), (%s, %s, %s), (%s, %s, %s)]
[parameters: ('0x582ac54ba0894c69a800bc982cbdb1cf', 'name', 'squadv1.1format..iqa3-train.json', '0x582ac54ba0894c69a800bc982cbdb1cf', 'description', '', '0x582ac54ba0894c69a800bc982cbdb1cf', 'created', '1604347113', '0x582ac54ba0894c69a800bc982cbdb1cf', 'license', '', '0x582ac54ba0894c69a800bc982cbdb1cf', 'source_url', '', '0x582ac54ba0894c69a800bc982cbdb1cf', 'link_url', '', '0x582ac54ba0894c69a800bc982cbdb1cf', 'link_format', '')]
(Background on this error at: http://sqlalche.me/e/13/gkpj)
```

@teetone and I were talking about this, and it's apparently possible to blow past the INT range on an `id` field without having MAXINT records because of things like `REPLACE`, which re-create a new row (thus incrementing the id). I have been doing a lot of `cl edit`s, so this seems like the culprit.

To fix this, I changed INT to BIGINT across all `id` PK fields.

After this change:
```
mysql> describe bundle_metadata;
+----------------+-------------+------+-----+---------+----------------+
| Field          | Type        | Null | Key | Default | Extra          |
+----------------+-------------+------+-----+---------+----------------+
| id             | bigint(20)  | NO   | PRI | NULL    | auto_increment |
| bundle_uuid    | varchar(63) | NO   | MUL | NULL    |                |
| metadata_key   | varchar(63) | NO   | MUL | NULL    |                |
| metadata_value | text        | NO   |     | NULL    |                |
+----------------+-------------+------+-----+---------+----------------+
```

The `BigInteger().with_variant(Integer, "sqlite")` is necessary because we want to use `BigInteger`, but sqlite doesn't allow `BigInteger` auto-incrementing columns. So, we use INTEGER in this case instead.