### PR TITLE
Enable finer-grained selection of workers via richer request_queue

### DIFF
--- a/codalab/lib/parsing_util.py
+++ b/codalab/lib/parsing_util.py
@@ -28,10 +28,10 @@ class FunctionTransformer(Transformer):
         return f"({' and '.join(exprs)})"
 
     def not_expr(self, atom):
-        return f" not {atom}"
+        return f"not ({atom})"
 
     def name(self, n):
-        return f"'{n}' in worker_tag"
+        return f"'{n}' in worker_tags"
 
 
 class RequestQueueParser:
@@ -46,4 +46,4 @@ class RequestQueueParser:
         # NOTE: this is potentially dangerous. The parser is designed to only accept alphanumeric input
         # (excepting its operators). Similarly, self.collection_name should be alphanumeric.
         # These two constraints make it hard to call functions or do bad things with double-underscores.
-        return eval(f"lambda worker_tag : {function_string}")
+        return eval(f"lambda worker_tags : {function_string}")

--- a/codalab/lib/parsing_util.py
+++ b/codalab/lib/parsing_util.py
@@ -1,0 +1,49 @@
+import functools
+from typing import Callable
+
+from lark import Lark, Transformer, v_args
+
+REQUEST_QUEUE_GRAMMAR = r"""
+    ?start: or_expr
+    ?or_expr: and_expr ("|" and_expr)*
+    ?and_expr: atom ("&" atom)*
+    ?atom: ALPHANUMERIC -> name
+        | "!" atom -> not_expr
+        | "(" or_expr ")"
+
+    ALPHANUMERIC: (LETTER|DIGIT)+
+    %import common.LETTER
+    %import common.DIGIT
+    %import common.WS
+    %ignore WS
+"""
+
+
+@v_args(inline=True)
+class FunctionTransformer(Transformer):
+    def or_expr(self, *exprs):
+        return f"({' or '.join(exprs)})"
+
+    def and_expr(self, *exprs):
+        return f"({' and '.join(exprs)})"
+
+    def not_expr(self, atom):
+        return f" not {atom}"
+
+    def name(self, n):
+        return f"'{n}' in worker_tag"
+
+
+class RequestQueueParser:
+    def __init__(self):
+        self.parser = Lark(REQUEST_QUEUE_GRAMMAR)
+        self.function_transformer = FunctionTransformer()
+
+    @functools.lru_cache(maxsize=128, typed=False)
+    def parse_request_queue_to_callable(self, request_queue: str) -> Callable:
+        tree = self.parser.parse(request_queue)
+        function_string = self.function_transformer.transform(tree)
+        # NOTE: this is potentially dangerous. The parser is designed to only accept alphanumeric input
+        # (excepting its operators). Similarly, self.collection_name should be alphanumeric.
+        # These two constraints make it hard to call functions or do bad things with double-underscores.
+        return eval(f"lambda worker_tag : {function_string}")

--- a/codalab/lib/parsing_util.py
+++ b/codalab/lib/parsing_util.py
@@ -44,6 +44,6 @@ class RequestQueueParser:
         tree = self.parser.parse(request_queue)
         function_string = self.function_transformer.transform(tree)
         # NOTE: this is potentially dangerous. The parser is designed to only accept alphanumeric input
-        # (excepting its operators). Similarly, self.collection_name should be alphanumeric.
-        # These two constraints make it hard to call functions or do bad things with double-underscores.
+        # (excepting its operators). This constraint makes it hard to call functions or
+        # do bad things with double-underscores.
         return eval(f"lambda worker_tags : {function_string}")

