### PR TITLE
Fix log message when filtering out bundles in the worker manager code

### DIFF
--- a/codalab/worker_manager/worker_manager.py
+++ b/codalab/worker_manager/worker_manager.py
@@ -89,7 +89,7 @@ class WorkerManager(object):
 
     def __init__(self, args):
         self.args = args
-        self.codalab_manager = CodaLabManager(args.temp_session)
+        self.codalab_manager = CodaLabManager(temporary=args.temp_session)
         self.codalab_client = self.codalab_manager.client(args.server)
         self.staged_uuids = []
         self.worker_manager_start_time = time.time()

--- a/codalab/worker_manager/worker_manager.py
+++ b/codalab/worker_manager/worker_manager.py
@@ -294,7 +294,7 @@ class WorkerManager(object):
         worker_memory_bytes: int = parse_size('{}m'.format(self.args.memory_mb))
         logger.info(
             f"Current worker manager allocates {self.args.cpus} CPUs, {self.args.gpus} GPUs, "
-            "and {worker_memory_bytes} bytes of RAM"
+            f"and {worker_memory_bytes} bytes of RAM"
         )
         for bundle in bundles:
             # Filter bundles based on the resources specified when creating the worker manager


### PR DESCRIPTION
### Reasons for making this change

Log the memory of the workers when filtering out a bundle in `worker_manager.py`.
