### PR TITLE
Log username and server when authentication to bundle service fails

### DIFF
--- a/codalab/worker/main.py
+++ b/codalab/worker/main.py
@@ -190,7 +190,8 @@ def connect_to_codalab_server(server, password_file):
         bundle_service = BundleServiceClient(server, username, password)
         return bundle_service
     except BundleAuthException as ex:
-        logger.error('Cannot log into the bundle service. Please check your worker credentials.\n')
+        logger.error('Cannot log into the bundle service. Please check your worker credentials.\n'
+                     f'Username: "{username}" , server "{server}"\n')
         logger.debug('Auth error: {}'.format(ex))
         sys.exit(1)
 

--- a/codalab/worker/main.py
+++ b/codalab/worker/main.py
@@ -190,8 +190,10 @@ def connect_to_codalab_server(server, password_file):
         bundle_service = BundleServiceClient(server, username, password)
         return bundle_service
     except BundleAuthException as ex:
-        logger.error('Cannot log into the bundle service. Please check your worker credentials.\n'
-                     f'Username: "{username}" , server "{server}"\n')
+        logger.error(
+            'Cannot log into the bundle service. Please check your worker credentials.\n'
+            f'Username: "{username}" , server "{server}"\n'
+        )
         logger.debug('Auth error: {}'.format(ex))
         sys.exit(1)
 


### PR DESCRIPTION
### Reasons for making this change

I get emails from sentry whenever a stanfordnlp worker fails. Sometimes, I get emails saying that there's been an authentication error; sometimes, this is because the bundleservice is down, and sometimes it's because someone put in the wrong password file. Logging the username and server would make it easier to pinpoint who / which server is affected.