--- a/codalab/model/tables.py
+++ b/codalab/model/tables.py
@@ -417,7 +417,9 @@ worker = Table(
     Column('user_id', String(63), ForeignKey(user.c.user_id), primary_key=True, nullable=False),
     Column('worker_id', String(127), primary_key=True, nullable=False),
     Column('group_uuid', String(63), ForeignKey(group.c.uuid), nullable=True),
-    Column('tag', Text, nullable=True),  # Comma-separated list of tags that allows for scheduling runs on specific workers.
+    Column(
+        'tag', Text, nullable=True
+    ),  # Comma-separated list of tags that allows for scheduling runs on specific workers.
     Column('cpus', Integer, nullable=False),  # Number of CPUs on worker.
     Column('gpus', Integer, nullable=False),  # Number of GPUs on worker.
     Column('memory_bytes', BigInteger, nullable=False),  # Total memory of worker.

--- a/codalab/model/tables.py
+++ b/codalab/model/tables.py
@@ -417,7 +417,7 @@ worker = Table(
     Column('user_id', String(63), ForeignKey(user.c.user_id), primary_key=True, nullable=False),
     Column('worker_id', String(127), primary_key=True, nullable=False),
     Column('group_uuid', String(63), ForeignKey(group.c.uuid), nullable=True),
-    Column('tag', Text, nullable=True),  # Tag that allows for scheduling runs on specific workers.
+    Column('tag', Text, nullable=True),  # Comma-separated list of tags that allows for scheduling runs on specific workers.
     Column('cpus', Integer, nullable=False),  # Number of CPUs on worker.
     Column('gpus', Integer, nullable=False),  # Number of GPUs on worker.
     Column('memory_bytes', BigInteger, nullable=False),  # Total memory of worker.

--- a/codalab/model/worker_model.py
+++ b/codalab/model/worker_model.py
@@ -59,7 +59,9 @@ class WorkerModel(object):
         """
         with self._engine.begin() as conn:
             worker_row = {
-                'tag': tag,
+                # Maintain backwards compatibility with workers that have string tags
+                # TODO(nfliu): remove support for string-only tags.
+                'tag': tag if (isinstance(tag, str) or not tag) else ",".join(tag),
                 'cpus': cpus,
                 'gpus': gpus,
                 'memory_bytes': memory_bytes,

--- a/codalab/model/worker_model.py
+++ b/codalab/model/worker_model.py
@@ -59,9 +59,7 @@ class WorkerModel(object):
         """
         with self._engine.begin() as conn:
             worker_row = {
-                # Maintain backwards compatibility with workers that have string tags
-                # TODO(nfliu): remove support for string-only tags.
-                'tag': tag if (isinstance(tag, str) or not tag) else ",".join(tag),
+                'tag': tag,
                 'cpus': cpus,
                 'gpus': gpus,
                 'memory_bytes': memory_bytes,

--- a/codalab/server/bundle_manager.py
+++ b/codalab/server/bundle_manager.py
@@ -8,7 +8,7 @@ import sys
 import threading
 import time
 import traceback
-from typing import List
+from typing import List, Sequence
 
 from codalab.objects.permission import (
     check_bundles_have_read_permission,
@@ -848,9 +848,18 @@ class BundleManager(object):
             return [
                 worker
                 for worker in workers
-                if (worker["tag"] and request_queue in worker["tag"].split(","))
+                if (
+                    worker["tag"]
+                    and BundleManager._request_queue_matches_worker_tags(
+                        request_queue=request_queue, worker_tags=worker["tag"].split(",")
+                    )
+                )
             ]
         return []
+
+    @staticmethod
+    def _request_queue_matches_worker_tags(request_queue: str, worker_tags: Sequence[str]):
+        return request_queue in worker_tags
 
     def _get_staged_bundles_to_run(self, workers, user_info_cache):
         """

--- a/codalab/server/bundle_manager.py
+++ b/codalab/server/bundle_manager.py
@@ -20,6 +20,8 @@ from codalab.server.worker_info_accessor import WorkerInfoAccessor
 from codalab.worker.file_util import remove_path
 from codalab.worker.bundle_state import State, RunResources
 
+import lark
+
 
 logger = logging.getLogger(__name__)
 
@@ -847,16 +849,20 @@ class BundleManager(object):
             # Strip off "tag=" from the request_queue value
             request_queue = request_queue[len(prefix) :]
         if request_queue:
-            return [
-                worker
-                for worker in workers
-                if (
-                    worker["tag"]
-                    and cls._request_queue_matches_worker_tags(
-                        request_queue=request_queue, worker_tags=worker["tag"].split(",")
+            try:
+                return [
+                    worker
+                    for worker in workers
+                    if (
+                        worker["tag"]
+                        and cls._request_queue_matches_worker_tags(
+                            request_queue=request_queue, worker_tags=worker["tag"].split(",")
+                        )
                     )
-                )
-            ]
+                ]
+            except lark.exceptions.LarkError as e:
+                logger.debug(traceback.format_exc())
+                return []
         return []
 
     @classmethod

--- a/codalab/server/bundle_manager.py
+++ b/codalab/server/bundle_manager.py
@@ -4,7 +4,6 @@ import datetime
 import logging
 import os
 import random
-import re
 import sys
 import threading
 import time
@@ -844,9 +843,13 @@ class BundleManager(object):
         prefix = "tag="
         if request_queue.startswith(prefix):
             # Strip off "tag=" from the request_queue value
-            request_queue = request_queue[len(prefix):]
+            request_queue = request_queue[len(prefix) :]
         if request_queue:
-            return [worker for worker in workers if (worker["tag"] and request_queue in worker["tag"].split(","))]
+            return [
+                worker
+                for worker in workers
+                if (worker["tag"] and request_queue in worker["tag"].split(","))
+            ]
         return []
 
     def _get_staged_bundles_to_run(self, workers, user_info_cache):

--- a/codalab/server/bundle_manager.py
+++ b/codalab/server/bundle_manager.py
@@ -860,7 +860,7 @@ class BundleManager(object):
                         )
                     )
                 ]
-            except lark.exceptions.LarkError as e:
+            except lark.exceptions.LarkError:
                 logger.debug(traceback.format_exc())
                 return []
         return []

--- a/codalab/server/bundle_manager.py
+++ b/codalab/server/bundle_manager.py
@@ -334,7 +334,7 @@ class BundleManager(object):
         1. For a given user, schedule the highest-priority bundles first, followed by bundles
            that request to run on a specific worker.
         2. If the bundle requests to run on a specific worker, schedule the bundle
-           to run on a worker that has a tag that exactly matches the bundle's request_queue.
+           to run on a worker that has a tag that matches the bundle's request_queue.
         3. If the bundle doesn't request to run on a specific worker,
           (1) try to schedule the bundle to run on a worker that belongs to the bundle's owner
           (2) if there is no such qualified private worker, uses CodaLab-owned workers, which have user ID root_user_id.
@@ -841,9 +841,12 @@ class BundleManager(object):
         :param workers: a list of workers
         :return: a list of matched workers
         """
-        tag_match = re.match('(?:tag=)?(.+)', request_queue)
-        if tag_match is not None:
-            return [worker for worker in workers if worker['tag'] == tag_match.group(1)]
+        prefix = "tag="
+        if request_queue.startswith(prefix):
+            # Strip off "tag=" from the request_queue value
+            request_queue = request_queue[len(prefix):]
+        if request_queue:
+            return [worker for worker in workers if (worker["tag"] and request_queue in worker["tag"].split(","))]
         return []
 
     def _get_staged_bundles_to_run(self, workers, user_info_cache):

--- a/codalab/worker/main.py
+++ b/codalab/worker/main.py
@@ -30,7 +30,9 @@ DEFAULT_EXIT_AFTER_NUM_RUNS = 999999999
 def parse_args():
     parser = argparse.ArgumentParser(description='CodaLab worker.')
     parser.add_argument(
-        '--tag', nargs="+", help='Alphanumeric tag(s) that allows for scheduling runs on specific workers.',
+        '--tag',
+        nargs="+",
+        help='Alphanumeric tag(s) that allows for scheduling runs on specific workers.',
     )
     parser.add_argument(
         '--server',

--- a/codalab/worker/main.py
+++ b/codalab/worker/main.py
@@ -30,7 +30,7 @@ DEFAULT_EXIT_AFTER_NUM_RUNS = 999999999
 def parse_args():
     parser = argparse.ArgumentParser(description='CodaLab worker.')
     parser.add_argument(
-        '--tag', help='Alphanumeric tag that allows for scheduling runs on specific workers.'
+        '--tag', nargs="+", help='Alphanumeric tag(s) that allows for scheduling runs on specific workers.',
     )
     parser.add_argument(
         '--server',
@@ -209,10 +209,12 @@ def connect_to_codalab_server(server, password_file):
 def main():
     args = parse_args()
 
-    if args.tag and not args.tag.isalnum():
-        raise argparse.ArgumentTypeError(
-            "Worker tag must be alphanumeric (only contain letters and numbers)."
-        )
+    if args.tag:
+        for tag in args.tag:
+            if not tag.isalnum():
+                raise argparse.ArgumentTypeError(
+                    f"Worker tags must be alphanumeric (only contain letters and numbers), but {tag} is not."
+                )
 
     # Configure logging
     logging.basicConfig(

--- a/codalab/worker/worker.py
+++ b/codalab/worker/worker.py
@@ -407,7 +407,7 @@ class Worker:
         processes must be handled asynchronously.
         """
         request = {
-            'tag': self.tag,
+            'tag': ",".join(self.tag),
             'group_name': self.group_name,
             'cpus': len(self.cpuset),
             'gpus': len(self.gpuset),

--- a/codalab/worker/worker.py
+++ b/codalab/worker/worker.py
@@ -8,7 +8,7 @@ import traceback
 import socket
 import http.client
 import sys
-from typing import Optional, Set, Dict
+from typing import List, Optional, Set, Dict
 
 import psutil
 

--- a/codalab/worker/worker.py
+++ b/codalab/worker/worker.py
@@ -59,7 +59,7 @@ class Worker:
         gpuset,  # type: Set[str]
         max_memory,  # type: Optional[int]
         worker_id,  # type: str
-        tag,  # type: str
+        tag,  # type: List[str]
         work_dir,  # type: str
         local_bundles_dir,  # type: Optional[str]
         exit_when_idle,  # type: str

--- a/codalab/worker/worker.py
+++ b/codalab/worker/worker.py
@@ -407,7 +407,7 @@ class Worker:
         processes must be handled asynchronously.
         """
         request = {
-            'tag': ",".join(self.tag),
+            'tag': ",".join(self.tag) if self.tag else self.tag,
             'group_name': self.group_name,
             'cpus': len(self.cpuset),
             'gpus': len(self.gpuset),

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ markdown2==2.3.10
 wheel==0.35.1
 urllib3<1.26
 retry==0.9.2
+lark-parser==0.11.2

--- a/tests/unit/lib/parsing_util_test.py
+++ b/tests/unit/lib/parsing_util_test.py
@@ -1,0 +1,100 @@
+import unittest
+from codalab.lib import parsing_util
+
+import lark
+from lark import Lark, Token
+from lark.tree import Tree
+
+class ParsingUtilTest(unittest.TestCase):
+    """
+    This class tests parsing_util.REQUEST_QUEUE_GRAMMAR and
+    parsing_util.FunctionTransformer . The logic that matches
+    request_queue values to workers is tested in the BundleManager tests.
+    """
+    def test_grammar_basic(self):
+        parser = Lark(parsing_util.REQUEST_QUEUE_GRAMMAR)
+        # Test single item
+        expected_tag1_tree = Tree('name', [Token('ALPHANUMERIC', 'tag1')])
+        expected_tag2_tree = Tree('name', [Token('ALPHANUMERIC', 'tag2')])
+        expected_tag3_tree = Tree('name', [Token('ALPHANUMERIC', 'tag3')])
+        self.assertEqual(parser.parse("tag1"), expected_tag1_tree)
+        # Test negation of single item
+        self.assertEqual(parser.parse("!tag1"), Tree('not_expr', [expected_tag1_tree]))
+        # Test or of two items
+        self.assertEqual(parser.parse("tag1 | tag2"), Tree('or_expr', [expected_tag1_tree, expected_tag2_tree]))
+        # Test and of two items
+        self.assertEqual(parser.parse("tag1 & tag2"), Tree('and_expr', [expected_tag1_tree, expected_tag2_tree]))
+        # Test nested expressions
+        self.assertEqual(parser.parse("tag1 | (tag2 & tag3)"),
+                         Tree('or_expr', [
+                             expected_tag1_tree,
+                             Tree('and_expr', [expected_tag2_tree, expected_tag3_tree])]))
+        self.assertEqual(parser.parse("tag1 & (tag2 | tag3)"),
+                         Tree('and_expr',[
+                             expected_tag1_tree,
+                             Tree('or_expr', [expected_tag2_tree, expected_tag3_tree])]))
+        # Test nesting with parens. Precedence (highest to lowest) is not, and, or.
+        self.assertEqual(parser.parse("!tag1 & tag2 | tag3"),
+                         Tree('or_expr', [
+                             Tree('and_expr', [
+                                 Tree('not_expr', [expected_tag1_tree]),
+                                 expected_tag2_tree]),
+                             expected_tag3_tree]))
+        self.assertEqual(parser.parse("!tag1 & tag2 | tag3"),
+                         parser.parse("(!tag1) & tag2 | tag3"))
+        self.assertEqual(parser.parse("!tag1 & (tag2 | tag3)"),
+                         Tree('and_expr', [
+                             Tree('not_expr', [expected_tag1_tree]),
+                             Tree('or_expr', [expected_tag2_tree, expected_tag3_tree])]))
+        self.assertEqual(parser.parse("!(tag1 & tag2) | tag3"),
+                         Tree('or_expr', [
+                             Tree('not_expr', [
+                                 Tree('and_expr', [
+                                     expected_tag1_tree,
+                                     expected_tag2_tree])]),
+                             expected_tag3_tree]))
+        self.assertEqual(parser.parse("!(tag1 & (tag2 | tag3))"),
+                         Tree('not_expr', [
+                             Tree('and_expr', [
+                                 expected_tag1_tree,
+                                 Tree('or_expr', [expected_tag2_tree, expected_tag3_tree])])]))
+
+
+    def test_grammar_invalid(self):
+        parser = Lark(parsing_util.REQUEST_QUEUE_GRAMMAR)
+        with self.assertRaises(lark.exceptions.UnexpectedCharacters):
+            parser.parse("tag_1")
+            parser.parse("not tag_1")
+        with self.assertRaises(lark.exceptions.UnexpectedEOF):
+            parser.parse("tag1 & tag2 |")
+            parser.parse("(tag1 & tag2")
+
+    def test_transformer_basic(self):
+        parser = Lark(parsing_util.REQUEST_QUEUE_GRAMMAR)
+        transformer = parsing_util.FunctionTransformer()
+        # Test single item
+        self.assertEqual(transformer.transform(parser.parse("tag1")), "'tag1' in worker_tags")
+        # Test negation of single item
+        self.assertEqual(transformer.transform(parser.parse("!tag1")), "not ('tag1' in worker_tags)")
+        # Test or of two items
+        self.assertEqual(transformer.transform(parser.parse("tag1 | tag2")),
+                         "('tag1' in worker_tags or 'tag2' in worker_tags)")
+        # Test and of two items
+        self.assertEqual(transformer.transform(parser.parse("tag1 & tag2")),
+                         "('tag1' in worker_tags and 'tag2' in worker_tags)")
+        # Test nested eworker_tagspressions
+        self.assertEqual(transformer.transform(parser.parse("tag1 | (tag2 & tag3)")),
+                         "('tag1' in worker_tags or ('tag2' in worker_tags and 'tag3' in worker_tags))")
+        self.assertEqual(transformer.transform(parser.parse("tag1 & (tag2 | tag3)")),
+                         "('tag1' in worker_tags and ('tag2' in worker_tags or 'tag3' in worker_tags))")
+        # Test nesting with parens. Precedence (highest to lowest) isnot, and, or.
+        self.assertEqual(transformer.transform(parser.parse("!tag1 & tag2 | tag3")),
+                         "((not ('tag1' in worker_tags) and 'tag2' in worker_tags) or 'tag3' in worker_tags)")
+        self.assertEqual(transformer.transform(parser.parse("(!tag1) & tag2 | tag3")),
+                         "((not ('tag1' in worker_tags) and 'tag2' in worker_tags) or 'tag3' in worker_tags)")
+        self.assertEqual(transformer.transform(parser.parse("!tag1 & (tag2 | tag3)")),
+                         "(not ('tag1' in worker_tags) and ('tag2' in worker_tags or 'tag3' in worker_tags))")
+        self.assertEqual(transformer.transform(parser.parse("!(tag1 & tag2) | tag3")),
+                         "(not (('tag1' in worker_tags and 'tag2' in worker_tags)) or 'tag3' in worker_tags)")
+        self.assertEqual(transformer.transform(parser.parse("!(tag1 & (tag2 | tag3))")),
+                         "not (('tag1' in worker_tags and ('tag2' in worker_tags or 'tag3' in worker_tags)))")

--- a/tests/unit/lib/parsing_util_test.py
+++ b/tests/unit/lib/parsing_util_test.py
@@ -5,12 +5,14 @@ import lark
 from lark import Lark, Token
 from lark.tree import Tree
 
+
 class ParsingUtilTest(unittest.TestCase):
     """
     This class tests parsing_util.REQUEST_QUEUE_GRAMMAR and
     parsing_util.FunctionTransformer . The logic that matches
     request_queue values to workers is tested in the BundleManager tests.
     """
+
     def test_grammar_basic(self):
         parser = Lark(parsing_util.REQUEST_QUEUE_GRAMMAR)
         # Test single item
@@ -21,44 +23,75 @@ class ParsingUtilTest(unittest.TestCase):
         # Test negation of single item
         self.assertEqual(parser.parse("!tag1"), Tree('not_expr', [expected_tag1_tree]))
         # Test or of two items
-        self.assertEqual(parser.parse("tag1 | tag2"), Tree('or_expr', [expected_tag1_tree, expected_tag2_tree]))
+        self.assertEqual(
+            parser.parse("tag1 | tag2"), Tree('or_expr', [expected_tag1_tree, expected_tag2_tree])
+        )
         # Test and of two items
-        self.assertEqual(parser.parse("tag1 & tag2"), Tree('and_expr', [expected_tag1_tree, expected_tag2_tree]))
+        self.assertEqual(
+            parser.parse("tag1 & tag2"), Tree('and_expr', [expected_tag1_tree, expected_tag2_tree])
+        )
         # Test nested expressions
-        self.assertEqual(parser.parse("tag1 | (tag2 & tag3)"),
-                         Tree('or_expr', [
-                             expected_tag1_tree,
-                             Tree('and_expr', [expected_tag2_tree, expected_tag3_tree])]))
-        self.assertEqual(parser.parse("tag1 & (tag2 | tag3)"),
-                         Tree('and_expr',[
-                             expected_tag1_tree,
-                             Tree('or_expr', [expected_tag2_tree, expected_tag3_tree])]))
+        self.assertEqual(
+            parser.parse("tag1 | (tag2 & tag3)"),
+            Tree(
+                'or_expr',
+                [expected_tag1_tree, Tree('and_expr', [expected_tag2_tree, expected_tag3_tree])],
+            ),
+        )
+        self.assertEqual(
+            parser.parse("tag1 & (tag2 | tag3)"),
+            Tree(
+                'and_expr',
+                [expected_tag1_tree, Tree('or_expr', [expected_tag2_tree, expected_tag3_tree])],
+            ),
+        )
         # Test nesting with parens. Precedence (highest to lowest) is not, and, or.
-        self.assertEqual(parser.parse("!tag1 & tag2 | tag3"),
-                         Tree('or_expr', [
-                             Tree('and_expr', [
-                                 Tree('not_expr', [expected_tag1_tree]),
-                                 expected_tag2_tree]),
-                             expected_tag3_tree]))
-        self.assertEqual(parser.parse("!tag1 & tag2 | tag3"),
-                         parser.parse("(!tag1) & tag2 | tag3"))
-        self.assertEqual(parser.parse("!tag1 & (tag2 | tag3)"),
-                         Tree('and_expr', [
-                             Tree('not_expr', [expected_tag1_tree]),
-                             Tree('or_expr', [expected_tag2_tree, expected_tag3_tree])]))
-        self.assertEqual(parser.parse("!(tag1 & tag2) | tag3"),
-                         Tree('or_expr', [
-                             Tree('not_expr', [
-                                 Tree('and_expr', [
-                                     expected_tag1_tree,
-                                     expected_tag2_tree])]),
-                             expected_tag3_tree]))
-        self.assertEqual(parser.parse("!(tag1 & (tag2 | tag3))"),
-                         Tree('not_expr', [
-                             Tree('and_expr', [
-                                 expected_tag1_tree,
-                                 Tree('or_expr', [expected_tag2_tree, expected_tag3_tree])])]))
-
+        self.assertEqual(
+            parser.parse("!tag1 & tag2 | tag3"),
+            Tree(
+                'or_expr',
+                [
+                    Tree('and_expr', [Tree('not_expr', [expected_tag1_tree]), expected_tag2_tree]),
+                    expected_tag3_tree,
+                ],
+            ),
+        )
+        self.assertEqual(parser.parse("!tag1 & tag2 | tag3"), parser.parse("(!tag1) & tag2 | tag3"))
+        self.assertEqual(
+            parser.parse("!tag1 & (tag2 | tag3)"),
+            Tree(
+                'and_expr',
+                [
+                    Tree('not_expr', [expected_tag1_tree]),
+                    Tree('or_expr', [expected_tag2_tree, expected_tag3_tree]),
+                ],
+            ),
+        )
+        self.assertEqual(
+            parser.parse("!(tag1 & tag2) | tag3"),
+            Tree(
+                'or_expr',
+                [
+                    Tree('not_expr', [Tree('and_expr', [expected_tag1_tree, expected_tag2_tree])]),
+                    expected_tag3_tree,
+                ],
+            ),
+        )
+        self.assertEqual(
+            parser.parse("!(tag1 & (tag2 | tag3))"),
+            Tree(
+                'not_expr',
+                [
+                    Tree(
+                        'and_expr',
+                        [
+                            expected_tag1_tree,
+                            Tree('or_expr', [expected_tag2_tree, expected_tag3_tree]),
+                        ],
+                    )
+                ],
+            ),
+        )
 
     def test_grammar_invalid(self):
         parser = Lark(parsing_util.REQUEST_QUEUE_GRAMMAR)
@@ -75,26 +108,46 @@ class ParsingUtilTest(unittest.TestCase):
         # Test single item
         self.assertEqual(transformer.transform(parser.parse("tag1")), "'tag1' in worker_tags")
         # Test negation of single item
-        self.assertEqual(transformer.transform(parser.parse("!tag1")), "not ('tag1' in worker_tags)")
+        self.assertEqual(
+            transformer.transform(parser.parse("!tag1")), "not ('tag1' in worker_tags)"
+        )
         # Test or of two items
-        self.assertEqual(transformer.transform(parser.parse("tag1 | tag2")),
-                         "('tag1' in worker_tags or 'tag2' in worker_tags)")
+        self.assertEqual(
+            transformer.transform(parser.parse("tag1 | tag2")),
+            "('tag1' in worker_tags or 'tag2' in worker_tags)",
+        )
         # Test and of two items
-        self.assertEqual(transformer.transform(parser.parse("tag1 & tag2")),
-                         "('tag1' in worker_tags and 'tag2' in worker_tags)")
+        self.assertEqual(
+            transformer.transform(parser.parse("tag1 & tag2")),
+            "('tag1' in worker_tags and 'tag2' in worker_tags)",
+        )
         # Test nested eworker_tagspressions
-        self.assertEqual(transformer.transform(parser.parse("tag1 | (tag2 & tag3)")),
-                         "('tag1' in worker_tags or ('tag2' in worker_tags and 'tag3' in worker_tags))")
-        self.assertEqual(transformer.transform(parser.parse("tag1 & (tag2 | tag3)")),
-                         "('tag1' in worker_tags and ('tag2' in worker_tags or 'tag3' in worker_tags))")
+        self.assertEqual(
+            transformer.transform(parser.parse("tag1 | (tag2 & tag3)")),
+            "('tag1' in worker_tags or ('tag2' in worker_tags and 'tag3' in worker_tags))",
+        )
+        self.assertEqual(
+            transformer.transform(parser.parse("tag1 & (tag2 | tag3)")),
+            "('tag1' in worker_tags and ('tag2' in worker_tags or 'tag3' in worker_tags))",
+        )
         # Test nesting with parens. Precedence (highest to lowest) isnot, and, or.
-        self.assertEqual(transformer.transform(parser.parse("!tag1 & tag2 | tag3")),
-                         "((not ('tag1' in worker_tags) and 'tag2' in worker_tags) or 'tag3' in worker_tags)")
-        self.assertEqual(transformer.transform(parser.parse("(!tag1) & tag2 | tag3")),
-                         "((not ('tag1' in worker_tags) and 'tag2' in worker_tags) or 'tag3' in worker_tags)")
-        self.assertEqual(transformer.transform(parser.parse("!tag1 & (tag2 | tag3)")),
-                         "(not ('tag1' in worker_tags) and ('tag2' in worker_tags or 'tag3' in worker_tags))")
-        self.assertEqual(transformer.transform(parser.parse("!(tag1 & tag2) | tag3")),
-                         "(not (('tag1' in worker_tags and 'tag2' in worker_tags)) or 'tag3' in worker_tags)")
-        self.assertEqual(transformer.transform(parser.parse("!(tag1 & (tag2 | tag3))")),
-                         "not (('tag1' in worker_tags and ('tag2' in worker_tags or 'tag3' in worker_tags)))")
+        self.assertEqual(
+            transformer.transform(parser.parse("!tag1 & tag2 | tag3")),
+            "((not ('tag1' in worker_tags) and 'tag2' in worker_tags) or 'tag3' in worker_tags)",
+        )
+        self.assertEqual(
+            transformer.transform(parser.parse("(!tag1) & tag2 | tag3")),
+            "((not ('tag1' in worker_tags) and 'tag2' in worker_tags) or 'tag3' in worker_tags)",
+        )
+        self.assertEqual(
+            transformer.transform(parser.parse("!tag1 & (tag2 | tag3)")),
+            "(not ('tag1' in worker_tags) and ('tag2' in worker_tags or 'tag3' in worker_tags))",
+        )
+        self.assertEqual(
+            transformer.transform(parser.parse("!(tag1 & tag2) | tag3")),
+            "(not (('tag1' in worker_tags and 'tag2' in worker_tags)) or 'tag3' in worker_tags)",
+        )
+        self.assertEqual(
+            transformer.transform(parser.parse("!(tag1 & (tag2 | tag3))")),
+            "not (('tag1' in worker_tags and ('tag2' in worker_tags or 'tag3' in worker_tags)))",
+        )

--- a/tests/unit/server/bundle_manager/mocked_test.py
+++ b/tests/unit/server/bundle_manager/mocked_test.py
@@ -231,9 +231,10 @@ class BundleManagerMockedManagerTest(unittest.TestCase):
         )
         self.assertEqual(len(sorted_workers_list), 3)
         self.assertEqual(sorted_workers_list[0]['worker_id'], 6)
-        self.assertEqual(set([sorted_workers_list[1]['worker_id'],
-                              sorted_workers_list[2]['worker_id']]),
-                         set([5, 8]))
+        self.assertEqual(
+            set([sorted_workers_list[1]['worker_id'], sorted_workers_list[2]['worker_id']]),
+            set([5, 8]),
+        )
 
     def test_get_matched_workers_with_tag(self):
         self.bundle.metadata.request_queue = "tag=worker_X"

--- a/tests/unit/server/bundle_manager/mocked_test.py
+++ b/tests/unit/server/bundle_manager/mocked_test.py
@@ -312,3 +312,20 @@ class BundleManagerMockedManagerTest(unittest.TestCase):
         )
         self.assertEqual(len(matched_workers), 1)
         self.assertEqual(matched_workers[0]['worker_id'], 8)
+
+    def test_get_matched_workers_not_existing_tag(self):
+        self.bundle.metadata.request_queue = "!workerX"
+        matched_workers = BundleManager._get_matched_workers(
+            self.bundle.metadata.request_queue, self.workers_list
+        )
+        self.assertEqual(len(matched_workers), 0)
+
+    def test_get_matched_workers_not_existing_tag_with_multiple(self):
+        self.bundle.metadata.request_queue = "!workerY"
+        matched_workers = BundleManager._get_matched_workers(
+            self.bundle.metadata.request_queue, self.workers_list
+        )
+        self.assertEqual(len(matched_workers), 3)
+        self.assertEqual(matched_workers[0]['worker_id'], 5)
+        self.assertEqual(matched_workers[1]['worker_id'], 6)
+        self.assertEqual(matched_workers[2]['worker_id'], 7)

--- a/tests/unit/server/bundle_manager/mocked_test.py
+++ b/tests/unit/server/bundle_manager/mocked_test.py
@@ -123,7 +123,7 @@ class BundleManagerMockedManagerTest(unittest.TestCase):
                 'memory_bytes': 2 * 1000,
                 'free_disk_bytes': 2 * 1000,
                 'exit_after_num_runs': 1000,
-                'tag': 'worker_X',
+                'tag': 'workerX',
                 'run_uuids': [],
                 'dependencies': [],
                 'shared_file_system': False,
@@ -137,7 +137,7 @@ class BundleManagerMockedManagerTest(unittest.TestCase):
                 'memory_bytes': 2 * 1000,
                 'free_disk_bytes': 2 * 1000,
                 'exit_after_num_runs': 1000,
-                'tag': 'worker_X',
+                'tag': 'workerX',
                 'run_uuids': [],
                 'dependencies': [],
                 'shared_file_system': False,
@@ -151,7 +151,7 @@ class BundleManagerMockedManagerTest(unittest.TestCase):
                 'memory_bytes': 2 * 1000,
                 'free_disk_bytes': 2 * 1000,
                 'exit_after_num_runs': 0,
-                'tag': 'worker_X',
+                'tag': 'workerX',
                 'run_uuids': [],
                 'dependencies': [],
                 'shared_file_system': False,
@@ -165,7 +165,7 @@ class BundleManagerMockedManagerTest(unittest.TestCase):
                 'memory_bytes': 2 * 1000,
                 'free_disk_bytes': 2 * 1000,
                 'exit_after_num_runs': 1000,
-                'tag': 'worker_Y,worker_X',
+                'tag': 'workerY,workerX',
                 'run_uuids': [],
                 'dependencies': [],
                 'shared_file_system': False,
@@ -225,7 +225,7 @@ class BundleManagerMockedManagerTest(unittest.TestCase):
     def test_filter_and_sort_workers_tag_exclusive_priority(self):
         # All other things being equal, tag_exclusive workers
         # should appear in the top from the returned sorted workers list.
-        self.bundle.metadata.request_queue = "tag=worker_X"
+        self.bundle.metadata.request_queue = "tag=workerX"
         sorted_workers_list = self.bundle_manager._filter_and_sort_workers(
             self.workers_list, self.bundle, self.bundle_resources
         )
@@ -237,7 +237,7 @@ class BundleManagerMockedManagerTest(unittest.TestCase):
         )
 
     def test_get_matched_workers_with_tag(self):
-        self.bundle.metadata.request_queue = "tag=worker_X"
+        self.bundle.metadata.request_queue = "tag=workerX"
         matched_workers = BundleManager._get_matched_workers(
             self.bundle.metadata.request_queue, self.workers_list
         )
@@ -255,7 +255,7 @@ class BundleManagerMockedManagerTest(unittest.TestCase):
         self.assertEqual(len(matched_workers), 0)
 
     def test_get_matched_workers_without_tag_prefix(self):
-        self.bundle.metadata.request_queue = "worker_X"
+        self.bundle.metadata.request_queue = "workerX"
         matched_workers = BundleManager._get_matched_workers(
             self.bundle.metadata.request_queue, self.workers_list
         )
@@ -266,7 +266,7 @@ class BundleManagerMockedManagerTest(unittest.TestCase):
         self.assertEqual(matched_workers[3]['worker_id'], 8)
 
     def test_get_matched_workers_multiple_tags(self):
-        self.bundle.metadata.request_queue = "worker_Y"
+        self.bundle.metadata.request_queue = "workerY"
         matched_workers = BundleManager._get_matched_workers(
             self.bundle.metadata.request_queue, self.workers_list
         )
@@ -274,7 +274,7 @@ class BundleManagerMockedManagerTest(unittest.TestCase):
         self.assertEqual(matched_workers[0]['worker_id'], 8)
 
     def test_get_matched_workers_not_exist_tag(self):
-        self.bundle.metadata.request_queue = "worker_Z"
+        self.bundle.metadata.request_queue = "workerZ"
         matched_workers = BundleManager._get_matched_workers(
             self.bundle.metadata.request_queue, self.workers_list
         )

--- a/tests/unit/server/bundle_manager/mocked_test.py
+++ b/tests/unit/server/bundle_manager/mocked_test.py
@@ -298,7 +298,7 @@ class BundleManagerMockedManagerTest(unittest.TestCase):
         self.assertEqual(matched_workers[2]['worker_id'], 7)
         self.assertEqual(matched_workers[3]['worker_id'], 8)
 
-    def test_get_matched_workers_non_existent_or_existing_tag(self):
+    def test_get_matched_workers_non_existent_and_existing_tag(self):
         self.bundle.metadata.request_queue = "workerZ & workerX"
         matched_workers = BundleManager._get_matched_workers(
             self.bundle.metadata.request_queue, self.workers_list

--- a/tests/unit/server/bundle_manager/mocked_test.py
+++ b/tests/unit/server/bundle_manager/mocked_test.py
@@ -286,3 +286,29 @@ class BundleManagerMockedManagerTest(unittest.TestCase):
             self.bundle.metadata.request_queue, self.workers_list
         )
         self.assertEqual(len(matched_workers), 0)
+
+    def test_get_matched_workers_non_existent_or_existing_tag(self):
+        self.bundle.metadata.request_queue = "workerZ|workerX"
+        matched_workers = BundleManager._get_matched_workers(
+            self.bundle.metadata.request_queue, self.workers_list
+        )
+        self.assertEqual(len(matched_workers), 4)
+        self.assertEqual(matched_workers[0]['worker_id'], 5)
+        self.assertEqual(matched_workers[1]['worker_id'], 6)
+        self.assertEqual(matched_workers[2]['worker_id'], 7)
+        self.assertEqual(matched_workers[3]['worker_id'], 8)
+
+    def test_get_matched_workers_non_existent_or_existing_tag(self):
+        self.bundle.metadata.request_queue = "workerZ & workerX"
+        matched_workers = BundleManager._get_matched_workers(
+            self.bundle.metadata.request_queue, self.workers_list
+        )
+        self.assertEqual(len(matched_workers), 0)
+
+    def test_get_matched_workers_non_existent_nested_or_existing_tags(self):
+        self.bundle.metadata.request_queue = "workerZ | (workerX & workerY)"
+        matched_workers = BundleManager._get_matched_workers(
+            self.bundle.metadata.request_queue, self.workers_list
+        )
+        self.assertEqual(len(matched_workers), 1)
+        self.assertEqual(matched_workers[0]['worker_id'], 8)

--- a/tests/unit/server/bundle_manager/mocked_test.py
+++ b/tests/unit/server/bundle_manager/mocked_test.py
@@ -158,6 +158,20 @@ class BundleManagerMockedManagerTest(unittest.TestCase):
                 'tag_exclusive': True,
                 'has_gpus': False,
             },
+            {
+                'worker_id': 8,
+                'cpus': 6,
+                'gpus': 0,
+                'memory_bytes': 2 * 1000,
+                'free_disk_bytes': 2 * 1000,
+                'exit_after_num_runs': 1000,
+                'tag': 'worker_Y,worker_X',
+                'run_uuids': [],
+                'dependencies': [],
+                'shared_file_system': False,
+                'tag_exclusive': False,
+                'has_gpus': False,
+            },
         ]
         return workers_list
 
@@ -194,7 +208,7 @@ class BundleManagerMockedManagerTest(unittest.TestCase):
         sorted_workers_list = self.bundle_manager._filter_and_sort_workers(
             self.workers_list, self.bundle, self.bundle_resources
         )
-        self.assertEqual(len(sorted_workers_list), 6)
+        self.assertEqual(len(sorted_workers_list), 7)
         self.assertEqual(sorted_workers_list[0]['worker_id'], 3)
         self.assertEqual(sorted_workers_list[1]['worker_id'], 4)
         self.assertEqual(sorted_workers_list[-1]['worker_id'], 0)
@@ -204,7 +218,7 @@ class BundleManagerMockedManagerTest(unittest.TestCase):
         sorted_workers_list = self.bundle_manager._filter_and_sort_workers(
             self.workers_list, self.bundle, self.bundle_resources
         )
-        self.assertEqual(len(sorted_workers_list), 6)
+        self.assertEqual(len(sorted_workers_list), 7)
         for worker in sorted_workers_list:
             self.assertEqual(worker['tag_exclusive'], False)
 
@@ -215,18 +229,22 @@ class BundleManagerMockedManagerTest(unittest.TestCase):
         sorted_workers_list = self.bundle_manager._filter_and_sort_workers(
             self.workers_list, self.bundle, self.bundle_resources
         )
-        self.assertEqual(len(sorted_workers_list), 2)
+        self.assertEqual(len(sorted_workers_list), 3)
         self.assertEqual(sorted_workers_list[0]['worker_id'], 6)
-        self.assertEqual(sorted_workers_list[1]['worker_id'], 5)
+        self.assertEqual(set([sorted_workers_list[1]['worker_id'],
+                              sorted_workers_list[2]['worker_id']]),
+                         set([5, 8]))
 
     def test_get_matched_workers_with_tag(self):
         self.bundle.metadata.request_queue = "tag=worker_X"
         matched_workers = BundleManager._get_matched_workers(
             self.bundle.metadata.request_queue, self.workers_list
         )
-        self.assertEqual(len(matched_workers), 3)
+        self.assertEqual(len(matched_workers), 4)
         self.assertEqual(matched_workers[0]['worker_id'], 5)
         self.assertEqual(matched_workers[1]['worker_id'], 6)
+        self.assertEqual(matched_workers[2]['worker_id'], 7)
+        self.assertEqual(matched_workers[3]['worker_id'], 8)
 
     def test_get_matched_workers_with_bad_formatted_tag(self):
         self.bundle.metadata.request_queue = "tag="
@@ -240,12 +258,22 @@ class BundleManagerMockedManagerTest(unittest.TestCase):
         matched_workers = BundleManager._get_matched_workers(
             self.bundle.metadata.request_queue, self.workers_list
         )
-        self.assertEqual(len(matched_workers), 3)
+        self.assertEqual(len(matched_workers), 4)
         self.assertEqual(matched_workers[0]['worker_id'], 5)
         self.assertEqual(matched_workers[1]['worker_id'], 6)
+        self.assertEqual(matched_workers[2]['worker_id'], 7)
+        self.assertEqual(matched_workers[3]['worker_id'], 8)
+
+    def test_get_matched_workers_multiple_tags(self):
+        self.bundle.metadata.request_queue = "worker_Y"
+        matched_workers = BundleManager._get_matched_workers(
+            self.bundle.metadata.request_queue, self.workers_list
+        )
+        self.assertEqual(len(matched_workers), 1)
+        self.assertEqual(matched_workers[0]['worker_id'], 8)
 
     def test_get_matched_workers_not_exist_tag(self):
-        self.bundle.metadata.request_queue = "worker_Y"
+        self.bundle.metadata.request_queue = "worker_Z"
         matched_workers = BundleManager._get_matched_workers(
             self.bundle.metadata.request_queue, self.workers_list
         )

--- a/tests/unit/server/bundle_manager_test.py
+++ b/tests/unit/server/bundle_manager_test.py
@@ -231,9 +231,10 @@ class BundleManagerMockedManagerTest(unittest.TestCase):
         )
         self.assertEqual(len(sorted_workers_list), 3)
         self.assertEqual(sorted_workers_list[0]['worker_id'], 6)
-        self.assertEqual(set([sorted_workers_list[1]['worker_id'],
-                              sorted_workers_list[2]['worker_id']]),
-                         set([5, 8]))
+        self.assertEqual(
+            set([sorted_workers_list[1]['worker_id'], sorted_workers_list[2]['worker_id']]),
+            set([5, 8]),
+        )
 
     def test_get_matched_workers_with_tag(self):
         self.bundle.metadata.request_queue = "tag=worker_X"

--- a/tests/unit/server/bundle_manager_test.py
+++ b/tests/unit/server/bundle_manager_test.py
@@ -312,3 +312,20 @@ class BundleManagerMockedManagerTest(unittest.TestCase):
         )
         self.assertEqual(len(matched_workers), 1)
         self.assertEqual(matched_workers[0]['worker_id'], 8)
+
+    def test_get_matched_workers_not_existing_tag(self):
+        self.bundle.metadata.request_queue = "!workerX"
+        matched_workers = BundleManager._get_matched_workers(
+            self.bundle.metadata.request_queue, self.workers_list
+        )
+        self.assertEqual(len(matched_workers), 0)
+
+    def test_get_matched_workers_not_existing_tag_with_multiple(self):
+        self.bundle.metadata.request_queue = "!workerY"
+        matched_workers = BundleManager._get_matched_workers(
+            self.bundle.metadata.request_queue, self.workers_list
+        )
+        self.assertEqual(len(matched_workers), 3)
+        self.assertEqual(matched_workers[0]['worker_id'], 5)
+        self.assertEqual(matched_workers[1]['worker_id'], 6)
+        self.assertEqual(matched_workers[2]['worker_id'], 7)

--- a/tests/unit/server/bundle_manager_test.py
+++ b/tests/unit/server/bundle_manager_test.py
@@ -123,7 +123,7 @@ class BundleManagerMockedManagerTest(unittest.TestCase):
                 'memory_bytes': 2 * 1000,
                 'free_disk_bytes': 2 * 1000,
                 'exit_after_num_runs': 1000,
-                'tag': 'worker_X',
+                'tag': 'workerX',
                 'run_uuids': [],
                 'dependencies': [],
                 'shared_file_system': False,
@@ -137,7 +137,7 @@ class BundleManagerMockedManagerTest(unittest.TestCase):
                 'memory_bytes': 2 * 1000,
                 'free_disk_bytes': 2 * 1000,
                 'exit_after_num_runs': 1000,
-                'tag': 'worker_X',
+                'tag': 'workerX',
                 'run_uuids': [],
                 'dependencies': [],
                 'shared_file_system': False,
@@ -151,7 +151,7 @@ class BundleManagerMockedManagerTest(unittest.TestCase):
                 'memory_bytes': 2 * 1000,
                 'free_disk_bytes': 2 * 1000,
                 'exit_after_num_runs': 0,
-                'tag': 'worker_X',
+                'tag': 'workerX',
                 'run_uuids': [],
                 'dependencies': [],
                 'shared_file_system': False,
@@ -165,7 +165,7 @@ class BundleManagerMockedManagerTest(unittest.TestCase):
                 'memory_bytes': 2 * 1000,
                 'free_disk_bytes': 2 * 1000,
                 'exit_after_num_runs': 1000,
-                'tag': 'worker_Y,worker_X',
+                'tag': 'workerY,workerX',
                 'run_uuids': [],
                 'dependencies': [],
                 'shared_file_system': False,
@@ -225,7 +225,7 @@ class BundleManagerMockedManagerTest(unittest.TestCase):
     def test_filter_and_sort_workers_tag_exclusive_priority(self):
         # All other things being equal, tag_exclusive workers
         # should appear in the top from the returned sorted workers list.
-        self.bundle.metadata.request_queue = "tag=worker_X"
+        self.bundle.metadata.request_queue = "tag=workerX"
         sorted_workers_list = self.bundle_manager._filter_and_sort_workers(
             self.workers_list, self.bundle, self.bundle_resources
         )
@@ -237,7 +237,7 @@ class BundleManagerMockedManagerTest(unittest.TestCase):
         )
 
     def test_get_matched_workers_with_tag(self):
