### PR TITLE
Bump version to 0.5.30

### DIFF
--- a/codalab/common.py
+++ b/codalab/common.py
@@ -8,7 +8,7 @@ import http.client
 
 # Increment this on master when ready to cut a release.
 # http://semver.org/
-CODALAB_VERSION = '0.5.29'
+CODALAB_VERSION = '0.5.30'
 BINARY_PLACEHOLDER = '<binary>'
 URLOPEN_TIMEOUT_SECONDS = 5 * 60
 

--- a/docs/REST-API-Reference.md
+++ b/docs/REST-API-Reference.md
@@ -1,6 +1,6 @@
 # REST API Reference
 
-_version 0.5.29_
+_version 0.5.30_
 
 This reference and the REST API itself is still under heavy development and is
 subject to change at any time. Feedback through our GitHub issues is appreciated!

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -1,5 +1,5 @@
 // Should match codalab/common.py#CODALAB_VERSION
-export const CODALAB_VERSION = '0.5.29';
+export const CODALAB_VERSION = '0.5.30';
 
 // Name Regex to match the backend in spec_utils.py
 export const NAME_REGEX = /^[a-zA-Z_][a-zA-Z0-9_.-]*$/i;

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import sys
 
 
 # should match codalab/common.py#CODALAB_VERSION
-CODALAB_VERSION = "0.5.29"
+CODALAB_VERSION = "0.5.30"
 
 
 class Install(install):


### PR DESCRIPTION
### Reasons for making this change

Bump new version

Full diff: https://github.com/codalab/codalab-worksheets/compare/v0.5.29...rc0.5.30

# Draft release notes

## Backend
- Add support for Azure Batch Worker Manager (#2946)
- Make gzip_file nonblocking / return faster (#3045)
- Fix "codalab-service start" command (#2997)

