### PR TITLE
Provide better UI response to the `rm` cmd

### DIFF
--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -318,7 +318,7 @@ class Worksheet extends React.Component {
         let force_delete = cmd === 'rm' && this.state.forceDelete ? '--force' : null;
         this.setState({ updating: true });
         const bundleCount: number = Object.keys(this.state.uuidBundlesCheckedCount).length;
-        // The toast info is used for showing message when a command being command
+        // This toast info is used for showing a message when a command is being performed
         const toastId = toast.info(this._getToastMsg(cmd, 0, bundleCount), {
             position: 'top-right',
             hideProgressBar: false,

--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -336,7 +336,7 @@ class Worksheet extends React.Component {
         )
             .done(() => {
                 this.clearCheckedBundles(() => {
-                    // The toast info is used for showing message when a command has already been executed
+                    // This toast info is used for showing a message when a command has finished executing
                     toast.update(toastId, {
                         render: this._getToastMsg(cmd, 1, bundleCount),
                         type: toast.TYPE.SUCCESS,

--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -303,8 +303,22 @@ class Worksheet extends React.Component {
         // The uuid are recorded by handleCheckBundle
         // Refreshes the checkbox after commands
         // If the action failed, the check will persist
+        const cmdMsgMap: { string: string } = { rm: ['deleting', 'deleted'] };
         let force_delete = cmd === 'rm' && this.state.forceDelete ? '--force' : null;
         this.setState({ updating: true });
+        let toastMsg =
+            (cmd in cmdMsgMap
+                ? Object.keys(this.state.uuidBundlesCheckedCount).length +
+                  ' bundles ' +
+                  cmdMsgMap[cmd][0]
+                : 'Executing ' + cmd + ' command') + '...';
+        const toastId = toast.info(toastMsg, {
+            position: 'top-right',
+            hideProgressBar: false,
+            closeOnClick: true,
+            pauseOnHover: false,
+            draggable: true,
+        });
         executeCommand(
             buildTerminalCommand([
                 cmd,
@@ -314,8 +328,17 @@ class Worksheet extends React.Component {
             worksheet_uuid,
         )
             .done(() => {
+                toastMsg =
+                    (cmd in cmdMsgMap
+                        ? Object.keys(this.state.uuidBundlesCheckedCount).length +
+                          ' bundles ' +
+                          cmdMsgMap[cmd][1]
+                        : 'Executed ' + cmd + ' command') + '!';
+
                 this.clearCheckedBundles(() => {
-                    toast.info('Executing ' + cmd + ' command', {
+                    toast.update(toastId, {
+                        render: toastMsg,
+                        type: toast.TYPE.SUCCESS,
                         position: 'top-right',
                         autoClose: 2000,
                         hideProgressBar: true,

--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -299,6 +299,8 @@ class Worksheet extends React.Component {
     };
 
     _getToastMsg = (command, state, count) => {
+        // Creates a toast message for a given command.
+        // count is the number of bundles on which this command was performed, if applicable.
         // state can take the value of 0 or 1
         // 0 represents the command is being executed
         // 1 represents the command has already been executed


### PR DESCRIPTION
### Reasons for making this change

- Message box should show up immediately so the user knows what's happening and disappear when the operation is complete.  
- Friendlier message content

Solution:
- When the `rm` cmd is being executed: "xx bundles deleting...", in an info message box.
- When the `rm` cmd has been executed: "xx bundles deleted!", in a success message box.

### Related issues

fixes #3177 

### Screenshots

![ezgif com-gif-maker](https://user-images.githubusercontent.com/34461466/105453365-dc5bf180-5c34-11eb-82ab-be1247dd59eb.gif)


### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
