### PR TITLE
Use a temporary CodaLabManager for WorkerManagers

### DIFF
--- a/codalab/lib/codalab_manager.py
+++ b/codalab/lib/codalab_manager.py
@@ -121,7 +121,7 @@ class CodaLabManager(object):
     temporary: don't use config files
     '''
 
-    def __init__(self, temporary=False, config=None, clients=None):
+    def __init__(self, temporary=False, config={}, clients={}):
         self.cache = {}
         self.temporary = temporary
 
@@ -328,7 +328,7 @@ class CodaLabManager(object):
     @cached
     def model(self):
         """
-        Return a model.  Called by the server.
+        Return a model. Called by the server.
         """
         model_class = self.config['server']['class']
         model = None
@@ -474,7 +474,7 @@ class CodaLabManager(object):
             token_info = auth['token_info']
             expires_at = token_info.get('expires_at', 0.0)
 
-            # If token is not nearing expiration, just return it.
+            # If token is not nearing expiration (more than 10 minutes left), just return it.
             if expires_at >= (time.time() + 10 * 60):
                 return token_info['access_token']
 

--- a/codalab/worker_manager/main.py
+++ b/codalab/worker_manager/main.py
@@ -14,6 +14,11 @@ def main():
     parser.add_argument(
         '--server', help='CodaLab instance to connect to', default='https://worksheets.codalab.org'
     )
+    parser.add_argument(
+        '--temp-session',
+        action='store_false',
+        help='Whether to use a temporary session (defaults to true).',
+    )
     parser.add_argument('--min-workers', help='Minimum number of workers', type=int, default=1)
     parser.add_argument('--max-workers', help='Maximum number of workers', type=int, default=10)
     parser.add_argument(

--- a/codalab/worker_manager/worker_manager.py
+++ b/codalab/worker_manager/worker_manager.py
@@ -89,7 +89,7 @@ class WorkerManager(object):
 
     def __init__(self, args):
         self.args = args
-        self.codalab_manager = CodaLabManager()
+        self.codalab_manager = CodaLabManager(args.temp_session)
         self.codalab_client = self.codalab_manager.client(args.server)
         self.staged_uuids = []
         self.worker_manager_start_time = time.time()

--- a/tests/unit/lib/codalab_manager_test.py
+++ b/tests/unit/lib/codalab_manager_test.py
@@ -1,0 +1,30 @@
+import os
+import unittest
+from pathlib import Path
+
+from codalab.lib.codalab_manager import CodaLabManager
+
+
+class CodalabManagerTest(unittest.TestCase):
+    def setUp(self):
+        os.environ['CODALAB_HOME'] = str(Path.home())
+
+    def tearDown(self):
+        def remove_file_if_exists(file):
+            file_path = os.path.join(str(Path.home()), file)
+            if os.path.exists(file_path):
+                os.remove(file_path)
+
+        # Remove the state and config json files created by the CodaLabManagers
+        remove_file_if_exists('state.json')
+        remove_file_if_exists('config.json')
+        del os.environ['CODALAB_HOME']
+
+    def test_get_state_for_temp_codalab_manager(self):
+        manager: CodaLabManager = CodaLabManager(temporary=True)
+        self.assertEqual(manager.state, {'auth': {}, 'sessions': {}})
+        manager.save_state()
+        self.assertFalse(
+            os.path.exists(manager.state_path),
+            msg='Assert that the current state is not written out to state_path for a temporary CodaLabManager',
+        )

--- a/tests/unit/lib/codalab_manager_test.py
+++ b/tests/unit/lib/codalab_manager_test.py
@@ -20,7 +20,7 @@ class CodalabManagerTest(unittest.TestCase):
         remove_file_if_exists('config.json')
         del os.environ['CODALAB_HOME']
 
-    def test_get_state_for_temp_codalab_manager(self):
+    def test_temp_codalab_manager(self):
         manager: CodaLabManager = CodaLabManager(temporary=True)
         self.assertEqual(manager.state, {'auth': {}, 'sessions': {}})
         manager.save_state()

--- a/tests/unit/lib/codalab_manager_test.py
+++ b/tests/unit/lib/codalab_manager_test.py
@@ -6,7 +6,13 @@ from codalab.lib.codalab_manager import CodaLabManager
 
 
 class CodalabManagerTest(unittest.TestCase):
+
+    codalab_home = None
+
     def setUp(self):
+        if 'CODALAB_HOME' in os.environ:
+            print(os.environ['CODALAB_HOME'])
+            self.codalab_home = os.environ['CODALAB_HOME']
         os.environ['CODALAB_HOME'] = str(Path.home())
 
     def tearDown(self):
@@ -18,7 +24,11 @@ class CodalabManagerTest(unittest.TestCase):
         # Remove the state and config json files created by the CodaLabManagers
         remove_file_if_exists('state.json')
         remove_file_if_exists('config.json')
-        del os.environ['CODALAB_HOME']
+
+        if self.codalab_home:
+            os.environ['CODALAB_HOME'] = self.codalab_home
+        else:
+            del os.environ['CODALAB_HOME']
 
     def test_temp_codalab_manager(self):
         manager: CodaLabManager = CodaLabManager(temporary=True)

--- a/tests/unit/rest/worksheets_test.py
+++ b/tests/unit/rest/worksheets_test.py
@@ -32,8 +32,14 @@ class WorksheetsTest(BaseTestCase):
         )
         # Verify the date_created and date_last_modified field has been set to the current time for a new created worksheet
         worksheet_info = self.app.get('/rest/interpret/worksheet/' + worksheet_id).json
-        date_created = datetime.datetime.strptime(worksheet_info['date_created'], '%Y-%m-%dT%H:%M:%S')
-        date_last_modified = datetime.datetime.strptime(worksheet_info['date_last_modified'], '%Y-%m-%dT%H:%M:%S')
+        date_created = datetime.datetime.strptime(
+            worksheet_info['date_created'], '%Y-%m-%dT%H:%M:%S'
+        )
+        date_last_modified = datetime.datetime.strptime(
+            worksheet_info['date_last_modified'], '%Y-%m-%dT%H:%M:%S'
+        )
         current_time = datetime.datetime.utcnow()
         self.assertAlmostEqual(current_time, date_created, delta=datetime.timedelta(seconds=1))
-        self.assertAlmostEqual(current_time, date_last_modified, delta=datetime.timedelta(seconds=1))
+        self.assertAlmostEqual(
+            current_time, date_last_modified, delta=datetime.timedelta(seconds=1)
+        )

--- a/tests/unit/worker_manager/slurm_batch_worker_manager_test.py
+++ b/tests/unit/worker_manager/slurm_batch_worker_manager_test.py
@@ -10,6 +10,7 @@ class SlurmBatchWorkerManagerTest(unittest.TestCase):
     def test_base_command(self):
         args: SimpleNamespace = SimpleNamespace(
             server='some_server',
+            temp_session=True,
             user='some_user',
             partition='some_partition',
             worker_executable='cl-worker',
@@ -47,6 +48,7 @@ class SlurmBatchWorkerManagerTest(unittest.TestCase):
     def test_filter_bundles(self):
         args: SimpleNamespace = SimpleNamespace(
             server='some_server',
+            temp_session=True,
             user='some_user',
             partition='some_partition',
             worker_executable='cl-worker',


### PR DESCRIPTION
### Reasons for making this change

The changes in this PR is an alternative way to fix the sessions issue. A temporary `CodaLabManager` maintains its state in memory and never writes to `state.json`. Therefore, a WorkerManager in a different screen session wouldn't be able to erase sessions information stored in `state.json`.

### Related issues

Related PR: https://github.com/codalab/codalab-worksheets/pull/3145
Resolves https://github.com/codalab/codalab-worksheets/issues/3078

### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
