### PR TITLE
Fix worker build by pinning golang version to 1.15

### DIFF
--- a/docker_config/dockerfiles/Dockerfile.worker
+++ b/docker_config/dockerfiles/Dockerfile.worker
@@ -1,4 +1,4 @@
-FROM golang as ecr-login-installation
+FROM golang:1.15 as ecr-login-installation
 # Install the Amazon ECR Docker Credential Helper
 # Use Docker multi-stage builds to get rid of intermediate layers related to installation
 


### PR DESCRIPTION
### Reasons for making this change

Fix worker build. The problem appears to have happened because `golang` may have recently changed the default "latest" tag to point to 1.16, and when you try running the amazon-ecr-credential-helper install scripts with golang 1.16, it fails. it works with 1.15, though, so this PR just pins the golang version to 1.15.

### Related issues

Fixes #3275.
