### PR TITLE
Disable the terminal when focusing on the search bar

### DIFF
--- a/frontend/src/components/NavBar.js
+++ b/frontend/src/components/NavBar.js
@@ -141,8 +141,6 @@ class NavBar extends React.Component<{
         });
     }
 
-    handleChange = (e, { value }) => this.setState({ value });
-
     handleResultSelect = (e, { result }) => {
         this.setState({ value: result.plaintextTitle || result.plaintextDescription });
         window.open('/worksheets/' + result.uuid, '_self');
@@ -158,6 +156,19 @@ class NavBar extends React.Component<{
             )}
         </div>
     );
+
+    handleSearchFocus = () => {
+        // Disable the terminal to avoid the search bar text being mirrored in the terminal
+        if (
+            $('#command_line')
+                .terminal()
+                .enabled()
+        ) {
+            $('#command_line')
+                .terminal()
+                .focus(false);
+        }
+    };
 
     handleSearchChange = (e, { value }) => {
         this.setState({ isLoading: true, value });
@@ -325,6 +336,7 @@ class NavBar extends React.Component<{
                                     onSearchChange={_.debounce(this.handleSearchChange, 500, {
                                         leading: true,
                                     })}
+                                    onFocus={this.handleSearchFocus}
                                     placeholder='search worksheets...'
                                     resultRenderer={this.resultRenderer}
                                     results={results}


### PR DESCRIPTION
### Reasons for making this change

Previously, the search bar text will be automatically mirrored to the open terminal. It is because the terminal is still in an activated state when we move focus to the search bar.
Also, I removed the unused `handleChange` function.

### Related issues

fixes #2367 
### Screenshots

![ezgif com-gif-maker](https://user-images.githubusercontent.com/34461466/104395214-19b9d400-54fd-11eb-862e-4d9f760106fb.gif)


### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