-        self.bundle.metadata.request_queue = "tag=worker_X"
+        self.bundle.metadata.request_queue = "tag=workerX"
         matched_workers = BundleManager._get_matched_workers(
             self.bundle.metadata.request_queue, self.workers_list
         )
@@ -255,7 +255,7 @@ class BundleManagerMockedManagerTest(unittest.TestCase):
         self.assertEqual(len(matched_workers), 0)
 
     def test_get_matched_workers_without_tag_prefix(self):
-        self.bundle.metadata.request_queue = "worker_X"
+        self.bundle.metadata.request_queue = "workerX"
         matched_workers = BundleManager._get_matched_workers(
             self.bundle.metadata.request_queue, self.workers_list
         )
@@ -266,7 +266,7 @@ class BundleManagerMockedManagerTest(unittest.TestCase):
         self.assertEqual(matched_workers[3]['worker_id'], 8)
 
     def test_get_matched_workers_multiple_tags(self):
-        self.bundle.metadata.request_queue = "worker_Y"
+        self.bundle.metadata.request_queue = "workerY"
         matched_workers = BundleManager._get_matched_workers(
             self.bundle.metadata.request_queue, self.workers_list
         )
@@ -274,7 +274,7 @@ class BundleManagerMockedManagerTest(unittest.TestCase):
         self.assertEqual(matched_workers[0]['worker_id'], 8)
 
     def test_get_matched_workers_not_exist_tag(self):
