### PR TITLE
Fix CodaLab Competition script

### DIFF
--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -2174,19 +2174,27 @@ class BundleModel(object):
             user_ids = [user_id]
         if username is not None:
             usernames = [username]
-        result = self.get_users(user_ids=user_ids, usernames=usernames, check_active=check_active)
+        result = self.get_users(
+            user_ids=user_ids, usernames=usernames, check_active=check_active, limit=1
+        )
         if result['results']:
             return result['results'][0]
         return None
 
-    def get_users(self, keywords=None, user_ids=None, usernames=None, check_active=True):
+    def get_users(
+        self,
+        keywords=None,
+        user_ids=None,
+        usernames=None,
+        check_active=True,
+        limit=SEARCH_RESULTS_LIMIT,
+    ):
         """
         see the documentation for `cl uls` for information about keyword structure.
         """
         clauses = []
         offset = 0
         format_func = None
-        limit = SEARCH_RESULTS_LIMIT
         count = False
         sort_key = [None]
         aux_fields = []  # Fields (e.g., sorting) that we need to include in the query

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -185,7 +185,9 @@ def build_bundles_document(bundle_uuids):
     if 'owner' in include_set:
         owner_ids = set(b['owner_id'] for b in bundles if b['owner_id'] is not None)
         json_api_include(
-            document, UserSchema(), local.model.get_users(user_ids=owner_ids)['results']
+            document,
+            UserSchema(),
+            local.model.get_users(user_ids=owner_ids, limit=len(owner_ids))['results'],
         )
 
     if 'group_permissions' in include_set:


### PR DESCRIPTION
### Reasons for making this change

Fixes the competition script. Previously, we limit the number of rows (default=10) when fetching users from the database, which caused errors downstream.

### Related issues

Resolves #2999 

### Checklist

* [ ] I've added and/or updated tests, if this is a backend change
* [ ] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [ ] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
