### PR TITLE
Fix target sizes for directories

### DIFF
--- a/codalab/worker/download_util.py
+++ b/codalab/worker/download_util.py
@@ -124,6 +124,7 @@ def _compute_target_info(path, depth):
         result['type'] = 'file'
     elif os.path.isdir(path):
         result['type'] = 'directory'
+        # Retrieve the size of the directory and all its contents
         result['size'] = get_size(path)
         if depth > 0:
             result['contents'] = [

--- a/codalab/worker/download_util.py
+++ b/codalab/worker/download_util.py
@@ -1,4 +1,5 @@
 import os
+from codalab.lib.path_util import get_size
 
 
 class PathException(Exception):
@@ -123,6 +124,7 @@ def _compute_target_info(path, depth):
         result['type'] = 'file'
     elif os.path.isdir(path):
         result['type'] = 'directory'
+        result['size'] = get_size(path)
         if depth > 0:
             result['contents'] = [
                 _compute_target_info(os.path.join(path, file_name), depth - 1)


### PR DESCRIPTION
Fixes #3120. This is technically a backwards incompatible change (cc @percyliang ), but I think it makes sense to report the target sizes for directories as equal to the size of their contents instead of always equal to 4096.