-        self.bundle.metadata.request_queue = "worker_Z"
+        self.bundle.metadata.request_queue = "workerZ"
         matched_workers = BundleManager._get_matched_workers(
             self.bundle.metadata.request_queue, self.workers_list
         )

--- a/tests/unit/server/bundle_manager_test.py
+++ b/tests/unit/server/bundle_manager_test.py
@@ -298,7 +298,7 @@ class BundleManagerMockedManagerTest(unittest.TestCase):
         self.assertEqual(matched_workers[2]['worker_id'], 7)
         self.assertEqual(matched_workers[3]['worker_id'], 8)
 
-    def test_get_matched_workers_non_existent_or_existing_tag(self):
+    def test_get_matched_workers_non_existent_and_existing_tag(self):
         self.bundle.metadata.request_queue = "workerZ & workerX"
         matched_workers = BundleManager._get_matched_workers(
             self.bundle.metadata.request_queue, self.workers_list

--- a/tests/unit/server/bundle_manager_test.py
+++ b/tests/unit/server/bundle_manager_test.py
@@ -286,3 +286,29 @@ class BundleManagerMockedManagerTest(unittest.TestCase):
             self.bundle.metadata.request_queue, self.workers_list
         )
         self.assertEqual(len(matched_workers), 0)
+
+    def test_get_matched_workers_non_existent_or_existing_tag(self):
+        self.bundle.metadata.request_queue = "workerZ|workerX"
+        matched_workers = BundleManager._get_matched_workers(
+            self.bundle.metadata.request_queue, self.workers_list
+        )
+        self.assertEqual(len(matched_workers), 4)
+        self.assertEqual(matched_workers[0]['worker_id'], 5)
+        self.assertEqual(matched_workers[1]['worker_id'], 6)
+        self.assertEqual(matched_workers[2]['worker_id'], 7)
+        self.assertEqual(matched_workers[3]['worker_id'], 8)
+
+    def test_get_matched_workers_non_existent_or_existing_tag(self):
+        self.bundle.metadata.request_queue = "workerZ & workerX"
+        matched_workers = BundleManager._get_matched_workers(
+            self.bundle.metadata.request_queue, self.workers_list
+        )
+        self.assertEqual(len(matched_workers), 0)
+
+    def test_get_matched_workers_non_existent_nested_or_existing_tags(self):
+        self.bundle.metadata.request_queue = "workerZ | (workerX & workerY)"
+        matched_workers = BundleManager._get_matched_workers(
+            self.bundle.metadata.request_queue, self.workers_list
+        )
+        self.assertEqual(len(matched_workers), 1)
+        self.assertEqual(matched_workers[0]['worker_id'], 8)

