### PR TITLE
Add logging for common tasks

### DIFF
--- a/codalab/worker/main.py
+++ b/codalab/worker/main.py
@@ -209,7 +209,7 @@ def main():
 
     # Configure logging
     logging.basicConfig(
-        format='%(asctime)s %(message)s', level=(logging.DEBUG if args.verbose else logging.INFO)
+        format='%(asctime)s %(message)s %(pathname)s %(lineno)d', level=(logging.DEBUG if args.verbose else logging.INFO)
     )
 
     logging.getLogger('urllib3').setLevel(logging.INFO)

--- a/codalab/worker/main.py
+++ b/codalab/worker/main.py
@@ -214,7 +214,6 @@ def main():
     )
 
     logging.getLogger('urllib3').setLevel(logging.INFO)
-
     # Initialize sentry logging
     if using_sentry():
         initialize_sentry()

--- a/codalab/worker/main.py
+++ b/codalab/worker/main.py
@@ -209,7 +209,8 @@ def main():
 
     # Configure logging
     logging.basicConfig(
-        format='%(asctime)s %(message)s %(pathname)s %(lineno)d', level=(logging.DEBUG if args.verbose else logging.INFO)
+        format='%(asctime)s %(message)s %(pathname)s %(lineno)d',
+        level=(logging.DEBUG if args.verbose else logging.INFO),
     )
 
     logging.getLogger('urllib3').setLevel(logging.INFO)

--- a/codalab/worker/worker.py
+++ b/codalab/worker/worker.py
@@ -27,7 +27,6 @@ from .bundle_state import BundleInfo, RunResources, BundleCheckinState
 from .worker_run_state import RunStateMachine, RunStage, RunState
 from .reader import Reader
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 """
 Codalab Worker

--- a/codalab/worker/worker.py
+++ b/codalab/worker/worker.py
@@ -27,6 +27,7 @@ from .bundle_state import BundleInfo, RunResources, BundleCheckinState
 from .worker_run_state import RunStateMachine, RunStage, RunState
 from .reader import Reader
 
+logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 """
 Codalab Worker

--- a/codalab/worker/worker_run_state.py
+++ b/codalab/worker/worker_run_state.py
@@ -205,7 +205,10 @@ class RunStateMachine(StateTransitioner):
             #   dependency_path:docker_dependency_path:ro
             docker_dependencies.append((dependency.parent_path, dependency.docker_path))
 
+        logger.info(f'{run_state.bundle.uuid} is preparing')
+
         if run_state.is_killed or run_state.is_restaged:
+            logger.info(f'{run_state.bundle.uuid} is cleaning up')
             return run_state._replace(stage=RunStage.CLEANING_UP)
 
         # Check CPU and GPU availability
@@ -219,6 +222,7 @@ class RunStateMachine(StateTransitioner):
             )
             logger.error(message)
             logger.error(traceback.format_exc())
+            logger.info(f'{run_state.bundle.uuid} is changing state to {message}')
             return run_state._replace(run_status=message)
 
         dependencies_ready = True
@@ -238,6 +242,7 @@ class RunStateMachine(StateTransitioner):
                     dependencies_ready = False
                 elif dependency_state.stage == DependencyStage.FAILED:
                     # Failed to download dependency; -> CLEANING_UP
+                    logger.info(f'{run_state.bundle.uuid} is cleaning up')
                     return run_state._replace(
                         stage=RunStage.CLEANING_UP,
                         failure_message='Failed to download dependency %s: %s'
@@ -256,6 +261,7 @@ class RunStateMachine(StateTransitioner):
             # Failed to pull image; -> CLEANING_UP
             message = 'Failed to download Docker image: %s' % image_state.message
             logger.error(message)
+            logger.info(f'{run_state.bundle.uuid} is cleaning up')
             return run_state._replace(stage=RunStage.CLEANING_UP, failure_message=message)
 
         # stop proceeding if dependency and image downloads aren't all done
@@ -265,6 +271,7 @@ class RunStateMachine(StateTransitioner):
                 status_message += "(and downloading %d other dependencies and docker images)" % len(
                     status_messages
                 )
+            logger.info(f'{run_state.bundle.uuid} is changing state to {status_message}')
             return run_state._replace(run_status=status_message)
 
         # All dependencies ready! Set up directories, symlinks and container. Start container.
@@ -278,7 +285,13 @@ class RunStateMachine(StateTransitioner):
                         "your worker is mounted properly or contact your administrators."
                     )
                     logger.error(message)
