### PR TITLE
Bump version to 0.5.39

### DIFF
--- a/codalab/common.py
+++ b/codalab/common.py
@@ -13,7 +13,7 @@ from retry import retry
 
 # Increment this on master when ready to cut a release.
 # http://semver.org/
-CODALAB_VERSION = '0.5.38'
+CODALAB_VERSION = '0.5.39'
 BINARY_PLACEHOLDER = '<binary>'
 URLOPEN_TIMEOUT_SECONDS = int(os.environ.get('CODALAB_URLOPEN_TIMEOUT_SECONDS', 5 * 60))
 

--- a/docker_config/dockerfiles/Dockerfile.worker
+++ b/docker_config/dockerfiles/Dockerfile.worker
@@ -1,4 +1,4 @@
-FROM golang as ecr-login-installation
+FROM golang:1.15 as ecr-login-installation
 # Install the Amazon ECR Docker Credential Helper
 # Use Docker multi-stage builds to get rid of intermediate layers related to installation
 

--- a/docs/REST-API-Reference.md
+++ b/docs/REST-API-Reference.md
@@ -1,6 +1,6 @@
 # REST API Reference
 
-_version 0.5.38_
+_version 0.5.39_
 
 This reference and the REST API itself is still under heavy development and is
 subject to change at any time. Feedback through our GitHub issues is appreciated!

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -1,5 +1,5 @@
 // Should match codalab/common.py#CODALAB_VERSION
-export const CODALAB_VERSION = '0.5.38';
+export const CODALAB_VERSION = '0.5.39';
 
 // Name Regex to match the backend in spec_utils.py
 export const NAME_REGEX = /^[a-zA-Z_][a-zA-Z0-9_.-]*$/i;

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import sys
 
 
 # should match codalab/common.py#CODALAB_VERSION
-CODALAB_VERSION = "0.5.38"
+CODALAB_VERSION = "0.5.39"
 
 
 class Install(install):


### PR DESCRIPTION
### Reasons for making this change

Bump new version 0.5.39

Full diff: https://github.com/codalab/codalab-worksheets/compare/v0.5.38...rc0.5.39

# Draft release notes

## Frontend
- Fix bug: Table cell renders as 'Forbidden' instead of 'Loading...' when the user has no access (#3250)
- Fix bug: 404 Page shows HTML (#3253)
- Fix bug: Manually bind context to `this` (#3271)

## Backend
- Speed up CLI by lazy loading some imports (#3212) 
- Fix worker Docker build by pinning golang version to 1.15 (#3276)

## Dev / docs / CI
- Fix table in "Storage Externalization" section in docs (#3262) 
