### PR TITLE
FIx the bug of `discard` button not closing the source editor

### DIFF
--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -1170,13 +1170,16 @@ class Worksheet extends React.Component {
                                 inSourceEditMode: false,
                                 editorEnabled: false,
                             }); // Needs to be after getting the raw contents
-                            if (saveChanges) {
-                                this.saveAndUpdateWorksheet(saveChanges, rawIndex);
-                            } else {
-                                this.reloadWorksheet(undefined, rawIndex);
-                            }
+                            this.saveAndUpdateWorksheet(saveChanges, rawIndex);
                         },
                     );
+                } else {
+                    var rawIndex = editor.getCursorPosition().row;
+                    this.setState({
+                        inSourceEditMode: false,
+                        editorEnabled: false,
+                    });
+                    this.reloadWorksheet(undefined, rawIndex);
                 }
             } else {
                 // Not allowed to edit the worksheet.


### PR DESCRIPTION
### Reasons for making this change

 "Discard" button cannot close the source editor.


### Screenshots

![ezgif com-gif-maker](https://user-images.githubusercontent.com/34461466/106707504-297d8300-65a6-11eb-8a30-a4d92353e3a4.gif)

### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