+                    logger.info(
+                        f'{run_state.bundle.uuid} is cleaning up and changing state to {message}'
+                    )
                     return run_state._replace(stage=RunStage.CLEANING_UP, failure_message=message)
+                logger.info(
+                    f'{run_state.bundle.uuid} is waiting for bundle directory to be created by the server'
+                )
                 return run_state._replace(
                     run_status="Waiting for bundle directory to be created by the server",
                     bundle_dir_wait_num_tries=run_state.bundle_dir_wait_num_tries - 1,
@@ -333,6 +346,9 @@ class RunStateMachine(StateTransitioner):
                 try:
                     mount_dependency(dependency, self.shared_file_system)
                 except OSError as e:
+                    logger.info(
+                        f'{run_state.bundle.uuid} is cleaning up and changing state to {str(e)}'
+                    )
                     return run_state._replace(stage=RunStage.CLEANING_UP, failure_message=str(e))
 
         if run_state.resources.network:
@@ -358,6 +374,7 @@ class RunStateMachine(StateTransitioner):
         except docker_utils.DockerUserErrorException as e:
             message = 'Cannot start Docker container: {}'.format(e)
             logger.warning(message)
+            logger.info(f'{run_state.bundle.uuid} is cleaning up and changing state to {message}')
             return run_state._replace(stage=RunStage.CLEANING_UP, failure_message=message)
         except Exception as e:
             message = 'Cannot start Docker container: {}'.format(e)
@@ -395,9 +412,11 @@ class RunStateMachine(StateTransitioner):
         2- If run is killed, kill the container
         3- If run is finished, move to CLEANING_UP state
         """
+        logger.info(f'{run_state.bundle.uuid} is running')
 
         def check_and_report_finished(run_state):
             try:
+                logger.info(f'{run_state.bundle.uuid} is checking finished')
                 finished, exitcode, failure_msg = docker_utils.check_finished(run_state.container)
             except docker_utils.DockerException:
                 logger.error(traceback.format_exc())
@@ -406,7 +425,15 @@ class RunStateMachine(StateTransitioner):
                 finished=finished, exitcode=exitcode, failure_message=failure_msg
             )
 
-        def check_resource_utilization(run_state):
+
+        def check_resource_utilization(run_state: RunState):
+            logger.info(f'{run_state.bundle.uuid} is checking resource utilization')
+            cpu_usage, memory_limit = docker_utils.get_container_stats_with_docker_stats(
+                run_state.container
+            )
+            run_state = run_state._replace(cpu_usage=cpu_usage)
+            run_state = run_state._replace(memory_limit=memory_limit)
+
             kill_messages = []
 
             run_stats = docker_utils.get_container_stats(run_state.container)
@@ -450,6 +477,7 @@ class RunStateMachine(StateTransitioner):
             return run_state
 
         def check_disk_utilization():
+            logger.info(f'{run_state.bundle.uuid} is checking disk utilization')
             running = True
             while running:
                 start_time = time.time()
@@ -506,6 +534,7 @@ class RunStateMachine(StateTransitioner):
             move to UPLOADING_RESULTS state
            Otherwise move to FINALIZING state
         """
+        logger.info(f'{run_state.bundle.uuid} is cleaning up')
 
         def remove_path_no_fail(path):
             try:
@@ -571,6 +600,7 @@ class RunStateMachine(StateTransitioner):
         If uploading and finished:
             Move to FINALIZING state
         """
+        logger.info(f'{run_state.bundle.uuid} is uploading results')
         if run_state.is_restaged:
             return run_state._replace(stage=RunStage.RESTAGED)
 
@@ -635,6 +665,7 @@ class RunStateMachine(StateTransitioner):
                 if run_state.failure_message
                 else run_state.kill_message
             )
+            logger.info(f'{run_state.bundle.uuid} is killed')
             run_state = run_state._replace(failure_message=failure_message)
         return run_state._replace(stage=RunStage.FINALIZING, run_status="Finalizing bundle")
 
@@ -644,11 +675,14 @@ class RunStateMachine(StateTransitioner):
         server, if bundle is going be sent back to the server, move on to the RESTAGED state. Otherwise,
         move on to the FINISHED state. Can also remove bundle_path now.
         """
+        logger.info(f'{run_state.bundle.uuid} is finalizing')
         if run_state.is_restaged:
+            logger.info(f'{run_state.bundle.uuid} is restaged')
             return run_state._replace(stage=RunStage.RESTAGED)
         elif run_state.finalized:
             if not self.shared_file_system:
                 remove_path(run_state.bundle_path)  # don't remove bundle if shared FS
+            logger.info(f'{run_state.bundle.uuid} is finished')
             return run_state._replace(stage=RunStage.FINISHED, run_status='Finished')
         else:
             return run_state

--- a/codalab/worker/worker_run_state.py
+++ b/codalab/worker/worker_run_state.py
@@ -428,12 +428,6 @@ class RunStateMachine(StateTransitioner):
 
         def check_resource_utilization(run_state: RunState):
             logger.info(f'{run_state.bundle.uuid} is checking resource utilization')
-            cpu_usage, memory_limit = docker_utils.get_container_stats_with_docker_stats(
-                run_state.container
-            )
-            run_state = run_state._replace(cpu_usage=cpu_usage)
-            run_state = run_state._replace(memory_limit=memory_limit)
-
             kill_messages = []
 
             run_stats = docker_utils.get_container_stats(run_state.container)

--- a/codalab/worker/worker_run_state.py
+++ b/codalab/worker/worker_run_state.py
@@ -128,9 +128,10 @@ DependencyToMount = namedtuple('DependencyToMount', 'docker_path, child_path, pa
 def log_bundle_transition(
     bundle_uuid: str, previous_state: str, next_state: str, reason: str, warn: bool = False
 ):
-    logger.info(
-        f'Bundle {bundle_uuid} is transitioning from {previous_state} to {next_state} due to {reason}'
-    )
+    info = f'Bundle {bundle_uuid} is transitioning from {previous_state} to {next_state}'
+    if reason != '':
+        info = info + f' due to: {reason}'
+    logger.info(info)
     if warn:
         logger.warning(traceback.format_exc())
 
@@ -222,7 +223,7 @@ class RunStateMachine(StateTransitioner):
                 run_state.bundle.uuid,
                 run_state.stage,
                 RunStage.CLEANING_UP,
-                'the bundle is either killed or restaged.',
+                'The bundle is either killed or restaged.',
                 True,
             )
             return run_state._replace(stage=RunStage.CLEANING_UP)
@@ -261,7 +262,7 @@ class RunStateMachine(StateTransitioner):
                         run_state.bundle.uuid,
                         run_state.stage,
                         RunStage.CLEANING_UP,
-                        f'dependency key {dep_key} has failed for this bundle',
+                        f'Dependency {dep} has failed for this bundle',
                         True,
                     )
                     return run_state._replace(

--- a/codalab/worker/worker_run_state.py
+++ b/codalab/worker/worker_run_state.py
@@ -293,7 +293,9 @@ class RunStateMachine(StateTransitioner):
                 status_message += "(and downloading %d other dependencies and docker images)" % len(
                     status_messages
                 )
-            logger.info(f'{run_state.bundle.uuid} is not ready yet since {status_message}')
+            logger.info(
+                f'bundle is not ready yet. uuid: {run_state.bundle.uuid}. status message: {status_message}'
+            )
             return run_state._replace(run_status=status_message)
 
         # All dependencies ready! Set up directories, symlinks and container. Start container.
@@ -458,7 +460,7 @@ class RunStateMachine(StateTransitioner):
             )
 
         def check_resource_utilization(run_state: RunState):
