### PR TITLE
Fix none concatenation error when interpreting worksheet

### DIFF
--- a/codalab/lib/worksheet_util.py
+++ b/codalab/lib/worksheet_util.py
@@ -412,7 +412,7 @@ def interpret_genpath(bundle_info, genpath, db_model=None, owner_cache=None):
     elif genpath == 'summary':
 
         def friendly_render_dep(dep):
-            key = dep['child_path'] or dep['parent_name']
+            key = dep['child_path'] or dep['parent_name'] or ''
             friendly_parent_name = formatting.verbose_contents_str(dep['parent_name'])
             value = (
                 key

--- a/codalab/lib/worksheet_util.py
+++ b/codalab/lib/worksheet_util.py
@@ -412,7 +412,7 @@ def interpret_genpath(bundle_info, genpath, db_model=None, owner_cache=None):
     elif genpath == 'summary':
 
         def friendly_render_dep(dep):
-            key = dep['child_path'] or dep['parent_name'] or ''
+            key = dep['child_path'] or dep['parent_name']
             friendly_parent_name = formatting.verbose_contents_str(dep['parent_name'])
             value = "%s{%s%s}" % (
                 key,

--- a/codalab/lib/worksheet_util.py
+++ b/codalab/lib/worksheet_util.py
@@ -414,12 +414,10 @@ def interpret_genpath(bundle_info, genpath, db_model=None, owner_cache=None):
         def friendly_render_dep(dep):
             key = dep['child_path'] or dep['parent_name'] or ''
             friendly_parent_name = formatting.verbose_contents_str(dep['parent_name'])
-            value = (
-                key
-                + '{'
-                + (friendly_parent_name + ':' if key != dep['parent_name'] else '')
-                + dep['parent_uuid'][0:4]
-                + '}'
+            value = "%s{%s%s}" % (
+                key,
+                friendly_parent_name + ':' if key != dep['parent_name'] else '',
+                dep['parent_uuid'][0:4],
             )
             return key, value
 


### PR DESCRIPTION
### Reasons for making this change

Fixes #3217. I'm not sure exactly when / why this issue is happening, but `key` is the only possible variable here that can be equal to `None`, so we might as well just give it a fallback to a string "None" if it is equal to `None` so that it doesn't cause this error.
