### PR TITLE
Use gevent workers for better performance; add performance test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,6 +90,7 @@ jobs:
           - copy netcat netcurl
           - edit
           - open wopen
+          - performance
     steps:
       - name: Clear free space
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,7 +80,7 @@ jobs:
     strategy:
       matrix:
         test:
-          - unittest gen-rest-docs gen-cli-docs gen-readthedocs basic auth status batch anonymous competition unicode rest1 upload1 upload2 upload3 upload4 download refs binary rm make worksheet_search worksheet_tags freeze detach perm search_time groups
+          # - unittest gen-rest-docs gen-cli-docs gen-readthedocs basic auth status batch anonymous competition unicode rest1 upload1 upload2 upload3 upload4 download refs binary rm make worksheet_search worksheet_tags freeze detach perm search_time groups
           - worker_manager
           - run
           - run2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,7 +80,7 @@ jobs:
     strategy:
       matrix:
         test:
-          # - unittest gen-rest-docs gen-cli-docs gen-readthedocs basic auth status batch anonymous competition unicode rest1 upload1 upload2 upload3 upload4 download refs binary rm make worksheet_search worksheet_tags freeze detach perm search_time groups
+          - unittest gen-rest-docs gen-cli-docs gen-readthedocs basic auth status batch anonymous competition unicode rest1 upload1 upload2 upload3 upload4 download refs binary rm make worksheet_search worksheet_tags freeze detach perm search_time groups
           - worker_manager
           - run
           - run2

--- a/codalab/bin/server.py
+++ b/codalab/bin/server.py
@@ -72,8 +72,11 @@ def main():
         run_server_with_watch()
     else:
         # gevent.monkey.patch_all() needs to be called before importing bottle.
-        import gevent.monkey; gevent.monkey.patch_all()
+        import gevent.monkey
+
+        gevent.monkey.patch_all()
         from codalab.server.rest_server import run_rest_server
+
         run_rest_server(CodaLabManager(), args.debug, args.processes)
 
 

--- a/codalab/bin/server.py
+++ b/codalab/bin/server.py
@@ -61,15 +61,7 @@ def main():
         'use more than 1 process to make the best use of multiple '
         'CPUs.',
         type=int,
-        default=1,
-    )
-    parser.add_argument(
-        '-t',
-        '--threads',
-        help='Number of threads to use. The server will be able to handle '
-        '(--processes) x (--threads) requests at the same time.',
-        type=int,
-        default=50,
+        default=10,
     )
     parser.add_argument(
         '-d', '--debug', help='Run the development server for debugging.', action='store_true'
@@ -79,9 +71,10 @@ def main():
     if args.watch:
         run_server_with_watch()
     else:
+        # gevent.monkey.patch_all() needs to be called before importing bottle.
+        import gevent.monkey; gevent.monkey.patch_all()
         from codalab.server.rest_server import run_rest_server
-
-        run_rest_server(CodaLabManager(), args.debug, args.processes, args.threads)
+        run_rest_server(CodaLabManager(), args.debug, args.processes)
 
 
 if __name__ == '__main__':

--- a/codalab/server/rest_server.py
+++ b/codalab/server/rest_server.py
@@ -273,9 +273,6 @@ def run_rest_server(manager, debug, num_processes):
         server='gunicorn',
         workers=num_processes,
         worker_class='gevent',
-        # workers=10,
-        # worker_class='gthread',
-        # processes=50,
         worker_tmp_dir='/tmp',  # don't use globally set tempdir
         timeout=5 * 60,
     )

--- a/codalab/server/rest_server.py
+++ b/codalab/server/rest_server.py
@@ -252,7 +252,7 @@ def create_rest_app(manager=CodaLabManager()):
     return root_app
 
 
-def run_rest_server(manager, debug, num_processes, num_threads):
+def run_rest_server(manager, debug, num_processes):
     """Runs the REST server."""
     logging.basicConfig(format='%(asctime)s %(message)s', level=logging.INFO)
 