--- a/tests/unit/server/bundle_manager_test.py
+++ b/tests/unit/server/bundle_manager_test.py
@@ -158,6 +158,20 @@ class BundleManagerMockedManagerTest(unittest.TestCase):
                 'tag_exclusive': True,
                 'has_gpus': False,
             },
+            {
+                'worker_id': 8,
+                'cpus': 6,
+                'gpus': 0,
+                'memory_bytes': 2 * 1000,
+                'free_disk_bytes': 2 * 1000,
+                'exit_after_num_runs': 1000,
+                'tag': 'worker_Y,worker_X',
+                'run_uuids': [],
+                'dependencies': [],
+                'shared_file_system': False,
+                'tag_exclusive': False,
+                'has_gpus': False,
+            },
         ]
         return workers_list
 
@@ -194,7 +208,7 @@ class BundleManagerMockedManagerTest(unittest.TestCase):
         sorted_workers_list = self.bundle_manager._filter_and_sort_workers(
             self.workers_list, self.bundle, self.bundle_resources
         )
-        self.assertEqual(len(sorted_workers_list), 6)
+        self.assertEqual(len(sorted_workers_list), 7)
         self.assertEqual(sorted_workers_list[0]['worker_id'], 3)
         self.assertEqual(sorted_workers_list[1]['worker_id'], 4)
         self.assertEqual(sorted_workers_list[-1]['worker_id'], 0)
