### PR TITLE
Show docker image download progress

### DIFF
--- a/codalab/worker/docker_image_manager.py
+++ b/codalab/worker/docker_image_manager.py
@@ -28,14 +28,12 @@ ImageCacheEntry = namedtuple(
 )
 
 
-docker_image_download_status = []
-
 
 class DockerImageManager:
 
     CACHE_TAG = 'codalab-image-cache/last-used'
 
-    def __init__(self, commit_file, max_image_cache_size, max_image_size):
+    def __init__(self, commit_file, max_image_cache_size, max_image_size, docker_image_download_status):
         """
         Initializes a DockerImageManager
         :param commit_file: String path to where the state file should be committed
@@ -53,6 +51,7 @@ class DockerImageManager:
         self._stop = False
         self._sleep_secs = 10
         self._cleanup_thread = None
+        self.docker_image_download_status = docker_image_download_status
 
     def start(self):
         logger.info("Starting docker image manager")
@@ -248,9 +247,8 @@ class DockerImageManager:
                     try:
                         client = docker.APIClient(base_url='unix://var/run/docker.sock')
                         self.generator = client.pull(image_spec, stream=True, decode=True)
-                        global docker_image_download_status
                         for line in self.generator:
-                            docker_image_download_status.append(line)
+                            self.docker_image_download_status.append(line)
 
                         logger.debug('Download for Docker image %s complete', image_spec)
                         self._downloading[image_spec]['success'] = True

--- a/codalab/worker/docker_image_manager.py
+++ b/codalab/worker/docker_image_manager.py
@@ -33,7 +33,9 @@ class DockerImageManager:
 
     CACHE_TAG = 'codalab-image-cache/last-used'
 
-    def __init__(self, commit_file, max_image_cache_size, max_image_size, docker_image_download_status):
+    def __init__(
+            self, commit_file, max_image_cache_size, max_image_size, docker_image_download_status
+    ):
         """
         Initializes a DockerImageManager
         :param commit_file: String path to where the state file should be committed
@@ -248,7 +250,7 @@ class DockerImageManager:
                         client = docker.APIClient(base_url='unix://var/run/docker.sock')
                         self.generator = client.pull(image_spec, stream=True, decode=True)
                         for line in self.generator:
-                            self.docker_image_download_status.append(line)
+                            self.docker_image_download_status[0] = line
 
                         logger.debug('Download for Docker image %s complete', image_spec)
                         self._downloading[image_spec]['success'] = True

--- a/codalab/worker/docker_image_manager.py
+++ b/codalab/worker/docker_image_manager.py
@@ -28,6 +28,9 @@ ImageCacheEntry = namedtuple(
 )
 
 
+docker_image_download_status = []
+
+
 class DockerImageManager:
 
     CACHE_TAG = 'codalab-image-cache/last-used'
@@ -243,7 +246,12 @@ class DockerImageManager:
                 def download():
                     logger.debug('Downloading Docker image %s', image_spec)
                     try:
-                        self._docker.images.pull(image_spec)
+                        client = docker.APIClient(base_url='unix://var/run/docker.sock')
+                        self.generator = client.pull(image_spec, stream=True, decode=True)
+                        global docker_image_download_status
+                        for line in self.generator:
+                            docker_image_download_status.append(line)
+
                         logger.debug('Download for Docker image %s complete', image_spec)
                         self._downloading[image_spec]['success'] = True
                         self._downloading[image_spec]['message'] = "Downloading image"

--- a/codalab/worker/main.py
+++ b/codalab/worker/main.py
@@ -254,10 +254,12 @@ def main():
         os.makedirs(local_bundles_dir, 0o770)
 
     docker_runtime = docker_utils.get_available_runtime()
+    docker_image_download_status = []
     image_manager = DockerImageManager(
         os.path.join(args.work_dir, 'images-state.json'),
         args.max_image_cache_size,
         args.max_image_size,
+        docker_image_download_status
     )
 
     worker = Worker(

--- a/codalab/worker/main.py
+++ b/codalab/worker/main.py
@@ -259,7 +259,7 @@ def main():
         os.path.join(args.work_dir, 'images-state.json'),
         args.max_image_cache_size,
         args.max_image_size,
-        docker_image_download_status
+        docker_image_download_status,
     )
 
     worker = Worker(

--- a/codalab/worker/worker.py
+++ b/codalab/worker/worker.py
@@ -70,7 +70,6 @@ class Worker:
         shared_file_system,  # type: bool
         tag_exclusive,  # type: bool
         group_name,  # type: str
-        docker_image_download_status,  # type: list
         docker_runtime=docker_utils.DEFAULT_RUNTIME,  # type: str
         docker_network_prefix='codalab_worker_network',  # type: str
         # A flag indicating if all the existing running bundles will be killed along with the worker.
@@ -133,7 +132,6 @@ class Worker:
             upload_bundle_callback=self.upload_bundle_contents,
             assign_cpu_and_gpu_sets_fn=self.assign_cpu_and_gpu_sets,
             shared_file_system=self.shared_file_system,
-            docker_image_download_status=docker_image_download_status,
         )
 
     def init_docker_networks(self, docker_network_prefix, verbose=True):

