### PR TITLE
Fix worker checkin service argument

### DIFF
--- a/codalab_service.py
+++ b/codalab_service.py
@@ -283,6 +283,12 @@ CODALAB_ARGUMENTS = [
         default='10g',
     ),
     CodalabArg(
+        name='worker_manager_worker_checkin_frequency_seconds',
+        help='Number of seconds worker will wait between check-ins of the worker manager',
+        type=int,
+        default=5,
+    ),
+    CodalabArg(
         name='worker_manager_idle_seconds',
         help='Number of seconds workers wait idle before exiting',
         type=int,

--- a/codalab_service.py
+++ b/codalab_service.py
@@ -284,7 +284,7 @@ CODALAB_ARGUMENTS = [
     ),
     CodalabArg(
         name='worker_manager_worker_checkin_frequency_seconds',
-        help='Number of seconds worker will wait between check-ins of the worker manager',
+        help='Number of seconds to wait between check-ins for a worker of the worker manager',
         type=int,
         default=5,
     ),

--- a/docker_config/compose_files/docker-compose.yml
+++ b/docker_config/compose_files/docker-compose.yml
@@ -136,7 +136,7 @@ services:
       --min-seconds-between-workers ${CODALAB_WORKER_MANAGER_SECONDS_BETWEEN_WORKERS}
       --sleep-time ${CODALAB_WORKER_MANAGER_SLEEP_TIME_SECONDS}
       --worker-idle-seconds ${CODALAB_WORKER_MANAGER_IDLE_SECONDS}
-      --worker-checkin-frequency-seconds ${CODALAB_WORKER_MANAGER_CHECKIN_FREQUENCY_SECONDS}
+      --worker-checkin-frequency-seconds ${CODALAB_WORKER_MANAGER_WORKER_CHECKIN_FREQUENCY_SECONDS}
       ${CODALAB_WORKER_MANAGER_TYPE}
       --job-queue ${CODALAB_WORKER_MANAGER_CPU_AWS_BATCH_QUEUE}
       --region ${CODALAB_WORKER_MANAGER_AWS_REGION}
@@ -161,7 +161,7 @@ services:
       --min-seconds-between-workers ${CODALAB_WORKER_MANAGER_SECONDS_BETWEEN_WORKERS}
       --sleep-time ${CODALAB_WORKER_MANAGER_SLEEP_TIME_SECONDS}
       --worker-idle-seconds ${CODALAB_WORKER_MANAGER_IDLE_SECONDS}
-      --worker-checkin-frequency-seconds ${CODALAB_WORKER_MANAGER_CHECKIN_FREQUENCY_SECONDS}
+      --worker-checkin-frequency-seconds ${CODALAB_WORKER_MANAGER_WORKER_CHECKIN_FREQUENCY_SECONDS}
       ${CODALAB_WORKER_MANAGER_TYPE}
       --job-queue ${CODALAB_WORKER_MANAGER_GPU_AWS_BATCH_QUEUE}
       --region ${CODALAB_WORKER_MANAGER_AWS_REGION}
@@ -187,7 +187,7 @@ services:
       --min-seconds-between-workers ${CODALAB_WORKER_MANAGER_SECONDS_BETWEEN_WORKERS}
       --sleep-time ${CODALAB_WORKER_MANAGER_SLEEP_TIME_SECONDS}
       --worker-idle-seconds ${CODALAB_WORKER_MANAGER_IDLE_SECONDS}
-      --worker-checkin-frequency-seconds ${CODALAB_WORKER_MANAGER_CHECKIN_FREQUENCY_SECONDS}
+      --worker-checkin-frequency-seconds ${CODALAB_WORKER_MANAGER_WORKER_CHECKIN_FREQUENCY_SECONDS}
       ${CODALAB_WORKER_MANAGER_TYPE}
       --account-name ${CODALAB_WORKER_MANAGER_AZURE_BATCH_ACCOUNT_NAME}
       --account-key ${CODALAB_WORKER_MANAGER_AZURE_BATCH_ACCOUNT_KEY}
@@ -214,7 +214,7 @@ services:
       --min-seconds-between-workers ${CODALAB_WORKER_MANAGER_SECONDS_BETWEEN_WORKERS}
       --sleep-time ${CODALAB_WORKER_MANAGER_SLEEP_TIME_SECONDS}
       --worker-idle-seconds ${CODALAB_WORKER_MANAGER_IDLE_SECONDS}
-      --worker-checkin-frequency-seconds ${CODALAB_WORKER_MANAGER_CHECKIN_FREQUENCY_SECONDS}
+      --worker-checkin-frequency-seconds ${CODALAB_WORKER_MANAGER_WORKER_CHECKIN_FREQUENCY_SECONDS}
       ${CODALAB_WORKER_MANAGER_TYPE}
       --account-name ${CODALAB_WORKER_MANAGER_AZURE_BATCH_ACCOUNT_NAME}
       --account-key ${CODALAB_WORKER_MANAGER_AZURE_BATCH_ACCOUNT_KEY}


### PR DESCRIPTION
Added a default for `CODALAB_WORKER_MANAGER_WORKER_CHECKIN_FREQUENCY_SECONDS`.
