### PR TITLE
Temporarily cancel the timeout

### DIFF
--- a/codalab/worker/rest_client.py
+++ b/codalab/worker/rest_client.py
@@ -92,7 +92,7 @@ class RestClient(object):
             # Return a file-like object containing the contents of the response
             # body, transparently decoding gzip streams if indicated by the
             # Content-Encoding header.
-            response = urllib.request.urlopen(request, timeout=timeout_seconds)
+            response = urllib.request.urlopen(request)
             encoding = response.headers.get('Content-Encoding')
             if not encoding or encoding == 'identity':
                 return response


### PR DESCRIPTION
### Reasons for making this change
Currently the `cl wait uuid` fails due to timeout. Since the time to wait for a running bundle to finish is unknown, I'm temporarily cancelling the timeout limit. 
<!-- Add a reason for making this change here. -->

### Related issues

<!-- Add a reference to issues resolved, if applicable (for example, "fixes #1"). -->

### Screenshots

<!-- Add screenshots, if necessary -->

### Checklist

* [ ] I've added a screenshot of the changes, if this is a frontend change
* [ ] I've added and/or updated tests, if this is a backend change
* [ ] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [ ] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
