### PR TITLE
Fix alembic migration by explicitly setting autoincrement to True

### DIFF
--- a/alembic/versions/2020110510_explicitly_set_autoincrement__4bac4855e710.py
+++ b/alembic/versions/2020110510_explicitly_set_autoincrement__4bac4855e710.py
@@ -1,0 +1,54 @@
+"""Explicitly set autoincrement to True
+
+Revision ID: 4bac4855e710
+Revises: fcb22a612d2a
+Create Date: 2020-11-05 10:27:43.989896
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '4bac4855e710'
+down_revision = 'fcb22a612d2a'
+
+
+def upgrade():
+    op.alter_column("bundle", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
+    op.alter_column("bundle_metadata", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
+    op.alter_column("bundle_dependency", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
+    op.alter_column("worksheet", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
+    op.alter_column("worksheet_item", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
+    op.alter_column("worksheet_tag", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
+    op.alter_column("group", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
+    op.alter_column("user_group", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
+    op.alter_column("group_bundle_permission", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
+    op.alter_column("group_object_permission", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
+    op.alter_column("user", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
+    op.alter_column("user_verification", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
+    op.alter_column("user_reset_code", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
+    op.alter_column("oauth2_client", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
+    op.alter_column("oauth2_token", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
+    op.alter_column("oauth2_auth_code", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
+    op.alter_column("chat", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
+
+
+def downgrade():
+    op.alter_column("bundle", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
+    op.alter_column("bundle_metadata", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
+    op.alter_column("bundle_dependency", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
+    op.alter_column("worksheet", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
+    op.alter_column("worksheet_item", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
+    op.alter_column("worksheet_tag", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
+    op.alter_column("group", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
+    op.alter_column("user_group", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
+    op.alter_column("group_bundle_permission", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
+    op.alter_column("group_object_permission", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
+    op.alter_column("user", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
+    op.alter_column("user_verification", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
+    op.alter_column("user_reset_code", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
+    op.alter_column("oauth2_client", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
+    op.alter_column("oauth2_token", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
+    op.alter_column("oauth2_auth_code", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
+    op.alter_column("chat", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)

--- a/alembic/versions/2020110510_explicitly_set_autoincrement__4bac4855e710.py
+++ b/alembic/versions/2020110510_explicitly_set_autoincrement__4bac4855e710.py
@@ -12,281 +12,64 @@ import sqlalchemy as sa
 # revision identifiers, used by Alembic.
 revision = '4bac4855e710'
 down_revision = 'fcb22a612d2a'
+TABLES = [
+    "bundle",
+    "bundle_metadata",
+    "bundle_dependency",
+    "worksheet",
+    "worksheet_item",
+    "worksheet_tag",
+    "group",
+    "user_group",
+    "group_bundle_permission",
+    "group_object_permission",
+    "user",
+    "user_verification",
+    "user_reset_code",
+    "oauth2_client",
+    "oauth2_token",
+    "oauth2_auth_code",
+    "chat",
+]
 
 
 def upgrade():
-    op.alter_column(
-        "bundle",
-        'id',
-        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        nullable=False,
-        autoincrement=True,
-    )
-    op.alter_column(
-        "bundle_metadata",
-        'id',
-        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        nullable=False,
-        autoincrement=True,
-    )
-    op.alter_column(
-        "bundle_dependency",
-        'id',
-        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        nullable=False,
-        autoincrement=True,
-    )
-    op.alter_column(
-        "worksheet",
-        'id',
-        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        nullable=False,
-        autoincrement=True,
-    )
-    op.alter_column(
-        "worksheet_item",
-        'id',
-        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        nullable=False,
-        autoincrement=True,
-    )
-    op.alter_column(
-        "worksheet_tag",
-        'id',
-        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        nullable=False,
-        autoincrement=True,
-    )
-    op.alter_column(
-        "group",
-        'id',
-        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        nullable=False,
-        autoincrement=True,
-    )
-    op.alter_column(
-        "user_group",
-        'id',
-        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        nullable=False,
-        autoincrement=True,
-    )
-    op.alter_column(
-        "group_bundle_permission",
-        'id',
-        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        nullable=False,
-        autoincrement=True,
-    )
-    op.alter_column(
-        "group_object_permission",
-        'id',
-        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        nullable=False,
-        autoincrement=True,
-    )
-    op.alter_column(
-        "user",
-        'id',
-        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        nullable=False,
-        autoincrement=True,
-    )
-    op.alter_column(
-        "user_verification",
-        'id',
-        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        nullable=False,
-        autoincrement=True,
-    )
-    op.alter_column(
-        "user_reset_code",
-        'id',
-        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        nullable=False,
-        autoincrement=True,
-    )
-    op.alter_column(
-        "oauth2_client",
-        'id',
-        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        nullable=False,
-        autoincrement=True,
-    )
-    op.alter_column(
-        "oauth2_token",
-        'id',
-        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        nullable=False,
-        autoincrement=True,
-    )
-    op.alter_column(
-        "oauth2_auth_code",
-        'id',
-        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        nullable=False,
-        autoincrement=True,
-    )
-    op.alter_column(
-        "chat",
-        'id',
-        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        nullable=False,
-        autoincrement=True,
-    )
+    for table in TABLES:
+        # This is necessary because the previous revision fcb22a612d2a suffers from a bug.
+        # In case (1), when upgrading to fcb22a612d2a , the id column does not retain the auto_increment property.
+        # In case (2), when starting from fcb22a612d2a , the id column has the auto_increment property.
+        # In case (1), upgrading to this revision, alembic is unable to make the id column auto_incrementing
+        # if it has a row with the id 0. The error is something like:
+        # ERROR 1062 (23000): ALTER TABLE causes auto_increment resequencing, resulting in duplicate entry
+        # '1' for key 'PRIMARY'
+        #
+        # This happens because the AUTO_INCREMENT value starts at 1, so a column with AUTO_INCREMENT
+        # cannot have a 0 row. As a result, we get around this by moving the 0 to the end of the table (the next ID),
+        # before setting it to be auto-incrementing.
+        # Note that this is MySQL-specific.
+        op.execute(
+            f'''
+        SET @maxid = (SELECT MAX(id)+1 FROM `{table}`);
+        UPDATE `{table}` SET id = @maxid WHERE id = 0;
+        '''
+        )
+        op.alter_column(
+            table,
+            'id',
+            type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+            existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+            nullable=False,
+            autoincrement=True,
+        )
 
 
 def downgrade():
-    op.alter_column(
-        "bundle",
-        'id',
-        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        nullable=False,
-        autoincrement=True,
-    )
-    op.alter_column(
-        "bundle_metadata",
-        'id',
-        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        nullable=False,
-        autoincrement=True,
-    )
-    op.alter_column(
-        "bundle_dependency",
-        'id',
-        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        nullable=False,
-        autoincrement=True,
-    )
-    op.alter_column(
-        "worksheet",
-        'id',
-        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        nullable=False,
-        autoincrement=True,
-    )
-    op.alter_column(
-        "worksheet_item",
-        'id',
-        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        nullable=False,
-        autoincrement=True,
-    )
-    op.alter_column(
-        "worksheet_tag",
-        'id',
-        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        nullable=False,
-        autoincrement=True,
-    )
-    op.alter_column(
-        "group",
-        'id',
-        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        nullable=False,
-        autoincrement=True,
-    )
-    op.alter_column(
-        "user_group",
-        'id',
-        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        nullable=False,
-        autoincrement=True,
-    )
-    op.alter_column(
-        "group_bundle_permission",
-        'id',
-        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        nullable=False,
-        autoincrement=True,
-    )
-    op.alter_column(
-        "group_object_permission",
-        'id',
-        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        nullable=False,
-        autoincrement=True,
-    )
-    op.alter_column(
-        "user",
-        'id',
-        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        nullable=False,
-        autoincrement=True,
-    )
-    op.alter_column(
-        "user_verification",
-        'id',
-        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        nullable=False,
-        autoincrement=True,
-    )
-    op.alter_column(
-        "user_reset_code",
-        'id',
-        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        nullable=False,
-        autoincrement=True,
-    )
-    op.alter_column(
-        "oauth2_client",
-        'id',
-        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        nullable=False,
-        autoincrement=True,
-    )
-    op.alter_column(
-        "oauth2_token",
-        'id',
-        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        nullable=False,
-        autoincrement=True,
-    )
-    op.alter_column(
-        "oauth2_auth_code",
-        'id',
-        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        nullable=False,
-        autoincrement=True,
-    )
-    op.alter_column(
-        "chat",
-        'id',
-        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
-        nullable=False,
-        autoincrement=True,
-    )
+    for table in TABLES:
+        op.alter_column(
+            table,
+            'id',
+            type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+            existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+            nullable=False,
+            autoincrement=True,
+        )

--- a/alembic/versions/2020110510_explicitly_set_autoincrement__4bac4855e710.py
+++ b/alembic/versions/2020110510_explicitly_set_autoincrement__4bac4855e710.py
@@ -15,40 +15,278 @@ down_revision = 'fcb22a612d2a'
 
 
 def upgrade():
-    op.alter_column("bundle", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
-    op.alter_column("bundle_metadata", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
-    op.alter_column("bundle_dependency", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
-    op.alter_column("worksheet", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
-    op.alter_column("worksheet_item", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
-    op.alter_column("worksheet_tag", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
-    op.alter_column("group", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
-    op.alter_column("user_group", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
-    op.alter_column("group_bundle_permission", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
-    op.alter_column("group_object_permission", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
-    op.alter_column("user", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
-    op.alter_column("user_verification", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
-    op.alter_column("user_reset_code", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
-    op.alter_column("oauth2_client", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
-    op.alter_column("oauth2_token", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
-    op.alter_column("oauth2_auth_code", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
-    op.alter_column("chat", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
+    op.alter_column(
+        "bundle",
+        'id',
+        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        nullable=False,
+        autoincrement=True,
+    )
+    op.alter_column(
+        "bundle_metadata",
+        'id',
+        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        nullable=False,
+        autoincrement=True,
+    )
+    op.alter_column(
+        "bundle_dependency",
+        'id',
+        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        nullable=False,
+        autoincrement=True,
+    )
+    op.alter_column(
+        "worksheet",
+        'id',
+        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        nullable=False,
+        autoincrement=True,
+    )
+    op.alter_column(
+        "worksheet_item",
+        'id',
+        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        nullable=False,
+        autoincrement=True,
+    )
+    op.alter_column(
+        "worksheet_tag",
+        'id',
+        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        nullable=False,
+        autoincrement=True,
+    )
+    op.alter_column(
+        "group",
+        'id',
+        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        nullable=False,
+        autoincrement=True,
+    )
+    op.alter_column(
+        "user_group",
+        'id',
+        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        nullable=False,
+        autoincrement=True,
+    )
+    op.alter_column(
+        "group_bundle_permission",
+        'id',
+        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        nullable=False,
+        autoincrement=True,
+    )
+    op.alter_column(
+        "group_object_permission",
+        'id',
+        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        nullable=False,
+        autoincrement=True,
+    )
+    op.alter_column(
+        "user",
+        'id',
+        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        nullable=False,
+        autoincrement=True,
+    )
+    op.alter_column(
+        "user_verification",
+        'id',
+        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        nullable=False,
+        autoincrement=True,
+    )
+    op.alter_column(
+        "user_reset_code",
+        'id',
+        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        nullable=False,
+        autoincrement=True,
+    )
+    op.alter_column(
+        "oauth2_client",
+        'id',
+        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        nullable=False,
+        autoincrement=True,
+    )
+    op.alter_column(
+        "oauth2_token",
+        'id',
+        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        nullable=False,
+        autoincrement=True,
+    )
+    op.alter_column(
+        "oauth2_auth_code",
+        'id',
+        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        nullable=False,
+        autoincrement=True,
+    )
+    op.alter_column(
+        "chat",
+        'id',
+        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        nullable=False,
+        autoincrement=True,
+    )
 
 
 def downgrade():
-    op.alter_column("bundle", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
-    op.alter_column("bundle_metadata", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
-    op.alter_column("bundle_dependency", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
-    op.alter_column("worksheet", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
-    op.alter_column("worksheet_item", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
-    op.alter_column("worksheet_tag", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
-    op.alter_column("group", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
-    op.alter_column("user_group", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
-    op.alter_column("group_bundle_permission", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
-    op.alter_column("group_object_permission", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
-    op.alter_column("user", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
-    op.alter_column("user_verification", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
-    op.alter_column("user_reset_code", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
-    op.alter_column("oauth2_client", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
-    op.alter_column("oauth2_token", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
-    op.alter_column("oauth2_auth_code", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
-    op.alter_column("chat", 'id', type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"), existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=False, autoincrement=True)
+    op.alter_column(
+        "bundle",
+        'id',
+        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        nullable=False,
+        autoincrement=True,
+    )
+    op.alter_column(
+        "bundle_metadata",
+        'id',
+        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        nullable=False,
+        autoincrement=True,
+    )
+    op.alter_column(
+        "bundle_dependency",
+        'id',
+        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        nullable=False,
+        autoincrement=True,
+    )
+    op.alter_column(
+        "worksheet",
+        'id',
+        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        nullable=False,
+        autoincrement=True,
+    )
+    op.alter_column(
+        "worksheet_item",
+        'id',
+        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        nullable=False,
+        autoincrement=True,
+    )
+    op.alter_column(
+        "worksheet_tag",
+        'id',
+        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        nullable=False,
+        autoincrement=True,
+    )
+    op.alter_column(
+        "group",
+        'id',
+        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        nullable=False,
+        autoincrement=True,
+    )
+    op.alter_column(
+        "user_group",
+        'id',
+        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        nullable=False,
+        autoincrement=True,
+    )
+    op.alter_column(
+        "group_bundle_permission",
+        'id',
+        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        nullable=False,
+        autoincrement=True,
+    )
+    op.alter_column(
+        "group_object_permission",
+        'id',
+        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        nullable=False,
+        autoincrement=True,
+    )
+    op.alter_column(
+        "user",
+        'id',
+        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        nullable=False,
+        autoincrement=True,
+    )
+    op.alter_column(
+        "user_verification",
+        'id',
+        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        nullable=False,
+        autoincrement=True,
+    )
+    op.alter_column(
+        "user_reset_code",
+        'id',
+        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        nullable=False,
+        autoincrement=True,
+    )
+    op.alter_column(
+        "oauth2_client",
+        'id',
+        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        nullable=False,
+        autoincrement=True,
+    )
+    op.alter_column(
+        "oauth2_token",
+        'id',
+        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        nullable=False,
+        autoincrement=True,
+    )
+    op.alter_column(
+        "oauth2_auth_code",
+        'id',
+        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        nullable=False,
+        autoincrement=True,
+    )
+    op.alter_column(
+        "chat",
+        'id',
+        type_=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        existing_type=sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        nullable=False,
+        autoincrement=True,
+    )

--- a/codalab/model/tables.py
+++ b/codalab/model/tables.py
@@ -25,7 +25,13 @@ db_metadata = MetaData()
 bundle = Table(
     'bundle',
     db_metadata,
-    Column('id', BigInteger().with_variant(Integer, "sqlite"), primary_key=True, nullable=False),
+    Column(
+        'id',
+        BigInteger().with_variant(Integer, "sqlite"),
+        primary_key=True,
+        nullable=False,
+        autoincrement=True,
+    ),
     Column('uuid', String(63), nullable=False),
     Column('bundle_type', String(63), nullable=False),
     # The command will be NULL except for run bundles.
@@ -44,7 +50,13 @@ bundle = Table(
 bundle_metadata = Table(
     'bundle_metadata',
     db_metadata,
-    Column('id', BigInteger().with_variant(Integer, "sqlite"), primary_key=True, nullable=False),
+    Column(
+        'id',
+        BigInteger().with_variant(Integer, "sqlite"),
+        primary_key=True,
+        nullable=False,
+        autoincrement=True,
+    ),
     Column('bundle_uuid', String(63), ForeignKey(bundle.c.uuid), nullable=False),
     Column('metadata_key', String(63), nullable=False),
     Column('metadata_value', Text, nullable=False),
@@ -55,7 +67,13 @@ bundle_metadata = Table(
 bundle_dependency = Table(
     'bundle_dependency',
     db_metadata,
-    Column('id', BigInteger().with_variant(Integer, "sqlite"), primary_key=True, nullable=False),
+    Column(
+        'id',
+        BigInteger().with_variant(Integer, "sqlite"),
+        primary_key=True,
+        nullable=False,
+        autoincrement=True,
+    ),
     Column('child_uuid', String(63), ForeignKey(bundle.c.uuid), nullable=False),
     Column('child_path', Text, nullable=False),
     # Deliberately omit ForeignKey(bundle.c.uuid), because bundles can have
@@ -69,7 +87,13 @@ bundle_dependency = Table(
 worksheet = Table(
     'worksheet',
     db_metadata,
-    Column('id', BigInteger().with_variant(Integer, "sqlite"), primary_key=True, nullable=False),
+    Column(
+        'id',
+        BigInteger().with_variant(Integer, "sqlite"),
+        primary_key=True,
+        nullable=False,
+        autoincrement=True,
+    ),
     Column('uuid', String(63), nullable=False),
     Column('name', String(255), nullable=False),
     Column('owner_id', String(255), nullable=True),
@@ -88,7 +112,13 @@ worksheet = Table(
 worksheet_item = Table(
     'worksheet_item',
     db_metadata,
-    Column('id', BigInteger().with_variant(Integer, "sqlite"), primary_key=True, nullable=False),
+    Column(
+        'id',
+        BigInteger().with_variant(Integer, "sqlite"),
+        primary_key=True,
+        nullable=False,
+        autoincrement=True,
+    ),
     Column('worksheet_uuid', String(63), ForeignKey(worksheet.c.uuid), nullable=False),
     # A worksheet item is either:
     # - type = bundle (bundle_uuid != null)
@@ -111,7 +141,13 @@ worksheet_item = Table(
 worksheet_tag = Table(
     'worksheet_tag',
     db_metadata,
-    Column('id', BigInteger().with_variant(Integer, "sqlite"), primary_key=True, nullable=False),
+    Column(
+        'id',
+        BigInteger().with_variant(Integer, "sqlite"),
+        primary_key=True,
+        nullable=False,
+        autoincrement=True,
+    ),
     Column('worksheet_uuid', String(63), ForeignKey(worksheet.c.uuid), nullable=False),
     Column('tag', String(63), nullable=False),
     Index('worksheet_tag_worksheet_uuid_index', 'worksheet_uuid'),
@@ -121,7 +157,13 @@ worksheet_tag = Table(
 group = Table(
     'group',
     db_metadata,
-    Column('id', BigInteger().with_variant(Integer, "sqlite"), primary_key=True, nullable=False),
+    Column(
+        'id',
+        BigInteger().with_variant(Integer, "sqlite"),
+        primary_key=True,
+        nullable=False,
+        autoincrement=True,
+    ),
     Column('uuid', String(63), nullable=False),
     Column('name', String(255), nullable=False),
     Column('user_defined', Boolean),
@@ -134,7 +176,13 @@ group = Table(
 user_group = Table(
     'user_group',
     db_metadata,
-    Column('id', BigInteger().with_variant(Integer, "sqlite"), primary_key=True, nullable=False),
+    Column(
+        'id',
+        BigInteger().with_variant(Integer, "sqlite"),
+        primary_key=True,
+        nullable=False,
+        autoincrement=True,
+    ),
     Column('group_uuid', String(63), ForeignKey(group.c.uuid), nullable=False),
     Column('user_id', String(63), ForeignKey("user.user_id"), nullable=False),
     # Whether a user is able to modify this group.
@@ -147,7 +195,13 @@ user_group = Table(
 group_bundle_permission = Table(
     'group_bundle_permission',
     db_metadata,
-    Column('id', BigInteger().with_variant(Integer, "sqlite"), primary_key=True, nullable=False),
+    Column(
+        'id',
+        BigInteger().with_variant(Integer, "sqlite"),
+        primary_key=True,
+        nullable=False,
+        autoincrement=True,
+    ),
     Column('group_uuid', String(63), ForeignKey(group.c.uuid), nullable=False),
     # Reference to a bundle
     Column('object_uuid', String(63), ForeignKey(bundle.c.uuid), nullable=False),
@@ -159,7 +213,13 @@ group_bundle_permission = Table(
 group_object_permission = Table(
     'group_object_permission',
     db_metadata,
-    Column('id', BigInteger().with_variant(Integer, "sqlite"), primary_key=True, nullable=False),
+    Column(
+        'id',
+        BigInteger().with_variant(Integer, "sqlite"),
+        primary_key=True,
+        nullable=False,
+        autoincrement=True,
+    ),
     Column('group_uuid', String(63), ForeignKey(group.c.uuid), nullable=False),
     # Reference to a worksheet object
     Column('object_uuid', String(63), ForeignKey(worksheet.c.uuid), nullable=False),
@@ -181,7 +241,13 @@ NOTIFICATIONS_GENERAL = 0x02  # Receive general notifications (new features)
 user = Table(
     'user',
     db_metadata,
-    Column('id', BigInteger().with_variant(Integer, "sqlite"), primary_key=True, nullable=False),
+    Column(
+        'id',
+        BigInteger().with_variant(Integer, "sqlite"),
+        primary_key=True,
+        nullable=False,
+        autoincrement=True,
+    ),
     # Basic information
     Column('user_id', String(63), nullable=False),
     Column('user_name', String(63), nullable=False, unique=True),
@@ -220,7 +286,13 @@ user = Table(
 user_verification = Table(
     'user_verification',
     db_metadata,
-    Column('id', BigInteger().with_variant(Integer, "sqlite"), primary_key=True, nullable=False),
+    Column(
+        'id',
+        BigInteger().with_variant(Integer, "sqlite"),
+        primary_key=True,
+        nullable=False,
+        autoincrement=True,
+    ),
     Column('user_id', String(63), ForeignKey(user.c.user_id), nullable=False),
     Column('date_created', DateTime, nullable=False),
     Column('date_sent', DateTime, nullable=True),
@@ -231,7 +303,13 @@ user_verification = Table(
 user_reset_code = Table(
     'user_reset_code',
     db_metadata,
-    Column('id', BigInteger().with_variant(Integer, "sqlite"), primary_key=True, nullable=False),
+    Column(
+        'id',
+        BigInteger().with_variant(Integer, "sqlite"),
+        primary_key=True,
+        nullable=False,
+        autoincrement=True,
+    ),
     Column('user_id', String(63), ForeignKey(user.c.user_id), nullable=False),
     Column('date_created', DateTime, nullable=False),
     Column('code', String(64), nullable=False),
@@ -242,7 +320,13 @@ user_reset_code = Table(
 oauth2_client = Table(
     'oauth2_client',
     db_metadata,
-    Column('id', BigInteger().with_variant(Integer, "sqlite"), primary_key=True, nullable=False),
+    Column(
+        'id',
+        BigInteger().with_variant(Integer, "sqlite"),
+        primary_key=True,
+        nullable=False,
+        autoincrement=True,
+    ),
     Column('client_id', String(63), nullable=False),
     Column('name', String(63), nullable=True),
     Column('secret', String(255), nullable=True),
@@ -261,7 +345,13 @@ oauth2_client = Table(
 oauth2_token = Table(
     'oauth2_token',
     db_metadata,
-    Column('id', BigInteger().with_variant(Integer, "sqlite"), primary_key=True, nullable=False),
+    Column(
+        'id',
+        BigInteger().with_variant(Integer, "sqlite"),
+        primary_key=True,
+        nullable=False,
+        autoincrement=True,
+    ),
     Column('client_id', String(63), ForeignKey(oauth2_client.c.client_id), nullable=False),
     Column('user_id', String(63), ForeignKey(user.c.user_id), nullable=False),
     Column('scopes', Text, nullable=False),
@@ -273,7 +363,13 @@ oauth2_token = Table(
 oauth2_auth_code = Table(
     'oauth2_auth_code',
     db_metadata,
-    Column('id', BigInteger().with_variant(Integer, "sqlite"), primary_key=True, nullable=False),
+    Column(
+        'id',
+        BigInteger().with_variant(Integer, "sqlite"),
+        primary_key=True,
+        nullable=False,
+        autoincrement=True,
+    ),
     Column('client_id', String(63), ForeignKey(oauth2_client.c.client_id), nullable=False),
     Column('user_id', String(63), ForeignKey(user.c.user_id), nullable=False),
     Column('scopes', Text, nullable=False),
@@ -287,7 +383,11 @@ chat = Table(
     'chat',
     db_metadata,
     Column(
-        'id', BigInteger().with_variant(Integer, "sqlite"), primary_key=True, nullable=False
+        'id',
+        BigInteger().with_variant(Integer, "sqlite"),
+        primary_key=True,
+        nullable=False,
+        autoincrement=True,
     ),  # Primary key
     Column('time', DateTime, nullable=False),  # When did the user send this query?
     Column('sender_user_id', String(63), nullable=True),  # Who sent it?


### PR DESCRIPTION
### Reasons for making this change

If you pull a fresh copy of codalab from master and run it locally, the database correctly has auto-increment. However, upgrading from an existing db removes the autoincrement. This seems like a bug on the alembic side (perhaps related to https://github.com/sqlalchemy/alembic/issues/413), but regardless, we have to deal with it and ensure that the DB schema when upgrading matches the DB schema when starting fresh from master.

I tested this by:

1. `git checkout f304d903` (before primary key change)
2. build server (just run `codalab_service start -bd`) , run some bundles
3. inspect the DB:

```
mysql> describe bundle_metadata;
+----------------+-------------+------+-----+---------+----------------+
| Field          | Type        | Null | Key | Default | Extra          |
+----------------+-------------+------+-----+---------+----------------+
| id             | int(11)     | NO   | PRI | NULL    | auto_increment |
| bundle_uuid    | varchar(63) | NO   | MUL | NULL    |                |
| metadata_key   | varchar(63) | NO   | MUL | NULL    |                |
| metadata_value | text        | NO   |     | NULL    |                |
+----------------+-------------+------+-----+---------+----------------+
4 rows in set (0.00 sec)

mysql> SELECT `AUTO_INCREMENT` FROM  INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'codalab_bundles' AND   TABLE_NAME   = 'bundle_metadata';
+----------------+
| AUTO_INCREMENT |
+----------------+
|            125 |
+----------------+
1 row in set (0.01 sec)
```

4. `git checkout 8e58f510` (this commit)
5. Rebuild server (just run `codalab_service start -bd`)
6. Inspect the db, ensure that int -> bigint, autoincrement remains, and the value of autoincrement remains constant:

```
mysql> describe bundle_metadata;
+----------------+-------------+------+-----+---------+----------------+
| Field          | Type        | Null | Key | Default | Extra          |
+----------------+-------------+------+-----+---------+----------------+
| id             | bigint(20)  | NO   | PRI | NULL    | auto_increment |
| bundle_uuid    | varchar(63) | NO   | MUL | NULL    |                |
| metadata_key   | varchar(63) | NO   | MUL | NULL    |                |
| metadata_value | text        | NO   |     | NULL    |                |
+----------------+-------------+------+-----+---------+----------------+
4 rows in set (0.00 sec)

mysql> SELECT `AUTO_INCREMENT` FROM  INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'codalab_bundles' AND   TABLE_NAME   = 'bundle_metadata';
+----------------+
| AUTO_INCREMENT |
+----------------+
|            125 |
+----------------+
1 row in set (0.00 sec)
```