### PR TITLE
Return x-codalab-target-size header

### DIFF
--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -722,10 +722,7 @@ def _update_bundle_contents_blob(uuid):
     check_bundles_have_all_permission(local.model, request.user, [uuid])
     bundle = local.model.get_bundle(uuid)
     if bundle.state in State.FINAL_STATES:
-        abort(
-            http.client.FORBIDDEN,
-            f'Contents cannot be modified, bundle already finalized, in state {State.FINAL_STATES}.',
-        )
+        abort(http.client.FORBIDDEN, 'Contents cannot be modified, bundle already finalized.')
 
     # Get and validate query parameters
     finalize_on_failure = query_get_bool('finalize_on_failure', default=False)

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -590,12 +590,14 @@ def _fetch_bundle_contents_blob(uuid, path=''):
     - `Content-Type: <guess of mimetype based on file extension>`
     - `Content-Encoding: [gzip|identity]`
     - `Target-Type: file`
+    - `X-CodaLab-Target-Size: <size of the target>`
 
     HTTP Response headers (for directories):
     - `Content-Disposition: attachment; filename=<bundle or directory name>.tar.gz`
     - `Content-Type: application/gzip`
     - `Content-Encoding: identity`
     - `Target-Type: directory`
+    - `X-CodaLab-Target-Size: <size of the target>`
     """
     byte_range = get_request_range()
     head_lines = query_get_type(int, 'head', default=0)
@@ -678,6 +680,7 @@ def _fetch_bundle_contents_blob(uuid, path=''):
     else:
         response.set_header('Content-Disposition', 'attachment; filename="%s"' % filename)
     response.set_header('Target-Type', target_info['type'])
+    response.set_header('X-Codalab-Target-Size', target_info['size'])
 
     return fileobj
 

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -598,6 +598,10 @@ def _fetch_bundle_contents_blob(uuid, path=''):
     - `Content-Encoding: identity`
     - `Target-Type: directory`
     - `X-CodaLab-Target-Size: <size of the target>`
+
+    Note that X-CodaLab-Target-Size is the uncompressed version of the target size. This means that it will
+    be equivalent to the downloaded file if from a single-file target, but will be the size of the uncompressed
+    archive, not the compressed archive, if from a directory target.
     """
     byte_range = get_request_range()
     head_lines = query_get_type(int, 'head', default=0)

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -722,7 +722,10 @@ def _update_bundle_contents_blob(uuid):
     check_bundles_have_all_permission(local.model, request.user, [uuid])
     bundle = local.model.get_bundle(uuid)
     if bundle.state in State.FINAL_STATES:
-        abort(http.client.FORBIDDEN, f'Contents cannot be modified, bundle already finalized, in state {State.FINAL_STATES}.')
+        abort(
+            http.client.FORBIDDEN,
+            f'Contents cannot be modified, bundle already finalized, in state {State.FINAL_STATES}.',
+        )
 
     # Get and validate query parameters
     finalize_on_failure = query_get_bool('finalize_on_failure', default=False)

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -722,7 +722,7 @@ def _update_bundle_contents_blob(uuid):
     check_bundles_have_all_permission(local.model, request.user, [uuid])
     bundle = local.model.get_bundle(uuid)
     if bundle.state in State.FINAL_STATES:
-        abort(http.client.FORBIDDEN, 'Contents cannot be modified, bundle already finalized.')
+        abort(http.client.FORBIDDEN, f'Contents cannot be modified, bundle already finalized, in state {State.FINAL_STATES}.')
 
     # Get and validate query parameters
     finalize_on_failure = query_get_bool('finalize_on_failure', default=False)

--- a/codalab/worker/worker.py
+++ b/codalab/worker/worker.py
@@ -158,12 +158,13 @@ class Worker:
         # that might have been created by other workers.
         try:
             self.docker.networks.prune(filters={"until": "1h"})
-        except (docker.errors.APIError, requests.exceptions.ReadTimeout) as e:
+        except (docker.errors.APIError, requests.exceptions.RequestException) as e:
             # docker.errors.APIError is raised when a prune is already running:
             # https://github.com/codalab/codalab-worksheets/issues/2635
             # docker.errors.APIError: 409 Client Error: Conflict ("a prune operation is already running").
-            # requests.exceptions.ReadTimeout is raised when the request to the Docker socket times out.
-            # https://github.com/docker/docker-py/issues/2266
+            # Any number of requests.exceptions.RequestException s are raised when the request to
+            # the Docker socket times out or otherwise fails.
+            # For example: https://github.com/docker/docker-py/issues/2266
             # Since pruning is a relatively non-essential routine (i.e., it's ok if pruning fails
             # on one or two iterations), we just ignore this issue.
             logger.warning("Cannot prune docker networks: %s", str(e))

