### PR TITLE
Revert gzip changes

### DIFF
--- a/codalab/worker/file_util.py
+++ b/codalab/worker/file_util.py
@@ -211,31 +211,37 @@ def gzip_file(file_path):
     """
     Returns a file-like object containing the gzipped version of the given file.
     """
-    BUFFER_SIZE = 100 * 1024 * 1024  # Zip in chunks of 100MB
-
-    class GzipStream:
-        def __init__(self, fileobj):
-            self.__input = fileobj
-            self.__buffer = BytesBuffer()
-            self.__gzip = gzip.GzipFile(None, mode='wb', fileobj=self.__buffer)
-
-        def read(self, size=-1):
-            while size < 0 or len(self.__buffer) < size:
-                s = self.__input.read(BUFFER_SIZE)
-                if not s:
-                    self.__gzip.close()
-                    break
-                self.__gzip.write(s)
-            return self.__buffer.read(size)
-
-        def close(self):
-            self.__input.close()
-
+    args = ['gzip', '-c', '-n', file_path]
     try:
-        file_path_obj = open_file(file_path)
-        return GzipStream(file_path_obj)
-    except Exception as e:
-        raise IOError(e)
+        proc = subprocess.Popen(args, stdout=subprocess.PIPE)
+        return proc.stdout
+    except subprocess.CalledProcessError as e:
+        raise IOError(e.output)
+    # BUFFER_SIZE = 100 * 1024 * 1024  # Zip in chunks of 100MB
+
+    # class GzipStream:
+    #     def __init__(self, fileobj):
+    #         self.__input = fileobj
+    #         self.__buffer = BytesBuffer()
+    #         self.__gzip = gzip.GzipFile(None, mode='wb', fileobj=self.__buffer)
+
+    #     def read(self, size=-1):
+    #         while size < 0 or len(self.__buffer) < size:
+    #             s = self.__input.read(BUFFER_SIZE)
+    #             if not s:
+    #                 self.__gzip.close()
+    #                 break
+    #             self.__gzip.write(s)
+    #         return self.__buffer.read(size)
+
+    #     def close(self):
+    #         self.__input.close()
+
+    # try:
+    #     file_path_obj = open_file(file_path)
+    #     return GzipStream(file_path_obj)
+    # except Exception as e:
+    #     raise IOError(e)
 
 
 def un_bz2_file(source, dest_path):

--- a/codalab/worker/file_util.py
+++ b/codalab/worker/file_util.py
@@ -210,6 +210,8 @@ def open_file(file_path, mode='r', compression_type=CompressionTypes.UNCOMPRESSE
 def gzip_file(file_path):
     """
     Returns a file-like object containing the gzipped version of the given file.
+    Note: For right now, it's important for gzip to run in a separate process,
+    otherwise things on CodaLab grind to a halt!
     """
     args = ['gzip', '-c', '-n', file_path]
     try:

--- a/codalab/worker/file_util.py
+++ b/codalab/worker/file_util.py
@@ -217,31 +217,6 @@ def gzip_file(file_path):
         return proc.stdout
     except subprocess.CalledProcessError as e:
         raise IOError(e.output)
-    # BUFFER_SIZE = 100 * 1024 * 1024  # Zip in chunks of 100MB
-
-    # class GzipStream:
-    #     def __init__(self, fileobj):
-    #         self.__input = fileobj
-    #         self.__buffer = BytesBuffer()
-    #         self.__gzip = gzip.GzipFile(None, mode='wb', fileobj=self.__buffer)
-
-    #     def read(self, size=-1):
-    #         while size < 0 or len(self.__buffer) < size:
-    #             s = self.__input.read(BUFFER_SIZE)
-    #             if not s:
-    #                 self.__gzip.close()
-    #                 break
-    #             self.__gzip.write(s)
-    #         return self.__buffer.read(size)
-
-    #     def close(self):
-    #         self.__input.close()
-
-    # try:
-    #     file_path_obj = open_file(file_path)
-    #     return GzipStream(file_path_obj)
-    # except Exception as e:
-    #     raise IOError(e)
 
 
 def un_bz2_file(source, dest_path):

--- a/tests/unit/server/upload_download_test.py
+++ b/tests/unit/server/upload_download_test.py
@@ -72,12 +72,6 @@ class BaseUploadDownloadBundleTest(TestBase):
             with self.download_manager.stream_file(target, gzipped=False) as f:
                 pass
 
-        with self.assertRaises(Exception):
-            with gzip.GzipFile(
-                fileobj=self.download_manager.stream_file(target, gzipped=True)
-            ) as f:
-                pass
-
         with self.assertRaises(IsADirectoryError):
             self.download_manager.read_file_section(target, offset=3, length=4, gzipped=False)
 

--- a/tests/unit/server/upload_download_test.py
+++ b/tests/unit/server/upload_download_test.py
@@ -72,7 +72,7 @@ class BaseUploadDownloadBundleTest(TestBase):
             with self.download_manager.stream_file(target, gzipped=False) as f:
                 pass
 
-        with self.assertRaises(OSError):
+        with self.assertRaises(Exception):
             with gzip.GzipFile(
                 fileobj=self.download_manager.stream_file(target, gzipped=True)
             ) as f:


### PR DESCRIPTION
One possible issue for the slowness could be that when I changed gzip_file earlier, I switched it from running gzip in a new process to just using the same existing process.

https://github.com/codalab/codalab-worksheets/pull/2952/files#diff-2b2d1ef00e8805335562a7967af36158e9140f6c4a5039f3462517795e4d67f6L109-L112


Previously, the codalab rest server may have run gzip in separate processes (which can then utilize multiple cores), but now, all that work is done in a single process.

If this is the issue, we could try either of the following:
- revert the gzip changes, so it uses subprocess to run gzip instead
- increase the number of processes for the server

This PR does the former.