### PR TITLE
Fix the bug of "Save" Button for worksheet not working

### DIFF
--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -1120,30 +1120,29 @@ class Worksheet extends React.Component {
             if (this.hasEditPermission()) {
                 var editor = ace.edit('worksheet-editor');
                 if (saveChanges) {
-                    // Use callback function to ensure the worksheet info will not be sent to the backend until the frontend state has finished updating
-                    this.setState(
-                        {
-                            ws: {
-                                ...this.state.ws,
-                                info: {
-                                    ...this.state.ws.info,
-                                    source: editor.getValue().split('\n'),
-                                },
+                    // Use promise here to ensure the worksheet info will not be sent to the backend until the frontend state has finished updating
+                    const setAsyncState = (newState) =>
+                        new Promise((resolve) => this.setState(newState, resolve));
+                    setAsyncState({
+                        ws: {
+                            ...this.state.ws,
+                            info: {
+                                ...this.state.ws.info,
+                                source: editor.getValue().split('\n'),
                             },
                         },
-                        () => {
-                            var rawIndex = editor.getCursorPosition().row;
-                            this.setState({
-                                inSourceEditMode: false,
-                                editorEnabled: false,
-                            }); // Needs to be after getting the raw contents
-                            if (saveChanges) {
-                                this.saveAndUpdateWorksheet(saveChanges, rawIndex);
-                            } else {
-                                this.reloadWorksheet(undefined, rawIndex);
-                            }
-                        },
-                    );
+                    }).then(() => {
+                        var rawIndex = editor.getCursorPosition().row;
+                        this.setState({
+                            inSourceEditMode: false,
+                            editorEnabled: false,
+                        }); // Needs to be after getting the raw contents
+                        if (saveChanges) {
+                            this.saveAndUpdateWorksheet(saveChanges, rawIndex);
+                        } else {
+                            this.reloadWorksheet(undefined, rawIndex);
+                        }
+                    });
                 }
             } else {
                 // Not allowed to edit the worksheet.

--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -1121,24 +1121,30 @@ class Worksheet extends React.Component {
                 var editor = ace.edit('worksheet-editor');
                 if (saveChanges) {
                     this.setState({
-                        ws: {
-                            ...this.state.ws,
-                            info: {
-                                ...this.state.ws.info,
-                                source: editor.getValue().split('\n'),
+                    // Use callback function to ensure the worksheet info will not be sent to the backend until the frontend state has finished updating
+                    this.setState(
+                        {
+                            ws: {
+                                ...this.state.ws,
+                                info: {
+                                    ...this.state.ws.info,
+                                    source: editor.getValue().split('\n'),
+                                },
                             },
                         },
-                    });
-                }
-                var rawIndex = editor.getCursorPosition().row;
-                this.setState({
-                    inSourceEditMode: false,
-                    editorEnabled: false,
-                }); // Needs to be after getting the raw contents
-                if (saveChanges) {
-                    this.saveAndUpdateWorksheet(saveChanges, rawIndex);
-                } else {
-                    this.reloadWorksheet(undefined, rawIndex);
+                        () => {
+                            var rawIndex = editor.getCursorPosition().row;
+                            this.setState({
+                                inSourceEditMode: false,
+                                editorEnabled: false,
+                            }); // Needs to be after getting the raw contents
+                            if (saveChanges) {
+                                this.saveAndUpdateWorksheet(saveChanges, rawIndex);
+                            } else {
+                                this.reloadWorksheet(undefined, rawIndex);
+                            }
+                        },
+                    );
                 }
             } else {
                 // Not allowed to edit the worksheet.

--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -1120,7 +1120,6 @@ class Worksheet extends React.Component {
             if (this.hasEditPermission()) {
                 var editor = ace.edit('worksheet-editor');
                 if (saveChanges) {
-                    this.setState({
                     // Use callback function to ensure the worksheet info will not be sent to the backend until the frontend state has finished updating
                     this.setState(
                         {

--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -1120,29 +1120,30 @@ class Worksheet extends React.Component {
             if (this.hasEditPermission()) {
                 var editor = ace.edit('worksheet-editor');
                 if (saveChanges) {
-                    // Use promise here to ensure the worksheet info will not be sent to the backend until the frontend state has finished updating
-                    const setAsyncState = (newState) =>
-                        new Promise((resolve) => this.setState(newState, resolve));
-                    setAsyncState({
-                        ws: {
-                            ...this.state.ws,
-                            info: {
-                                ...this.state.ws.info,
-                                source: editor.getValue().split('\n'),
+                    // Use callback function to ensure the worksheet info will not be sent to the backend until the frontend state has finished updating
+                    this.setState(
+                        {
+                            ws: {
+                                ...this.state.ws,
+                                info: {
+                                    ...this.state.ws.info,
+                                    source: editor.getValue().split('\n'),
+                                },
                             },
                         },
-                    }).then(() => {
-                        var rawIndex = editor.getCursorPosition().row;
-                        this.setState({
-                            inSourceEditMode: false,
-                            editorEnabled: false,
-                        }); // Needs to be after getting the raw contents
-                        if (saveChanges) {
-                            this.saveAndUpdateWorksheet(saveChanges, rawIndex);
-                        } else {
-                            this.reloadWorksheet(undefined, rawIndex);
-                        }
-                    });
+                        () => {
+                            var rawIndex = editor.getCursorPosition().row;
+                            this.setState({
+                                inSourceEditMode: false,
+                                editorEnabled: false,
+                            }); // Needs to be after getting the raw contents
+                            if (saveChanges) {
+                                this.saveAndUpdateWorksheet(saveChanges, rawIndex);
+                            } else {
+                                this.reloadWorksheet(undefined, rawIndex);
+                            }
+                        },
+                    );
                 }
             } else {
                 // Not allowed to edit the worksheet.


### PR DESCRIPTION
### Reasons for making this change

The save button did not work. The reason is `setState` is an async function. We should first ensure the frontend state has already been updated properly before we make requests to the backend.

### Related issues

fixes #3007 

### Screenshots

![ezgif com-gif-maker](https://user-images.githubusercontent.com/34461466/98098356-12ae7f80-1e43-11eb-8fd7-3896961a499f.gif)


### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
