### PR TITLE
Suppress printing the stacktrace of login error

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,7 +80,8 @@ jobs:
     strategy:
       matrix:
         test:
-          - unittest gen-rest-docs gen-cli-docs gen-readthedocs basic auth status batch anonymous competition unicode rest1 upload1 upload2 upload3 upload4 download refs binary rm make worksheet_search worksheet_tags freeze detach perm search_time groups worker_manager
+          - unittest gen-rest-docs gen-cli-docs gen-readthedocs basic auth status batch anonymous competition unicode rest1 upload1 upload2 upload3 upload4 download refs binary rm make worksheet_search worksheet_tags freeze detach perm search_time groups
+          - worker_manager
           - run
           - run2
           - search link read kill write mimic workers edit_user sharing_workers

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,7 +80,7 @@ jobs:
     strategy:
       matrix:
         test:
-          - unittest gen-rest-docs gen-cli-docs gen-readthedocs basic auth status batch anonymous competition unicode rest1 upload1 upload2 upload3 upload4 download refs binary rm make worksheet_search worksheet_tags freeze detach perm search_time groups
+          - unittest gen-rest-docs gen-cli-docs gen-readthedocs basic auth status batch anonymous competition unicode rest1 upload1 upload2 upload3 upload4 download refs binary rm make worksheet_search worksheet_tags freeze detach perm search_time groups worker_manager
           - run
           - run2
           - search link read kill write mimic workers edit_user sharing_workers

