### PR TITLE
Fix the bug of dependencies with same shorten uuid

### DIFF
--- a/frontend/src/components/worksheets/NewRun/NewRun.jsx
+++ b/frontend/src/components/worksheets/NewRun/NewRun.jsx
@@ -287,7 +287,7 @@ class NewRun extends React.Component<{
 
         for (let dep of dependencies) {
             const key = dep.alias;
-            let value = shorten_uuid(dep.target.uuid);
+            let value = dep.target.uuid;
             if(dep.target.path) value += '/' + dep.target.path;
             args.push(key + ':' + value);
         }

--- a/frontend/src/components/worksheets/RunBundleBuilder.js
+++ b/frontend/src/components/worksheets/RunBundleBuilder.js
@@ -138,8 +138,8 @@ class RunBundleBuilder extends React.Component<Props> {
         for (var i = 0; i < dependencyKeyList.length; i++) {
             var key = dependencyKeyList[i];
             var target = selectedDependencies[i];
-            var shortUuid = shorten_uuid(target.uuid);
-            target = target.path === '' ? shortUuid : shortUuid + '/' + target.path;
+            var uuid = target.uuid;
+            target = target.path === '' ? uuid : uuid + '/' + target.path;
             clCommand.push(key + ':' + target);
         }
         if (command !== null) clCommand.push(command);


### PR DESCRIPTION
### Reasons for making this change

When two dependencies have the same shorten uuid, a new run cannot be started.
It is because previously the dependencies are represented by shorten uuid & name when being passed to the backend. When the backend validated the dependency, it will fail. 

### Related issues

fixes #3322 

### Screenshots

<img width="548" alt="Screen Shot 2021-03-17 at 4 25 16 PM" src="https://user-images.githubusercontent.com/34461466/111553076-dc620480-8740-11eb-8178-4873cf91d6f7.png">


### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
