### PR TITLE
Change size of large bundle in stress test from 16g to 32g

### DIFF
--- a/tests/stress/stress_test.py
+++ b/tests/stress/stress_test.py
@@ -313,7 +313,7 @@ def main():
 
     if args.heavy:
         print('Setting the heavy configuration...')
-        args.large_file_size_gb = 32
+        args.large_file_size_gb = 16
         args.gpu_runs_count = 50
         args.multiple_cpus_runs_count = 50
         args.bundle_upload_count = 500


### PR DESCRIPTION
The dev server has 13G of memory, so a 16G file should be sufficient.