-            logger.info(f'Checking resource utilization for {run_state.bundle.uuid}')
+            logger.info(f'Checking resource utilization for bundle. uuid: {run_state.bundle.uuid}')
             kill_messages = []
 
             run_stats = docker_utils.get_container_stats(run_state.container)
@@ -502,7 +504,7 @@ class RunStateMachine(StateTransitioner):
             return run_state
 
         def check_disk_utilization():
-            logger.info(f'Checking disk utilization for {run_state.bundle.uuid}')
+            logger.info(f'Checking disk utilization for bundle. uuid: {run_state.bundle.uuid}')
             running = True
             while running:
                 start_time = time.time()
@@ -687,13 +689,15 @@ class RunStateMachine(StateTransitioner):
             # upload failed
             failure_message = run_state.failure_message
             if failure_message:
-                failure_message = f'{failure_message}. {self.uploading[run_state.bundle.uuid]["run_status"]}'
+                failure_message = (
+                    f'{failure_message}. {self.uploading[run_state.bundle.uuid]["run_status"]}'
+                )
             else:
                 failure_message = self.uploading[run_state.bundle.uuid]['run_status']
-            logger.info(f'upload failed, uuid: {run_state.bundle.uuid}. failure message: {failure_message}')
-            run_state = run_state._replace(
-                failure_message=failure_message
+            logger.info(
+                f'Upload failed. uuid: {run_state.bundle.uuid}. failure message: {failure_message}'
             )
+            run_state = run_state._replace(failure_message=failure_message)
 
         self.uploading.remove(run_state.bundle.uuid)
         return self.finalize_run(run_state)
@@ -713,7 +717,7 @@ class RunStateMachine(StateTransitioner):
                 bundle_uuid=run_state.bundle.uuid,
                 previous_stage=run_state.stage,
                 next_stage=RunStage.FINALIZING,
-                reason=f'Bundle is killed. uuid: {run_state.bundle.uuid}. failure message: {failure_message}'
+                reason=f'Bundle is killed. uuid: {run_state.bundle.uuid}. failure message: {failure_message}',
             )
             run_state = run_state._replace(failure_message=failure_message)
         else:

