### PR TITLE
Handle the login failure in a graceful way

### DIFF
--- a/codalab/rest/account.py
+++ b/codalab/rest/account.py
@@ -42,6 +42,8 @@ def do_login():
 
     user = local.model.get_user(username=username)
     if not (user and user.check_password(password)):
+        if error_uri is None:
+            error_uri = '/'
         return redirect_with_query(
             error_uri, {"error": "Login/password did not match.", "next": success_uri}
         )


### PR DESCRIPTION
### Reasons for making this change
When the login credentials don't match and error_uri is None, the program is failing in a way that involves type matching, whereas it should indicate explicitly that error_uri is None. I give the error_uri a default value, when it's None to handle it. 
<!-- Add a reason for making this change here. -->

### Related issues
#2993 
<!-- Add a reference to issues resolved, if applicable (for example, "fixes #1"). -->

### Screenshots

<!-- Add screenshots, if necessary -->

### Checklist

* [ ] I've added a screenshot of the changes, if this is a frontend change
* [ ] I've added and/or updated tests, if this is a backend change
* [ ] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [ ] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