@@ -204,7 +218,7 @@ class BundleManagerMockedManagerTest(unittest.TestCase):
         sorted_workers_list = self.bundle_manager._filter_and_sort_workers(
             self.workers_list, self.bundle, self.bundle_resources
         )
-        self.assertEqual(len(sorted_workers_list), 6)
+        self.assertEqual(len(sorted_workers_list), 7)
         for worker in sorted_workers_list:
             self.assertEqual(worker['tag_exclusive'], False)
 
@@ -215,18 +229,22 @@ class BundleManagerMockedManagerTest(unittest.TestCase):
         sorted_workers_list = self.bundle_manager._filter_and_sort_workers(
             self.workers_list, self.bundle, self.bundle_resources
         )
-        self.assertEqual(len(sorted_workers_list), 2)
+        self.assertEqual(len(sorted_workers_list), 3)
         self.assertEqual(sorted_workers_list[0]['worker_id'], 6)
-        self.assertEqual(sorted_workers_list[1]['worker_id'], 5)
+        self.assertEqual(set([sorted_workers_list[1]['worker_id'],
+                              sorted_workers_list[2]['worker_id']]),
+                         set([5, 8]))
 
     def test_get_matched_workers_with_tag(self):
         self.bundle.metadata.request_queue = "tag=worker_X"
         matched_workers = BundleManager._get_matched_workers(
             self.bundle.metadata.request_queue, self.workers_list
         )
