### PR TITLE
Fix error with existing bundles failing after bundle freeze upgrade

### DIFF
--- a/codalab/worker/bundle_state.py
+++ b/codalab/worker/bundle_state.py
@@ -123,7 +123,7 @@ class BundleInfo(object):
             command=dct["command"],
             data_hash=dct["data_hash"],
             state=dct["state"],
-            frozen=dct["frozen"],
+            frozen=dct.get("frozen"),
             is_anonymous=dct["is_anonymous"],
             metadata=dct["metadata"],
             dependencies=dct["dependencies"],


### PR DESCRIPTION
Fixes https://github.com/codalab/codalab-worksheets/issues/3410 by not failing if the "frozen" keyword is not present.
