### PR TITLE
404 Page Not Showing HTML

### DIFF
--- a/frontend/src/components/Bundle/Bundle.js
+++ b/frontend/src/components/Bundle/Bundle.js
@@ -8,6 +8,7 @@ import { renderFormat, renderPermissions, shorten_uuid } from '../../util/worksh
 import { BundleEditableField } from '../EditableField';
 import { FileBrowser } from '../FileBrowser/FileBrowser';
 import './Bundle.scss';
+import ErrorMessage from '../worksheets/ErrorMessage';
 
 class Bundle extends React.Component<
     {
@@ -181,7 +182,7 @@ class Bundle extends React.Component<
         if (!bundleInfo) {
             // Error
             if (this.state.errorMessages.length > 0) {
-                return renderErrorMessages(this.state.errorMessages);
+                return <ErrorMessage message={"Not found: '/bundles/" + this.props.uuid + "'"} />;
             }
 
             // Still loading


### PR DESCRIPTION
### Reasons for making this change

Fix the bug that when the rest server is down, if a bundle could not be found, the 404 page will show HTML, which is bad for the user experience.

### Related issues

fixes #3226 

### Screenshots

<img width="1513" alt="Screen Shot 2021-02-10 at 3 38 59 PM" src="https://user-images.githubusercontent.com/34461466/107587389-871d5b00-6bb6-11eb-99ad-30dff75d3bfc.png">


### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
