### PR TITLE
Bump version to 0.5.44

### DIFF
--- a/codalab/common.py
+++ b/codalab/common.py
@@ -15,7 +15,7 @@ from enum import Enum
 
 # Increment this on master when ready to cut a release.
 # http://semver.org/
-CODALAB_VERSION = '0.5.43'
+CODALAB_VERSION = '0.5.44'
 BINARY_PLACEHOLDER = '<binary>'
 URLOPEN_TIMEOUT_SECONDS = int(os.environ.get('CODALAB_URLOPEN_TIMEOUT_SECONDS', 5 * 60))
 

--- a/docs/REST-API-Reference.md
+++ b/docs/REST-API-Reference.md
@@ -1,6 +1,6 @@
 # REST API Reference
 
-_version 0.5.43_
+_version 0.5.44_
 
 This reference and the REST API itself is still under heavy development and is
 subject to change at any time. Feedback through our GitHub issues is appreciated!

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -1,5 +1,5 @@
 // Should match codalab/common.py#CODALAB_VERSION
-export const CODALAB_VERSION = '0.5.43';
+export const CODALAB_VERSION = '0.5.44';
 
 // Name Regex to match the backend in spec_utils.py
 export const NAME_REGEX = /^[a-zA-Z_][a-zA-Z0-9_.-]*$/i;

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import sys
 
 
 # should match codalab/common.py#CODALAB_VERSION
-CODALAB_VERSION = "0.5.43"
+CODALAB_VERSION = "0.5.44"
 
 
 class Install(install):


### PR DESCRIPTION
### Reasons for making this change
Bump new version

Full diff: https://github.com/codalab/codalab-worksheets/compare/v0.5.43...rc0.5.44

# Draft release notes

## Frontend
- Add meta description to home page (#3365)
- Make username clickable (#3366)
- Add UI Button for Content Block that User Can Specify Subpath Inside a Bundle (#3333)
- Fix target sizes for directories -- return data_size if user requests the whole bundle (#3372)
- Use useSWR as a cache for the search directive (#3353)

## Backend
- Disallow editing metadata of frozen worksheets; enable unfreezing worksheets (#3295)
- Implement GCP worker manager (#3341) 
- Change link mount to read only (#3375)