--- a/codalab/worker/worker.py
+++ b/codalab/worker/worker.py
@@ -158,13 +158,12 @@ class Worker:
         # that might have been created by other workers.
         try:
             self.docker.networks.prune(filters={"until": "1h"})
-        except (docker.errors.APIError, requests.exceptions.RequestException) as e:
+        except (docker.errors.APIError, requests.exceptions.ReadTimeout) as e:
             # docker.errors.APIError is raised when a prune is already running:
             # https://github.com/codalab/codalab-worksheets/issues/2635
             # docker.errors.APIError: 409 Client Error: Conflict ("a prune operation is already running").
-            # Any number of requests.exceptions.RequestException s are raised when the request to
-            # the Docker socket times out or otherwise fails.
-            # For example: https://github.com/docker/docker-py/issues/2266
+            # requests.exceptions.ReadTimeout is raised when the request to the Docker socket times out.
+            # https://github.com/docker/docker-py/issues/2266
             # Since pruning is a relatively non-essential routine (i.e., it's ok if pruning fails
             # on one or two iterations), we just ignore this issue.
             logger.warning("Cannot prune docker networks: %s", str(e))

--- a/docs/REST-API-Reference.md
+++ b/docs/REST-API-Reference.md
@@ -539,12 +539,18 @@ HTTP Response headers (for single-file targets):
 - `Content-Type: <guess of mimetype based on file extension>`
 - `Content-Encoding: [gzip|identity]`
 - `Target-Type: file`
+- `X-CodaLab-Target-Size: <size of the target>`
 
 HTTP Response headers (for directories):
 - `Content-Disposition: attachment; filename=<bundle or directory name>.tar.gz`
 - `Content-Type: application/gzip`
 - `Content-Encoding: identity`
 - `Target-Type: directory`
+- `X-CodaLab-Target-Size: <size of the target>`
+
+Note that X-CodaLab-Target-Size is the uncompressed version of the target size. This means that it will
+be equivalent to the downloaded file if from a single-file target, but will be the size of the uncompressed
+archive, not the compressed archive, if from a directory target.
 
 ### `GET /bundles/<uuid:re:0x[0-9a-f]{32}>/contents/blob/`
 
@@ -575,12 +581,18 @@ HTTP Response headers (for single-file targets):
 - `Content-Type: <guess of mimetype based on file extension>`
 - `Content-Encoding: [gzip|identity]`
 - `Target-Type: file`
+- `X-CodaLab-Target-Size: <size of the target>`
 
 HTTP Response headers (for directories):
 - `Content-Disposition: attachment; filename=<bundle or directory name>.tar.gz`
 - `Content-Type: application/gzip`
 - `Content-Encoding: identity`
 - `Target-Type: directory`
+- `X-CodaLab-Target-Size: <size of the target>`
+
+Note that X-CodaLab-Target-Size is the uncompressed version of the target size. This means that it will
+be equivalent to the downloaded file if from a single-file target, but will be the size of the uncompressed
+archive, not the compressed archive, if from a directory target.
 
 ### `PUT /bundles/<uuid:re:0x[0-9a-f]{32}>/contents/blob/`
 

--- a/tests/unit/rest/bundles_test.py
+++ b/tests/unit/rest/bundles_test.py
@@ -1,5 +1,7 @@
 from .base import BaseTestCase
 from freezegun import freeze_time
+from io import BytesIO, StringIO
+import tarfile
 
 
 @freeze_time("2012-01-14")
@@ -79,3 +81,111 @@ class BundlesTest(BaseTestCase):
                 }
             ],
         )
