### PR TITLE
Azure Blob part 1: Add MockBlobStorageFileSystem

### DIFF
--- a/codalab/lib/beam/filesystems.py
+++ b/codalab/lib/beam/filesystems.py
@@ -2,9 +2,9 @@ import os
 from azure.storage.blob import BlobServiceClient
 
 # Test connection string for Azurite (local development)
-TEST_CONN_STR = "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;"
+TEST_CONN_STR = ("DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;"
 "AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;"
-"BlobEndpoint=http://azurite:10000/devstoreaccount1;"
+"BlobEndpoint=http://azurite:10000/devstoreaccount1;")
 
 # The Apache beam BlobStorageFileSystem expects the AZURE_STORAGE_CONNECTION_STRING environment variable
 # to be set to the correct Azure Blob Storage connection string.
@@ -18,5 +18,5 @@ client = BlobServiceClient.from_connection_string(AZURE_BLOB_CONNECTION_STRING)
 
 # This is the account name of the account, which determines the first part of Azure URLs. For example,
 # if AZURE_BLOB_ACCOUNT_NAME is equal to "devstoreaccount1", all Azure URLs for objects within that account
-# will start with "azfs://"
+# will start with "azfs://devstoreaccount1/"
 AZURE_BLOB_ACCOUNT_NAME = client.account_name

--- a/codalab/lib/beam/mockblobstoragefilesystem.py
+++ b/codalab/lib/beam/mockblobstoragefilesystem.py
@@ -1,0 +1,89 @@
+"""Mock Azure Blob Storage filesystem that is backed by a local filesystem instead.
+This means that while URLs will still start with azfs://, adding / removing files
+will actually change files in the local /tmp/codalab/azfs-mock/ directory instead.
+
+This is used only for unit tests for speed, so that unit tests do not need to depend on
+a Blob Storage container / Azurite running in the background.
+"""
+
+from apache_beam.io.filesystem import FileSystem
+from apache_beam.io.localfilesystem import LocalFileSystem
+import os
+from io import BytesIO
+
+__all__ = ['MockBlobStorageFileSystem']
+
+
+class MockBlobStorageFileSystem(LocalFileSystem):
+  AZFS_MOCK_LOCATION = "/tmp/codalab/azfs-mock/"
+
+  def __init__(self, *args, **kwargs):
+    os.makedirs(MockBlobStorageFileSystem.AZFS_MOCK_LOCATION, exist_ok=True)
+    super().__init__(*args, **kwargs)
+
+  @classmethod
+  def scheme(cls):
+    """URI scheme for the FileSystem
+    """
+    return 'azfs'
+
+  def _local_to_azfs(self, path):
+      return "azfs://" + path[len(MockBlobStorageFileSystem.AZFS_MOCK_LOCATION):]
+
+  def _azfs_to_local(self, path):
+      if not path.startswith("azfs://"):
+        return path
+      path = MockBlobStorageFileSystem.AZFS_MOCK_LOCATION + path[len("azfs://"):]
+      os.makedirs(os.path.dirname(path), exist_ok=True)
+      return path
+
+  def join(self, basepath, *paths):
+    return super().join(basepath, *paths)
+
+  def split(self, path):
+    return super().split(path)
+
+  def mkdirs(self, path):
+    return super().mkdirs(self._azfs_to_local(path))
+
+  def has_dirs(self):
+    return super().has_dirs()
+
+  def _list(self, dir_or_prefix):
+    for file_metadata in super()._list(self._azfs_to_local(dir_or_prefix)):
+      file_metadata.path = self._local_to_azfs(file_metadata.path)
+      yield file_metadata
+  
+  def create(
+      self,
+      path,
+      *args, **kwargs):
+    return super().create(self._azfs_to_local(path), *args, **kwargs)
+  
+  def open(
+      self,
+      path,
+      *args, **kwargs):
+    return BytesIO(super().open(self._azfs_to_local(path), *args, **kwargs).read())
+
+  def copy(self, source_file_names, destination_file_names):
+    return super().copy([self._azfs_to_local(p) for p in source_file_names], [self._azfs_to_local(p) for p in destination_file_names])
+
+  def rename(self, source_file_names, destination_file_names):
+    print([self._azfs_to_local(p) for p in source_file_names], [self._azfs_to_local(p) for p in destination_file_names])
+    return super().rename([self._azfs_to_local(p) for p in source_file_names], [self._azfs_to_local(p) for p in destination_file_names])
+  
+  def exists(self, path):
+    return super().exists(self._azfs_to_local(path))
+
+  def size(self, path):
+    return super().size(self._azfs_to_local(path))
+
+  def last_updated(self, path):
+    return super().last_updated(self._azfs_to_local(path))
+
+  def checksum(self, path):
+    return super().checksum(self._azfs_to_local(path))
+
+  def delete(self, paths):
+    return super().delete([self._azfs_to_local(path) for path in paths])

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,7 @@ per-file-ignores =
   #  Modifying those texts in accordance with flake8 will change how the generated markdown look like
   ./scripts/gen-rest-docs.py: E501
 
-[mypy-apache_beam,apache_beam.io.filesystem,apache_beam.io.filesystems]
+[mypy-apache_beam,apache_beam.io.filesystem,apache_beam.io.filesystems,apache_beam.io.localfilesystem,apache_beam.io]
 ignore_missing_imports = True
 
 [mypy-azure.storage.blob]

--- a/tests/unit/azure_blob_mock.py
+++ b/tests/unit/azure_blob_mock.py
@@ -1,0 +1,28 @@
+"""Modifies Apache Beam so that we use MockBlobStorageFileSystem
+instead of BlobStorageFileSystem for azfs:// URLs.
+
+This allows unit tests that test Azure Blob Storage integration to be
+lighter, as they can use the filesystem-backed MockBlobStorageFileSystem
+rather than having to run Azurite for BlobStorageFileSystem.
+
+To use this in a test, add the following to the top of the imports in that file:
+
+```
+import tests.unit.azure_blob_mock  # noqa: F401
+```
+
+"""
+
+# Import MockBlobStorageFileSystem, which is associated with the azfs:// URL.
+from codalab.lib.beam.mockblobstoragefilesystem import MockBlobStorageFileSystem  # noqa: F401
+from apache_beam.io.filesystems import BlobStorageFileSystem
+
+
+class DummyClass:
+    pass
+
+
+# By overwriting the __bases__ attribute of BlobStorageFileSystem, we effectively
+# disable BlobStorageFileSystem (the default Azure Blob Storage file system built into Beam),
+# so that Apache Beam does not recognize it when parsing azfs:// URLs.
+BlobStorageFileSystem.__bases__ = (DummyClass,)


### PR DESCRIPTION
### Reasons for making this change

Part 1 of #3198.

Adds the testing utility MockBlobStorageFileSystem, which is a mock Azure Blob Storage filesystem that is backed by a local filesystem instead.

This means that while URLs will still start with azfs://, adding / removing files
will actually change files in the local /tmp/codalab/azfs-mock/ directory instead.

This is used only for unit tests for speed, so that unit tests do not need to depend on
a Blob Storage container / Azurite running in the background.