### PR TITLE
Bump version to 0.5.33

### DIFF
--- a/codalab/common.py
+++ b/codalab/common.py
@@ -9,7 +9,7 @@ import http.client
 
 # Increment this on master when ready to cut a release.
 # http://semver.org/
-CODALAB_VERSION = '0.5.32'
+CODALAB_VERSION = '0.5.33'
 BINARY_PLACEHOLDER = '<binary>'
 URLOPEN_TIMEOUT_SECONDS = int(os.environ.get('CODALAB_URLOPEN_TIMEOUT_SECONDS', 5 * 60))
 

--- a/docs/REST-API-Reference.md
+++ b/docs/REST-API-Reference.md
@@ -1,6 +1,6 @@
 # REST API Reference
 
-_version 0.5.32_
+_version 0.5.33_
 
 This reference and the REST API itself is still under heavy development and is
 subject to change at any time. Feedback through our GitHub issues is appreciated!

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -1,5 +1,5 @@
 // Should match codalab/common.py#CODALAB_VERSION
-export const CODALAB_VERSION = '0.5.32';
+export const CODALAB_VERSION = '0.5.33';
 
 // Name Regex to match the backend in spec_utils.py
 export const NAME_REGEX = /^[a-zA-Z_][a-zA-Z0-9_.-]*$/i;

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import sys
 
 
 # should match codalab/common.py#CODALAB_VERSION
-CODALAB_VERSION = "0.5.32"
+CODALAB_VERSION = "0.5.33"
 
 
 class Install(install):


### PR DESCRIPTION
### Reasons for making this change
Bump new version

Full diff: https://github.com/codalab/codalab-worksheets/compare/v0.5.32...rc0.5.33

# Draft release notes

## CLI
- Add cl open command for opening bundles in browser (#3113)
- Add cl wopen for opening worksheets in browser from CLI (7932c10f043bfd38617e7d6fb89e37f33a07045f)
- Enable customizing cl search and cl ls output columns (#3142)

## Backend
- Handle any requests exceptions when pruning docker networks (#3103)
- Make workermanager filtering more end-user debuggable (#3079)
- Make timeout configurable with environment variable (#3115)
- Allow archives to be uploaded from a URL with a query string (#3094)
- Add option to disable prefiltering in WorkerManager (#3119)
- Increase max nginx body size to 1000 GB (#3126)
- Revert gzip changes (#3131)

## Dev / docs / CI
- Group commands in pre-commit.sh by language (#3114)
- Fix some frontend vulnerabilities with `npm audit fix` (#3138)