--- a/codalab/common.py
+++ b/codalab/common.py
@@ -61,6 +61,12 @@ class PermissionError(UsageError):
     """
 
 
+class LoginPermissionError(ValueError):
+    """
+    Raised when the login credentials are incorrect.
+    """
+
+
 # Listed in order of most specific to least specific.
 http_codes_and_exceptions = [
     (http.client.FORBIDDEN, PermissionError),

--- a/codalab/server/auth.py
+++ b/codalab/server/auth.py
@@ -6,7 +6,7 @@ import json
 import urllib.request
 import urllib.parse
 import urllib.error
-from codalab.common import URLOPEN_TIMEOUT_SECONDS
+from codalab.common import URLOPEN_TIMEOUT_SECONDS, LoginPermissionError
 
 
 # TODO(sckoo): clean up auth logic across:
@@ -66,5 +66,6 @@ class RestOAuthHandler(object):
         except urllib.error.HTTPError as e:
             if e.code == 401:
                 return None
-            print("Invalid username or password.")
-            raise
+            if e.code == 404:
+                raise LoginPermissionError("Invalid username or password.")
+            raise e

--- a/codalab/server/auth.py
+++ b/codalab/server/auth.py
@@ -66,4 +66,5 @@ class RestOAuthHandler(object):
         except urllib.error.HTTPError as e:
             if e.code == 401:
                 return None
+            print("Invalid username or password.")
             raise

--- a/codalab/server/auth.py
+++ b/codalab/server/auth.py
@@ -66,6 +66,6 @@ class RestOAuthHandler(object):
         except urllib.error.HTTPError as e:
             if e.code == 401:
                 return None
-            if e.code == 404:
+            elif e.code == 404:
                 raise LoginPermissionError("Invalid username or password.")
             raise e

--- a/codalab/worker_manager/worker_manager.py
+++ b/codalab/worker_manager/worker_manager.py
@@ -147,27 +147,24 @@ class WorkerManager(object):
         return command
 
     def run_loop(self):
-        while True:
-            try:
-                self.run_one_iteration()
-            except (
-                urllib.error.URLError,
-                http.client.HTTPException,
-                socket.error,
-                JsonApiException,
-                NotFoundError,
-            ):
-                # Sometimes, network errors occur when running the WorkerManager . These are often
-                # transient exceptions, and retrying the command would lead to success---as a result,
-                # we ignore these network-based exceptions (rather than fatally exiting from the
-                # WorkerManager )
-                traceback.print_exc()
-            except LoginPermissionError:
-                print("Invalid username or password. Please try again:")
-            if self.args.once:
-                break
-            logger.debug('Sleeping {} seconds'.format(self.args.sleep_time))
-            time.sleep(self.args.sleep_time)
+        try:
+            self.run_one_iteration()
+        except (
+            urllib.error.URLError,
+            http.client.HTTPException,
+            socket.error,
+            JsonApiException,
+            NotFoundError,
+        ):
+            # Sometimes, network errors occur when running the WorkerManager . These are often
+            # transient exceptions, and retrying the command would lead to success---as a result,
+            # we ignore these network-based exceptions (rather than fatally exiting from the
+            # WorkerManager )
+            traceback.print_exc()
+        except LoginPermissionError:
+            print("Invalid username or password. Please try again:")
+        logger.debug('Sleeping {} seconds'.format(self.args.sleep_time))
+        time.sleep(self.args.sleep_time)
 
     def run_one_iteration(self):
         if self.args.restart_after_seconds:

--- a/codalab/worker_manager/worker_manager.py
+++ b/codalab/worker_manager/worker_manager.py
@@ -154,7 +154,6 @@ class WorkerManager(object):
                 urllib.error.URLError,
                 http.client.HTTPException,
                 socket.error,
-                NotFoundError,
                 JsonApiException,
             ):
                 # Sometimes, network errors occur when running the WorkerManager . These are often
@@ -162,6 +161,8 @@ class WorkerManager(object):
                 # we ignore these network-based exceptions (rather than fatally exiting from the
                 # WorkerManager )
                 traceback.print_exc()
+            except NotFoundError:
+                print("Some resources is not found. Please check the message above ^^")
             if self.args.once:
                 break
             logger.debug('Sleeping {} seconds'.format(self.args.sleep_time))

--- a/codalab/worker_manager/worker_manager.py
+++ b/codalab/worker_manager/worker_manager.py
@@ -11,7 +11,7 @@ from argparse import ArgumentParser
 from collections import namedtuple
 from typing import Dict, List, Union
 
-from codalab.common import NotFoundError
+from codalab.common import NotFoundError, LoginPermissionError
 from codalab.client.json_api_client import JsonApiException
 from codalab.lib.codalab_manager import CodaLabManager
 from codalab.lib.formatting import parse_size
@@ -155,14 +155,15 @@ class WorkerManager(object):
                 http.client.HTTPException,
                 socket.error,
                 JsonApiException,
+                NotFoundError,
             ):
                 # Sometimes, network errors occur when running the WorkerManager . These are often
                 # transient exceptions, and retrying the command would lead to success---as a result,
                 # we ignore these network-based exceptions (rather than fatally exiting from the
                 # WorkerManager )
                 traceback.print_exc()
-            except NotFoundError:
-                print("Some resources is not found. Please check the message above ^^")
+            except LoginPermissionError:
+                print("Invalid username or password. Please try again:")
             if self.args.once:
                 break
             logger.debug('Sleeping {} seconds'.format(self.args.sleep_time))

--- a/codalab/worker_manager/worker_manager.py
+++ b/codalab/worker_manager/worker_manager.py
@@ -17,7 +17,6 @@ from codalab.lib.codalab_manager import CodaLabManager
 from codalab.lib.formatting import parse_size
 from codalab.worker.bundle_state import State
 
-
 logger = logging.getLogger(__name__)
 
 # Type aliases
@@ -147,24 +146,26 @@ class WorkerManager(object):
         return command
 
     def run_loop(self):
-        try:
-            self.run_one_iteration()
-        except (
-            urllib.error.URLError,
-            http.client.HTTPException,
-            socket.error,
-            JsonApiException,
-            NotFoundError,
-        ):
-            # Sometimes, network errors occur when running the WorkerManager . These are often
-            # transient exceptions, and retrying the command would lead to success---as a result,
-            # we ignore these network-based exceptions (rather than fatally exiting from the
-            # WorkerManager )
-            traceback.print_exc()
-        except LoginPermissionError:
-            print("Invalid username or password. Please try again:")
-        logger.debug('Sleeping {} seconds'.format(self.args.sleep_time))
-        time.sleep(self.args.sleep_time)
+        while True:
+            try:
+                self.run_one_iteration()
+            except (
+                urllib.error.URLError,
+                http.client.HTTPException,
+                socket.error,
+                JsonApiException,
+                NotFoundError,
+            ):
+                # Sometimes, network errors occur when running the WorkerManager . These are often
+                # transient exceptions, and retrying the command would lead to success---as a result,
+                # we ignore these network-based exceptions (rather than fatally exiting from the
+                # WorkerManager )
+                traceback.print_exc()
+            except LoginPermissionError:
+                print("Invalid username or password. Please try again:")
+                break
+            logger.debug('Sleeping {} seconds'.format(self.args.sleep_time))
+            time.sleep(self.args.sleep_time)
 
     def run_one_iteration(self):
         if self.args.restart_after_seconds:

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -2390,7 +2390,7 @@ def test_nonexistent(ctx):
 
 
 @TestModule.register('worker_manager')
-def test_false_login(ctx):
+def test_incorrect_login(ctx):
     username = os.getenv("CODALAB_USERNAME")
     password = os.getenv("CODALAB_PASSWORD")
     del os.environ["CODALAB_USERNAME"]


### PR DESCRIPTION
### Reasons for making this change
Suppress extra stack traces for errors occurring when login credentials are incorrect
<!-- Add a reason for making this change here. -->

### Related issues
#2316
<!-- Add a reference to issues resolved, if applicable (for example, "fixes #1"). -->

### Screenshots
![image](https://user-images.githubusercontent.com/18689351/100053563-28292080-2dd5-11eb-8a2d-c9b33dd4402d.png)


<!-- Add screenshots, if necessary -->

### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
