### PR TITLE
Bump to version 0.5.38

### DIFF
--- a/codalab/common.py
+++ b/codalab/common.py
@@ -13,7 +13,7 @@ from retry import retry
 
 # Increment this on master when ready to cut a release.
 # http://semver.org/
-CODALAB_VERSION = '0.5.37'
+CODALAB_VERSION = '0.5.38'
 BINARY_PLACEHOLDER = '<binary>'
 URLOPEN_TIMEOUT_SECONDS = int(os.environ.get('CODALAB_URLOPEN_TIMEOUT_SECONDS', 5 * 60))
 

--- a/docs/REST-API-Reference.md
+++ b/docs/REST-API-Reference.md
@@ -1,6 +1,6 @@
 # REST API Reference
 
-_version 0.5.37_
+_version 0.5.38_
 
 This reference and the REST API itself is still under heavy development and is
 subject to change at any time. Feedback through our GitHub issues is appreciated!

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -1,5 +1,5 @@
 // Should match codalab/common.py#CODALAB_VERSION
-export const CODALAB_VERSION = '0.5.37';
+export const CODALAB_VERSION = '0.5.38';
 
 // Name Regex to match the backend in spec_utils.py
 export const NAME_REGEX = /^[a-zA-Z_][a-zA-Z0-9_.-]*$/i;

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import sys
 
 
 # should match codalab/common.py#CODALAB_VERSION
-CODALAB_VERSION = "0.5.37"
+CODALAB_VERSION = "0.5.38"
 
 
 class Install(install):


### PR DESCRIPTION
### Reasons for making this change

Bump new version 0.5.38

Full diff: https://github.com/codalab/codalab-worksheets/compare/v0.5.37...rc0.5.38

# Draft release notes

## Frontend
- Bundle status refresh endpoint refreshes only the specified bundle (#3216)
- Add Avatar for Users (#3240) 
## Backend
- Create a test for codalab service start (#3147)
- Azure Blob part 1: Add MockBlobStorageFileSystem (#3244)
## Dev / docs / CI
- Update Competitions documentation (#3246)
