### PR TITLE
Bump version to 0.5.35

### DIFF
--- a/codalab/common.py
+++ b/codalab/common.py
@@ -13,7 +13,7 @@ from retry import retry
 
 # Increment this on master when ready to cut a release.
 # http://semver.org/
-CODALAB_VERSION = '0.5.34'
+CODALAB_VERSION = '0.5.35'
 BINARY_PLACEHOLDER = '<binary>'
 URLOPEN_TIMEOUT_SECONDS = int(os.environ.get('CODALAB_URLOPEN_TIMEOUT_SECONDS', 5 * 60))
 

--- a/docs/REST-API-Reference.md
+++ b/docs/REST-API-Reference.md
@@ -1,6 +1,6 @@
 # REST API Reference
 
-_version 0.5.34_
+_version 0.5.35_
 
 This reference and the REST API itself is still under heavy development and is
 subject to change at any time. Feedback through our GitHub issues is appreciated!

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -1,5 +1,5 @@
 // Should match codalab/common.py#CODALAB_VERSION
-export const CODALAB_VERSION = '0.5.34';
+export const CODALAB_VERSION = '0.5.35';
 
 // Name Regex to match the backend in spec_utils.py
 export const NAME_REGEX = /^[a-zA-Z_][a-zA-Z0-9_.-]*$/i;

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import sys
 
 
 # should match codalab/common.py#CODALAB_VERSION
-CODALAB_VERSION = "0.5.34"
+CODALAB_VERSION = "0.5.35"
 
 
 class Install(install):

--- a/tests/stress/stress_test.py
+++ b/tests/stress/stress_test.py
@@ -114,54 +114,38 @@ class StressTestRunner:
     def run(self):
         print('Cleaning up stress test files from other runs...')
         cleanup(self._cl, StressTestRunner._TAG, should_wait=False)
-
         print('Running stress tests...')
         self._start_heartbeat()
-
-        self._test_large_bundle_result()
-        print('_test_large_bundle_result finished')
+        self._test_large_bundle()
+        print('_test_large_bundle finished')
         self.cleanup()
-
-        self._test_large_bundle_upload()
-        print('_test_large_bundle_upload finished')
-        self.cleanup()
-
         self._test_many_gpu_runs()
         print('_test_many_gpu_runs finished')
         self.cleanup()
-
         self._test_multiple_cpus_runs_count()
         print('_test_multiple_cpus_runs_count finished')
         self.cleanup()
-
         self._test_many_bundle_uploads()
         print('_test_many_bundle_uploads finished')
         self.cleanup()
-
         self._test_many_worksheet_copies()
         print('_test_many_worksheet_copies finished')
         self.cleanup()
-
         self._test_parallel_runs()
         print('_test_parallel_runs finished')
         self.cleanup()
-
         self._test_many_docker_runs()
         print('_test_many_docker_runs finished')
         self.cleanup()
-
         self._test_infinite_memory()
         print('_test_infinite_memory finished')
         self.cleanup()
-
         self._test_infinite_gpu()
         print('_test_infinite_gpu finished')
         self.cleanup()
-
         self._test_infinite_disk()
         print('_test_infinite_disk finished')
         self.cleanup()
-
         self._test_many_disk_writes()
         print('_test_many_disk_writes finished')
         self.cleanup()
@@ -185,38 +169,14 @@ class StressTestRunner:
             # Have heartbeat run every 30 seconds
             time.sleep(30)
 
-    def _test_large_bundle_result(self) -> None:
-        def create_large_file_in_bundle(large_file_size_gb: int) -> TestFile:
-            code: str = 'with open("largefile", "wb") as out:\n\tout.truncate({} * 1024 * 1024 * 1024)'.format(
-                large_file_size_gb
-            )
-            return TestFile('large_dependency.py', content=code)
-
-        self._set_worksheet('large_bundle_result')
-        file: TestFile = create_large_file_in_bundle(self._args.large_dependency_size_gb)
-        self._run_bundle([self._cl, 'upload', file.name()])
-        file.delete()
-
-        dependency_uuid: str = self._run_bundle(
-            [self._cl, 'run', ':' + file.name(), 'python ' + file.name()]
-        )
-        uuid: str = self._run_bundle(
-            [
-                self._cl,
-                'run',
-                'large_bundle:{}'.format(dependency_uuid),
-                'wc -c large_bundle/largefile',
-            ]
-        )
-        # Wait for the run to finish before cleaning up the dependency
-        run_command([cl, 'wait', uuid])
-
-    def _test_large_bundle_upload(self) -> None:
-        self._set_worksheet('large_bundle_upload')
-        large_file: TestFile = TestFile('large_file', self._args.large_file_size_gb * 1000)
-        dependency_uuid: str = self._run_bundle([self._cl, 'upload', large_file.name()])
+    def _test_large_bundle(self):
+        self._set_worksheet('large_bundles')
+        # Set this to larger than the max memory on the system to test that data is being
+        # streamed when the large bundle is being used as a dependency.
+        large_file = TestFile('large_file', self._args.large_file_size_gb * 1000)
+        dependency_uuid = self._run_bundle([self._cl, 'upload', large_file.name()])
         large_file.delete()
-        uuid: str = self._run_bundle(
+        uuid = self._run_bundle(
             [
                 self._cl,
                 'run',
@@ -366,9 +326,6 @@ def main():
 
     if args.heavy:
         print('Setting the heavy configuration...')
-        # Set the sizes of the large files to be bigger than the max memory on the system to test that data
-        # is being streamed when the large bundles are used as a dependencies.
-        args.large_dependency_size_gb = 16
         args.large_file_size_gb = 16
         args.gpu_runs_count = 50
         args.multiple_cpus_runs_count = 50
@@ -433,12 +390,6 @@ if __name__ == '__main__':
     )
 
     # Custom stress test runner arguments
-    parser.add_argument(
-        '--large-dependency-size-gb',
-        type=int,
-        help='Size of large dependency in GB (defaults to 1). Set this to larger than the max memory on the system to test that data is being streamed',
-        default=1,
-    )
     parser.add_argument(
         '--large-file-size-gb',
         type=int,


### PR DESCRIPTION
### Reasons for making this change

Bump new version

Full diff: https://github.com/codalab/codalab-worksheets/compare/v0.5.34...rc0.5.35

# Draft release notes

## Frontend
- Disable the terminal when focusing on the search bar (#3178)
- New Landing Page for Users (in beta, accessible through `/users` URL) (#3088, #3192) 
- Fix bug of pressing enter on image crashes (#3195) 

## Backend
- Remove period from "Download starting" status message (#3185) 
- Add ability to configure sentry environment (#3189)
- Get additional stats data from docker (#3081) 
- Expose slurm constraints to slurm batch worker manager (#3196)

## Dev / docs / CI
- Add messages to stress test (#3157) 
- Fix mock import (#3183)
- Add instructions for filling out the competition form (#3193) 
- Fix flaky BundlesTest (#3167)

