### PR TITLE
Make Docker timeouts consistent and more lenient across the board

### DIFF
--- a/codalab/lib/completers.py
+++ b/codalab/lib/completers.py
@@ -13,6 +13,7 @@ from argcomplete import warn
 
 from codalab.common import NotFoundError
 from codalab.lib import spec_util, worksheet_util, cli_util
+from codalab.worker.docker_utils import DEFAULT_DOCKER_TIMEOUT
 from codalab.worker.download_util import BundleTarget
 
 
@@ -206,7 +207,7 @@ class DockerImagesCompleter(CodaLabCompleter):
         first_slash = prefix.find('/')
         trimmed_prefix = prefix[0:first_slash] if first_slash >= 0 else prefix
         try:
-            client = docker.from_env()
+            client = docker.from_env(timeout=DEFAULT_DOCKER_TIMEOUT)
             return (img['name'] for img in client.images.search(trimmed_prefix))
         except docker.errors.APIError as ex:
             warn('Error: {}'.format(ex))

--- a/codalab/worker/docker_image_manager.py
+++ b/codalab/worker/docker_image_manager.py
@@ -10,6 +10,7 @@ from docker import DockerClient
 from codalab.lib.telemetry_util import capture_exception, using_sentry
 import codalab.worker.docker_utils as docker_utils
 
+from .docker_utils import DEFAULT_DOCKER_TIMEOUT
 from codalab.worker.fsm import DependencyStage
 from codalab.worker.state_committer import JsonStateCommitter
 from codalab.worker.worker_thread import ThreadDict
@@ -39,7 +40,7 @@ class DockerImageManager:
         :param max_image_size: Total size in bytes that the image can have
         """
         self._state_committer = JsonStateCommitter(commit_file)  # type: JsonStateCommitter
-        self._docker = docker.from_env()  # type: DockerClient
+        self._docker = docker.from_env(timeout=DEFAULT_DOCKER_TIMEOUT)  # type: DockerClient
         self._downloading = ThreadDict(
             fields={'success': False, 'status': 'Download starting.'}, lock=True
         )

--- a/codalab/worker/docker_utils.py
+++ b/codalab/worker/docker_utils.py
@@ -21,7 +21,7 @@ from urllib3.util.retry import Retry
 MIN_API_VERSION = '1.17'
 NVIDIA_RUNTIME = 'nvidia'
 DEFAULT_RUNTIME = 'runc'
-DEFAULT_TIMEOUT = 720
+DEFAULT_DOCKER_TIMEOUT = 720
 DEFAULT_CONTAINER_RUNNING_TIME = 0
 # Docker Registry HTTP API v2 URI prefix
 URI_PREFIX = 'https://hub.docker.com/v2/repositories/'
@@ -38,7 +38,7 @@ MEMORY_LIMIT_ERROR_REGEX = (
 )
 
 logger = logging.getLogger(__name__)
-client = docker.from_env(timeout=DEFAULT_TIMEOUT)
+client = docker.from_env(timeout=DEFAULT_DOCKER_TIMEOUT)
 
 
 def wrap_exception(message):

--- a/codalab/worker/worker.py
+++ b/codalab/worker/worker.py
@@ -19,6 +19,7 @@ import requests
 
 from .bundle_service_client import BundleServiceException, BundleServiceClient
 from .dependency_manager import DependencyManager
+from .docker_utils import DEFAULT_DOCKER_TIMEOUT
 from .docker_image_manager import DockerImageManager
 from .download_util import BUNDLE_NO_LONGER_RUNNING_MESSAGE
 from .state_committer import JsonStateCommitter
@@ -83,7 +84,7 @@ class Worker:
         self.state_committer = JsonStateCommitter(commit_file)
         self.bundle_service = bundle_service
 
-        self.docker = docker.from_env()
+        self.docker = docker.from_env(timeout=DEFAULT_DOCKER_TIMEOUT)
         self.cpuset = cpuset
         self.gpuset = gpuset
         self.max_memory = (


### PR DESCRIPTION
### Reasons for making this change

Sometimes, bundles fail to run with failure messages like `failed to download Docker image: Image maven:latest was downloaded successfully, but it cannot be found locally due to unhandled error UnixHTTPConnectionPool(host='localhost', port=None): Read timed out. (read timeout=60)` . This bumps up the docker timeout across the board, since I noticed it wasn't being set in some places.