### PR TITLE
Use a temporary CodaLabManager for unit tests

### DIFF
--- a/tests/unit/server/bundle_manager/__init__.py
+++ b/tests/unit/server/bundle_manager/__init__.py
@@ -68,7 +68,7 @@ class TestBase:
     """
 
     def setUp(self):
-        self.codalab_manager = CodaLabManager()
+        self.codalab_manager = CodaLabManager(temporary=True)
         self.codalab_manager.config['server']['class'] = 'SQLiteModel'
         self.bundle_manager = BundleManager(self.codalab_manager)
         self.download_manager = self.codalab_manager.download_manager()


### PR DESCRIPTION
### Reasons for making this change

When I was reviewing #3151, I realized that the transient CodaLabManager created before unit tests should also be set to `temporary=True`. This should make tests a bit faster, and it should also make it easier to parallelize tests in the future (plus it's best for unit tests to have no side effects).