@@ -272,8 +272,10 @@ def run_rest_server(manager, debug, num_processes, num_threads):
         debug=debug,
         server='gunicorn',
         workers=num_processes,
-        worker_class='gthread',
-        threads=num_threads,
+        worker_class='gevent',
+        # workers=10,
+        # worker_class='gthread',
+        # processes=50,
         worker_tmp_dir='/tmp',  # don't use globally set tempdir
         timeout=5 * 60,
     )

--- a/codalab/worker/file_util.py
+++ b/codalab/worker/file_util.py
@@ -211,31 +211,37 @@ def gzip_file(file_path):
     """
     Returns a file-like object containing the gzipped version of the given file.
     """
-    BUFFER_SIZE = 100 * 1024 * 1024  # Zip in chunks of 100MB
-
-    class GzipStream:
-        def __init__(self, fileobj):
-            self.__input = fileobj
-            self.__buffer = BytesBuffer()
-            self.__gzip = gzip.GzipFile(None, mode='wb', fileobj=self.__buffer)
-
-        def read(self, size=-1):
-            while size < 0 or len(self.__buffer) < size:
-                s = self.__input.read(BUFFER_SIZE)
-                if not s:
-                    self.__gzip.close()
-                    break
-                self.__gzip.write(s)
-            return self.__buffer.read(size)
-
-        def close(self):
-            self.__input.close()
-
+    args = ['gzip', '-c', '-n', file_path]
     try:
-        file_path_obj = open_file(file_path)
-        return GzipStream(file_path_obj)
-    except Exception as e:
-        raise IOError(e)
+        proc = subprocess.Popen(args, stdout=subprocess.PIPE)
+        return proc.stdout
+    except subprocess.CalledProcessError as e:
+        raise IOError(e.output)
+    # BUFFER_SIZE = 100 * 1024 * 1024  # Zip in chunks of 100MB
+
+    # class GzipStream:
+    #     def __init__(self, fileobj):
+    #         self.__input = fileobj
+    #         self.__buffer = BytesBuffer()
+    #         self.__gzip = gzip.GzipFile(None, mode='wb', fileobj=self.__buffer)
+
+    #     def read(self, size=-1):
+    #         while size < 0 or len(self.__buffer) < size:
+    #             s = self.__input.read(BUFFER_SIZE)
+    #             if not s:
+    #                 self.__gzip.close()
+    #                 break
+    #             self.__gzip.write(s)
+    #         return self.__buffer.read(size)
+
+    #     def close(self):
+    #         self.__input.close()
+
+    # try:
+    #     file_path_obj = open_file(file_path)
+    #     return GzipStream(file_path_obj)
+    # except Exception as e:
+    #     raise IOError(e)
 
 
 def un_bz2_file(source, dest_path):

--- a/codalab/worker/file_util.py
+++ b/codalab/worker/file_util.py
@@ -211,12 +211,12 @@ def gzip_file(file_path):
     """
     Returns a file-like object containing the gzipped version of the given file.
     """
-    # args = ['gzip', '-c', '-n', file_path]
-    # try:
-    #     proc = subprocess.Popen(args, stdout=subprocess.PIPE)
-    #     return proc.stdout
-    # except subprocess.CalledProcessError as e:
-    #     raise IOError(e.output)
+    args = ['gzip', '-c', '-n', file_path]
+    try:
+        proc = subprocess.Popen(args, stdout=subprocess.PIPE)
+        return proc.stdout
+    except subprocess.CalledProcessError as e:
+        raise IOError(e.output)
     BUFFER_SIZE = 10 * 1024 * 1024 # Zip in chunks of 10MB
     class GzipStream:
         def __init__(self, fileobj):

--- a/codalab/worker/file_util.py
+++ b/codalab/worker/file_util.py
@@ -211,7 +211,7 @@ def gzip_file(file_path):
     """
     Returns a file-like object containing the gzipped version of the given file.
     """