-        self.assertEqual(len(matched_workers), 3)
+        self.assertEqual(len(matched_workers), 4)
         self.assertEqual(matched_workers[0]['worker_id'], 5)
         self.assertEqual(matched_workers[1]['worker_id'], 6)
+        self.assertEqual(matched_workers[2]['worker_id'], 7)
+        self.assertEqual(matched_workers[3]['worker_id'], 8)
 
     def test_get_matched_workers_with_bad_formatted_tag(self):
         self.bundle.metadata.request_queue = "tag="
@@ -240,12 +258,22 @@ class BundleManagerMockedManagerTest(unittest.TestCase):
         matched_workers = BundleManager._get_matched_workers(
             self.bundle.metadata.request_queue, self.workers_list
         )
-        self.assertEqual(len(matched_workers), 3)
+        self.assertEqual(len(matched_workers), 4)
         self.assertEqual(matched_workers[0]['worker_id'], 5)
         self.assertEqual(matched_workers[1]['worker_id'], 6)
+        self.assertEqual(matched_workers[2]['worker_id'], 7)
+        self.assertEqual(matched_workers[3]['worker_id'], 8)
+
+    def test_get_matched_workers_multiple_tags(self):
+        self.bundle.metadata.request_queue = "worker_Y"
+        matched_workers = BundleManager._get_matched_workers(
+            self.bundle.metadata.request_queue, self.workers_list
+        )
+        self.assertEqual(len(matched_workers), 1)
+        self.assertEqual(matched_workers[0]['worker_id'], 8)
 
     def test_get_matched_workers_not_exist_tag(self):
