### PR TITLE
Remove "last modified date" from frontend

### DIFF
--- a/frontend/src/components/worksheets/Worksheet/WorksheetHeader.js
+++ b/frontend/src/components/worksheets/Worksheet/WorksheetHeader.js
@@ -67,13 +67,6 @@ export default ({
                                 onChange={() => reloadWorksheet()}
                                 allowASCII={true}
                             />
-                            {/* Hide invalid last modified date */}
-                            {info && info['date_last_modified'] ? (
-                                <div style={{ fontWeight: 'normal', fontSize: 'small' }}>
-                                    Last Modified Date:{' '}
-                                    {new Date(info['date_last_modified']).toString()}
-                                </div>
-                            ) : null}
                         </h5>
                         <Grid item style={{ paddingTop: '10px' }}>
                             {info && (


### PR DESCRIPTION
Sorry, I think I missed this in my review of #3073. Right now, the "last modified date" shows up prominently under the title:

![image](https://user-images.githubusercontent.com/1689183/104053106-b0625a00-51b8-11eb-9df4-75cdc810cb9f.png)

I don't think it should be in such a prominent place, given that the title bar is also sticky (so we're taking up additional screen space from the user), and the user would likely not have to refer to the "last modified date" very much often. We should probably rethink where to add it on the frontend -- maybe we add a button at the top right saying "worksheet info" that shows this information -- but I don't think it belongs below the title. I'm just reverting this change in this PR, but we should consider where to add it later in the future.

What do you think, @yuqijin ?