### PR TITLE
Table cell render as 'Forbidden' instead of 'Loading...' when the user has no access

### DIFF
--- a/codalab/rest/interpret.py
+++ b/codalab/rest/interpret.py
@@ -16,7 +16,7 @@ import json
 import yaml
 from bottle import get, post, local, request, abort, httplib
 
-from codalab.common import UsageError, NotFoundError
+from codalab.common import UsageError, NotFoundError, PermissionError
 from codalab.lib import formatting, spec_util
 from codalab.lib.worksheet_util import (
     TYPE_DIRECTIVE,
@@ -680,6 +680,10 @@ def interpret_file_genpath(target_cache, bundle_uuid, genpath, post):
                             info = ''.join(contents)
         except NotFoundError:
             pass
+        except PermissionError:
+            # Use the array of length 3 to pass the PermissionError to the frontend
+            info = ["Forbidden", "Forbidden", "Forbidden"]
+            return info
 
         # Try to interpret the structure of the file by looking inside it.
         target_cache[target] = info

--- a/codalab/rest/interpret.py
+++ b/codalab/rest/interpret.py
@@ -682,7 +682,7 @@ def interpret_file_genpath(target_cache, bundle_uuid, genpath, post):
             pass
         except PermissionError:
             # Use the array of length 3 to pass the PermissionError to the frontend
-            info = ["Forbidden", "Forbidden", "Forbidden"]
+            info = ["Forbidden"]
             return info
 
         # Try to interpret the structure of the file by looking inside it.

--- a/codalab/rest/interpret.py
+++ b/codalab/rest/interpret.py
@@ -681,7 +681,7 @@ def interpret_file_genpath(target_cache, bundle_uuid, genpath, post):
         except NotFoundError:
             pass
         except PermissionError:
-            # Use the array of length 3 to pass the PermissionError to the frontend
+            # Use an array of length 1 to pass the PermissionError to the frontend
             info = ["Forbidden"]
             return info
 

--- a/frontend/src/components/worksheets/items/TableItem/BundleRow.js
+++ b/frontend/src/components/worksheets/items/TableItem/BundleRow.js
@@ -163,12 +163,13 @@ class BundleRow extends Component {
                     rowContent = rowContent['path'].split('/')[1];
                 }
             }
-            if (Array.isArray(rowContent) && rowContent.length === 3) {
-                // Cell is a bundle genpath triple -- see is_bundle_genpath_triple() in backend.
-                if (rowContent[0] === 'Forbidden') {
+            if (Array.isArray(rowContent)) {
+                if (rowContent.length === 1) {
                     // This means that the user has no access to the cell since PermissionError occurred.
+                    // ['Forbidden'] will be returned
                     rowContent = <span style={{ color: 'grey' }}>Forbidden</span>;
-                } else {
+                } else if (rowContent.length === 3) {
+                    // Cell is a bundle genpath triple -- see is_bundle_genpath_triple() in backend.
                     // This means that the cell is only briefly loaded.
                     rowContent = <span style={{ color: 'grey' }}>Loading...</span>;
                 }

--- a/frontend/src/components/worksheets/items/TableItem/BundleRow.js
+++ b/frontend/src/components/worksheets/items/TableItem/BundleRow.js
@@ -165,8 +165,13 @@ class BundleRow extends Component {
             }
             if (Array.isArray(rowContent) && rowContent.length === 3) {
                 // Cell is a bundle genpath triple -- see is_bundle_genpath_triple() in backend.
-                // This means that the cell is only briefly loaded.
-                rowContent = <span style={{ color: 'grey' }}>Loading...</span>;
+                if (rowContent[0] === 'Forbidden') {
+                    // This means that the user has no access to the cell since PermissionError occurred.
+                    rowContent = <span style={{ color: 'grey' }}>Forbidden</span>;
+                } else {
+                    // This means that the cell is only briefly loaded.
+                    rowContent = <span style={{ color: 'grey' }}>Loading...</span>;
+                }
             }
             if (url)
                 rowContent = (


### PR DESCRIPTION
### Reasons for making this change

Based on Percy's suggestion, use 'Forbidden' instead to avoid confusion when permission error occurs since 'Loading...' is misleading

### Related issues

fixes #3239 

### Screenshots

<img width="996" alt="Screen Shot 2021-02-09 at 12 09 55 AM" src="https://user-images.githubusercontent.com/34461466/107334853-19fdae80-6a6c-11eb-9fd1-8c9b8b2f8c77.png">


### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
