### PR TITLE
Enable customizing cl search and cl ls output columns

### DIFF
--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -2140,7 +2140,7 @@ class BundleCLI(object):
                 '-f',
                 '--field',
                 type=str,
-                default="uuid,name,summary,owner,created,data_size,state",
+                default=','.join(DEFAULT_BUNDLE_INFO_LIST_FIELDS),
                 help='Print out these comma-separated fields in the results table',
             ),
             Commands.Argument('-u', '--uuid-only', help='Print only uuids.', action='store_true'),

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -2054,7 +2054,7 @@ class BundleCLI(object):
                 '-f',
                 '--field',
                 type=str,
-                default="uuid,name,summary,owner,created,data_size,state",
+                default=','.join(DEFAULT_BUNDLE_INFO_LIST_FIELDS),
                 help='Print out these comma-separated fields in the results table',
             ),
             Commands.Argument(

--- a/docs/CLI-Reference.md
+++ b/docs/CLI-Reference.md
@@ -139,6 +139,7 @@ Usage: `cl <command> <arguments>`
       search .format=<format>                : Apply <format> function (see worksheet markdown).
     Arguments:
       keywords              Keywords to search for.
+      -f, --field           Print out these comma-separated fields in the results table
       -a, --append          Append these bundles to the current worksheet.
       -u, --uuid-only       Print only uuids.
       -w, --worksheet-spec  Operate on this worksheet ([(<alias>|<address>)::](<uuid>|<name>)).
@@ -146,6 +147,7 @@ Usage: `cl <command> <arguments>`
 ### ls
     List bundles in a worksheet.
     Arguments:
+      -f, --field           Print out these comma-separated fields in the results table
       -u, --uuid-only       Print only uuids.
       -w, --worksheet-spec  Operate on this worksheet ([(<alias>|<address>)::](<uuid>|<name>)).
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1135,6 +1135,7 @@ def test_search(ctx):
     uuid1 = _run_command([cl, 'upload', test_path('a.txt'), '-n', name])
     uuid2 = _run_command([cl, 'upload', test_path('b.txt'), '-n', name])
     check_equals(uuid1, _run_command([cl, 'search', uuid1, '-u']))
+    check_equals(uuid1[:8], _run_command([cl, 'search', 'uuid=' + uuid1, '-f uuid']).split("\n")[2])
     check_equals(uuid1, _run_command([cl, 'search', 'uuid=' + uuid1, '-u']))
     check_equals('', _run_command([cl, 'search', 'uuid=' + uuid1[0:8], '-u']))
     check_equals(uuid1, _run_command([cl, 'search', 'uuid=' + uuid1[0:8] + '.*', '-u']))

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1135,7 +1135,7 @@ def test_search(ctx):
     uuid1 = _run_command([cl, 'upload', test_path('a.txt'), '-n', name])
     uuid2 = _run_command([cl, 'upload', test_path('b.txt'), '-n', name])
     check_equals(uuid1, _run_command([cl, 'search', uuid1, '-u']))
-    check_equals(uuid1[:8], _run_command([cl, 'search', 'uuid=' + uuid1, '-f uuid']).split("\n")[2])
+    check_equals(uuid1[:8], _run_command([cl, 'search', 'uuid=' + uuid1, '-f', 'uuid']).split("\n")[2])
     check_equals(uuid1, _run_command([cl, 'search', 'uuid=' + uuid1, '-u']))
     check_equals('', _run_command([cl, 'search', 'uuid=' + uuid1[0:8], '-u']))
     check_equals(uuid1, _run_command([cl, 'search', 'uuid=' + uuid1[0:8] + '.*', '-u']))


### PR DESCRIPTION
### Reasons for making this change

Right now, `cl search` and `cl ls` display a fixed set of columns (although all the information is fetched). This enables the user to pick what fields they want to show up.

I have a use case where I need to do a `cl search` and examine the `request_priority` of each search result. Right now, I have to do:

1. `cl search <critera>`
2. iterate through search results, running `cl info -f` on each search result

This blows up the # of network roundtrips considerably, slowing things down. Now, I can just do:

1. `cl search <critera> -f uuid,name,request_priority`

and I can get something like:

```
uuid      name                 request_priority
-----------------------------------------------
0x58947c  glove.840B.300d
0xa60e66  select_ensemble
0xdf051b  run-predictions      0
0xfe18a1  predictions-albert
0x005f26  run-predictions      0
0x8cb148  predictions-electra
0x27b373  run-predictions      0
0xfa3087  predictions-electra
0xb1f4ea  src
0x42180e  electra_model
```
