### PR TITLE
Fix the bug of rerun bundle inserting to wrong position

### DIFF
--- a/frontend/src/components/worksheets/items/TableItem/BundleRow.js
+++ b/frontend/src/components/worksheets/items/TableItem/BundleRow.js
@@ -335,7 +335,7 @@ class BundleRow extends Component {
                                         this.setState({ showNewRun: 0, showDetail: false });
                                         onHideNewRerun();
                                     }}
-                                    after_sort_key={this.props.after_sort_key + 1}
+                                    after_sort_key={this.props.after_sort_key}
                                     reloadWorksheet={reloadWorksheet}
                                     defaultRun={runProp}
                                 />
@@ -348,7 +348,7 @@ class BundleRow extends Component {
                         <TableCell colSpan='100%' classes={{ root: classes.insertPanel }}>
                             <div className={classes.insertBox}>
                                 <NewRun
-                                    after_sort_key={this.props.after_sort_key + 1}
+                                    after_sort_key={this.props.after_sort_key}
                                     ws={this.props.ws}
                                     onSubmit={() => this.props.onHideNewRun()}
                                     reloadWorksheet={reloadWorksheet}


### PR DESCRIPTION
### Related issues

fixes #3381 

### Screenshots

![ezgif com-gif-maker (2)](https://user-images.githubusercontent.com/34461466/114798183-a321b200-9d49-11eb-82b1-5f259189b61a.gif)


### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
