### PR TITLE
Fix flakiness of upload-download test

### DIFF
--- a/tests/unit/server/upload_download_test.py
+++ b/tests/unit/server/upload_download_test.py
@@ -131,8 +131,8 @@ class BaseUploadDownloadBundleTest(TestBase):
         # Directory size can vary based on platform, so removing it before checking equality.
         info["contents"][1].pop("size")
         self.assertEqual(
-            info["contents"],
-            [
+            set(info["contents"]),
+            set([
                 {'name': 'item.txt', 'size': 11, 'perm': self.DEFAULT_PERM, 'type': 'file'},
                 {
                     'name': 'src',
@@ -142,7 +142,7 @@ class BaseUploadDownloadBundleTest(TestBase):
                         {'name': 'item2.txt', 'size': 11, 'perm': self.DEFAULT_PERM, 'type': 'file'}
                     ],
                 },
-            ],
+            ]),
         )
         self.check_folder_target_contents(
             target, expected_members=['.', './item.txt', './src', './src/item2.txt']

--- a/tests/unit/server/upload_download_test.py
+++ b/tests/unit/server/upload_download_test.py
@@ -131,18 +131,26 @@ class BaseUploadDownloadBundleTest(TestBase):
         # Directory size can vary based on platform, so removing it before checking equality.
         info["contents"][1].pop("size")
         self.assertEqual(
-            set(info["contents"]),
-            set([
-                {'name': 'item.txt', 'size': 11, 'perm': self.DEFAULT_PERM, 'type': 'file'},
-                {
-                    'name': 'src',
-                    'perm': 493,
-                    'type': 'directory',
-                    'contents': [
-                        {'name': 'item2.txt', 'size': 11, 'perm': self.DEFAULT_PERM, 'type': 'file'}
-                    ],
-                },
-            ]),
+            sorted(info["contents"], key=lambda x: x["name"]),
+            sorted(
+                [
+                    {'name': 'item.txt', 'size': 11, 'perm': self.DEFAULT_PERM, 'type': 'file'},
+                    {
+                        'name': 'src',
+                        'perm': 493,
+                        'type': 'directory',
+                        'contents': [
+                            {
+                                'name': 'item2.txt',
+                                'size': 11,
+                                'perm': self.DEFAULT_PERM,
+                                'type': 'file',
+                            }
+                        ],
+                    },
+                ],
+                key=lambda x: x["name"],
+            ),
         )
         self.check_folder_target_contents(
             target, expected_members=['.', './item.txt', './src', './src/item2.txt']

--- a/tests/unit/server/upload_download_test.py
+++ b/tests/unit/server/upload_download_test.py
@@ -129,12 +129,13 @@ class BaseUploadDownloadBundleTest(TestBase):
         self.assertEqual(info["type"], "directory")
         self.assertEqual(str(info["resolved_target"]), f"{bundle.uuid}:")
         # Directory size can vary based on platform, so removing it before checking equality.
+        info["contents"][0].pop("size")
         info["contents"][1].pop("size")
         self.assertEqual(
             sorted(info["contents"], key=lambda x: x["name"]),
             sorted(
                 [
-                    {'name': 'item.txt', 'size': 11, 'perm': self.DEFAULT_PERM, 'type': 'file'},
+                    {'name': 'item.txt', 'perm': self.DEFAULT_PERM, 'type': 'file'},
                     {
                         'name': 'src',
                         'perm': 493,

--- a/tests/unit/server/upload_download_test.py
+++ b/tests/unit/server/upload_download_test.py
@@ -97,7 +97,7 @@ class BaseUploadDownloadBundleTest(TestBase):
         with tarfile.open(
             fileobj=self.download_manager.stream_tarred_gzipped_directory(target), mode='r:gz'
         ) as f:
-            self.assertEqual(f.getnames(), expected_members)
+            self.assertEqual(sorted(f.getnames()), sorted(expected_members))
 
     def test_bundle_single_file(self):
         """Running get_target_info for a bundle with a single file."""


### PR DESCRIPTION
Sometimes, the contents can vary in order; this PR changes the logic in the test to check only for contents without depending on the order in which the contents are retrieved.