### PR TITLE
Increase max nginx body size to 1000 GB

### DIFF
--- a/docker_config/compose_files/files/nginx.conf
+++ b/docker_config/compose_files/files/nginx.conf
@@ -83,7 +83,7 @@ http {
 
     server_name localhost 127.0.0.1;
     charset     utf-8;
-    client_max_body_size  64000m;
+    client_max_body_size  1000g;
     client_body_buffer_size 64m;
 
     # Turn off request body buffering to allow direct streaming uploads.

--- a/docker_config/compose_files/files/nginx.conf.ssl
+++ b/docker_config/compose_files/files/nginx.conf.ssl
@@ -98,7 +98,7 @@ http {
 
     server_name localhost 127.0.0.1;
     charset     utf-8;
-    client_max_body_size  64000m;
+    client_max_body_size  1000g;
     client_body_buffer_size 64m;
 
     # Turn off request body buffering to allow direct streaming uploads.


### PR DESCRIPTION
### Reasons for making this change

Fixes #3082 by increasing max nginx body size to 1000 GB. It was initially set to 64000 MB (the threshold at which uploads were failing) before 🤔 