### PR TITLE
Make timeout configurable with environment variable

### DIFF
--- a/codalab/common.py
+++ b/codalab/common.py
@@ -11,11 +11,7 @@ import http.client
 # http://semver.org/
 CODALAB_VERSION = '0.5.32'
 BINARY_PLACEHOLDER = '<binary>'
-ENV_TIMEOUT = os.environ.get('CODALAB_URLOPEN_TIMEOUT_SECONDS')
-if ENV_TIMEOUT is None:
-    URLOPEN_TIMEOUT_SECONDS = 5 * 60
-else:
-    URLOPEN_TIMEOUT_SECONDS = int(ENV_TIMEOUT)
+URLOPEN_TIMEOUT_SECONDS = int(os.environ.get('CODALAB_URLOPEN_TIMEOUT_SECONDS', 5 * 60))
 
 
 class IntegrityError(ValueError):

--- a/codalab/common.py
+++ b/codalab/common.py
@@ -4,13 +4,18 @@ This module exports some simple names used throughout the CodaLab bundle system:
   - The State class, an enumeration of all legal bundle states.
   - precondition, a utility method that check's a function's input preconditions.
 """
+import os
 import http.client
 
 # Increment this on master when ready to cut a release.
 # http://semver.org/
 CODALAB_VERSION = '0.5.32'
 BINARY_PLACEHOLDER = '<binary>'
-URLOPEN_TIMEOUT_SECONDS = 5 * 60
+ENV_TIMEOUT = os.environ.get('CODALAB_URLOPEN_TIMEOUT_SECONDS')
+if ENV_TIMEOUT is None:
+    URLOPEN_TIMEOUT_SECONDS = 5 * 60
+else:
+    URLOPEN_TIMEOUT_SECONDS = int(ENV_TIMEOUT)
 
 
 class IntegrityError(ValueError):


### PR DESCRIPTION
### Reasons for making this change

I've been running into issues with timeouts and noticed a prior change that increased it. This helped, but didn't eliminate the issue. Instead of increasing it, it would be convenient for it to be user configurable through an environment variable.

### Checklist

* [ ] I've added and/or updated tests, if this is a backend change
* [ x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [ ] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
