### PR TITLE
Add flag to exit workermanager after X seconds have elapsed since the last launched worker

### DIFF
--- a/codalab/worker_manager/main.py
+++ b/codalab/worker_manager/main.py
@@ -39,7 +39,7 @@ def main():
     parser.add_argument(
         '--exit-after-seconds',
         type=int,
-        help='Stop the worker manager after this many seconds have passed',
+        help='Stop the worker manager after this many seconds have passed since the last worker was launched',
     )
     parser.add_argument(
         '--once',

--- a/codalab/worker_manager/main.py
+++ b/codalab/worker_manager/main.py
@@ -37,6 +37,11 @@ def main():
         '--sleep-time', help='Number of seconds to wait between checks', default=5, type=int
     )
     parser.add_argument(
+        '--exit-after-seconds',
+        type=int,
+        help='Stop the worker manager after this many seconds have passed',
+    )
+    parser.add_argument(
         '--once',
         help='Just run once and exit instead of looping (for debugging)',
         action='store_true',

--- a/codalab/worker_manager/worker_manager.py
+++ b/codalab/worker_manager/worker_manager.py
@@ -1,8 +1,10 @@
 from collections import namedtuple
+from datetime import datetime
 import http
 import logging
 import os
 import socket
+import sys
 import time
 import traceback
 import urllib
@@ -141,6 +143,15 @@ class WorkerManager(object):
             time.sleep(self.args.sleep_time)
 
     def run_one_iteration(self):
+        if self.args.exit_after_seconds:
+            seconds_since_last_worker = int(time.time() - self.last_worker_start_time)
+            if seconds_since_last_worker > self.args.exit_after_seconds and self.last_worker_start_time != 0:
+                logger.info(
+                    f"{seconds_since_last_worker} seconds have passed since the last worker was launched, "
+                    f"which is greater than {self.args.exit_after_seconds}"
+                )
+                logger.info("Exiting...")
+                sys.exit(0)
         # Get staged bundles for the current user. The principle here is that we want to get all of
         # the staged bundles can be run by this user.
         keywords = ['state=' + State.STAGED] + self.args.search


### PR DESCRIPTION
### Reasons for making this change

We don't want people to run their workermanagers forever if they aren't using them---this pollutes `sc`, and prevents them from getting the latest version of the workermanager. This flag optionally exits the worker manager after X seconds have elapsed since the last worker was launched.