-        self.bundle.metadata.request_queue = "worker_Y"
+        self.bundle.metadata.request_queue = "worker_Z"
         matched_workers = BundleManager._get_matched_workers(
             self.bundle.metadata.request_queue, self.workers_list
         )


### PR DESCRIPTION
### Reasons for making this change

Fixes #3245 . This enables bundles to more-flexibly select workers to run on. This is built upon #3335 , so go look at that first.

### Changes:

- Instead of simply checking whether a bundle's `request_queue` exactly matches a worker's `tag` (or any of the tags, after #3335), this uses a small DSL to parse out finer-grained specifications. The defaults remain unchanged---if you provide a `request_queue` that is a single string, and have a single worker tag, everything should work as it did before.
- `request_queue` can now contain logical NOT (`!`), OR (`|`), and AND (`&`). A worker will be matched with a bundle only if the workers tags satisfy the `request_queue`.

For example, the tag:
- `sometag` matches any worker that has the tag `sometag`
- `!sometag` matches any worker that has a tag, but does not have the tag `sometag`
- `sometag | othertag` matches any worker that has either the `sometag` or `othertag` tags
- `sometag & othertag` matches any worker that has _both_ the `sometag` or `othertag` tags.

Operator precedence follows Python---NOT has the highest precedence, followed by AND and then OR. When in doubt, parens are also supported.

Implementation-wise, I wrote a simple grammar to parse the `request_queue` values. The parsing is done by the [Lark parser](https://github.com/lark-parser/lark). The lark parser produces an expression tree, which is then transformed into a string conditional. For example, for the `request_queue` value `sometag`, the conditional is `sometag in worker_tags` (where `worker_tags` is a `List[str]` with the tags of any worker). This string is _evaluated_ into a lambda function, and then run on a given worker's tags to determine if the worker satisfies the `request_queue`.

Some points of discussion:
- It's a reasonable concern that parsing the `request_queue` might be a bit slow. I've used `functools.lru_cache` to cache the calls to the parser, so recently-used `request_queue` values don't need to be parsed every time.
- There are some obvious security implications here, since user-input code is being run. I put in a few safeguards, but I'm curious what people think:

(1) The grammar only successfully parses `request_queue` if all characters are alphanumeric (excluding the operators). So, no `()` or `__` for python trickery.
(2) TODO: I want to put a max length on the `request_queue` field, since a malicious user could try to crash the server by inserting very long values that take awhile to parse. I think even very long values should be fine (since the grammar won't infinitely generate), but a length limit seems like a reasonable precaution anyway.

Anyway, looking forward to hearing your feedback on this!