--- a/codalab/worker/worker_run_state.py
+++ b/codalab/worker/worker_run_state.py
@@ -152,7 +152,7 @@ class RunStateMachine(StateTransitioner):
 
     _ROOT = '/'
     _CURRENT_DIRECTORY = '.'
-    RESTAGEG_REASON = 'The bundle is not in terminal states {READY, FAILED, KILLED} when the worker checks termination'
+    RESTAGED_REASON = 'The bundle is not in terminal states {READY, FAILED, KILLED} when the worker checks termination'
 
     def __init__(
         self,
@@ -403,7 +403,7 @@ class RunStateMachine(StateTransitioner):
             )
             self.worker_docker_network.connect(container)
         except docker_utils.DockerUserErrorException as e:
-            message = 'Cannot start Docker container.'.format(e)
+            message = 'Cannot start Docker container: {}'.format(e)
             log_bundle_transition(
                 bundle_uuid=run_state.bundle.uuid,
                 previous_stage=run_state.stage,
@@ -607,7 +607,7 @@ class RunStateMachine(StateTransitioner):
                 bundle_uuid=run_state.bundle.uuid,
                 previous_stage=run_state.stage,
                 next_stage=RunStage.RESTAGED,
-                reason=self.RESTAGEG_REASON,
+                reason=self.RESTAGED_REASON,
             )
             return run_state._replace(stage=RunStage.RESTAGED)
 
@@ -648,7 +648,7 @@ class RunStateMachine(StateTransitioner):
                 bundle_uuid=run_state.bundle.uuid,
                 previous_stage=run_state.stage,
                 next_stage=RunStage.RESTAGED,
