### PR TITLE
Run interactive session as the root user

### DIFF
--- a/codalab/lib/interactive_session.py
+++ b/codalab/lib/interactive_session.py
@@ -143,12 +143,14 @@ class InteractiveSession:
                 volumes[get_docker_path(key)] = dependency_local_path
 
         name = self._get_container_name()
-        # Start a container as a non-root user. Root (id = 0) is the default user within a container.
+        # Start a container as a root user. Root (id = 0) is the default user within a container.
         command = [
             'docker run',
             '-it',
             f'--name {name}',
             f'-w {os.path.sep}{self._session_uuid}',
+            # TODO: figure out a way to run as a non-root user and be able to save the bash_history on any machine
+            # '-u 1',
         ]
         command.extend(
             [

--- a/codalab/lib/interactive_session.py
+++ b/codalab/lib/interactive_session.py
@@ -31,7 +31,7 @@ class InteractiveSession:
         9. Stop and remove the interactive session container.
     """
 
-    _BASH_HISTORY_CONTAINER_PATH = "/usr/sbin/.bash_history"
+    _BASH_HISTORY_CONTAINER_PATH = "/root/.bash_history"
     _CHOOSE_COMMAND_INSTRUCTIONS = (
         "\n\n#\n"
         "# Choose the commands to use for cl run:\n"
@@ -144,13 +144,11 @@ class InteractiveSession:
 
         name = self._get_container_name()
         # Start a container as a non-root user. Root (id = 0) is the default user within a container.
-        # When passing a numeric ID, the user does not have to exist in the container.
         command = [
             'docker run',
             '-it',
             f'--name {name}',
             f'-w {os.path.sep}{self._session_uuid}',
-            '-u 1',
         ]
         command.extend(
             [

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -403,7 +403,7 @@ def _fetch_locations():
     bundle_uuids = query_get_list('uuids')
     bundle_link_urls = local.model.get_bundle_metadata(bundle_uuids, "link_url")
     uuids_to_locations = {
-        uuid: bundle_link_urls.get("uuid") or local.bundle_store.get_bundle_location(uuid)
+        uuid: bundle_link_urls.get(uuid) or local.bundle_store.get_bundle_location(uuid)
         for uuid in bundle_uuids
     }
     return dict(data=uuids_to_locations)

--- a/tests/unit/lib/interactive_session_test.py
+++ b/tests/unit/lib/interactive_session_test.py
@@ -14,9 +14,9 @@ class InteractiveSessionTest(unittest.TestCase):
         )
         session._host_bash_history_path = ".bash_history"
         expected_regex = (
-            'docker run -it --name interactive-session-0x[a-z0-9]{32} -w \/0x[a-z0-9]{32} -u 1 -v '
+            'docker run -it --name interactive-session-0x[a-z0-9]{32} -w \/0x[a-z0-9]{32} -v '
             '[\s\S]{0,100}local\/path1:\/0x[a-z0-9]{32}\/key:ro -v [\s\S]{0,100}local\/path2:\/0x[a-z0-9]{32}\/key2:ro '
-            '-v \.bash_history:\/usr\/sbin\/\.bash_history:rw some-docker-image bash'
+            '-v \.bash_history:\/root\/.bash_history:rw some-docker-image bash'
         )
         self.assertTrue(re.match(expected_regex, session.get_docker_run_command()))
 
@@ -31,9 +31,9 @@ class InteractiveSessionTest(unittest.TestCase):
         )
         session._host_bash_history_path = ".bash_history"
         expected_regex = (
-            'docker run -it --name interactive-session-0x[a-z0-9]{32} -w \/0x[a-z0-9]{32} -u 1 -v '
+            'docker run -it --name interactive-session-0x[a-z0-9]{32} -w \/0x[a-z0-9]{32} -v '
             '[\s\S]{0,100}local\/path1/sub/path1:\/0x[a-z0-9]{32}\/key:ro -v [\s\S]{0,100}local\/path2/sub/path2'
-            ':\/0x[a-z0-9]{32}\/key2:ro -v \.bash_history:\/usr\/sbin\/\.bash_history:rw some-docker-image bash'
+            ':\/0x[a-z0-9]{32}\/key2:ro -v \.bash_history:\/root\/.bash_history:rw some-docker-image bash'
         )
         self.assertTrue(re.match(expected_regex, session.get_docker_run_command()))
 


### PR DESCRIPTION
### Reasons for making this change

On certain machines (e.g. Stanford Jag machines), the bash history is not being written out to `/usr/sbin/.bash_history` for non-root users. This is a temporary fix is to revert my previous change and run the interactive session as the root user, until I figure out a solution that will work on any machine.

Also,  fixes `cl run --interactive + --link`.

Resolves #3342 #3340