### PR TITLE
Add cl open command for opening bundles in browser

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,7 +80,7 @@ jobs:
     strategy:
       matrix:
         test:
-          - unittest gen-rest-docs gen-cli-docs gen-readthedocs basic auth status batch anonymous competition unicode rest1 upload1 upload2 upload3 upload4 download refs binary rm make worksheet_search worksheet_tags freeze detach perm search_time groups open
+          - unittest gen-rest-docs gen-cli-docs gen-readthedocs basic auth status batch anonymous competition unicode rest1 upload1 upload2 upload3 upload4 download refs binary rm make worksheet_search worksheet_tags freeze detach perm search_time groups
           - worker_manager
           - run
           - run2
@@ -89,6 +89,7 @@ jobs:
           - memoize
           - copy netcat netcurl
           - edit
+          - open
     steps:
       - name: Clear free space
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,7 +80,7 @@ jobs:
     strategy:
       matrix:
         test:
-          - unittest gen-rest-docs gen-cli-docs gen-readthedocs basic auth status batch anonymous competition unicode rest1 upload1 upload2 upload3 upload4 download refs binary rm make worksheet_search worksheet_tags freeze detach perm search_time groups
+          - unittest gen-rest-docs gen-cli-docs gen-readthedocs basic auth status batch anonymous competition unicode rest1 upload1 upload2 upload3 upload4 download refs binary rm make worksheet_search worksheet_tags freeze detach perm search_time groups open
           - worker_manager
           - run
           - run2

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -2882,7 +2882,7 @@ class BundleCLI(object):
             'bundles', params={'specs': args.bundle_spec, 'worksheet': worksheet_uuid},
         )
 
-        for i, info in enumerate(bundles):
+        for info in bundles:
             webbrowser.open(self.bundle_url(info['id']))
 
         # Headless client should fire OpenBundle UI action

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -2861,10 +2861,10 @@ class BundleCLI(object):
     @Commands.command(
         'open',
         aliases=('o',),
-        help='Open a bundle detail page in a local web browser.',
+        help='Open bundle(s) detail page(s) in a local web browser.',
         arguments=(
             Commands.Argument(
-                'bundle_spec', help=BUNDLE_SPEC_FORMAT, nargs='*', completer=BundlesCompleter
+                'bundle_spec', help=BUNDLE_SPEC_FORMAT, nargs='+', completer=BundlesCompleter
             ),
             Commands.Argument(
                 '-w',

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -2879,7 +2879,7 @@ class BundleCLI(object):
         client, worksheet_uuid = self.parse_client_worksheet_uuid(args.worksheet_spec)
 
         bundles = client.fetch(
-            'bundles', params={'specs': args.bundle_spec, 'worksheet': worksheet_uuid,},
+            'bundles', params={'specs': args.bundle_spec, 'worksheet': worksheet_uuid},
         )
 
         for i, info in enumerate(bundles):

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -2885,7 +2885,7 @@ class BundleCLI(object):
         for i, info in enumerate(bundles):
             webbrowser.open(self.bundle_url(info['id']))
 
-        # Headless client should fire OpenBundle UI action if no special flags used
+        # Headless client should fire OpenBundle UI action
         if self.headless:
             return ui_actions.serialize([ui_actions.OpenBundle(bundle['id']) for bundle in bundles])
 

--- a/codalab/lib/cli_util.py
+++ b/codalab/lib/cli_util.py
@@ -23,6 +23,7 @@ BUNDLE_SPEC_FORMAT = '[%s%s]%s' % (
     BASIC_BUNDLE_SPEC_FORMAT,
 )
 
+BUNDLES_URL_SEPARATOR = '/bundles/'
 WORKSHEETS_URL_SEPARATOR = '/worksheets/'
 
 TARGET_SPEC_FORMAT = '%s[%s<subpath within bundle>]' % (BUNDLE_SPEC_FORMAT, os.sep)

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1632,6 +1632,7 @@ def test_status(ctx):
     check_contains("Commands for bundles", cl_output)
     check_equals(cl_output, help_output)
 
+
 @TestModule.register('batch')
 def test_batch(ctx):
     """Test batch resolution of bundle uuids"""
@@ -2412,7 +2413,7 @@ def test_incorrect_login(ctx):
 
 
 @TestModule.register('open')
-def test_rm(ctx):
+def test_open(ctx):
     uuid = _run_command([cl, 'run', 'echo hello'])
     _run_command([cl, 'open', uuid], expected_exit_code=0)
     _run_command([cl, 'open', uuid, '^1'], expected_exit_code=0)

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1632,7 +1632,6 @@ def test_status(ctx):
     check_contains("Commands for bundles", cl_output)
     check_equals(cl_output, help_output)
 
-
 @TestModule.register('batch')
 def test_batch(ctx):
     """Test batch resolution of bundle uuids"""
@@ -2410,6 +2409,16 @@ def test_incorrect_login(ctx):
     )
     check_equals(str(result), "Invalid username or password. Please try again:")
     os.environ["CODALAB_PASSWORD"] = password
+
+
+@TestModule.register('open')
+def test_rm(ctx):
+    uuid = _run_command([cl, 'run', 'echo hello'])
+    _run_command([cl, 'open', uuid], expected_exit_code=0)
+    _run_command([cl, 'open', uuid, '^1'], expected_exit_code=0)
+
+    # Bundle spec 'nonexistent' does not exist, so open should fail.
+    _run_command([cl, 'open', 'nonexistent'], expected_exit_code=1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Reasons for making this change

This adds a new command `cl open` to open bundles in the browser from the cli. This is useful because when debugging bundles, I often have a workflow like:
- run some `cl search` / have some bundle name i want to investigate
- `cl info` on the short uuid from `cl search` / the bundle name
- get the full uuid from the `cl info` output
- copy and paste this into my browser

Instead, now I can do:
- `cl open <bundle ref>`
