### PR TITLE
Add option to quit SlurmWorkerManager after X jobs fail to start

### DIFF
--- a/codalab/worker_manager/slurm_batch_worker_manager.py
+++ b/codalab/worker_manager/slurm_batch_worker_manager.py
@@ -89,7 +89,9 @@ class SlurmBatchWorkerManager(WorkerManager):
             help='Directory where to store Slurm batch scripts, logs, etc',
         )
         subparser.add_argument(
-            '--exit-after-num-failed', type=int, help='Stop the worker manager when this many jobs have failed to start'
+            '--exit-after-num-failed',
+            type=int,
+            help='Stop the worker manager when this many jobs have failed to start',
         )
 
     def __init__(self, args):
@@ -151,8 +153,13 @@ class SlurmBatchWorkerManager(WorkerManager):
                 jobs_to_remove.add(job_id)
                 logger.error("Failed to start job {}".format(job_id))
                 self.num_failed += 1
-                if self.exit_after_num_failed is not None and self.num_failed > self.exit_after_num_failed:
-                    logger.info(f"Failed to start {self.num_failed} jobs in total, which is more than {self.exit_after_num_failed}")
+                if (
+                    self.exit_after_num_failed is not None
+                    and self.num_failed > self.exit_after_num_failed
+                ):
+                    logger.info(
+                        f"Failed to start {self.num_failed} jobs in total, which is more than {self.exit_after_num_failed}"
+                    )
                     logger.info("Exiting...")
                     sys.exit(0)
             elif 'COMPLETED' in job_state or 'CANCELLED' in job_state or "TIMEOUT" in job_state:

--- a/tests/unit/worker_manager/slurm_batch_worker_manager_test.py
+++ b/tests/unit/worker_manager/slurm_batch_worker_manager_test.py
@@ -22,6 +22,8 @@ class SlurmBatchWorkerManagerTest(unittest.TestCase):
             worker_tag_exclusive=False,
             worker_pass_down_termination=False,
             password_file=None,
+            slurm_work_dir=None,
+            exit_after_num_failed=None,
         )
 
         worker_manager = SlurmBatchWorkerManager(args)


### PR DESCRIPTION
### Reasons for making this change

Sometimes, issues cause the SlurmWorkerManager to continually launch workers that fail to start (e.g., wrong password file). This adds an option to stop such worker managers after some number of bundles fail to start.