### PR TITLE
Fix bug of cursoring with keyboard shortcut after cutting a bundle

### DIFF
--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -1056,6 +1056,7 @@ class Worksheet extends React.Component {
                     return;
                 }
                 this.toggleCmdDialogNoEvent('copy');
+                Mousetrap.reset();
             });
             if (this.state.ws.info.edit_permission) {
                 Mousetrap.bind(['backspace', 'del'], () => {

--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -1075,12 +1075,14 @@ class Worksheet extends React.Component {
                         return;
                     }
                     this.toggleCmdDialogNoEvent('kill');
+                    Mousetrap.reset();
                 });
                 Mousetrap.bind(['a d'], () => {
                     if (this.state.openedDialog) {
                         return;
                     }
                     this.toggleCmdDialogNoEvent('cut');
+                    Mousetrap.reset();
                 });
 
                 // Confirm bulk bundle operation


### PR DESCRIPTION
### Reasons for making this change

The bug is due to we use keyboard shortcut `a d` to cut a bundle, but `a` is not a standard modifier in Mousetrap, and there also exists a keyboard shortcut `a k`, so `a` is treated as `k` in Mousetrap's array. We need to reset the array after using the keyboard shortcut to avoid the cursoring was executed twice when we only press one `k`

### Related issues

fixes #3176 

### Screenshots

![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/34461466/105101002-0fe72200-5a63-11eb-8bea-4ef54a2242cd.gif)


### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
