### PR TITLE
Replace uid with username in dashboard URL

### DIFF
--- a/frontend/src/CodalabApp.js
+++ b/frontend/src/CodalabApp.js
@@ -112,11 +112,11 @@ function CodalabApp() {
                             />
                             <Route path='/bundles/:uuid' component={BundleRoute} />
                             <Route
-                                path='/dashboard/:uid'
+                                path='/users/:username'
                                 component={(props) => <DashboardRoute {...props} auth={fakeAuth} />}
                             />
                             <Route
-                                path='/dashboard'
+                                path='/users'
                                 render={(props) => <NewDashboard {...props} auth={fakeAuth} />}
                             />
                             <Route component={PageNotFound} />

--- a/frontend/src/components/Dashboard/NewDashboard.js
+++ b/frontend/src/components/Dashboard/NewDashboard.js
@@ -10,7 +10,7 @@ import { withRouter } from 'react-router';
  */
 class NewDashboard extends React.Component<{
     // ID of user.
-    uid: string,
+    username: string,
     classes: {},
     auth: {
         isAuthenticated: boolean,
@@ -26,7 +26,7 @@ class NewDashboard extends React.Component<{
         }
         this.state = {
             userInfo: null, // User info of the current user. (null is the default)
-            authUid: null, // User Id of the current authenticated user
+            authUsername: null, // User Id of the current authenticated user
             ownDashboard: false, // Whether the dashboard is owned by current user
         };
     }
@@ -40,19 +40,19 @@ class NewDashboard extends React.Component<{
             cache: false,
             type: 'GET',
             success: function(data) {
-                let authUid: String = data.data.id;
+                let authUsername: String = data.data.attributes.user_name;
                 // Redirect to current user's own dashboard
-                this.setState({ authUid: authUid });
+                this.setState({ authUsername: authUsername });
                 let ownDashboard: boolean;
-                if (!this.props.uid) {
-                    this.props.history.push('/dashboard/' + authUid);
+                if (!this.props.username) {
+                    this.props.history.push('/users/' + authUsername);
                     ownDashboard = true;
                 } else {
-                    ownDashboard = authUid === this.props.uid;
+                    ownDashboard = authUsername === this.props.username;
                 }
 
                 $.ajax({
-                    url: ownDashboard ? '/rest/user' : '/rest/users/' + this.props.uid,
+                    url: ownDashboard ? '/rest/user' : '/rest/users/' + this.props.username,
                     dataType: 'json',
                     cache: false,
                     type: 'GET',

--- a/frontend/src/components/Dashboard/SideBar.js
+++ b/frontend/src/components/Dashboard/SideBar.js
@@ -30,9 +30,6 @@ const styles = ({ spacing, palette }) => {
             '& > *:nth-child(1)': {
                 marginRight: 8,
             },
-            '& > *:nth-child(2)': {
-                flex: 'auto',
-            },
         },
         placeholderBox: {
             marginBottom: 800,

--- a/frontend/src/routes/DashboardRoute.js
+++ b/frontend/src/routes/DashboardRoute.js
@@ -12,16 +12,16 @@ class DashboardRoute extends React.Component<{
     /** Constructor. */
     constructor(props) {
         super(props);
-        const { uid } = this.props.match.params;
+        const { username } = this.props.match.params;
         this.state = {
-            uid,
+            username,
         };
     }
 
     /** Renderer. */
     render() {
-        const { uid } = this.props.match.params;
-        return <NewDahboard uid={uid} auth={this.props.auth} />;
+        const { username } = this.props.match.params;
+        return <NewDahboard username={username} auth={this.props.auth} />;
     }
 }
 


### PR DESCRIPTION
### Reasons for making this change

`https://worksheets.codalab.org/users/` to redirect to user's own dashboard;
`https://worksheets.codalab.org/users/<username>` to redirect to other user's dashboard.


### Related issues

fixes #3191 

### Screenshots

![image](https://user-images.githubusercontent.com/34461466/104831914-eac79900-5841-11eb-999a-f58eb2f8a74b.png)


### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
