### PR TITLE
Add stress tests within test_cli.py for uploading large files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,6 +90,7 @@ jobs:
           - copy netcat netcurl
           - edit
           - open wopen
+          - stress
     steps:
       - name: Clear free space
         run: |

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -888,7 +888,7 @@ def test_stress(ctx):
     def upload_size(size_gb):
         with tempfile.NamedTemporaryFile() as f:
             f.truncate(1024 * 1024 * 1024 * size_gb)
-        _run_command([cl, 'upload', f.name])
+            _run_command([cl, 'upload', f.name])
 
     upload_size(5)
     upload_size(50)

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -883,7 +883,7 @@ def test_download(ctx):
 
 
 @TestModule.register('stress')
-def test_upload3(ctx):
+def test_stress(ctx):
     # Stress tests with uploading / downloading large files.
     def upload_size(size_gb):
         with tempfile.NamedTemporaryFile() as f:

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -882,6 +882,20 @@ def test_download(ctx):
     _run_command([cl, 'download', uuid + '/not-exists'], 1)
 
 
+@TestModule.register('stress')
+def test_upload3(ctx):
+    # Stress tests with uploading / downloading large files.
+    def upload_size(size_gb):
+        with tempfile.NamedTemporaryFile() as f:
+            f.truncate(1024 * 1024 * 1024 * size_gb)
+        _run_command([cl, 'upload', f.name])
+
+    upload_size(5)
+    upload_size(50)
+    upload_size(70)
+    upload_size(100)
+
+
 @TestModule.register('refs')
 def test_refs(ctx):
     # Test references

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -886,10 +886,11 @@ def test_download(ctx):
 def test_stress(ctx):
     # Stress tests with uploading / downloading large files.
     def upload_size(size_gb):
-        with tempfile.NamedTemporaryFile() as f:
+        with tempfile.NamedTemporaryFile(suffix=f"-{size_gb}gb") as f:
             f.truncate(1024 * 1024 * 1024 * size_gb)
             _run_command([cl, 'upload', f.name])
 
+    upload_size(.01)
     upload_size(5)
     upload_size(50)
     upload_size(70)


### PR DESCRIPTION
### Reasons for making this change

Adding tests to debug issues with uploading large files and preventing future regressions. I'm adding these tests directly in test_cli.py; that way, they won't be dependent on worksheets-dev.codalab.org as the stress tests are, so they'll hopefully be isolated, run more often, be less flaky, and run faster (as large files no longer have to be transferred across the network, since it's just accessing `localhost`).

### Related issues

#3082