-    BUFFER_SIZE = 10 * 1024 * 1024  # Zip in chunks of 10MB
+    BUFFER_SIZE = 100 * 1024 * 1024  # Zip in chunks of 100 MB
 
     class GzipStream:
         def __init__(self, fileobj):

--- a/codalab/worker/file_util.py
+++ b/codalab/worker/file_util.py
@@ -211,12 +211,36 @@ def gzip_file(file_path):
     """
     Returns a file-like object containing the gzipped version of the given file.
     """
-    args = ['gzip', '-c', '-n', file_path]
+    # args = ['gzip', '-c', '-n', file_path]
+    # try:
+    #     proc = subprocess.Popen(args, stdout=subprocess.PIPE)
+    #     return proc.stdout
+    # except subprocess.CalledProcessError as e:
+    #     raise IOError(e.output)
+    BUFFER_SIZE = 10 * 1024 * 1024 # Zip in chunks of 10MB
+    class GzipStream:
+        def __init__(self, fileobj):
+            self.__input = fileobj
+            self.__buffer = BytesBuffer()
+            self.__gzip = gzip.GzipFile(None, mode='wb', fileobj=self.__buffer)
+
+        def read(self, size=-1):
+            while size < 0 or len(self.__buffer) < size:
+                s = self.__input.read(BUFFER_SIZE)
+                if not s:
+                    self.__gzip.close()
+                    break
+                self.__gzip.write(s)
+            return self.__buffer.read(size)
+
+        def close(self):
+            self.__input.close()
+
     try:
-        proc = subprocess.Popen(args, stdout=subprocess.PIPE)
-        return proc.stdout
-    except subprocess.CalledProcessError as e:
-        raise IOError(e.output)
+        file_path_obj = open_file(file_path)
+        return GzipStream(file_path_obj)
+    except Exception as e:
+        raise IOError(e)
 
 
 def un_bz2_file(source, dest_path):

--- a/codalab/worker/file_util.py
+++ b/codalab/worker/file_util.py
@@ -211,12 +211,6 @@ def gzip_file(file_path):
     """
     Returns a file-like object containing the gzipped version of the given file.
     """
-    args = ['gzip', '-c', '-n', file_path]
-    try:
-        proc = subprocess.Popen(args, stdout=subprocess.PIPE)
-        return proc.stdout
-    except subprocess.CalledProcessError as e:
-        raise IOError(e.output)
     BUFFER_SIZE = 10 * 1024 * 1024 # Zip in chunks of 10MB
     class GzipStream:
         def __init__(self, fileobj):

--- a/codalab/worker/file_util.py
+++ b/codalab/worker/file_util.py
@@ -211,7 +211,8 @@ def gzip_file(file_path):
     """
     Returns a file-like object containing the gzipped version of the given file.
     """
-    BUFFER_SIZE = 10 * 1024 * 1024 # Zip in chunks of 10MB
+    BUFFER_SIZE = 10 * 1024 * 1024  # Zip in chunks of 10MB
+
     class GzipStream:
         def __init__(self, fileobj):
             self.__input = fileobj

--- a/codalab/worker/file_util.py
+++ b/codalab/worker/file_util.py
@@ -217,31 +217,6 @@ def gzip_file(file_path):
         return proc.stdout
     except subprocess.CalledProcessError as e:
         raise IOError(e.output)
