### PR TITLE
Fix target sizes for directories -- return data_size if user requests the whole bundle

### DIFF
--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -691,8 +691,15 @@ def _fetch_bundle_contents_blob(uuid, path=''):
     else:
         response.set_header('Content-Disposition', 'attachment; filename="%s"' % filename)
     response.set_header('Target-Type', target_info['type'])
-    response.set_header('X-Codalab-Target-Size', target_info['size'])
-
+    if target_info['type'] == 'file':
+        size = target_info['size']
+    elif not path and bundle_name:
+        # return data_size if the user requests the actual bundle
+        size = local.model.get_bundle(target.bundle_uuid).metadata.data_size
+    else:
+        # if request is for a subdir in a bundle then return 0
+        size = 0
+    response.set_header('X-Codalab-Target-Size', size)
     return fileobj
 
 

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -695,7 +695,7 @@ def _fetch_bundle_contents_blob(uuid, path=''):
         size = target_info['size']
     elif not path and bundle_name:
         # return data_size if the user requests the actual bundle
-        size = local.model.get_bundle(target.bundle_uuid).metadata.data_size
+        size = local.model.get_bundle_metadata([target.bundle_uuid], 'data_size')[target.bundle_uuid]
     else:
         # if request is for a subdir in a bundle then return 0
         size = 0

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -695,7 +695,9 @@ def _fetch_bundle_contents_blob(uuid, path=''):
         size = target_info['size']
     elif not path and bundle_name:
         # return data_size if the user requests the actual bundle
-        size = local.model.get_bundle_metadata([target.bundle_uuid], 'data_size')[target.bundle_uuid]
+        size = local.model.get_bundle_metadata([target.bundle_uuid], 'data_size').get(
+            target.bundle_uuid, 0
+        )
     else:
         # if request is for a subdir in a bundle then return 0
         size = 0


### PR DESCRIPTION
### Reasons for making this change

The target size of directories should be reported as the size of the entire directory.

### Related issues

fixes #3120  

### Screenshots

Correct target size for a bundle:

![image](https://user-images.githubusercontent.com/29891066/113062089-0b786d00-9168-11eb-908f-387e01a5e2c1.png)

Target size for a subdir is set to 0:

![image](https://user-images.githubusercontent.com/29891066/113062166-2d71ef80-9168-11eb-9978-dae2b9e68fb5.png)

Target size for a file:

![image](https://user-images.githubusercontent.com/29891066/113062422-8d689600-9168-11eb-83f5-f80e778cc1d3.png)


### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
