### PR TITLE
Group commands in pre-commit.sh by language

### DIFF
--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -23,11 +23,13 @@ venv/bin/python scripts/gen-cli-docs.py  # Outputs to `docs`
 venv/bin/mkdocs build  # Outputs to `site`
 # Note: run `venv/bin/mkdocs serve` for a live preview
 
-# Fix Python style (mutates code!)
+# Python style checks and linting
+## Fix Python style (mutates code!)
 venv/bin/black codalab scripts *.py
-# Check if there are any mypy errors
+## Check if there are any mypy or flake8 errors
 venv/bin/mypy .
 venv/bin/flake8 .
 
-# Fix Javascript style (mutates code!)
+# Javascript style checks and linting
+## Fix Javascript style (mutates code!)
 npm run --prefix frontend format

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -23,10 +23,11 @@ venv/bin/python scripts/gen-cli-docs.py  # Outputs to `docs`
 venv/bin/mkdocs build  # Outputs to `site`
 # Note: run `venv/bin/mkdocs serve` for a live preview
 
-# Fix Python and JavaScript style (mutates code!)
+# Fix Python style (mutates code!)
 venv/bin/black codalab scripts *.py
-npm run --prefix frontend format
-
 # Check if there are any mypy errors
 venv/bin/mypy .
 venv/bin/flake8 .
+
+# Fix Javascript style (mutates code!)
+npm run --prefix frontend format


### PR DESCRIPTION
### Reasons for making this change

I don't have `npm` on my machine (and it isn't bundled in the virtualenv, either). It's a bit inconvenient that I need to install `npm` in order for the flake8 / mypy checks to run, so I rearranged the order such that things installed in the virtualenv are checked first, followed by dependencies not covered by the virtualenv (e.g., `npm`)