### PR TITLE
Redo the stats of docker images

### DIFF
--- a/codalab/bundles/run_bundle.py
+++ b/codalab/bundles/run_bundle.py
@@ -37,9 +37,9 @@ class RunBundle(DerivedBundle):
                                                                 'priority bundles are queued behind bundles with no specified priority.', default=None))
     METADATA_SPECS.append(MetadataSpec('request_network', bool, 'Whether to allow network access.', default=False))
     METADATA_SPECS.append(
-        MetadataSpec('cpu_usage', float, 'Portion of CPU used by this container (e.g., 0.24)', default=0.0, generated=True))
+        MetadataSpec('cpu_usage', float, 'Proportion of current CPU usage for a running bundle. This field is only relevant for running bundles. (e.g., 0.24)', default=0.0, generated=True))
     METADATA_SPECS.append(
-        MetadataSpec('memory_limit', int, 'Limit of Memory available to this container (e.g., 2085326848)', default=0, generated=True))
+        MetadataSpec('memory_limit', int, 'How much memory this container can use at any given time.', default=0, generated=True))
 
     METADATA_SPECS.append(MetadataSpec('exclude_patterns', list, 'Exclude these file patterns from being saved into the bundle contents.', default=[]))
 

--- a/codalab/bundles/run_bundle.py
+++ b/codalab/bundles/run_bundle.py
@@ -39,7 +39,7 @@ class RunBundle(DerivedBundle):
     METADATA_SPECS.append(
         MetadataSpec('cpu_usage', float, 'Proportion of current CPU usage for a running bundle. This field is only relevant for running bundles. (e.g., 0.24)', default=0.0, generated=True))
     METADATA_SPECS.append(
-        MetadataSpec('memory_limit', int, 'How much memory this container can use at any given time.', default=0, generated=True))
+        MetadataSpec('memory_limit', int, 'The maximum amount of memory the container can use.', default=0, generated=True))
 
     METADATA_SPECS.append(MetadataSpec('exclude_patterns', list, 'Exclude these file patterns from being saved into the bundle contents.', default=[]))
 

--- a/codalab/bundles/run_bundle.py
+++ b/codalab/bundles/run_bundle.py
@@ -39,7 +39,7 @@ class RunBundle(DerivedBundle):
     METADATA_SPECS.append(
         MetadataSpec('cpu_usage', float, 'Proportion of current CPU usage for a running bundle. This field is only relevant for running bundles. (e.g., 0.24)', default=0.0, generated=True))
     METADATA_SPECS.append(
-        MetadataSpec('memory_limit', int, 'The maximum amount of memory the container can use.', default=0, generated=True))
+        MetadataSpec('memory_usage', float, 'Proportion of current memory usage based on the memory limit.', default=0.0, generated=True))
 
     METADATA_SPECS.append(MetadataSpec('exclude_patterns', list, 'Exclude these file patterns from being saved into the bundle contents.', default=[]))
 

--- a/codalab/bundles/run_bundle.py
+++ b/codalab/bundles/run_bundle.py
@@ -36,6 +36,11 @@ class RunBundle(DerivedBundle):
     METADATA_SPECS.append(MetadataSpec('request_priority', int, 'Job priority (higher is more important). Negative '
                                                                 'priority bundles are queued behind bundles with no specified priority.', default=None))
     METADATA_SPECS.append(MetadataSpec('request_network', bool, 'Whether to allow network access.', default=False))
+    METADATA_SPECS.append(
+        MetadataSpec('cpu_usage', float, 'Portion of CPU used by this container (e.g., 0.24)', default=0.0, generated=True))
+    METADATA_SPECS.append(
+        MetadataSpec('memory_limit', int, 'Limit of Memory available to this container (e.g., 2085326848)', default=0, generated=True))
+
     METADATA_SPECS.append(MetadataSpec('exclude_patterns', list, 'Exclude these file patterns from being saved into the bundle contents.', default=[]))
 
     METADATA_SPECS.append(MetadataSpec('actions', list, 'Actions (e.g., kill) that were performed on this run.', generated=True))

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -935,6 +935,14 @@ class BundleModel(object):
             worker_run_row = {'user_id': user_id, 'worker_id': worker_id, 'run_uuid': bundle.uuid}
             connection.execute(cl_worker_run.insert().values(worker_run_row))
 
