### PR TITLE
Fix the bug of delete keyboard shortcut not working

### DIFF
--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -236,6 +236,7 @@ class Worksheet extends React.Component {
         //      shouldn't be necessary. However, if we want more control on what happens after
         //      bulk operation, this might be useful
         let bundlesCount = this.state.uuidBundlesCheckedCount;
+        document.activeElement.blur();
         if (check) {
             //A bundle is checked
             if (


### PR DESCRIPTION
### Reasons for making this change

Previously, if we check some bundles without clicking on the bundles when we press the backspace or delete, the keyboard shortcut does not work. The reason is the activeElement has been set to the checked bundles, so the Mousetrap did not work.

### Related issues

fixes #2920 

### Screenshots

![ezgif com-gif-maker](https://user-images.githubusercontent.com/34461466/98100966-72f2f080-1e46-11eb-8694-b4b72ec6a795.gif)


### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
