### PR TITLE
Read state from state.json to persist sessions

### DIFF
--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1135,7 +1135,9 @@ def test_search(ctx):
     uuid1 = _run_command([cl, 'upload', test_path('a.txt'), '-n', name])
     uuid2 = _run_command([cl, 'upload', test_path('b.txt'), '-n', name])
     check_equals(uuid1, _run_command([cl, 'search', uuid1, '-u']))
-    check_equals(uuid1[:8], _run_command([cl, 'search', 'uuid=' + uuid1, '-f', 'uuid']).split("\n")[2])
+    check_equals(
+        uuid1[:8], _run_command([cl, 'search', 'uuid=' + uuid1, '-f', 'uuid']).split("\n")[2]
+    )
     check_equals(uuid1, _run_command([cl, 'search', 'uuid=' + uuid1, '-u']))
     check_equals('', _run_command([cl, 'search', 'uuid=' + uuid1[0:8], '-u']))
     check_equals(uuid1, _run_command([cl, 'search', 'uuid=' + uuid1[0:8] + '.*', '-u']))

--- a/tests/unit/lib/codalab_manager_test.py
+++ b/tests/unit/lib/codalab_manager_test.py
@@ -1,21 +1,23 @@
 import os
 import unittest
+from pathlib import Path
 
 from codalab.lib.codalab_manager import CodaLabManager
 
 
 class CodalabManagerTest(unittest.TestCase):
     def setUp(self):
-        os.environ['CODALAB_HOME'] = '.'
+        os.environ['CODALAB_HOME'] = str(Path.home())
 
     def tearDown(self):
-        try:
-            # Remove the state and config json files created by the CodaLabManagers
-            os.remove('state.json')
-            os.remove('config.json')
-        except:
-            pass
+        def remove_file_if_exists(file):
+            file_path = os.path.join(str(Path.home()), file)
+            if os.path.exists(file_path):
+                os.remove(file_path)
 
+        # Remove the state and config json files created by the CodaLabManagers
+        remove_file_if_exists('state.json')
+        remove_file_if_exists('config.json')
         del os.environ['CODALAB_HOME']
 
     def test_get_state_for_temp_codalab_manager(self):

--- a/tests/unit/lib/codalab_manager_test.py
+++ b/tests/unit/lib/codalab_manager_test.py
@@ -1,0 +1,100 @@
+import os
+import unittest
+
+from codalab.lib.codalab_manager import CodaLabManager
+
+
+class CodalabManagerTest(unittest.TestCase):
+    def setUp(self):
+        os.environ['CODALAB_HOME'] = '.'
+
+    def tearDown(self):
+        try:
+            # Remove the state and config json files created by the CodaLabManagers
+            os.remove('state.json')
+            os.remove('config.json')
+        except:
+            pass
+
+        del os.environ['CODALAB_HOME']
+
+    def test_get_state_for_temp_codalab_manager(self):
+        manager: CodaLabManager = CodaLabManager(temporary=True)
+        self.assertEqual(manager.get_state(), {'auth': {}, 'sessions': {}})
+        manager.save_state()
+        self.assertFalse(
+            os.path.exists(manager.state_path),
+            msg='Assert that the current state is not written out to state_path for a temporary CodaLabManager',
+        )
+
+    def test_state_persistence(self):
+        manager1: CodaLabManager = CodaLabManager(temporary=False)
+        manager1.state['auth'] = {'https://worksheets.codalab.org': 'old_token'}
+        manager1.save_state()
+        os.environ['CODALAB_SESSION'] = 'session1'
+        manager1.set_current_worksheet_uuid('https://worksheets.codalab.org', '0x1')
+        self.assertEqual(
+            manager1.get_state(),
+            {
+                'auth': {'https://worksheets.codalab.org': 'old_token'},
+                'sessions': {
+                    'session1': {
+                        'address': 'https://worksheets.codalab.org',
+                        'worksheet_uuid': '0x1',
+                    }
+                },
+            },
+        )
+
+        manager2: CodaLabManager = CodaLabManager(temporary=False)
+        manager2.state['auth'] = {'https://worksheets.codalab.org': 'new_token'}
+        manager2.save_state()
+        os.environ['CODALAB_SESSION'] = 'session2'
+        manager2.set_current_worksheet_uuid('https://worksheets.codalab.org', '0x2')
+
+        # Assert that the new token is respected and both sessions are kept
+        self.assertEqual(
+            manager2.get_state(),
+            {
+                'auth': {'https://worksheets.codalab.org': 'new_token'},
+                'sessions': {
+                    'session1': {
+                        'address': 'https://worksheets.codalab.org',
+                        'worksheet_uuid': '0x1',
+                    },
+                    'session2': {
+                        'address': 'https://worksheets.codalab.org',
+                        'worksheet_uuid': '0x2',
+                    },
+                },
+            },
+        )
+        self.assertEqual(
+            manager1.get_state(),
+            manager2.get_state(),
+            msg='Assert that both CodaLabManagers have the same state',
+        )
+
+        manager1.logout('https://worksheets.codalab.org')
+        # Assert that the token is cleared after logging out, but sessions are kept
+        self.assertEqual(
+            manager2.get_state(),
+            {
+                'auth': {},
+                'sessions': {
+                    'session1': {
+                        'address': 'https://worksheets.codalab.org',
+                        'worksheet_uuid': '0x1',
+                    },
+                    'session2': {
+                        'address': 'https://worksheets.codalab.org',
+                        'worksheet_uuid': '0x2',
+                    },
+                },
+            },
+        )
+        self.assertEqual(
+            manager1.get_state(),
+            manager2.get_state(),
+            msg='Assert that both CodaLabManagers still have the same state',
+        )


### PR DESCRIPTION
### Reasons for making this change

This PR fixes the issues where users get logged out abruptly or the CLI forgets what worksheet the user was working on. These issues happen when a user has more than one session running with multiple instances of the client each with a `CodaLabManager` on a single machine for a particular CodaLab instance. That is why only our Stanford users run into these issues, as they usually have multiple screen sessions running worker managers for https://codalab.stanford.edu.

Before this fix, a `CodaLabManager` would read from `state.json` once on initialization. For any operations that alter the state, it would make changes to its own copy stored in memory and override whatever was already written out to `state.json`. This causes problems as any old `CodaLabManager` could wipe out any new session information written by a newer `CodaLabManager`.

The fix is to simply always read the state from `state.json`.

### Related issues

Resolves #3078 

### Checklist

* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
