### PR TITLE
Fix slurm worker manager constraints

### DIFF
--- a/codalab/worker_manager/slurm_batch_worker_manager.py
+++ b/codalab/worker_manager/slurm_batch_worker_manager.py
@@ -408,7 +408,8 @@ class SlurmBatchWorkerManager(WorkerManager):
             gpu_gres_value += ":" + self.args.gpu_type
         gpu_gres_value += ":" + str(self.args.gpus)
         slurm_args['gres'] = gpu_gres_value
-        slurm_args['constraint'] = self.args.constraint
+        if self.args.constraint:
+            slurm_args['constraint'] = self.args.constraint
         # job-name is unique
         slurm_args['job-name'] = worker_id
         slurm_args['cpus-per-task'] = str(self.args.cpus)


### PR DESCRIPTION
The current logic breaks if constraints aren't provided.