### PR TITLE
Add option to restart WorkerManager processes after X seconds

### DIFF
--- a/codalab/worker_manager/main.py
+++ b/codalab/worker_manager/main.py
@@ -37,6 +37,11 @@ def main():
         '--sleep-time', help='Number of seconds to wait between checks', default=5, type=int
     )
     parser.add_argument(
+        '--restart-after-seconds',
+        type=int,
+        help='Restart the worker manager after this many seconds have passed since launch',
+    )
+    parser.add_argument(
         '--once',
         help='Just run once and exit instead of looping (for debugging)',
         action='store_true',

--- a/codalab/worker_manager/worker_manager.py
+++ b/codalab/worker_manager/worker_manager.py
@@ -2,7 +2,9 @@ from collections import namedtuple
 import http
 import logging
 import os
+import psutil
 import socket
+import sys
 import time
 import traceback
 import urllib
@@ -19,6 +21,20 @@ logger = logging.getLogger(__name__)
 # `active` is a Boolean field that's set to true if the worker is
 # actively running at the moment. (As opposed to being staged, queued, preparing etc)
 WorkerJob = namedtuple('WorkerJob', ['active'])
+
+
+def restart():
+    """
+    Restarts the current program, cleaning up file objects and descriptors
+    """
+    try:
+        p = psutil.Process(os.getpid())
+        for handler in p.open_files() + p.connections():
+            os.close(handler.fd)
+    except Exception as e:
+        logger.error(e)
+    python = sys.executable
+    os.execl(python, python, *sys.argv)
 
 
 class WorkerManager(object):
@@ -71,6 +87,7 @@ class WorkerManager(object):
         self.codalab_manager = CodaLabManager()
         self.codalab_client = self.codalab_manager.client(args.server)
         self.staged_uuids = []
+        self.worker_manager_start_time = time.time()
         self.last_worker_start_time = 0
         logger.info('Started worker manager.')
 
@@ -141,6 +158,15 @@ class WorkerManager(object):
             time.sleep(self.args.sleep_time)
 
     def run_one_iteration(self):
+        if self.args.restart_after_seconds:
+            seconds_since_start = int(time.time() - self.worker_manager_start_time)
+            if seconds_since_start > self.args.restart_after_seconds:
+                logger.info(
+                    f"{seconds_since_start} seconds have elapsed since this WorkerManager "
+                    f"was started, which is greater than {self.args.restart_after_seconds}"
+                )
+                logger.info("Restarting...")
+                restart()
         # Get staged bundles for the current user. The principle here is that we want to get all of
         # the staged bundles can be run by this user.
         keywords = ['state=' + State.STAGED] + self.args.search


### PR DESCRIPTION
### Reasons for making this change

Continuation of #3049 .

To test (doesn't have to be on the cluster):
```
cl-worker-manager --restart-after-seconds 10 slurm-batch --partition jag-lo
```

You should see a `Restarting...` message followed by the `Started worker manager` string after ~10 seconds