+        cpu_usage: float = 0.0
+        if 'cpu_usage' in worker_run.as_dict:
+            cpu_usage = worker_run.cpu_usage
+
+        memory_limit: int = 0
+        if 'memory_limit' in worker_run.as_dict:
+            memory_limit = worker_run.memory_limit
+
         metadata_update = {
             'run_status': worker_run.run_status,
             'last_updated': int(time.time()),
@@ -942,6 +950,8 @@ class BundleModel(object):
             'time_user': worker_run.container_time_user,
             'time_system': worker_run.container_time_system,
             'remote': worker_run.remote,
+            'cpu_usage': cpu_usage,
+            'memory_limit': memory_limit,
         }
 
         if worker_run.docker_image is not None:

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -939,9 +939,9 @@ class BundleModel(object):
         if 'cpu_usage' in worker_run.as_dict:
             cpu_usage = worker_run.cpu_usage
 
-        memory_limit: int = 0
-        if 'memory_limit' in worker_run.as_dict:
-            memory_limit = worker_run.memory_limit
+        memory_usage: int = 0
+        if 'memory_usage' in worker_run.as_dict:
+            memory_usage = worker_run.memory_usage
 
         metadata_update = {
             'run_status': worker_run.run_status,
@@ -951,7 +951,7 @@ class BundleModel(object):
             'time_system': worker_run.container_time_system,
             'remote': worker_run.remote,
             'cpu_usage': cpu_usage,
-            'memory_limit': memory_limit,
+            'memory_usage': memory_usage,
         }
 
         if worker_run.docker_image is not None:

--- a/codalab/worker/bundle_state.py
+++ b/codalab/worker/bundle_state.py
@@ -224,9 +224,9 @@ class BundleCheckinState(object):
             remote=dct['remote'],
             exitcode=dct['exitcode'],
             failure_message=dct['failure_message'],
+            cpu_usage=dct.get('cpu_usage'),
+            memory_limit=dct.get('memory_limit'),
             bundle_profile_stats=dct.get('bundle_profile_stats'),
-            cpu_usage=dct['cpu_usage'],
-            memory_limit=dct['memory_limit'],
         )
 
     @property

--- a/codalab/worker/bundle_state.py
+++ b/codalab/worker/bundle_state.py
@@ -193,7 +193,7 @@ class BundleCheckinState(object):
         failure_message,  # type: Optional[str]
         bundle_profile_stats,  # type: dict
         cpu_usage,  # type: float
-        memory_limit,  # type: int
+        memory_usage,  # type: int
     ):
         self.uuid = uuid
         self.run_status = run_status
@@ -207,6 +207,7 @@ class BundleCheckinState(object):
         self.exitcode = exitcode
         self.failure_message = failure_message
         self.cpu_usage = cpu_usage
+        self.memory_usage = memory_usage
         self.memory_limit = memory_limit
         self.bundle_profile_stats = bundle_profile_stats
 
@@ -225,7 +226,7 @@ class BundleCheckinState(object):
             exitcode=dct['exitcode'],
             failure_message=dct['failure_message'],
             cpu_usage=dct.get('cpu_usage'),
-            memory_limit=dct.get('memory_limit'),
+            memory_usage=dct.get('memory_usage'),
             bundle_profile_stats=dct.get('bundle_profile_stats'),
         )
 

--- a/codalab/worker/bundle_state.py
+++ b/codalab/worker/bundle_state.py
@@ -192,6 +192,8 @@ class BundleCheckinState(object):
         exitcode,  # type: Optional[str]
         failure_message,  # type: Optional[str]
         bundle_profile_stats,  # type: dict
