### PR TITLE
Undo referencing to unassigned container

### DIFF
--- a/codalab/worker/docker_utils.py
+++ b/codalab/worker/docker_utils.py
@@ -203,7 +203,7 @@ def start_bundle_container(
         # because a container with the same name already exists. So, we try to remove
         # the container here.
         try:
-            container.remove(force=True)
+            client.api.remove_container(container_name, force=True)
         except Exception:
             logger.warning("Failed to clean up Docker container after failed launch.")
             traceback.print_exc()


### PR DESCRIPTION
### Reasons for making this change
here - https://github.com/codalab/codalab-worksheets/blob/master/codalab/worker/docker_utils.py#L206: the container is defined outside the except block. In case that an APIError is thrown, it can't find the definition of container. 

The reason of this approach comes from the `remove` api of the `Container`:
```    
def remove(self, **kwargs):
        """
        Remove this container. Similar to the ``docker rm`` command.

        Args:
            v (bool): Remove the volumes associated with the container
            link (bool): Remove the specified link and not the underlying
                container
            force (bool): Force the removal of a running container (uses
                ``SIGKILL``)

        Raises:
            :py:class:`docker.errors.APIError`
                If the server returns an error.
        """
        return self.client.api.remove_container(self.id, **kwargs)
```
<!-- Add a reason for making this change here. -->

### Related issues

<!-- Add a reference to issues resolved, if applicable (for example, "fixes #1"). -->

### Screenshots

<!-- Add screenshots, if necessary -->

### Checklist

* [ ] I've added a screenshot of the changes, if this is a frontend change
* [ ] I've added and/or updated tests, if this is a backend change
* [ ] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [ ] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
