### PR TITLE
change link mount to read only

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,6 +115,7 @@ jobs:
           VERSION: ${{ github.head_ref || 'master' }}
       - name: Run tests
         run: |
+          sh ./test-setup.sh
           python3 codalab_service.py start --services default --version ${VERSION}
           python3 test_runner.py --version ${VERSION} ${TEST}
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -214,6 +214,7 @@ jobs:
           VERSION: ${{ github.head_ref || 'master' }}
       - name: Run shared filesystem tests
         run: |
+          sh ./test-setup.sh
           python3 codalab_service.py start --services default --version ${VERSION} --shared-file-system
           python3 test_runner.py --version ${VERSION} ${TEST}
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,7 +115,7 @@ jobs:
           VERSION: ${{ github.head_ref || 'master' }}
       - name: Run tests
         run: |
-          sh ./test-setup.sh
+          sh ./tests/test-setup.sh
           python3 codalab_service.py start --services default --version ${VERSION}
           python3 test_runner.py --version ${VERSION} ${TEST}
         env:
@@ -214,7 +214,7 @@ jobs:
           VERSION: ${{ github.head_ref || 'master' }}
       - name: Run shared filesystem tests
         run: |
-          sh ./test-setup.sh
+          sh ./tests/test-setup.sh
           python3 codalab_service.py start --services default --version ${VERSION} --shared-file-system
           python3 test_runner.py --version ${VERSION} ${TEST}
         env:

--- a/codalab_service.py
+++ b/codalab_service.py
@@ -627,7 +627,7 @@ class CodalabServiceManager(object):
             for mount_path in self.args.link_mounts.split(","):
                 mount_path = os.path.abspath(mount_path)
                 compose_options["x-codalab-server"]["volumes"].append(
-                    f"{mount_path}:/opt/codalab-worksheets-link-mounts{mount_path}"
+                    f"{mount_path}:/opt/codalab-worksheets-link-mounts{mount_path}:ro"
                 )
             docker_compose_custom_path = os.path.join(
                 self.args.codalab_home, 'docker-compose-custom.yml'

--- a/docs/Server-Setup.md
+++ b/docs/Server-Setup.md
@@ -137,7 +137,11 @@ hour because lots of packages have to be installed):
 
 ## Testing
 
-Since tests run against an existing instance, make sure you update your instance first.
+Run test-setup.sh first to set up required files and directories.
+
+    sh ./tests/test-setup.sh 
+
+Since tests run against an existing instance, make sure you update your instance.
 
     ./codalab_service.py start -bd -s rest-server
 
@@ -151,6 +155,7 @@ Or to run a specific test (e.g., basic):
 
 In sum, to start an instance and run tests on it:
 
+    sh ./tests/test-setup.sh
     ./codalab_service.py start -bd
     python test_runner.py default
 

--- a/test-setup.sh
+++ b/test-setup.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Run this script before start service to running link tests.
+
+mkdir -p /tmp/codalab/link-mounts/test
+echo 'hello world!' > /tmp/codalab/link-mounts/test.txt
+echo 'hello world!' > /tmp/codalab/link-mounts/test/test.txt

--- a/test-setup.sh
+++ b/test-setup.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-# Run this script before start service to running link tests.
-
-mkdir -p /tmp/codalab/link-mounts/test
-echo 'hello world!' > /tmp/codalab/link-mounts/test.txt
-echo 'hello world!' > /tmp/codalab/link-mounts/test/test.txt

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1392,6 +1392,7 @@ def test_link(ctx):
     # this test is running inside a Docker container (so the host directory /tmp/codalab/link-mounts is
     # mounted at /opt/codalab-worksheets-link-mounts/tmp/codalab/link-mounts).
 
+    # Test file is created by tests/test-setup.sh
     host_filename = "/tmp/codalab/link-mounts/test.txt"
     uuid = _run_command([cl, 'upload', host_filename, '--link'])
     check_equals(State.READY, get_info(uuid, 'state'))
@@ -1404,7 +1405,7 @@ def test_link(ctx):
     check_equals("hello world!", _run_command([cl, 'cat', run_uuid + '/stdout']))
 
     # Upload directory
-
+    # Test file and directory is created by tests/test-setup.sh
     host_dirname = "/tmp/codalab/link-mounts/test"
     uuid = _run_command([cl, 'upload', host_dirname, '--link'])
     check_equals(State.READY, get_info(uuid, 'state'))

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1405,7 +1405,7 @@ def test_link(ctx):
     check_equals("hello world!", _run_command([cl, 'cat', run_uuid + '/stdout']))
 
     # Upload directory
-    # Test file and directory is created by tests/test-setup.sh
+    # Test file and directory are created by tests/test-setup.sh
     host_dirname = "/tmp/codalab/link-mounts/test"
     uuid = _run_command([cl, 'upload', host_dirname, '--link'])
     check_equals(State.READY, get_info(uuid, 'state'))

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1387,10 +1387,6 @@ def test_link(ctx):
     # Upload file
     # /tmp/codalab/link-mounts is the absolute path of the default link mounts folder on the host. By default, it is mounted
     # when no other argument for CODALAB_LINK_MOUNTS is specified.
-    #
-    # We create the temporary file at /opt/codalab-worksheets-link-mounts/tmp/codalab/link-mounts because
-    # this test is running inside a Docker container (so the host directory /tmp/codalab/link-mounts is
-    # mounted at /opt/codalab-worksheets-link-mounts/tmp/codalab/link-mounts).
 
     # Test file is created by tests/test-setup.sh
     host_filename = "/tmp/codalab/link-mounts/test.txt"

--- a/tests/test-setup.sh
+++ b/tests/test-setup.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # When running tests, run this script before starting codalab with codalab_service.py.
+# This script is required for setup of the link tests.
 
 mkdir -p /tmp/codalab/link-mounts/test
 echo 'hello world!' > /tmp/codalab/link-mounts/test.txt

--- a/tests/test-setup.sh
+++ b/tests/test-setup.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# When running tests, run this script before starting codalab with codalab_service.py.
+
+mkdir -p /tmp/codalab/link-mounts/test
+echo 'hello world!' > /tmp/codalab/link-mounts/test.txt
+echo 'hello world!' > /tmp/codalab/link-mounts/test/test.txt


### PR DESCRIPTION
### Reasons for making this change

Docker should mount directories in CODALAB_LINK_MOUNTS as read-only.

### Related issues
fixes #3349 

### Screenshots

<!-- Add screenshots, if necessary -->
![image](https://user-images.githubusercontent.com/29891066/113276697-f2b9a580-9294-11eb-807f-32b0209f79ed.png)

After the change the mode is now `ro`

### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