+        cpu_usage,  # type: float
+        memory_limit,  # type: int
     ):
         self.uuid = uuid
         self.run_status = run_status
@@ -204,6 +206,8 @@ class BundleCheckinState(object):
         self.remote = remote
         self.exitcode = exitcode
         self.failure_message = failure_message
+        self.cpu_usage = cpu_usage
+        self.memory_limit = memory_limit
         self.bundle_profile_stats = bundle_profile_stats
 
     @classmethod
@@ -221,6 +225,8 @@ class BundleCheckinState(object):
             exitcode=dct['exitcode'],
             failure_message=dct['failure_message'],
             bundle_profile_stats=dct.get('bundle_profile_stats'),
+            cpu_usage=dct['cpu_usage'],
+            memory_limit=dct['memory_limit'],
         )
 
     @property

--- a/codalab/worker/bundle_state.py
+++ b/codalab/worker/bundle_state.py
@@ -208,7 +208,6 @@ class BundleCheckinState(object):
         self.failure_message = failure_message
         self.cpu_usage = cpu_usage
         self.memory_usage = memory_usage
-        self.memory_limit = memory_limit
         self.bundle_profile_stats = bundle_profile_stats
 
     @classmethod

--- a/codalab/worker/docker_utils.py
+++ b/codalab/worker/docker_utils.py
@@ -270,9 +270,9 @@ def get_container_stats_with_docker_stats(container: docker.models.containers.Co
             container_stats: dict = client.containers.get(container.name).stats(stream=False)
 
             cpu_usage: float = get_cpu_usage(container_stats)
-            memory_limit: int = get_memory_limit(container_stats)
+            memory_usage: float = get_memory_usage(container_stats)
 
-            return cpu_usage, memory_limit
+            return cpu_usage, memory_usage
         except docker.errors.NotFound:
             raise
     else:
@@ -304,11 +304,12 @@ def get_cpu_usage(container_stats: dict) -> float:
         return 0.0
 
 
-def get_memory_limit(container_stats: dict) -> int:
+def get_memory_usage(container_stats: dict) -> float:
     """Takes a dictionary of container stats returned by docker stats, returns memory usage"""
     try:
-        memory_limit: int = container_stats['memory_stats']['limit']
-        return memory_limit
+        memory_limit: float = container_stats['memory_stats']['limit']
+        current_memory_usage: float = container_stats['memory_stats']['usage']
+        return current_memory_usage / memory_limit
     except KeyError:
         return 0
 

--- a/codalab/worker/docker_utils.py
+++ b/codalab/worker/docker_utils.py
@@ -263,6 +263,57 @@ def get_container_stats(container):
 
 
 @wrap_exception('Unable to check Docker API for container')
+def get_container_stats_with_docker_stats(container: docker.models.containers.Container):
+    """Returns the cpu usage and memory limit of a container using the Docker Stats API."""
+    if container_exists(container):
+        try:
+            container_stats: dict = client.containers.get(container.name).stats(stream=False)
+
+            cpu_usage: float = get_cpu_usage(container_stats)
+            memory_limit: int = get_memory_limit(container_stats)
+
+            return cpu_usage, memory_limit
+        except docker.errors.NotFound:
+            raise
+    else:
+        return 0.0, 0
+
+
+def get_cpu_usage(container_stats: dict) -> float:
+    """Calculates CPU usage from container stats returned from the Docker Stats API.
+       The way of calculation comes from here:
+       https://www.jcham.com/2016/02/09/calculating-cpu-percent-and-memory-percentage-for-containers/
+       That method is also based on how the docker client calculates it:
+       https://github.com/moby/moby/blob/131e2bf12b2e1b3ee31b628a501f96bbb901f479/api/client/stats.go#L309"""
+    try:
+        cpu_delta: int = container_stats['cpu_stats']['cpu_usage']['total_usage'] - container_stats[
+            'precpu_stats'
+        ]['cpu_usage']['total_usage']
+        system_delta: int = container_stats['cpu_stats']['system_cpu_usage'] - container_stats[
+            'precpu_stats'
+        ]['system_cpu_usage']
+        if system_delta > 0 and cpu_delta > 0:
+            cpu_usage: float = float(cpu_delta / system_delta) * float(
+                len(container_stats['cpu_stats']['cpu_usage']['percpu_usage'])
+            )
+            return cpu_usage
+        return 0.0
+    except KeyError:
+        # The stats returned may be missing some keys if the bundle is not fully ready or has exited.
+        # We can just skip for now and wait until this function is called the next time.
+        return 0.0
+
+
+def get_memory_limit(container_stats: dict) -> int:
+    """Takes a dictionary of container stats returned by docker stats, returns memory usage"""
+    try:
+        memory_limit: int = container_stats['memory_stats']['limit']
+        return memory_limit
+    except KeyError:
+        return 0
+
+
+@wrap_exception('Unable to check Docker API for container')
 def container_exists(container):
     try:
         client.containers.get(container.id)

--- a/codalab/worker/worker.py
+++ b/codalab/worker/worker.py
@@ -560,6 +560,8 @@ class Worker:
                 exitcode=run_state.exitcode,
                 failure_message=run_state.failure_message,
                 bundle_profile_stats=run_state.bundle_profile_stats,
+                cpu_usage=run_state.cpu_usage,
+                memory_limit=run_state.memory_limit,
             )
             for run_state in self.runs.values()
         ]
