### PR TITLE
Remove period from "Download starting" status message

### DIFF
--- a/codalab/worker/docker_image_manager.py
+++ b/codalab/worker/docker_image_manager.py
@@ -42,7 +42,7 @@ class DockerImageManager:
         self._state_committer = JsonStateCommitter(commit_file)  # type: JsonStateCommitter
         self._docker = docker.from_env(timeout=DEFAULT_DOCKER_TIMEOUT)  # type: DockerClient
         self._downloading = ThreadDict(
-            fields={'success': False, 'status': 'Download starting.'}, lock=True
+            fields={'success': False, 'status': 'Download starting'}, lock=True
         )
         self._max_image_cache_size = max_image_cache_size
         self._max_image_size = max_image_size


### PR DESCRIPTION
### Reasons for making this change

Fixes #3184 -- all other run_status messages don't end with a period, and removing the period will also make the message look correct if we add parentheses after it, as in the issue.