### PR TITLE
Bump version to 0.5.45

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
           restore-keys: |
             pip-
       - name: Ensure the "cl" command can be properly installed.
-      - run: pip install -e . && cl --help
+        run: pip install -e . && cl
 
   test_frontend:
     name: Test Frontend

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,14 @@ jobs:
           restore-keys: |
             pip-
       - run: ./pre-commit.sh && git diff --exit-code
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: pip-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            pip-
+      - name: Ensure the "cl" command can be properly installed.
+      - run: pip install -e . && cl --help
 
   test_frontend:
     name: Test Frontend

--- a/codalab/common.py
+++ b/codalab/common.py
@@ -15,7 +15,7 @@ from enum import Enum
 
 # Increment this on master when ready to cut a release.
 # http://semver.org/
-CODALAB_VERSION = '0.5.44'
+CODALAB_VERSION = '0.5.45'
 BINARY_PLACEHOLDER = '<binary>'
 URLOPEN_TIMEOUT_SECONDS = int(os.environ.get('CODALAB_URLOPEN_TIMEOUT_SECONDS', 5 * 60))
 

--- a/docs/REST-API-Reference.md
+++ b/docs/REST-API-Reference.md
@@ -1,6 +1,6 @@
 # REST API Reference
 
-_version 0.5.44_
+_version 0.5.45_
 
 This reference and the REST API itself is still under heavy development and is
 subject to change at any time. Feedback through our GitHub issues is appreciated!

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -1,5 +1,5 @@
 // Should match codalab/common.py#CODALAB_VERSION
-export const CODALAB_VERSION = '0.5.44';
+export const CODALAB_VERSION = '0.5.45';
 
 // Name Regex to match the backend in spec_utils.py
 export const NAME_REGEX = /^[a-zA-Z_][a-zA-Z0-9_.-]*$/i;

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ psutil==5.7.2
 # Use a forked version of ratarmount that works with file objects.
 # TODO (Ashwin): integrate these changes upstream so we can use the standard ratarmount package.
 # For a full diff, see https://github.com/epicfaace/ratarmount/pull/1.
-git+https://github.com/epicfaace/ratarmount.git@83d310d8efdf34351650ee98e7f44cf1c00dbf6e#egg=ratarmount
+ratarmount @ git+https://github.com/codalab/ratarmount.git@83d310d8efdf34351650ee98e7f44cf1c00dbf6e#egg=ratarmount
 
 six==1.15.0
 SQLAlchemy==1.3.19

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import sys
 
 
 # should match codalab/common.py#CODALAB_VERSION
-CODALAB_VERSION = "0.5.44"
+CODALAB_VERSION = "0.5.45"
 
 
 class Install(install):

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ def get_requirements(*requirements_file_paths):
     for requirements_file_path in requirements_file_paths:
         with open(requirements_file_path) as requirements_file:
             for line in requirements_file:
-                if line[0:2] != '-r' and line.find('git') == -1:
+                if line[0:2] != '-r':
                     requirements.append(line.strip())
     return requirements
 


### PR DESCRIPTION
### Reasons for making this change
Bump new version

Full diff: https://github.com/codalab/codalab-worksheets/compare/v0.5.44...rc0.5.45

# Draft release notes

## Frontend
- The new profile page has now been released and shows by default when you go to the codalab home page. Feedback welcome! (#3376) 
- fix the bug of rerun bundle inserting to wrong position (#3399)
- Fix Latex rendering bug (#3390)
- Fix inconsistency update bug for the partial update mechanism (#3398)

## Backend
- Bump bottle from 0.12.18 to 0.12.19 (#3388)
- Run cl run --interactive as a non-root user (#3393) 
- Enable freezing and unfreezing bundles (#3318, #3411)
- Store tracebacks in bundle metadata and send them to sentry (#3257) 
- Enforce disk quota on bundle uploads (#3379, #3409)
- Use shallow clones for git, for speed (#3413) 

## Dev / docs
- Docs: clarify that you can run different tests using test_runner.py (#3386)
- Add Quickstart Example Documentation (#3279)
