### PR TITLE
Handle any requests exceptions when pruning docker networks

### DIFF
--- a/codalab/worker/worker.py
+++ b/codalab/worker/worker.py
@@ -158,12 +158,13 @@ class Worker:
         # that might have been created by other workers.
         try:
             self.docker.networks.prune(filters={"until": "1h"})
-        except (docker.errors.APIError, requests.exceptions.ReadTimeout) as e:
+        except (docker.errors.APIError, requests.exceptions.RequestException) as e:
             # docker.errors.APIError is raised when a prune is already running:
             # https://github.com/codalab/codalab-worksheets/issues/2635
             # docker.errors.APIError: 409 Client Error: Conflict ("a prune operation is already running").
-            # requests.exceptions.ReadTimeout is raised when the request to the Docker socket times out.
-            # https://github.com/docker/docker-py/issues/2266
+            # Any number of requests.exceptions.RequestException s are raised when the request to
+            # the Docker socket times out or otherwise fails.
+            # For example: https://github.com/docker/docker-py/issues/2266
             # Since pruning is a relatively non-essential routine (i.e., it's ok if pruning fails
             # on one or two iterations), we just ignore this issue.
             logger.warning("Cannot prune docker networks: %s", str(e))


### PR DESCRIPTION
### Reasons for making this change

Sometimes, workers crash due to transient docker issues. I haven't gotten to the bottom of why theses issues happen, but the traceback in every case points to this line where we prune networks as the culprit that triggers the worker crash—this lets the code catch (and ignore) more such network-related issues.