### PR TITLE
Fix version of urllib to be <1.26

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ requests-oauthlib==1.1.0
 oauthlib==2.1.0
 markdown2==2.3.10
 wheel==0.35.1
+urllib3<1.26


### PR DESCRIPTION
### Reasons for making this change
Currently there's a version conflict: urllib3 has the most recent version 1.26.2, but apache beam doesn't support any version >=1.26. 
<!-- Add a reason for making this change here. -->

### Related issues
#3058
<!-- Add a reference to issues resolved, if applicable (for example, "fixes #1"). -->

### Screenshots

<!-- Add screenshots, if necessary -->

### Checklist

* [ ] I've added a screenshot of the changes, if this is a frontend change
* [ ] I've added and/or updated tests, if this is a backend change
* [ ] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [ ] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
