### PR TITLE
Bundle status refresh endpoint refreshes only the specified bundle 

### DIFF
--- a/codalab/rest/interpret.py
+++ b/codalab/rest/interpret.py
@@ -300,17 +300,17 @@ def fetch_interpreted_worksheet(uuid):
     # The bundle_infos for bundles that don't need updating are also None.
     if bundle_uuids:
         for i, block in enumerate(interpreted_blocks['blocks']):
-            if 'bundle_info' not in block:
+            if not ('bundles_spec' in block and 'bundle_infos' in block['bundles_spec']):
                 interpreted_blocks['blocks'][i] = None
             else:
-                if isinstance(block['bundle_info'], dict):
-                    block['bundle_info'] = [block['bundle_info']]
+                if isinstance(block['bundles_spec']['bundle_infos'], dict):
+                    block['bundles_spec']['bundle_infos'] = [block['bundles_spec']['bundle_infos']]
                 is_relevant_block = False
-                for j, bundle in enumerate(block['bundle_info']):
+                for j, bundle in enumerate(block['bundles_spec']['bundle_infos']):
                     if bundle['uuid'] in bundle_uuids:
                         is_relevant_block = True
                     else:
-                        block['bundle_info'][j] = None
+                        block['bundles_spec']['bundle_infos'][j] = None
                 if not is_relevant_block:
                     interpreted_blocks['blocks'][i] = None
     # Grouped individual items into blocks
@@ -347,7 +347,7 @@ def fetch_interpreted_worksheet(uuid):
     # Frontend doesn't use individual 'items' for now
     del worksheet_info['items']
     if bundle_uuids:
-        return {'blocks': worksheet_info['blocks']}
+        return {'blocks': worksheet_info['blocks'], 'uuid': uuid}
     return worksheet_info
 
 

--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -1531,6 +1531,8 @@ class Worksheet extends React.Component {
                         'bundle_infos' in partialUpdateItems[i]['bundles_spec']
                     )
                 )
+                    // Partial Update mechanism only designs for the blocks consisting of bundles
+                    // Check whether the block contains the field of 'bundle_infos' to determine whether it is a non-None block containing a list of bundle_infos, which represent a list of bundles
                     continue;
                 // Update rows
                 ws.info.blocks[i]['rows'] = partialUpdateItems[i]['rows'];

