### PR TITLE
Add option to disable prefiltering in WorkerManager

### DIFF
--- a/codalab/worker_manager/main.py
+++ b/codalab/worker_manager/main.py
@@ -31,6 +31,11 @@ def main():
         help='Restart the worker manager after this many seconds have passed since launch',
     )
     parser.add_argument(
+        '--no-prefilter',
+        action='store_true',
+        help='If set, do not filter run bundles by whether the created workers satisfy their requested resources.',
+    )
+    parser.add_argument(
         '--once',
         help='Just run once and exit instead of looping (for debugging)',
         action='store_true',

--- a/codalab/worker_manager/main.py
+++ b/codalab/worker_manager/main.py
@@ -19,18 +19,6 @@ def main():
     parser.add_argument(
         '--search', nargs='*', help='Monitor only runs that satisfy these criteria', default=[]
     )
-    parser.add_argument('--worker-tag', help='Tag to look for and put on workers')
-    parser.add_argument(
-        '--worker-work-dir-prefix', help="Prefix to use for each worker's working directory."
-    )
-    parser.add_argument(
-        '--worker-max-work-dir-size', help='Maximum size of the temporary bundle data'
-    )
-    parser.add_argument(
-        '--worker-delete-work-dir-on-exit',
-        action='store_true',
-        help="Delete a worker's working directory when the worker process exits.",
-    )
     parser.add_argument(
         '--verbose', action='store_true', help='Whether to print out extra information'
     )
@@ -48,15 +36,27 @@ def main():
         action='store_true',
     )
     parser.add_argument(
-        '--worker-idle-seconds',
-        help='Workers wait this long for extra runs before quitting',
-        default=10 * 60,
-        type=int,
-    )
-    parser.add_argument(
         '--min-seconds-between-workers',
         help='Minimum time to wait between launching workers',
         default=1 * 60,
+        type=int,
+    )
+    parser.add_argument('--worker-tag', help='Tag to look for and put on workers')
+    parser.add_argument(
+        '--worker-work-dir-prefix', help="Prefix to use for each worker's working directory."
+    )
+    parser.add_argument(
+        '--worker-max-work-dir-size', help='Maximum size of the temporary bundle data'
+    )
+    parser.add_argument(
+        '--worker-delete-work-dir-on-exit',
+        action='store_true',
+        help="Delete a worker's working directory when the worker process exits.",
+    )
+    parser.add_argument(
+        '--worker-idle-seconds',
+        help='Workers wait this long for extra runs before quitting',
+        default=10 * 60,
         type=int,
     )
     parser.add_argument(

--- a/codalab/worker_manager/worker_manager.py
+++ b/codalab/worker_manager/worker_manager.py
@@ -198,7 +198,7 @@ class WorkerManager(object):
         )
         # Unless no_prefilter is set, filter out otherwise-eligible run bundles that request more
         # resources than this WorkerManager's workers have.
-        if not args.no_prefilter:
+        if not self.args.no_prefilter:
             bundles = self.filter_bundles(bundles)
 
         new_staged_uuids = [bundle['uuid'] for bundle in bundles]

--- a/codalab/worker_manager/worker_manager.py
+++ b/codalab/worker_manager/worker_manager.py
@@ -196,7 +196,10 @@ class WorkerManager(object):
         bundles: BundlesPayload = self.codalab_client.fetch(
             'bundles', params={'worksheet': None, 'keywords': keywords, 'include': ['owner']}
         )
-        bundles = self.filter_bundles(bundles)
+        # Unless no_prefilter is set, filter out otherwise-eligible run bundles that request more
+        # resources than this WorkerManager's workers have.
+        if not args.no_prefilter:
+            bundles = self.filter_bundles(bundles)
 
         new_staged_uuids = [bundle['uuid'] for bundle in bundles]
         old_staged_uuids = self.staged_uuids


### PR DESCRIPTION
### Reasons for making this change

Sometimes, it's useful to launch workers even if they can't fulfill the staged bundles. This adds a flag that prevents the workermanager from pre-emptively filtering out bundles that can't be fulfilled by the current workermanager's workers.