### PR TITLE
Fix race condition in the Stress Test

### DIFF
--- a/tests/stress/stress_test.py
+++ b/tests/stress/stress_test.py
@@ -165,14 +165,16 @@ class StressTestRunner:
         large_file = TestFile('large_file', self._args.large_file_size_gb * 1000)
         dependency_uuid = self._run_bundle([self._cl, 'upload', large_file.name()])
         large_file.delete()
-        self._run_bundle(
+        uuid = self._run_bundle(
             [
                 self._cl,
                 'run',
-                'wc -c large_dependency',
                 'large_dependency:{}'.format(dependency_uuid),
+                'wc -c large_dependency',
             ]
         )
+        # Wait for the run to finish before cleaning up the dependency
+        run_command([cl, 'wait', uuid])
 
     def _test_many_gpu_runs(self):
         self._set_worksheet('many_gpu_runs')


### PR DESCRIPTION
### Reasons for making this change

There is a race condition where the dependency can be deleted before the bundle finishes. This fix waits for the bundle to finish before cleanup.

### Checklist

* [ ] I've added a screenshot of the changes, if this is a frontend change
* [ ] I've added and/or updated tests, if this is a backend change
* [ ] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [ ] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