@@ -655,6 +657,8 @@ class Worker:
                 finished=False,
                 finalized=False,
                 is_restaged=False,
+                cpu_usage=0.0,
+                memory_limit=0,
             )
             # Start measuring bundle stats for the initial bundle state.
             self.start_stage_stats(bundle.uuid, RunStage.PREPARING)

--- a/codalab/worker/worker.py
+++ b/codalab/worker/worker.py
@@ -561,7 +561,7 @@ class Worker:
                 failure_message=run_state.failure_message,
                 bundle_profile_stats=run_state.bundle_profile_stats,
                 cpu_usage=run_state.cpu_usage,
-                memory_limit=run_state.memory_limit,
+                memory_usage=run_state.memory_usage,
             )
             for run_state in self.runs.values()
         ]
@@ -658,7 +658,7 @@ class Worker:
                 finalized=False,
                 is_restaged=False,
                 cpu_usage=0.0,
-                memory_limit=0,
+                memory_usage=0.0,
             )
             # Start measuring bundle stats for the initial bundle state.
             self.start_stage_stats(bundle.uuid, RunStage.PREPARING)

--- a/codalab/worker/worker_run_state.py
+++ b/codalab/worker/worker_run_state.py
@@ -468,7 +468,7 @@ class RunStateMachine(StateTransitioner):
                 run_state.container
             )
             run_state = run_state._replace(cpu_usage=cpu_usage)
-            run_state = run_state._replace(memory_limit=memory_limit)
+            run_state = run_state._replace(memory_usage=memory_usage)
 
             kill_messages = []
 

--- a/codalab/worker/worker_run_state.py
+++ b/codalab/worker/worker_run_state.py
@@ -104,7 +104,7 @@ RunState = namedtuple(
         'finalized',  # bool
         'is_restaged',  # bool
         'cpu_usage',  # float
-        'memory_limit',  # int
+        'memory_usage',  # float
         'bundle_profile_stats',  # dict
     ],
 )
@@ -464,7 +464,7 @@ class RunStateMachine(StateTransitioner):
 
         def check_resource_utilization(run_state: RunState):
             logger.info(f'Checking resource utilization for bundle. uuid: {run_state.bundle.uuid}')