+
+    def test_upload_file(self):
+        """Upload a single file as a bundle, then retrieve its
+        contents through the REST API.
+        """
+        worksheet_id = self.create_worksheet()
+        body = {
+            "data": [
+                {
+                    "attributes": {
+                        "bundle_type": "dataset",
+                        "metadata": {
+                            "description": "",
+                            "license": "",
+                            "name": "File.txt",
+                            "source_url": "",
+                            "tags": [],
+                        },
+                    },
+                    "type": "bundles",
+                }
+            ]
+        }
+        response = self.app.post_json(f'/rest/bundles?worksheet={worksheet_id}', body)
+        self.assertEqual(response.status_int, 200)
+        data = response.json["data"]
+        bundle_id = data[0]["id"]
+
+        response = self.app.request(
+            f'/rest/bundles/{bundle_id}/contents/blob/?finalize=1&filename=File.txt&unpack=0',
+            method='PUT',
+            content_type='application/octet-stream',
+            body='hello world'.encode(),
+        )
+        self.assertEqual(response.status_int, 200)
+
+        response = self.app.head(f'/rest/bundles/{bundle_id}/contents/blob/')
+        self.assertEqual(response.status_int, 200)
+        self.assertEqual(response.headers['Content-Type'], 'text/plain')
+        self.assertEqual(response.headers['Content-Encoding'], 'identity')
+        self.assertEqual(response.headers['Content-Disposition'], 'inline; filename="File.txt"')
+        self.assertEqual(response.headers['Target-Type'], 'file')
+        self.assertEqual(response.headers['X-Codalab-Target-Size'], '11')
+
+    def test_upload_zip_file(self):
+        """Upload a zip file as a bundle, then retrieve the contents of the file,
+        as well as individual files within the bundle, using the REST API.
+        """
+        worksheet_id = self.create_worksheet()
+        body = {
+            "data": [
+                {
+                    "attributes": {
+                        "bundle_type": "dataset",
+                        "metadata": {
+                            "description": "",
+                            "license": "",
+                            "name": "File",
+                            "source_url": "",
+                            "tags": [],
+                        },
+                    },
+                    "type": "bundles",
+                }
+            ]
+        }
+        response = self.app.post_json(f'/rest/bundles?worksheet={worksheet_id}', body)
+        self.assertEqual(response.status_int, 200)
+        data = response.json["data"]
+        bundle_id = data[0]["id"]
+
+        f = BytesIO()
+        with tarfile.open(fileobj=f, mode='w:gz') as tf:
+            tinfo = tarfile.TarInfo("file1.txt")
+            tinfo.size = 6
+            tf.addfile(tinfo, BytesIO("file 1".encode()))
+
+            tinfo = tarfile.TarInfo("file-two.txt")
+            tinfo.size = 8
+            tf.addfile(tinfo, BytesIO("file two".encode()))
+        f.seek(0)
+        response = self.app.request(
+            f'/rest/bundles/{bundle_id}/contents/blob/?finalize=1&filename=File.tar.gz&unpack=1',
+            method='PUT',
+            content_type='application/octet-stream',
+            body=f.read(),
+        )
+        self.assertEqual(response.status_int, 200)
+
+        response = self.app.head(f'/rest/bundles/{bundle_id}/contents/blob/')
+        self.assertEqual(response.status_int, 200)
+        self.assertEqual(response.headers['Content-Type'], 'application/gzip')
+        self.assertEqual(response.headers['Content-Encoding'], 'identity')
+        self.assertEqual(
+            response.headers['Content-Disposition'], 'attachment; filename="File.tar.gz"'
+        )
+        self.assertEqual(response.headers['Target-Type'], 'directory')
+        self.assertEqual(response.headers['X-Codalab-Target-Size'], '128')
+
+        response = self.app.head(f'/rest/bundles/{bundle_id}/contents/blob/file-two.txt')
+        self.assertEqual(response.status_int, 200)
+        self.assertEqual(response.headers['Content-Type'], 'text/plain')
+        self.assertEqual(response.headers['Content-Encoding'], 'identity')
+        self.assertEqual(response.headers['Content-Disposition'], 'inline; filename="file-two.txt"')
+        self.assertEqual(response.headers['Target-Type'], 'file')
+        self.assertEqual(response.headers['X-Codalab-Target-Size'], '8')
+
+        self.app.head(f'/rest/bundles/{bundle_id}/contents/blob/invalid.txt', status=404)

--- a/tests/unit/rest/bundles_test.py
+++ b/tests/unit/rest/bundles_test.py
@@ -178,7 +178,7 @@ class BundlesTest(BaseTestCase):
             response.headers['Content-Disposition'], 'attachment; filename="File.tar.gz"'
         )
         self.assertEqual(response.headers['Target-Type'], 'directory')
-        self.assertEqual(response.headers['X-Codalab-Target-Size'], '128')
+        self.assertEqual(response.headers['X-Codalab-Target-Size'], '4096')
 
         response = self.app.head(f'/rest/bundles/{bundle_id}/contents/blob/file-two.txt')
         self.assertEqual(response.status_int, 200)

--- a/tests/unit/rest/bundles_test.py
+++ b/tests/unit/rest/bundles_test.py
@@ -1,6 +1,6 @@
 from .base import BaseTestCase
 from freezegun import freeze_time
-from io import BytesIO, StringIO
+from io import BytesIO
 import tarfile
 
 


### PR DESCRIPTION
Return x-codalab-target-size header -- returns the target size when downloading a bundle or a particular file from a bundle.

Fixes #3102.

Also added unit test coverage for file uploading / downloading through the REST API endpoints.