### PR TITLE
Manually bind context to `this` for calllback function to solve "undefined" error

### DIFF
--- a/frontend/src/components/Bundle/Bundle.js
+++ b/frontend/src/components/Bundle/Bundle.js
@@ -153,21 +153,23 @@ class Bundle extends React.Component<
                     this.setState(stateUpdate);
                 }
             })
-            .fail(function(xhr, status, err) {
-                // 404 Not Found errors are normal if contents aren't available yet, so ignore them
-                if (xhr.status !== 404) {
-                    this.setState({
-                        bundleInfo: null,
-                        fileContents: null,
-                        stdout: null,
-                        stderr: null,
-                        errorMessages: this.state.errorMessages.concat([xhr.responseText]),
-                    });
-                } else {
-                    // If contents aren't available yet, then also clear stdout and stderr.
-                    this.setState({ fileContents: null, stdout: null, stderr: null });
-                }
-            });
+            .fail(
+                function(xhr, status, err) {
+                    // 404 Not Found errors are normal if contents aren't available yet, so ignore them
+                    if (xhr.status !== 404) {
+                        this.setState({
+                            bundleInfo: null,
+                            fileContents: null,
+                            stdout: null,
+                            stderr: null,
+                            errorMessages: this.state.errorMessages.concat([xhr.responseText]),
+                        });
+                    } else {
+                        // If contents aren't available yet, then also clear stdout and stderr.
+                        this.setState({ fileContents: null, stdout: null, stderr: null });
+                    }
+                }.bind(this),
+            );
     };
 
     componentDidMount() {


### PR DESCRIPTION
### Reasons for making this change

Manually bind context to `this` to have access inside the callback function. 

### Related issues

fixes #3265 

### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
