### PR TITLE
Unit test - don't expect a fixed time_quota / disk_quota

### DIFF
--- a/tests/unit/rest/user_test.py
+++ b/tests/unit/rest/user_test.py
@@ -22,6 +22,8 @@ class UserTest(BaseTestCase):
         del data["attributes"]["time_used"]
         del data["attributes"]["date_joined"]
         del data["attributes"]["last_login"]
+        del data["attributes"]["disk_quota"]
+        del data["attributes"]["time_quota"]
         self.assertEqual(
             data,
             {
@@ -31,8 +33,6 @@ class UserTest(BaseTestCase):
                     "first_name": "",
                     "parallel_run_quota": 100,
                     "last_name": "",
-                    "time_quota": 3153600000,
-                    "disk_quota": 107374000000,
                     "url": None,
                     "notifications": 2,
                     "user_name": "codalab",


### PR DESCRIPTION
### Reasons for making this change

Don't expect a fixed time_quota / disk_quota for the user REST test. This is because it's common for users to change their disk quota or time quota on the local codalab instance, and in that case, we still want it to be easy to run the tests and for the tests to pass.