-            cpu_usage, memory_limit = docker_utils.get_container_stats_with_docker_stats(
+            cpu_usage, memory_usage = docker_utils.get_container_stats_with_docker_stats(
                 run_state.container
             )
             run_state = run_state._replace(cpu_usage=cpu_usage)

--- a/codalab/worker/worker_run_state.py
+++ b/codalab/worker/worker_run_state.py
@@ -467,7 +467,7 @@ class RunStateMachine(StateTransitioner):
             cpu_usage, memory_usage = docker_utils.get_container_stats_with_docker_stats(
                 run_state.container
             )
-            run_state = run_state._replace(cpu_usage=cpu_usage)
+            run_state = run_state._replace(cpu_usage=cpu_usage, memory_usage=memory_usage)
             run_state = run_state._replace(memory_usage=memory_usage)
 
             kill_messages = []

--- a/codalab/worker/worker_run_state.py
+++ b/codalab/worker/worker_run_state.py
@@ -103,6 +103,8 @@ RunState = namedtuple(
         'finished',  # bool
         'finalized',  # bool
         'is_restaged',  # bool
+        'cpu_usage',  # float
+        'memory_limit',  # int
         'bundle_profile_stats',  # dict
     ],
 )
@@ -462,6 +464,12 @@ class RunStateMachine(StateTransitioner):
 
         def check_resource_utilization(run_state: RunState):
             logger.info(f'Checking resource utilization for bundle. uuid: {run_state.bundle.uuid}')
+            cpu_usage, memory_limit = docker_utils.get_container_stats_with_docker_stats(
+                run_state.container
+            )
+            run_state = run_state._replace(cpu_usage=cpu_usage)
+            run_state = run_state._replace(memory_limit=memory_limit)
+
             kill_messages = []
 
             run_stats = docker_utils.get_container_stats(run_state.container)

--- a/tests/unit/server/bundle_manager/__init__.py
+++ b/tests/unit/server/bundle_manager/__init__.py
@@ -271,7 +271,6 @@ class TestBase:
             failure_message="",
             cpu_usage=0.0,
             memory_usage=0.0,
-            memory_limit=0,
             bundle_profile_stats={
                 RunStage.PREPARING: {'start': 15, 'end': 20, 'elapsed': 5},
                 RunStage.RUNNING: {'start': 15, 'end': 20, 'elapsed': 5},

--- a/tests/unit/server/bundle_manager/__init__.py
+++ b/tests/unit/server/bundle_manager/__init__.py
@@ -269,6 +269,8 @@ class TestBase:
             remote="",
             exitcode=0,
             failure_message="",
+            cpu_usage=0.0,
+            memory_limit=0,
             bundle_profile_stats={
                 RunStage.PREPARING: {'start': 15, 'end': 20, 'elapsed': 5},
                 RunStage.RUNNING: {'start': 15, 'end': 20, 'elapsed': 5},

--- a/tests/unit/server/bundle_manager/__init__.py
+++ b/tests/unit/server/bundle_manager/__init__.py
@@ -270,6 +270,7 @@ class TestBase:
             exitcode=0,
             failure_message="",
             cpu_usage=0.0,
+            memory_usage=0.0,
             memory_limit=0,
             bundle_profile_stats={
                 RunStage.PREPARING: {'start': 15, 'end': 20, 'elapsed': 5},


### PR DESCRIPTION
This reverts commit dd81f5f0f5668ba4009a79418dd6c45e10a7d24e.
Re-add the stats of docker images, such as cpu usage and memory limit. 

### Reasons for making this change

<!-- Add a reason for making this change here. -->

### Related issues

fixes https://github.com/codalab/codalab-worksheets/issues/3003, fixes https://github.com/codalab/codalab-worksheets/issues/3234

### Screenshots

<!-- Add screenshots, if necessary -->

### Checklist

* [ ] I've added a screenshot of the changes, if this is a frontend change
* [ ] I've added and/or updated tests, if this is a backend change
* [ ] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [ ] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
