### PR TITLE
Bump to version 0.5.27

### DIFF
--- a/codalab/common.py
+++ b/codalab/common.py
@@ -8,7 +8,7 @@ import http.client
 
 # Increment this on master when ready to cut a release.
 # http://semver.org/
-CODALAB_VERSION = '0.5.26'
+CODALAB_VERSION = '0.5.27'
 BINARY_PLACEHOLDER = '<binary>'
 URLOPEN_TIMEOUT_SECONDS = 5 * 60
 

--- a/docs/REST-API-Reference.md
+++ b/docs/REST-API-Reference.md
@@ -1,6 +1,6 @@
 # REST API Reference
 
-_version 0.5.26_
+_version 0.5.27_
 
 This reference and the REST API itself is still under heavy development and is
 subject to change at any time. Feedback through our GitHub issues is appreciated!

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -1,5 +1,5 @@
 // Should match codalab/common.py#CODALAB_VERSION
-export const CODALAB_VERSION = '0.5.26';
+export const CODALAB_VERSION = '0.5.27';
 
 // Name Regex to match the backend in spec_utils.py
 export const NAME_REGEX = /^[a-zA-Z_][a-zA-Z0-9_.-]*$/i;

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import sys
 
 
 # should match codalab/common.py#CODALAB_VERSION
-CODALAB_VERSION = "0.5.26"
+CODALAB_VERSION = "0.5.27"
 
 
 class Install(install):


### PR DESCRIPTION
### Reasons for making this change
Bump new version

Full diff: https://github.com/codalab/codalab-worksheets/compare/v0.5.26...rc0.5.27 
# Draft release notes

## Frontend
- Fix bug of insertion after pasting bundles; Enable <Add Schema> when focusing on a bundle #2995 
- Keep all other fields intact and clear only the password field when failing in sign up #2991
- Show a dialog for schema deletion #2994 
- Fix frontend focus issue #2963 
- Fix the bug of delete keyboard shortcut not working #3017
- [Blob Storage] Set up abstraction for parsing linked URLs #2969 
- Fix the bug of "Save" Button for worksheet not working #3016
- Fix CodaLab Competition script #3028
- Remove the usage of string refs #3019

## Backend
- Change urlopen timeout from 30 to 120 seconds #2998 
- Switch INT id PK to BIGINT id PK, retaining auto-increment #3008
- Stream file when gzip compressing #3012 
- Add stress test for bundle in memory #3015
- Make fetching image sizes from docker hub more robust #3020
- Fix alembic migration by explicitly setting auto-increment to True #3022
- Change size of large bundle in stress test from 16g to 32g #3024
- Increase timeout when downloading dependencies #3027
- Make Docker timeouts consistent and more lenient across the board #3043

## Dev / docs / CI
- Add a new blog for announcements #2433 
- Add required CI check for when all ci tasks are complete #2983 
- Fix CI #3030

## Dependency upgrades
- Upgrade apache beam #3002 
- Only install pypi dataclasses if < py3.7 #3039 