### PR TITLE
Bump to version 0.5.29

### DIFF
--- a/codalab/common.py
+++ b/codalab/common.py
@@ -8,7 +8,7 @@ import http.client
 
 # Increment this on master when ready to cut a release.
 # http://semver.org/
-CODALAB_VERSION = '0.5.27'
+CODALAB_VERSION = '0.5.28'
 BINARY_PLACEHOLDER = '<binary>'
 URLOPEN_TIMEOUT_SECONDS = 5 * 60
 

--- a/codalab/common.py
+++ b/codalab/common.py
@@ -8,7 +8,7 @@ import http.client
 
 # Increment this on master when ready to cut a release.
 # http://semver.org/
-CODALAB_VERSION = '0.5.28'
+CODALAB_VERSION = '0.5.29'
 BINARY_PLACEHOLDER = '<binary>'
 URLOPEN_TIMEOUT_SECONDS = 5 * 60
 

--- a/docs/REST-API-Reference.md
+++ b/docs/REST-API-Reference.md
@@ -1,6 +1,6 @@
 # REST API Reference
 
-_version 0.5.28_
+_version 0.5.29_
 
 This reference and the REST API itself is still under heavy development and is
 subject to change at any time. Feedback through our GitHub issues is appreciated!

--- a/docs/REST-API-Reference.md
+++ b/docs/REST-API-Reference.md
@@ -1,6 +1,6 @@
 # REST API Reference
 
-_version 0.5.27_
+_version 0.5.28_
 
 This reference and the REST API itself is still under heavy development and is
 subject to change at any time. Feedback through our GitHub issues is appreciated!

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -1,5 +1,5 @@
 // Should match codalab/common.py#CODALAB_VERSION
-export const CODALAB_VERSION = '0.5.28';
+export const CODALAB_VERSION = '0.5.29';
 
 // Name Regex to match the backend in spec_utils.py
 export const NAME_REGEX = /^[a-zA-Z_][a-zA-Z0-9_.-]*$/i;

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -1,5 +1,5 @@
 // Should match codalab/common.py#CODALAB_VERSION
-export const CODALAB_VERSION = '0.5.27';
+export const CODALAB_VERSION = '0.5.28';
 
 // Name Regex to match the backend in spec_utils.py
 export const NAME_REGEX = /^[a-zA-Z_][a-zA-Z0-9_.-]*$/i;

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import sys
 
 
 # should match codalab/common.py#CODALAB_VERSION
-CODALAB_VERSION = "0.5.28"
+CODALAB_VERSION = "0.5.29"
 
 
 class Install(install):

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import sys
 
 
 # should match codalab/common.py#CODALAB_VERSION
-CODALAB_VERSION = "0.5.27"
+CODALAB_VERSION = "0.5.28"
 
 
 class Install(install):


### PR DESCRIPTION
### Reasons for making this change

Bump new version

Full diff: https://github.com/codalab/codalab-worksheets/compare/v0.5.27...rc0.5.29

# Draft release notes

## Frontend
- Fix the bug of table items don't async load (#3047)
- Consider the height of Worksheet Header and Nav Bar when deciding whether an element is on the screen or not (#3023)

## Backend
- Log username and server when authentication to bundle service fails (#3046 )
- Add option to restart WorkerManager processes after X seconds (#3050) 
- Add option to quit SlurmWorkerManager after X jobs fail to start (#3048)
- Fix version of urllib to be <1.26 (#3059)
- Fix warning of "Length of raw_to_block does not match the length of raw_items" (#3038)

## Dev / docs / CI
- Allow egg and wheel coexist (#3014)
- Resolve crash of a null-valued bundle spec (#3000)
