### PR TITLE
[DRAFT] Give default values to cpu_usage and memory_limit

### DIFF
--- a/codalab/bundles/run_bundle.py
+++ b/codalab/bundles/run_bundle.py
@@ -37,9 +37,9 @@ class RunBundle(DerivedBundle):
                                                                 'priority bundles are queued behind bundles with no specified priority.', default=None))
     METADATA_SPECS.append(MetadataSpec('request_network', bool, 'Whether to allow network access.', default=False))
     METADATA_SPECS.append(
-        MetadataSpec('cpu_usage', float, 'Portion of CPU used by this container (e.g., 0.24)', generated=True))
+        MetadataSpec('cpu_usage', float, 'Portion of CPU used by this container (e.g., 0.24)', default=0.0, generated=True))
     METADATA_SPECS.append(
-        MetadataSpec('memory_limit', int, 'Limit of Memory available to this container (e.g., 2085326848)', generated=True))
+        MetadataSpec('memory_limit', int, 'Limit of Memory available to this container (e.g., 2085326848)', default=0, generated=True))
 
     METADATA_SPECS.append(MetadataSpec('exclude_patterns', list, 'Exclude these file patterns from being saved into the bundle contents.', default=[]))
 

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -928,6 +928,14 @@ class BundleModel(object):
             worker_run_row = {'user_id': user_id, 'worker_id': worker_id, 'run_uuid': bundle.uuid}
             connection.execute(cl_worker_run.insert().values(worker_run_row))
 
+        cpu_usage: float = 0.0
+        if 'cpu_usage' in worker_run.as_dict:
+            cpu_usage = worker_run.cpu_usage
+
+        memory_limit: int = 0
+        if 'memory_limit' in worker_run.as_dict:
+            memory_limit = worker_run.memory_limit
+
         metadata_update = {
             'run_status': worker_run.run_status,
             'last_updated': int(time.time()),
@@ -935,8 +943,8 @@ class BundleModel(object):
             'time_user': worker_run.container_time_user,
             'time_system': worker_run.container_time_system,
             'remote': worker_run.remote,
-            'cpu_usage': worker_run.cpu_usage,  # > type: float
-            'memory_limit': worker_run.memory_limit,  # > type: int
+            'cpu_usage': cpu_usage,
+            'memory_limit': memory_limit,
         }
 
         if worker_run.docker_image is not None:


### PR DESCRIPTION
### Reasons for making this change
Give default values to cpu_usage and memory_limit when they are missing, in case that workers are not updated so the values are not added. 
<!-- Add a reason for making this change here. -->

### Related issues
#3217 
<!-- Add a reference to issues resolved, if applicable (for example, "fixes #1"). -->

### Screenshots

<!-- Add screenshots, if necessary -->

### Checklist

* [ ] I've added a screenshot of the changes, if this is a frontend change
* [ ] I've added and/or updated tests, if this is a backend change
* [ ] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [ ] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
