### PR TITLE
Cache the directives being fetched to avoid duplicate fetch of the same directives

### DIFF
--- a/frontend/src/components/worksheets/items/PlaceholderItem.js
+++ b/frontend/src/components/worksheets/items/PlaceholderItem.js
@@ -32,16 +32,19 @@ export default forwardRef((props, ref) => {
     useEffect(() => {
         (async function() {
             try {
-                const { blocks } = await fetchData({ directive, worksheetUUID });
-                setItem(blocks.length === 0 ? null : blocks[0]);
-                if (blocks.length > 0) {
-                    let actualBlock = blocks[0];
-                    // replace with existing sort keys if there is one
-                    if (sort_keys) {
-                        actualBlock['sort_keys'] = sort_keys;
+                // no need to fetch again a same directive
+                if (!props.skipDirectiveFetch) {
+                    const { blocks } = await fetchData({ directive, worksheetUUID });
+                    setItem(blocks.length === 0 ? null : blocks[0]);
+                    if (blocks.length > 0) {
+                        let actualBlock = blocks[0];
+                        // replace with existing sort keys if there is one
+                        if (sort_keys) {
+                            actualBlock['sort_keys'] = sort_keys;
+                        }
+                        actualBlock.loadedFromPlaceholder = true;
+                        onAsyncItemLoad(actualBlock);
                     }
-                    actualBlock.loadedFromPlaceholder = true;
-                    onAsyncItemLoad(actualBlock);
                 }
             } catch (e) {
                 console.error(e);


### PR DESCRIPTION
### Reasons for making this change

Previously, in order to resolve a directive, multiple requests will be made.
The problem is due to the Worksheet component rerender several times, and every time it re-render, it creates the placeholder items if the results of directives have not been fetched since the fetch of directives is an async process, which results in multiple requests.

To solve it and improve performance, create a cache to store the directives being fetched to avoid duplicate fetch of the same directives. 
Here 'same' is determined by both `directive` and `version`, e.g. `wsearch .mine` in version `1`

### Related issues

fixes #3277 

### Screenshots

Prev:
<img width="693" alt="Screen Shot 2021-02-24 at 1 40 49 AM" src="https://user-images.githubusercontent.com/34461466/109092712-e5286300-76cb-11eb-8588-be8a26c500f4.png">

After:
<img width="815" alt="Screen Shot 2021-02-24 at 6 05 23 PM" src="https://user-images.githubusercontent.com/34461466/109092719-e8235380-76cb-11eb-9adb-b960306de658.png">

### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