-    # BUFFER_SIZE = 100 * 1024 * 1024  # Zip in chunks of 100MB
-
-    # class GzipStream:
-    #     def __init__(self, fileobj):
-    #         self.__input = fileobj
-    #         self.__buffer = BytesBuffer()
-    #         self.__gzip = gzip.GzipFile(None, mode='wb', fileobj=self.__buffer)
-
-    #     def read(self, size=-1):
-    #         while size < 0 or len(self.__buffer) < size:
-    #             s = self.__input.read(BUFFER_SIZE)
-    #             if not s:
-    #                 self.__gzip.close()
-    #                 break
-    #             self.__gzip.write(s)
-    #         return self.__buffer.read(size)
-
-    #     def close(self):
-    #         self.__input.close()
-
-    # try:
-    #     file_path_obj = open_file(file_path)
-    #     return GzipStream(file_path_obj)
-    # except Exception as e:
-    #     raise IOError(e)
 
 
 def un_bz2_file(source, dest_path):

--- a/docker_config/dockerfiles/Dockerfile.server
+++ b/docker_config/dockerfiles/Dockerfile.server
@@ -27,6 +27,9 @@ RUN apt-get update && \
     rsync && \
     rm -rf /var/lib/apt/lists/*;
  
+# Required for gevent: https://stackoverflow.com/questions/40184788/protocol-not-found-socket-getprotobyname
+RUN apt-get update && apt-get -o Dpkg::Options::="--force-confmiss" install --reinstall -y netbase
+
 # Set Python3.6 as the default python3 version
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 1
 

--- a/docs/Code-Overview.md
+++ b/docs/Code-Overview.md
@@ -258,6 +258,13 @@ nosetests tests.unit.rest
 python3 test_runner.py default
 ```
 
+Certain tests in this file are not run with the "default" keyword, but can be manually run:
+
+```
+python3 test_runner.py docker
+python3 test_runner.py performance
+```
+
 - End-to-end UI tests for the web interface in [tests/ui](https://github.com/codalab/codalab-worksheets/tree/master/tests/ui)
 
 ```

--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -19,5 +19,6 @@ coverage==5.3
 # Server-specific
 alembic==1.4.3
 gunicorn==20.0.4
+gevent==20.12.1
 oauthlib==2.1.0
 mysqlclient==1.4.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,3 +64,6 @@ ignore_missing_imports = True
 
 [mypy-urllib3.util.retry]
 ignore_missing_imports = True
+
+[mypy-gevent,mypy-gevent.monkey]
+ignore_missing_imports = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,5 +65,5 @@ ignore_missing_imports = True
 [mypy-urllib3.util.retry]
 ignore_missing_imports = True
 
-[mypy-gevent,mypy-gevent.monkey]
+[mypy-gevent,gevent.monkey]
 ignore_missing_imports = True

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -2084,7 +2084,7 @@ def test_workers(ctx):
     assert len(worker_info) >= 10
 
 
-@TestModule.register('performance')
+@TestModule.register('performance', default=False)
 def test_performance(ctx):
     """Performance testing. While many threads upload / download large files,
     periodically run `cl workers` to ensure that the command still works and

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -2101,7 +2101,7 @@ def test_performance(ctx):
                 uuid = _run_command([cl, 'upload', f.name])
                 _run_command([cl, 'download', uuid, '-o', f"{f.name}-output"])
                 os.unlink(f"{f.name}-output")
-            time.sleep(random.random())
+            time.sleep(random.random() * 2)
             with tempfile.TemporaryDirectory() as dirname:
                 with open(os.path.join(dirname, "test1.txt"), "w+") as f:
                     f.write("hello world!")
@@ -2110,7 +2110,7 @@ def test_performance(ctx):
                 uuid = _run_command([cl, 'upload', dirname])
                 _run_command([cl, 'download', uuid, '-o', f"{f.name}-output"])
                 os.unlink(f"{f.name}-output")
-            time.sleep(random.random())
+            time.sleep(random.random() * 2)
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
         futures = [executor.submit(do_work) for _ in range(0, 10)]

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -2096,10 +2096,8 @@ def test_performance(ctx):
         upload / download a large directory.
         """
         for _ in range(0, 2):
-            with tempfile.NamedTemporaryFile(
-                mode='w'
-            ) as f:
-                f.truncate(1024 * 1024 * 50) # 50 MB
+            with tempfile.NamedTemporaryFile(mode='w') as f:
+                f.truncate(1024 * 1024 * 50)  # 50 MB
                 uuid = _run_command([cl, 'upload', f.name])
                 _run_command([cl, 'download', uuid, '-o', f"{f.name}-output"])
             time.sleep(random.random())
@@ -2107,7 +2105,7 @@ def test_performance(ctx):
                 with open(os.path.join(dirname, "test1.txt"), "w+") as f:
                     f.write("hello world!")
                 with open(os.path.join(dirname, "test2.txt"), "w+") as f:
-                    f.truncate(1024 * 1024 * 50) # 50 MB
+                    f.truncate(1024 * 1024 * 50)  # 50 MB
                 uuid = _run_command([cl, 'upload', dirname])
                 _run_command([cl, 'download', uuid, '-o', f"{f.name}-output"])
             time.sleep(random.random())
@@ -2122,10 +2120,13 @@ def test_performance(ctx):
             time_taken = time.time() - start
             times.append(time_taken)
             print("Time taken for `cl workers`:", time_taken)
-        message = f"All times taken for `cl workers`: {times}. Average time: {sum(times) / len(times)}"
+        message = (
+            f"All times taken for `cl workers`: {times}. Average time: {sum(times) / len(times)}"
+        )
         print(message)
         if sum(times) / len(times) > 5:
             raise Exception(f"Took too long for `cl workers`. {message}")
+
 
 @TestModule.register('sharing_workers')
 def test_sharing_workers(ctx):

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -2100,6 +2100,7 @@ def test_performance(ctx):
                 f.truncate(1024 * 1024 * 50)  # 50 MB
                 uuid = _run_command([cl, 'upload', f.name])
                 _run_command([cl, 'download', uuid, '-o', f"{f.name}-output"])
+                os.unlink(f"{f.name}-output")
             time.sleep(random.random())
             with tempfile.TemporaryDirectory() as dirname:
                 with open(os.path.join(dirname, "test1.txt"), "w+") as f:
@@ -2108,6 +2109,7 @@ def test_performance(ctx):
                     f.truncate(1024 * 1024 * 50)  # 50 MB
                 uuid = _run_command([cl, 'upload', dirname])
                 _run_command([cl, 'download', uuid, '-o', f"{f.name}-output"])
+                os.unlink(f"{f.name}-output")
             time.sleep(random.random())
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -2097,14 +2097,17 @@ def test_performance(ctx):
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
         futures = [executor.submit(do_work) for _ in range(0, 10)]
+        times = []
         while any(not f.done() for f in futures):
             start = time.time()
             _run_command([cl, 'workers'])
             time_taken = time.time() - start
-            print("Time for cl workers: ", time_taken)
+            times.append(time_taken)
+            print("Time taken for `cl workers`:", time_taken)
             if time_taken > 5:
-                raise Exception(f"Took too long for cl workers: {time_taken}")
+                raise Exception(f"Took too long for `cl workers`: {time_taken}. All times taken: {times}. Average time: {sum(times) / len(times)}")
             time.sleep(2)
+        print(f"Success. All times taken for `cl workers`: {times}. Average time: {sum(times) / len(times)}")
 
 
 @TestModule.register('sharing_workers')

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -2087,7 +2087,7 @@ def test_workers(ctx):
 def test_performance(ctx):
 
     def do_work():
-        for _ in range(0, 20):
+        for _ in range(0, 1):
             with tempfile.NamedTemporaryFile(
                 mode='w'
             ) as f:
@@ -2095,8 +2095,8 @@ def test_performance(ctx):
                 uuid = _run_command([cl, 'upload', f.name])
                 _run_command([cl, 'download', uuid, '-o', f"{f.name}-output"])
 
-    with concurrent.futures.ThreadPoolExecutor(max_workers=20) as executor:
-        futures = [executor.submit(do_work) for _ in range(0, 20)]
+    with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
+        futures = [executor.submit(do_work) for _ in range(0, 10)]
         while any(not f.done() for f in futures):
             start = time.time()
             _run_command([cl, 'workers'])

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -2087,7 +2087,7 @@ def test_workers(ctx):
 def test_performance(ctx):
 
     def do_work():
-        for _ in range(0, 1):
+        for _ in range(0, 2):
             with tempfile.NamedTemporaryFile(
                 mode='w'
             ) as f:
@@ -2104,11 +2104,11 @@ def test_performance(ctx):
             time_taken = time.time() - start
             times.append(time_taken)
             print("Time taken for `cl workers`:", time_taken)
-            if time_taken > 5:
-                raise Exception(f"Took too long for `cl workers`: {time_taken}. All times taken: {times}. Average time: {sum(times) / len(times)}")
             time.sleep(2)
-        print(f"Success. All times taken for `cl workers`: {times}. Average time: {sum(times) / len(times)}")
-
+        message = f"All times taken for `cl workers`: {times}. Average time: {sum(times) / len(times)}"
+        print(message)
+        if any(time > 10 for time in times):
+            raise Exception(f"Took too long for `cl workers`. {message}")
 
 @TestModule.register('sharing_workers')
 def test_sharing_workers(ctx):

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -2087,15 +2087,16 @@ def test_workers(ctx):
 def test_performance(ctx):
 
     def do_work():
-        with tempfile.NamedTemporaryFile(
-            mode='w'
-        ) as f:
-            f.truncate(1024 * 1024 * 50) # 50 MB
-            uuid = _run_command([cl, 'upload', f.name])
-            _run_command([cl, 'download', uuid, '-o', f"{f.name}-output"])
+        for _ in range(0, 20):
+            with tempfile.NamedTemporaryFile(
+                mode='w'
+            ) as f:
+                f.truncate(1024 * 1024 * 50) # 50 MB
+                uuid = _run_command([cl, 'upload', f.name])
+                _run_command([cl, 'download', uuid, '-o', f"{f.name}-output"])
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
-        futures = [executor.submit(do_work) for _ in range(0, 30)]
+        futures = [executor.submit(do_work) for _ in range(0, 10)]
         while any(not f.done() for f in futures):
             start = time.time()
             result = _run_command([cl, 'workers'])
@@ -2103,7 +2104,7 @@ def test_performance(ctx):
             print("Time for cl workers: ", time_taken)
             if time_taken > 10:
                 raise Exception(f"Took too long for cl workers: {time_taken}")
-            time.sleep(5000)
+            time.sleep(5)
 
 
 @TestModule.register('sharing_workers')

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -2092,8 +2092,8 @@ def test_performance(ctx):
     """
 
     def do_work():
-        """Do some random work: upload / download a large file, then
-        upload / download a large directory.
+        """Do some random work: upload / download a 50 MB file, then
+        upload / download a 50 MB directory.
         """
         for _ in range(0, 2):
             with tempfile.NamedTemporaryFile(mode='w') as f:

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -2095,16 +2095,16 @@ def test_performance(ctx):
                 uuid = _run_command([cl, 'upload', f.name])
                 _run_command([cl, 'download', uuid, '-o', f"{f.name}-output"])
 
-    with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
-        futures = [executor.submit(do_work) for _ in range(0, 10)]
+    with concurrent.futures.ThreadPoolExecutor(max_workers=20) as executor:
+        futures = [executor.submit(do_work) for _ in range(0, 20)]
         while any(not f.done() for f in futures):
             start = time.time()
-            result = _run_command([cl, 'workers'])
+            _run_command([cl, 'workers'])
             time_taken = time.time() - start
             print("Time for cl workers: ", time_taken)
-            if time_taken > 10:
+            if time_taken > 5:
                 raise Exception(f"Took too long for cl workers: {time_taken}")
-            time.sleep(5)
+            time.sleep(2)
 
 
 @TestModule.register('sharing_workers')

--- a/tests/unit/server/upload_download_test.py
+++ b/tests/unit/server/upload_download_test.py
@@ -72,7 +72,7 @@ class BaseUploadDownloadBundleTest(TestBase):
             with self.download_manager.stream_file(target, gzipped=False) as f:
                 pass
 
-        with self.assertRaises(Exception):
+        with self.assertRaises(OSError):
             with gzip.GzipFile(
                 fileobj=self.download_manager.stream_file(target, gzipped=True)
             ) as f:

--- a/tests/unit/server/upload_download_test.py
+++ b/tests/unit/server/upload_download_test.py
@@ -72,7 +72,7 @@ class BaseUploadDownloadBundleTest(TestBase):
             with self.download_manager.stream_file(target, gzipped=False) as f:
                 pass
 
-        with self.assertRaises(OSError):
+        with self.assertRaises(Exception):
             with gzip.GzipFile(
                 fileobj=self.download_manager.stream_file(target, gzipped=True)
             ) as f:


### PR DESCRIPTION
## Motivation

@percyliang I did a basic performance test for #3131, and it was slightly faster to switch to use gzip subprocesses. However, when I tried adding a test to test_cli.py for performance testing (in this PR), it turned out that whether or not we use gzip in a subprocess, it's really slow and the server times out / goes down.

I dug deeper and it appears that gevent workers are better suited for I/O-bounded applications, like ours, than gthread, which we're currently using. See this for more info: https://medium.com/building-the-system/gunicorn-3-means-of-concurrency-efbb547674b7

## This PR

Thus, this PR does two things:
- Revert https://github.com/codalab/codalab-worksheets/commit/561da0ee8a7925aca4d251e4aac3c06fa4d91a48, so that we use gevent with 10 processes instead of using gthread with a single process / 50 threads.
- Create a performance test in test_cli.py. This test uploads and downloads files / directories at 10x concurrency, then periodically runs "cl workers" and times how long that command takes.

## Performance test results

I ran the performance test using varying combinations of worker types, and whether we use the gzip subprocess or stick with the existing code (gzipstream). The times taken should start very small, but gradually increase as the server gets more load with the concurrent uploads / downloads.

**gthread, gzipstream (what we currently have in master):**
`cl workers` times out, server went down

```
>> cl workers
 (exit code test-cli exception, expected 0 BAD)
...
codalab.client.json_api_client.JsonApiException: Unable to create bundles: timed out
```

**gthread, gzip subprocess (what #3131 would have done):**
`cl workers` times out, server went down. Same error message as above

**gevent with 10 workers, gzipstream:**
All times (s) taken for `cl workers`: [0.7127954959869385, 0.6075131893157959, 0.7263393402099609, 7.872021913528442, 8.671122312545776, 7.271690130233765, 0.5290284156799316, 0.4893498420715332, 2.7468934059143066, 7.838416576385498, 8.023988962173462, 6.165715456008911]. Average time: 4.304572920004527

**gevent with 10 workers, gzip subprocess:**
All times (s) taken for `cl workers`: [0.7731211185455322, 0.6943981647491455, 0.37362003326416016, 5.811000347137451, 9.235201120376587, 8.597550868988037, 3.903759002685547, 0.5644106864929199, 0.6485815048217773, 3.2893669605255127, 9.11350131034851, 9.951630115509033, 8.249640464782715, 0.6637413501739502]. Average time: 4.419251646314349

It appears that when we use gevent, there's not a very big difference between using / not using the gzip subprocess (and perhaps it's slightly worse to use the gzip processes), so this PR doesn't add the gzip subprocess back in (unlike #3131).

Finally, I also tried using gthread with 10 workers (we currently use only 1 worker), but it still timed out in the performance test. This leads me to believe that we should not use gthread at all, as even scaling the number of workers doesn't help with the concurrent requests in the performance test.