--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -1211,7 +1211,6 @@ class Worksheet extends React.Component {
             dataType: 'json',
             cache: false,
             success: function(worksheet_content) {
-                console.log('content: ', worksheet_content);
                 if (this.state.isUpdatingBundles && worksheet_content.uuid === this.state.ws.uuid) {
                     if (worksheet_content.blocks) {
                         self.reloadWorksheet(worksheet_content.blocks);

--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -1202,7 +1202,7 @@ class Worksheet extends React.Component {
         var self = this;
         var queryParams = Object.keys(bundleUuids)
             .map(function(bundle_uuid) {
-                return 'uuid=' + bundle_uuid;
+                return 'bundle_uuid=' + bundle_uuid;
             })
             .join('&');
         $.ajax({
@@ -1211,6 +1211,7 @@ class Worksheet extends React.Component {
             dataType: 'json',
             cache: false,
             success: function(worksheet_content) {
+                console.log('content: ', worksheet_content);
                 if (this.state.isUpdatingBundles && worksheet_content.uuid === this.state.ws.uuid) {
                     if (worksheet_content.blocks) {
                         self.reloadWorksheet(worksheet_content.blocks);
@@ -1524,9 +1525,25 @@ class Worksheet extends React.Component {
         } else {
             var ws = _.clone(this.state.ws);
             for (var i = 0; i < partialUpdateItems.length; i++) {
-                if (!partialUpdateItems[i]) continue;
+                if (
+                    !partialUpdateItems[i] ||
+                    !(
+                        'bundles_spec' in partialUpdateItems[i] &&
+                        'bundle_infos' in partialUpdateItems[i]['bundles_spec']
+                    )
+                )
+                    continue;
+                // Update rows
                 // update interpreted items
-                ws.info.blocks[i] = partialUpdateItems[i];
+                for (
+                    let j = 0;
+                    j < partialUpdateItems[i]['bundles_spec']['bundle_infos'].length;
+                    j++
+                ) {
+                    if (partialUpdateItems[i]['bundles_spec']['bundle_infos'][j])
+                        ws.info.blocks[i]['bundles_spec']['bundle_infos'][j] =
+                            partialUpdateItems[i]['bundles_spec']['bundle_infos'][j];
+                }
             }
             this.setState({ ws: ws, version: this.state.version + 1 });
             this.checkRunBundle(ws.info);

--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -1534,6 +1534,7 @@ class Worksheet extends React.Component {
                 )
                     continue;
                 // Update rows
+                ws.info.blocks[i]['rows'] = partialUpdateItems[i]['rows'];
                 // update interpreted items
                 for (
                     let j = 0;

--- a/tests/unit/rest/worksheets_test.py
+++ b/tests/unit/rest/worksheets_test.py
@@ -40,3 +40,94 @@ class WorksheetsTest(BaseTestCase):
         current_time = datetime.datetime.isoformat(frozen_time.time_to_freeze)
         self.assertEqual(current_time, worksheet_info["date_created"])
         self.assertEqual(current_time, worksheet_info["date_last_modified"])
+
+    def test_refresh(self):
+        """Upload 3 bundles to a worksheet, then specify a bundle_uuid to refresh, only the queried bundle info should be returned
+        """
+        worksheet_id = self.create_worksheet()
+        body = {
+            'data': [
+                {
+                    'type': 'bundles',
+                    'attributes': {
+                        'bundle_type': 'run',
+                        'command': 'echo TEST',
+                        'metadata': {
+                            'name': 'run-echo',
+                            'description': '',
+                            'tags': [''],
+                            'allow_failed_dependencies': False,
+                            'request_docker_image': 'codalab/default-cpu:latest',
+                            'request_time': '',
+                            'request_memory': '4g',
+                            'request_disk': '',
+                            'request_cpus': 1,
+                            'request_gpus': 0,
+                            'request_queue': '',
+                            'request_priority': 0,
+                            'request_network': False,
+                            'exclude_patterns': [],
+                        },
+                        'dependencies': [],
+                    },
+                },
+                {
+                    'type': 'bundles',
+                    'attributes': {
+                        'bundle_type': 'run',
+                        'command': 'echo TEST',
+                        'metadata': {
+                            'name': 'run-echo',
+                            'description': '',
+                            'tags': [''],
+                            'allow_failed_dependencies': False,
+                            'request_docker_image': 'codalab/default-cpu:latest',
+                            'request_time': '',
+                            'request_memory': '4g',
+                            'request_disk': '',
+                            'request_cpus': 1,
+                            'request_gpus': 0,
+                            'request_queue': '',
+                            'request_priority': 0,
+                            'request_network': False,
+                            'exclude_patterns': [],
+                        },
+                        'dependencies': [],
+                    },
+                },
+                {
+                    'type': 'bundles',
+                    'attributes': {
+                        'bundle_type': 'run',
+                        'command': 'echo TEST',
+                        'metadata': {
+                            'name': 'run-echo',
+                            'description': '',
+                            'tags': [''],
+                            'allow_failed_dependencies': False,
+                            'request_docker_image': 'codalab/default-cpu:latest',
+                            'request_time': '',
+                            'request_memory': '4g',
+                            'request_disk': '',
+                            'request_cpus': 1,
+                            'request_gpus': 0,
+                            'request_queue': '',
+                            'request_priority': 0,
+                            'request_network': False,
+                            'exclude_patterns': [],
+                        },
+                        'dependencies': [],
+                    },
+                }
+            ]
+        }
+        response = self.app.post_json(f'/rest/bundles?worksheet={worksheet_id}', body)
+        self.assertEqual(response.status_int, 200)
+        data = response.json["data"]
+        bundle_id = data[0]["id"]
+
+        # Verify that only the queried bundle info should be returned, so there will only be 1 non-null element in the block_infos
+        refreshed_bundles = self.app.get("/rest/interpret/worksheet/" + worksheet_id + "?bundle_uuid=" + bundle_id).json
+        blocks_info = refreshed_bundles["blocks"][0]["bundles_spec"]["bundle_infos"]
+        bundles_count = sum(1 for bundle in blocks_info if bundle)
+        self.assertEqual(1, bundles_count)


### PR DESCRIPTION
### Reasons for making this change

We had a `partial update` mechanism in our system, however, it seems like this mechanism lost consistency between backend and frontend during the development, so even if a bundle status refresh endpoint always refreshes the entire worksheet. Now the bugs are fixed and only the bundles that need updating aren't `None` during network transmission.

### Related issues

fixes #1999 

### Screenshots
Before: 
<img width="1143" alt="Screen Shot 2021-01-24 at 6 54 41 PM" src="https://user-images.githubusercontent.com/34461466/105656309-c0e02900-5e76-11eb-9dcc-7d1d030c812d.png">

After:
<img width="1147" alt="Screen Shot 2021-01-24 at 6 53 16 PM" src="https://user-images.githubusercontent.com/34461466/105656327-cb9abe00-5e76-11eb-98b8-ff3cb086f780.png">
<img width="988" alt="Screen Shot 2021-01-24 at 6 47 10 PM" src="https://user-images.githubusercontent.com/34461466/105656334-ce95ae80-5e76-11eb-96c6-e21653d2daab.png">



### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
