### PR TITLE
Make docker image status more granular with the percentage done 

### DIFF
--- a/codalab/worker/docker_image_manager.py
+++ b/codalab/worker/docker_image_manager.py
@@ -243,10 +243,18 @@ class DockerImageManager:
                 def download():
                     logger.debug('Downloading Docker image %s', image_spec)
                     try:
-                        self._docker.images.pull(image_spec)
+                        for line in self._docker.api.pull(image_spec, stream=True, decode=True):
+                            self._downloading[image_spec]['status'] = ''
+                            # Set the status to the percent completed
+                            if line['status'] == 'Downloading':
+                                self._downloading[image_spec]['status'] = '(%d%%)' % (
+                                    line['progressDetail']['current']
+                                    * 100
+                                    / line['progressDetail']['total']
+                                )
+
                         logger.debug('Download for Docker image %s complete', image_spec)
                         self._downloading[image_spec]['success'] = True
-                        self._downloading[image_spec]['message'] = "Downloading image"
                     except (docker.errors.APIError, docker.errors.ImageNotFound) as ex:
                         logger.debug('Download for Docker image %s failed: %s', image_spec, ex)
                         self._downloading[image_spec]['success'] = False

--- a/codalab/worker/worker_run_state.py
+++ b/codalab/worker/worker_run_state.py
@@ -277,7 +277,7 @@ class RunStateMachine(StateTransitioner):
         image_state = self.docker_image_manager.get(docker_image)
         if image_state.stage == DependencyStage.DOWNLOADING:
             status_messages.append(
-                'Pulling docker image: ' + (image_state.message or docker_image or "")
+                'Pulling docker image %s %s' % (docker_image, image_state.message)
             )
             dependencies_ready = False
         elif image_state.stage == DependencyStage.FAILED:


### PR DESCRIPTION
Unrevert #3383 with a cherry-pick of commit `16b8277d10b5723eabdab8fb5f0bdd8d2e849bfc`.