### PR TITLE
Replace a bad image tag

### DIFF
--- a/tests/stress/stress_test.py
+++ b/tests/stress/stress_test.py
@@ -85,7 +85,7 @@ class StressTestRunner:
         'couchbase:latest',
         'golang:latest',
         'iwane/numpy-matplotlib',
-        'jenkins:jenkins',
+        'jenkins/jenkins',
         'larger/rdp:dev',
         'maven:latest',
         'mysql:latest',

--- a/tests/stress/stress_test.py
+++ b/tests/stress/stress_test.py
@@ -85,7 +85,7 @@ class StressTestRunner:
         'couchbase:latest',
         'golang:latest',
         'iwane/numpy-matplotlib',
-        'jenkins:2.60.3',
+        'jenkins:jenkins',
         'larger/rdp:dev',
         'maven:latest',
         'mysql:latest',

--- a/tests/stress/stress_test.py
+++ b/tests/stress/stress_test.py
@@ -85,7 +85,7 @@ class StressTestRunner:
         'couchbase:latest',
         'golang:latest',
         'iwane/numpy-matplotlib',
-        'jenkins:latest',
+        'jenkins:2.60.3',
         'larger/rdp:dev',
         'maven:latest',
         'mysql:latest',


### PR DESCRIPTION
### Reasons for making this change
jenkins:latest doesn't work anymore. Even though it exists [here](https://hub.docker.com/_/jenkins), `docker pull jenkins:latest` or `docker pull alpine` works neither locally nor on the dev server. I replaced it with a specific version tag according to this [article](https://vsupalov.com/docker-latest-tag/). 
<!-- Add a reason for making this change here. -->

### Related issues

<!-- Add a reference to issues resolved, if applicable (for example, "fixes #1"). -->

### Screenshots

<!-- Add screenshots, if necessary -->

### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
