### PR TITLE
Make fetching image sizes from docker hub more robust

### DIFF
--- a/codalab/worker/docker_utils.py
+++ b/codalab/worker/docker_utils.py
@@ -355,7 +355,7 @@ def get_image_size_without_pulling(image_spec):
 
     requests_session = requests.Session()
     # Retry 5 times, sleeping for [0.1s, 0.2s, 0.4s, ...] between retries.
-    retries = Retry(total=5, backoff_factor=0.1)
+    retries = Retry(total=5, backoff_factor=0.1, status_forcelist=[413, 429, 500, 502, 503, 504])
     requests_session.mounft('https://', HTTPAdapter(max_retries=retries))
 
     while True:

--- a/codalab/worker/docker_utils.py
+++ b/codalab/worker/docker_utils.py
@@ -356,7 +356,7 @@ def get_image_size_without_pulling(image_spec):
     requests_session = requests.Session()
     # Retry 5 times, sleeping for [0.1s, 0.2s, 0.4s, ...] between retries.
     retries = Retry(total=5, backoff_factor=0.1, status_forcelist=[413, 429, 500, 502, 503, 504])
-    requests_session.mounft('https://', HTTPAdapter(max_retries=retries))
+    requests_session.mount('https://', HTTPAdapter(max_retries=retries))
 
     while True:
         response = requests_session.get(url=request + str(page_number))

--- a/codalab/worker/docker_utils.py
+++ b/codalab/worker/docker_utils.py
@@ -13,7 +13,9 @@ from dateutil import parser, tz
 import datetime
 import re
 import requests
+from requests.adapters import HTTPAdapter
 import traceback
+from urllib3.util.retry import Retry
 
 
 MIN_API_VERSION = '1.17'
@@ -350,8 +352,14 @@ def get_image_size_without_pulling(image_spec):
     request = uri_prefix_adjusted + image_name + '/tags/?page='
     image_size_bytes = None
     page_number = 1
+
+    requests_session = requests.Session()
+    # Retry 5 times, sleeping for [0.1s, 0.2s, 0.4s, ...] between retries.
+    retries = Retry(total=5, backoff_factor=0.1)
+    requests_session.mounft('https://', HTTPAdapter(max_retries=retries))
+
     while True:
-        response = requests.get(url=request + str(page_number))
+        response = requests_session.get(url=request + str(page_number))
         data = response.json()
         if len(data['results']) == 0:
             break

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,3 +61,6 @@ ignore_missing_imports = True
 
 [mypy-markdown2]
 ignore_missing_imports = True
+
+[mypy-urllib3.util.retry]
+ignore_missing_imports = True


### PR DESCRIPTION
### Reasons for making this change

Sometimes, transient network issues means that network requests to docker hub fail. This simply adds a retry mechanism.