--- a/codalab/worker/worker.py
+++ b/codalab/worker/worker.py
@@ -133,7 +133,7 @@ class Worker:
             upload_bundle_callback=self.upload_bundle_contents,
             assign_cpu_and_gpu_sets_fn=self.assign_cpu_and_gpu_sets,
             shared_file_system=self.shared_file_system,
-            docker_image_download_status=docker_image_download_status
+            docker_image_download_status=docker_image_download_status,
         )
 
     def init_docker_networks(self, docker_network_prefix, verbose=True):

--- a/codalab/worker/worker.py
+++ b/codalab/worker/worker.py
@@ -70,6 +70,7 @@ class Worker:
         shared_file_system,  # type: bool
         tag_exclusive,  # type: bool
         group_name,  # type: str
+        docker_image_download_status,  # type: list
         docker_runtime=docker_utils.DEFAULT_RUNTIME,  # type: str
         docker_network_prefix='codalab_worker_network',  # type: str
         # A flag indicating if all the existing running bundles will be killed along with the worker.
@@ -79,6 +80,7 @@ class Worker:
         # A flag indicating if the worker will exit if it encounters an exception
         exit_on_exception=False,  # type: bool
     ):
+
         self.image_manager = image_manager
         self.dependency_manager = dependency_manager
         self.reader = Reader()
@@ -131,6 +133,7 @@ class Worker:
             upload_bundle_callback=self.upload_bundle_contents,
             assign_cpu_and_gpu_sets_fn=self.assign_cpu_and_gpu_sets,
             shared_file_system=self.shared_file_system,
+            docker_image_download_status=docker_image_download_status
         )
 
     def init_docker_networks(self, docker_network_prefix, verbose=True):

--- a/codalab/worker/worker_run_state.py
+++ b/codalab/worker/worker_run_state.py
@@ -167,7 +167,6 @@ class RunStateMachine(StateTransitioner):
         assign_cpu_and_gpu_sets_fn,  # Function to call to assign CPU and GPU resources to each run
         shared_file_system,  # If True, bundle mount is shared with server
         docker_image_download_status,
-
     ):
         super(RunStateMachine, self).__init__()
         self.add_transition(RunStage.PREPARING, self._transition_from_PREPARING)
@@ -299,9 +298,8 @@ class RunStateMachine(StateTransitioner):
                 'Pulling docker image: ' + (image_state.message or docker_image or "")
             )
             if len(self.docker_image_download_status) > 0:
-                latest_status = self.docker_image_download_status[len(self.docker_image_download_status) - 1]
                 status_messages += (
-                    f'\nPulling status:\n {get_message_of_download_status(latest_status)}'
+                    f'\nPulling status:\n {get_message_of_download_status(self.docker_image_download_status[0])}'
                 )
             dependencies_ready = False
         elif image_state.stage == DependencyStage.FAILED:

--- a/codalab/worker/worker_run_state.py
+++ b/codalab/worker/worker_run_state.py
@@ -166,7 +166,6 @@ class RunStateMachine(StateTransitioner):
         upload_bundle_callback,  # Function to call to upload bundle results to the server
         assign_cpu_and_gpu_sets_fn,  # Function to call to assign CPU and GPU resources to each run
         shared_file_system,  # If True, bundle mount is shared with server
-        docker_image_download_status,
     ):
         super(RunStateMachine, self).__init__()
         self.add_transition(RunStage.PREPARING, self._transition_from_PREPARING)
@@ -179,7 +178,6 @@ class RunStateMachine(StateTransitioner):
 
         self.dependency_manager = dependency_manager
         self.docker_image_manager = docker_image_manager
-        self.docker_image_download_status = docker_image_download_status
         self.worker_docker_network = worker_docker_network
         self.docker_network_external = docker_network_external
         self.docker_network_internal = docker_network_internal
@@ -297,9 +295,11 @@ class RunStateMachine(StateTransitioner):
             status_messages.append(
                 'Pulling docker image: ' + (image_state.message or docker_image or "")
             )
-            if len(self.docker_image_download_status) > 0:
+            # if "message" in self.docker_image_manager._downloading[docker_image]:
+
+            if image_state.message:
                 status_messages += (
-                    f'\nPulling status:\n {get_message_of_download_status(self.docker_image_download_status[0])}'
+                    f'\nPulling status:\n {get_message_of_download_status(image_state.message)}'
                 )
             dependencies_ready = False
         elif image_state.stage == DependencyStage.FAILED:

--- a/codalab/worker/worker_run_state.py
+++ b/codalab/worker/worker_run_state.py
@@ -17,7 +17,6 @@ from codalab.worker.bundle_state import State, DependencyKey
 from codalab.worker.fsm import DependencyStage, StateTransitioner
 from codalab.worker.worker_thread import ThreadDict
 
-from codalab.worker.docker_image_manager import docker_image_download_status
 
 logger = logging.getLogger(__name__)
 
