### PR TITLE
Bump version to v0.5.43

### DIFF
--- a/codalab/common.py
+++ b/codalab/common.py
@@ -15,7 +15,7 @@ from enum import Enum
 
 # Increment this on master when ready to cut a release.
 # http://semver.org/
-CODALAB_VERSION = '0.5.42'
+CODALAB_VERSION = '0.5.43'
 BINARY_PLACEHOLDER = '<binary>'
 URLOPEN_TIMEOUT_SECONDS = int(os.environ.get('CODALAB_URLOPEN_TIMEOUT_SECONDS', 5 * 60))
 

--- a/docs/REST-API-Reference.md
+++ b/docs/REST-API-Reference.md
@@ -1,6 +1,6 @@
 # REST API Reference
 
-_version 0.5.42_
+_version 0.5.43_
 
 This reference and the REST API itself is still under heavy development and is
 subject to change at any time. Feedback through our GitHub issues is appreciated!

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -1,5 +1,5 @@
 // Should match codalab/common.py#CODALAB_VERSION
-export const CODALAB_VERSION = '0.5.42';
+export const CODALAB_VERSION = '0.5.43';
 
 // Name Regex to match the backend in spec_utils.py
 export const NAME_REGEX = /^[a-zA-Z_][a-zA-Z0-9_.-]*$/i;

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import sys
 
 
 # should match codalab/common.py#CODALAB_VERSION
-CODALAB_VERSION = "0.5.42"
+CODALAB_VERSION = "0.5.43"
 
 
 class Install(install):


### PR DESCRIPTION
# Draft release notes

## Frontend
- Bump elliptic from 6.5.3 to 6.5.4 in /frontend (#3332)
- Use complete uuid to represent the dependencies (#3352)

## Backend
- Blob Storage: update requirements, add new args to codalab-service (#3304)
- Blob Storage: Add storage_type and is_dir columns (#3300)