### PR TITLE
Upgrade urllib3 to 1.26.4

### DIFF
--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -7,7 +7,7 @@
 # Only for development
 -r requirements.dev.txt
 
-boto3==1.15.7
+boto3==1.17.33
 azure-batch==9.0.0
 
 # For testing

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ fusepy==2.0.4
 python-dateutil==2.8.1
 diffimg==0.2.3
 selenium==3.141.0
-requests==2.24.0
+requests==2.25.0
 azure-storage-blob==12.4.0
 azure-core==1.8.0
 sentry-sdk==0.18.0
@@ -29,5 +29,5 @@ requests-oauthlib==1.1.0
 oauthlib==2.1.0
 markdown2==2.3.10
 wheel==0.35.1
-urllib3<1.26
+urllib3==1.26.4
 retry==0.9.2


### PR DESCRIPTION
Fixes a security vulnerability (https://github.com/advisories/GHSA-5phf-pp7p-vc2r). Technically, this vulnerability doesn't affect urllib3 < 1.26 (so it doesn't impact codalab; seems to be an issue with github showing a false positive), but we might as well upgrade the package so that github doesn't keep showing this alert as a false positive.

I had to bump the requests and boto3 versions so that urllib3 > 1.26 would be supported, as well.