@@ -167,6 +166,8 @@ class RunStateMachine(StateTransitioner):
         upload_bundle_callback,  # Function to call to upload bundle results to the server
         assign_cpu_and_gpu_sets_fn,  # Function to call to assign CPU and GPU resources to each run
         shared_file_system,  # If True, bundle mount is shared with server
+        docker_image_download_status,
+
     ):
         super(RunStateMachine, self).__init__()
         self.add_transition(RunStage.PREPARING, self._transition_from_PREPARING)
@@ -179,6 +180,7 @@ class RunStateMachine(StateTransitioner):
 
         self.dependency_manager = dependency_manager
         self.docker_image_manager = docker_image_manager
+        self.docker_image_download_status = docker_image_download_status
         self.worker_docker_network = worker_docker_network
         self.docker_network_external = docker_network_external
         self.docker_network_internal = docker_network_internal
@@ -296,8 +298,8 @@ class RunStateMachine(StateTransitioner):
             status_messages.append(
                 'Pulling docker image: ' + (image_state.message or docker_image or "")
             )
-            if len(docker_image_download_status) > 0:
-                latest_status = docker_image_download_status[len(docker_image_download_status) - 1]
+            if len(self.docker_image_download_status) > 0:
+                latest_status = self.docker_image_download_status[len(self.docker_image_download_status) - 1]
                 status_messages += (
                     f'\nPulling status:\n {get_message_of_download_status(latest_status)}'
                 )


### PR DESCRIPTION
### Reasons for making this change
Post the progress of docker image downloading to frontend. 
<!-- Add a reason for making this change here. -->

### Related issues
#3174 
<!-- Add a reference to issues resolved, if applicable (for example, "fixes #1"). -->

### Screenshots
![image](https://user-images.githubusercontent.com/18689351/108475960-496ba280-7246-11eb-969c-7174d670cb66.png)
```
2021-02-19 08:05:02,993 status dict is {'status': 'Downloading', 'progressDetail': {'current': 31185373, 'total': 42069114}, 'progress': '[=====================================>             ]  31.19MB/42.07MB', 'id': '63e877180dd1'} /opt/codalab/worker/worker_run_state.py 212
2021-02-19 08:05:02,994 yibo - latest download status is status: Downloading
layer being extracted: 63e877180dd1
[=====================================>             ]  31.19MB/42.07MB /opt/codalab/worker/worker_run_state.py 281
2021-02-19 08:05:02,995 status dict is {'status': 'Downloading', 'progressDetail': {'current': 31185373, 'total': 42069114}, 'progress': '[=====================================>             ]  31.19MB/42.07MB', 'id': '63e877180dd1'} /opt/codalab/worker/worker_run_state.py 212
2021-02-19 08:05:12,175 yibo - runstate has the image maven:latest /opt/codalab/worker/worker_run_state.py 200
2021-02-19 08:05:12,177 yibo - image spec is maven:latest /opt/codalab/worker/docker_image_manager.py 165
2021-02-19 08:05:12,177 yibo - length of docker image download status is 323 /opt/codalab/worker/worker_run_state.py 276
2021-02-19 08:05:12,178 status dict is {'status': 'Extracting', 'progressDetail': {'current': 26836992, 'total': 42069114}, 'progress': '[===============================>                   ]  26.84MB/42.07MB', 'id': '63e877180dd1'} /opt/codalab/worker/worker_run_state.py 212
2021-02-19 08:05:12,179 yibo - latest download status is status: Extracting
layer being extracted: 63e877180dd1
[===============================>                   ]  26.84MB/42.07MB /opt/codalab/worker/worker_run_state.py 281
2021-02-19 08:05:12,184 status dict is {'status': 'Extracting', 'progressDetail': {'current': 26836992, 'total': 42069114}, 'progress': '[===============================>                   ]  26.84MB/42.07MB', 'id': '63e877180dd1'} /opt/codalab/worker/worker_run_state.py 212
2021-02-19 08:05:20,715 yibo - runstate has the image maven:latest /opt/codalab/worker/worker_run_state.py 200
2021-02-19 08:05:20,716 yibo - image spec is maven:latest /opt/codalab/worker/docker_image_manager.py 165
2021-02-19 08:05:20,716 yibo - length of docker image download status is 458 /opt/codalab/worker/worker_run_state.py 276
2021-02-19 08:05:20,716 status dict is {'status': 'Extracting', 'progressDetail': {'current': 30081024, 'total': 195798723}, 'progress': '[=======>                                           ]  30.08MB/195.8MB', 'id': '58ee7ac9a7c3'} /opt/codalab/worker/worker_run_state.py 212
2021-02-19 08:05:20,717 yibo - latest download status is status: Extracting
layer being extracted: 58ee7ac9a7c3
[=======>                                           ]  30.08MB/195.8MB /opt/codalab/worker/worker_run_state.py 281
```
<!-- Add screenshots, if necessary -->

### Checklist

* [ ] I've added a screenshot of the changes, if this is a frontend change
* [ ] I've added and/or updated tests, if this is a backend change
* [ ] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [ ] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