-                reason=self.RESTAGEG_REASON,
+                reason=self.RESTAGED_REASON,
             )
             return run_state._replace(stage=RunStage.RESTAGED)
 

--- a/codalab/worker/worker_run_state.py
+++ b/codalab/worker/worker_run_state.py
@@ -152,7 +152,7 @@ class RunStateMachine(StateTransitioner):
 
     _ROOT = '/'
     _CURRENT_DIRECTORY = '.'
-    RESTAGE_COMMON_REASON = 'The bundle is not in terminal states {READY, FAILED, KILLED} when the worker checks termination'
+    RESTAGEG_REASON = 'The bundle is not in terminal states {READY, FAILED, KILLED} when the worker checks termination'
 
     def __init__(
         self,
@@ -403,12 +403,12 @@ class RunStateMachine(StateTransitioner):
             )
             self.worker_docker_network.connect(container)
         except docker_utils.DockerUserErrorException as e:
-            message = 'Cannot start Docker container: {}'.format(e)
+            message = 'Cannot start Docker container.'.format(e)
             log_bundle_transition(
                 bundle_uuid=run_state.bundle.uuid,
                 previous_stage=run_state.stage,
                 next_stage=RunStage.CLEANING_UP,
-                reason=message,
+                reason='Cannot start Docker container.',
                 level=logging.ERROR,
             )
             return run_state._replace(stage=RunStage.CLEANING_UP, failure_message=message)
@@ -533,7 +533,7 @@ class RunStateMachine(StateTransitioner):
                 bundle_uuid=run_state.bundle.uuid,
                 previous_stage=run_state.stage,
                 next_stage=RunStage.CLEANING_UP,
-                reason=f'the bundle is {"killed" if run_state.is_killed else "restaged"}',
+                reason=f'the bundle was {"killed" if run_state.is_killed else "restaged"}',
             )
             if docker_utils.container_exists(run_state.container):
                 try:
@@ -607,7 +607,7 @@ class RunStateMachine(StateTransitioner):
                 bundle_uuid=run_state.bundle.uuid,
                 previous_stage=run_state.stage,
                 next_stage=RunStage.RESTAGED,
-                reason=self.RESTAGE_COMMON_REASON,
+                reason=self.RESTAGEG_REASON,
             )
             return run_state._replace(stage=RunStage.RESTAGED)
 
@@ -648,7 +648,7 @@ class RunStateMachine(StateTransitioner):
                 bundle_uuid=run_state.bundle.uuid,
                 previous_stage=run_state.stage,
                 next_stage=RunStage.RESTAGED,
-                reason=self.RESTAGE_COMMON_REASON,
+                reason=self.RESTAGEG_REASON,
             )
             return run_state._replace(stage=RunStage.RESTAGED)
 

--- a/tests/unit/rest/worksheets_test.py
+++ b/tests/unit/rest/worksheets_test.py
@@ -118,7 +118,7 @@ class WorksheetsTest(BaseTestCase):
                         },
                         'dependencies': [],
                     },
-                }
+                },
             ]
         }
         response = self.app.post_json(f'/rest/bundles?worksheet={worksheet_id}', body)
@@ -127,7 +127,9 @@ class WorksheetsTest(BaseTestCase):
         bundle_id = data[0]["id"]
 
         # Verify that only the queried bundle info should be returned, so there will only be 1 non-null element in the block_infos
-        refreshed_bundles = self.app.get("/rest/interpret/worksheet/" + worksheet_id + "?bundle_uuid=" + bundle_id).json
+        refreshed_bundles = self.app.get(
+            "/rest/interpret/worksheet/" + worksheet_id + "?bundle_uuid=" + bundle_id
+        ).json
         blocks_info = refreshed_bundles["blocks"][0]["bundles_spec"]["bundle_infos"]
         bundles_count = sum(1 for bundle in blocks_info if bundle)
         self.assertEqual(1, bundles_count)


### PR DESCRIPTION
### Reasons for making this change
Add logging for common tasks like uploading reports and finalizing bundles. 
<!-- Add a reason for making this change here. -->

