### PR TITLE
Fix flaky datetime tests by freezing current time

### DIFF
--- a/tests/unit/rest/worksheets_test.py
+++ b/tests/unit/rest/worksheets_test.py
@@ -26,8 +26,8 @@ class WorksheetsTest(BaseTestCase):
                     "relationships": {
                         "items": {
                             "data": [
-                                {"type": "worksheet-items", "id": f"('name', '{worksheet_name}')",},
-                                {"type": "worksheet-items", "id": f"('uuid', '{worksheet_id}')",},
+                                {"type": "worksheet-items", "id": f"('name', '{worksheet_name}')"},
+                                {"type": "worksheet-items", "id": f"('uuid', '{worksheet_id}')"},
                             ]
                         }
                     },

--- a/tests/unit/rest/worksheets_test.py
+++ b/tests/unit/rest/worksheets_test.py
@@ -1,14 +1,18 @@
 import uuid
 from .base import BaseTestCase
 import datetime
+from freezegun import freeze_time
 
 
 class WorksheetsTest(BaseTestCase):
-    def test_create(self):
+    @freeze_time("2012-01-14", as_kwarg="frozen_time")
+    def test_create(self, frozen_time):
+        """Create a new worksheet, then ensure that the proper fields are returned.
+        """
         worksheet_name = f"codalab-{uuid.uuid4()}"
         response = self.app.post_json(
-            '/rest/worksheets',
-            {'data': [{'type': 'worksheets', 'attributes': {'name': worksheet_name}}]},
+            "/rest/worksheets",
+            {"data": [{"type": "worksheets", "attributes": {"name": worksheet_name}}]},
         )
         worksheet_id = response.json["data"][0]["id"]
         data = response.json["data"]
@@ -22,18 +26,17 @@ class WorksheetsTest(BaseTestCase):
                     "relationships": {
                         "items": {
                             "data": [
-                                {"type": "worksheet-items", "id": f"('name', '{worksheet_name}')"},
-                                {"type": "worksheet-items", "id": f"('uuid', '{worksheet_id}')"},
+                                {"type": "worksheet-items", "id": f"('name', '{worksheet_name}')",},
+                                {"type": "worksheet-items", "id": f"('uuid', '{worksheet_id}')",},
                             ]
                         }
                     },
                 }
             ],
         )
-        # Verify the date_created and date_last_modified field has been set to the current time for a new created worksheet
-        worksheet_info = self.app.get('/rest/interpret/worksheet/' + worksheet_id).json
-        date_created = datetime.datetime.strptime(worksheet_info['date_created'], '%Y-%m-%dT%H:%M:%S')
-        date_last_modified = datetime.datetime.strptime(worksheet_info['date_last_modified'], '%Y-%m-%dT%H:%M:%S')
-        current_time = datetime.datetime.utcnow()
-        self.assertAlmostEqual(current_time, date_created, delta=datetime.timedelta(seconds=1))
-        self.assertAlmostEqual(current_time, date_last_modified, delta=datetime.timedelta(seconds=1))
+
+        # Verify that the date_created and date_last_modified fields are set to the current time for a newly created worksheet.
+        worksheet_info = self.app.get("/rest/interpret/worksheet/" + worksheet_id).json
+        current_time = datetime.datetime.isoformat(frozen_time.time_to_freeze)
+        self.assertEqual(current_time, worksheet_info["date_created"])
+        self.assertEqual(current_time, worksheet_info["date_last_modified"])


### PR DESCRIPTION
### Reasons for making this change

Fixes #3162. Makes the datetime tests less flaky by freezing the current time to a fixed value (`2012-01-14`). This way, we can check for exact equality for the date created / date modified fields, so there's no chance of the test failing if the test runs slower than an interval such as 1s.