### PR TITLE
Implement partial refresh of worksheet for updating markup_block

### DIFF
--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -135,7 +135,7 @@ class Worksheet extends React.Component {
                 info['date_created'] = addUTCTimeZone(info['date_created']);
                 info['date_last_modified'] = addUTCTimeZone(info['date_last_modified']);
                 // Use the cache to update directive block if we are in the partial update mode
-                if (!props.searchRefresh) {
+                if (props.skipSearchRefresh) {
                     for (let i: number = 0; i < info.blocks.length; i++) {
                         const directive: string = info.blocks[i]['directive'];
                         if (
@@ -1431,7 +1431,7 @@ class Worksheet extends React.Component {
             textDeleted = false,
             fromDeleteCommand = false,
             uploadFiles = false,
-            searchRefresh = true,
+            skipSearchRefresh = false, // if true, then the search results won't be refreshed to improve performance
         } = {},
     ) => {
         if (partialUpdateItems === undefined) {
@@ -1439,7 +1439,7 @@ class Worksheet extends React.Component {
             this.setState({ updating: true });
             this.fetch({
                 brief: true,
-                searchRefresh: searchRefresh,
+                skipSearchRefresh: skipSearchRefresh,
                 success: function(data) {
                     if (this.state.ws.uuid !== data.uuid) {
                         this.setState({

--- a/frontend/src/components/worksheets/items/TextEditorItem/TextEditorItem.js
+++ b/frontend/src/components/worksheets/items/TextEditorItem/TextEditorItem.js
@@ -93,7 +93,9 @@ class TextEditorItem extends React.Component<{
             type: 'POST',
             success: (data, status, jqXHR) => {
                 const moveIndex = true ? mode === 'create' : false;
-                const param = { moveIndex };
+                // No need to refresh the search results when only updating markdown items
+                const searchRefresh = false;
+                const param = { moveIndex, searchRefresh };
                 closeEditor();
                 reloadWorksheet(undefined, undefined, param);
             },

--- a/frontend/src/components/worksheets/items/TextEditorItem/TextEditorItem.js
+++ b/frontend/src/components/worksheets/items/TextEditorItem/TextEditorItem.js
@@ -94,8 +94,8 @@ class TextEditorItem extends React.Component<{
             success: (data, status, jqXHR) => {
                 const moveIndex = true ? mode === 'create' : false;
                 // No need to refresh the search results when only updating markdown items
-                const searchRefresh = false;
-                const param = { moveIndex, searchRefresh };
+                const skipSearchRefresh = true;
+                const param = { moveIndex, skipSearchRefresh };
                 closeEditor();
                 reloadWorksheet(undefined, undefined, param);
             },


### PR DESCRIPTION
### Reasons for making this change

Improve performance by not refreshing the search results when only updating markup_block.

The improvement only makes sense to markup_block.

**Need refresh search results:**
- table_block
- schema_block

**Can't update block through UI:**
- record_block
- contents_block
- image_block
- graph_block
- subworksheets_block
- placeholder_block

### Related issues

fixes #2174 

### Screenshots

![ezgif com-gif-maker](https://user-images.githubusercontent.com/34461466/108492311-d9671780-7259-11eb-9f0a-edf8b6c1fbd1.gif)


### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
