### PR TITLE
Separate unit test to another row

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,8 +80,9 @@ jobs:
     strategy:
       matrix:
         test:
-          - unittest gen-rest-docs gen-cli-docs gen-readthedocs basic auth status batch anonymous competition unicode rest1 upload1 upload2 upload3 upload4 download refs binary rm make worksheet_search worksheet_tags freeze detach perm search_time groups
+          - gen-rest-docs gen-cli-docs gen-readthedocs basic auth status batch anonymous competition unicode rest1 upload1 upload2 upload3 upload4 download refs binary rm make worksheet_search worksheet_tags freeze detach perm search_time groups
           - worker_manager
+          - unittest
           - run
           - run2
           - search link read kill write mimic workers edit_user sharing_workers


### PR DESCRIPTION
### Reasons for making this change
Split the unit test to another row to improve the efficiency and debug-ability. 
Before the change, the time for unit tests and all the other tests in that line to finish is about 9m30s to 10m. 
After the change, the time for unit tests to finish is 4m and for other tests in that line to finish is 8m44s. 
<!-- Add a reason for making this change here. -->

### Related issues

<!-- Add a reference to issues resolved, if applicable (for example, "fixes #1"). -->

### Screenshots

<!-- Add screenshots, if necessary -->

### Checklist

* [ ] I've added a screenshot of the changes, if this is a frontend change
* [ ] I've added and/or updated tests, if this is a backend change
* [ ] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [ ] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