### Related issues
#3204 
<!-- Add a reference to issues resolved, if applicable (for example, "fixes #1"). -->

### Screenshots
```
2021-02-04 08:16:43,481 Connecting to http://rest-server:2900 /opt/codalab/worker/main.py 173
2021-02-04 08:16:43,539 Loaded 0 dependencies, 0 paths from cache. /opt/codalab/worker/dependency_manager.py 111
2021-02-04 08:16:43,567 Looking for auth config /usr/local/lib/python3.6/dist-packages/docker/auth.py 41
2021-02-04 08:16:43,568 Using credentials store "ecr-login" /usr/local/lib/python3.6/dist-packages/docker/auth.py 233
2021-02-04 08:16:43,568 Looking for auth entry for 'https://index.docker.io/v1/' /usr/local/lib/python3.6/dist-packages/docker/auth.py 261
2021-02-04 08:16:43,577 No entry found /usr/local/lib/python3.6/dist-packages/docker/auth.py 277
2021-02-04 08:16:43,577 No entry in credstore - fetching from auth dict /usr/local/lib/python3.6/dist-packages/docker/auth.py 238
2021-02-04 08:16:43,577 Looking for auth entry for 'docker.io' /usr/local/lib/python3.6/dist-packages/docker/auth.py 242
2021-02-04 08:16:43,577 No entry found /usr/local/lib/python3.6/dist-packages/docker/auth.py 253
2021-02-04 08:16:43,577 No auth config found /usr/local/lib/python3.6/dist-packages/docker/auth.py 58
2021-02-04 08:16:44,833 Cannot initialize NVIDIA runtime, no GPU support: Problem getting NVIDIA devices: 400 Client Error: Bad Request ("Unknown runtime specified nvidia") /opt/codalab/worker/docker_utils.py 102
2021-02-04 08:16:44,834 Trying paths: ['/root/.docker/config.json', '/root/.dockercfg'] /usr/local/lib/python3.6/dist-packages/docker/utils/config.py 21
2021-02-04 08:16:44,834 Found file at path: /root/.docker/config.json /usr/local/lib/python3.6/dist-packages/docker/utils/config.py 25
2021-02-04 08:16:44,835 Found 'credsStore' section /usr/local/lib/python3.6/dist-packages/docker/auth.py 189
2021-02-04 08:16:44,835 Trying paths: ['/root/.docker/config.json', '/root/.dockercfg'] /usr/local/lib/python3.6/dist-packages/docker/utils/config.py 21
2021-02-04 08:16:44,835 Found file at path: /root/.docker/config.json /usr/local/lib/python3.6/dist-packages/docker/utils/config.py 25
2021-02-04 08:16:44,835 Found 'credsStore' section /usr/local/lib/python3.6/dist-packages/docker/auth.py 189
2021-02-04 08:16:44,841 Creating docker network codalab-worker-network_general /opt/codalab/worker/worker.py 146
2021-02-04 08:16:44,847 Network codalab-worker-network_general already exists, reusing /opt/codalab/worker/worker.py 153
2021-02-04 08:16:44,854 Creating docker network codalab-worker-network_ext /opt/codalab/worker/worker.py 146
2021-02-04 08:16:44,859 Network codalab-worker-network_ext already exists, reusing /opt/codalab/worker/worker.py 153
2021-02-04 08:16:44,866 Creating docker network codalab-worker-network_int /opt/codalab/worker/worker.py 146
2021-02-04 08:16:44,873 Network codalab-worker-network_int already exists, reusing /opt/codalab/worker/worker.py 153
2021-02-04 08:16:44,882 Worker started! /opt/codalab/worker/main.py 287
2021-02-04 08:16:44,886 Starting docker image manager /opt/codalab/worker/docker_image_manager.py 55
2021-02-04 08:16:44,887 Starting local dependency manager /opt/codalab/worker/dependency_manager.py 164
2021-02-04 08:16:47,966 Connected! Successful check in! /opt/codalab/worker/worker.py 429
```
<!-- Add screenshots, if necessary -->

### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
