### PR TITLE
Simplify uploads by removing local path support

### DIFF
--- a/codalab/lib/file_util.py
+++ b/codalab/lib/file_util.py
@@ -56,7 +56,7 @@ def strip_git_ext(path):
 
 
 def git_clone(source_url, target_path):
-    return subprocess.call(['git', 'clone', '--depth=1', source_url, target_path])
+    return subprocess.call(['git', 'clone', '--depth', '1', source_url, target_path])
 
 
 def download_url(source_url, target_path, print_status=False):

--- a/codalab/lib/file_util.py
+++ b/codalab/lib/file_util.py
@@ -56,7 +56,7 @@ def strip_git_ext(path):
 
 
 def git_clone(source_url, target_path):
-    return subprocess.call(['git', 'clone', source_url, target_path])
+    return subprocess.call(['git', 'clone', '--depth=1', source_url, target_path])
 
 
 def download_url(source_url, target_path, print_status=False):

--- a/codalab/lib/file_util.py
+++ b/codalab/lib/file_util.py
@@ -56,7 +56,7 @@ def strip_git_ext(path):
 
 
 def git_clone(source_url, target_path):
-    return subprocess.call(['git', 'clone', '--depth', '1', source_url, target_path])
+    return subprocess.call(['git', 'clone', source_url, target_path])
 
 
 def download_url(source_url, target_path, print_status=False):

--- a/codalab/lib/path_util.py
+++ b/codalab/lib/path_util.py
@@ -235,12 +235,11 @@ def hash_file_contents(path):
 ################################################################################
 
 
-def copy(source_path, dest_path, follow_symlinks=False, exclude_patterns=None):
+def copy(source_path, dest_path, follow_symlinks=False):
     """
     Copy |source_path| to |dest_path|.
     Assume dest_path doesn't exist.
     |follow_symlinks|: whether to follow symlinks
-    |exclude_patterns|: patterns to not copy
     Note: this only works in Linux.
     """
     if os.path.exists(dest_path):
@@ -266,9 +265,6 @@ def copy(source_path, dest_path, follow_symlinks=False, exclude_patterns=None):
             + ('/' if not os.path.islink(source_path) and os.path.isdir(source_path) else ''),
             dest_path,
         ]
-        if exclude_patterns is not None:
-            for pattern in exclude_patterns:
-                command.extend(['--exclude', pattern])
         if subprocess.call(command) != 0:
             raise path_error('Unable to copy %s to' % source_path, dest_path)
 

--- a/codalab/lib/path_util.py
+++ b/codalab/lib/path_util.py
@@ -21,6 +21,7 @@ import os
 import shutil
 import subprocess
 import sys
+from typing import Optional
 
 from codalab.common import precondition, UsageError
 from codalab.lib import file_util
@@ -235,7 +236,7 @@ def hash_file_contents(path):
 ################################################################################
 
 
-def copy(source_path, dest_path, follow_symlinks=False):
+def copy(source_path: str, dest_path: str, follow_symlinks: Optional[bool] = False):
     """
     Copy |source_path| to |dest_path|.
     Assume dest_path doesn't exist.

--- a/codalab/lib/upload_manager.py
+++ b/codalab/lib/upload_manager.py
@@ -24,7 +24,7 @@ class UploadManager(object):
 
     def upload_to_bundle_store(
         self,
-        bundle: Any,
+        bundle: Bundle,
         sources: List[Any],
         git: bool,
         unpack: bool,

--- a/codalab/lib/upload_manager.py
+++ b/codalab/lib/upload_manager.py
@@ -120,8 +120,7 @@ class UploadManager(object):
     def _simplify_archive(self, path):
         """
         Modifies |path| in place: If |path| is a directory containing exactly
-        one file / directory that is not ignored, then replace |path| with that
-        file / directory.
+        one file / directory, then replace |path| with that file / directory.
         """
         if not os.path.isdir(path):
             return

--- a/codalab/lib/upload_manager.py
+++ b/codalab/lib/upload_manager.py
@@ -125,7 +125,7 @@ class UploadManager(object):
         if not os.path.isdir(path):
             return
 
-        files = [f for f in os.listdir(path)]
+        files = os.listdir(path)
         if len(files) == 1:
             self._simplify_directory(path, files[0])
 

--- a/codalab/lib/upload_manager.py
+++ b/codalab/lib/upload_manager.py
@@ -17,19 +17,14 @@ class UploadManager(object):
         from codalab.lib import zip_util
 
         # exclude these patterns by default
-        DEFAULT_EXCLUDE_PATTERNS = ['.DS_Store', '__MACOSX', '^\._.*']
         self._bundle_model = bundle_model
         self._bundle_store = bundle_store
-        self._default_exclude_patterns = DEFAULT_EXCLUDE_PATTERNS
         self.zip_util = zip_util
 
     def upload_to_bundle_store(
         self,
         bundle,
         sources,
-        follow_symlinks,
-        exclude_patterns,
-        remove_sources,
         git,
         unpack,
         simplify_archives,
@@ -40,11 +35,6 @@ class UploadManager(object):
 
         |sources|: specifies the locations of the contents to upload. Each element is
                    either a URL, a local path or a tuple (filename, binary file-like object).
-        |follow_symlinks|: for local path(s), whether to follow (resolve) symlinks,
-                           but only if remove_sources is False.
-        |exclude_patterns|: for local path(s), don't upload these patterns (e.g., *.o),
-                            but only if remove_sources is False.
-        |remove_sources|: for local path(s), whether |sources| should be removed
         |git|: for URLs, whether |source| is a git repo to clone.
         |unpack|: for each source in |sources|, whether to unpack it if it's an archive.
         |simplify_archives|: whether to simplify unpacked archives so that if they
@@ -58,18 +48,13 @@ class UploadManager(object):
         - If |git|, then each source is replaced with the result of running 'git clone |source|'
         - If |unpack| is True or a source is an archive (zip, tar.gz, etc.), then unpack the source.
         """
-        exclude_patterns = (
-            self._default_exclude_patterns + exclude_patterns
-            if exclude_patterns
-            else self._default_exclude_patterns
-        )
         bundle_path = self._bundle_store.get_bundle_location(bundle.uuid)
         try:
             path_util.make_directory(bundle_path)
             # Note that for uploads with a single source, the directory
             # structure is simplified at the end.
             for source in sources:
-                is_url, is_local_path, is_fileobj, filename = self._interpret_source(source)
+                is_url, is_fileobj, filename = self._interpret_source(source)
                 source_output_path = os.path.join(bundle_path, filename)
                 if is_url:
                     if git:
@@ -84,26 +69,6 @@ class UploadManager(object):
                                 remove_source=True,
                                 simplify_archive=simplify_archives,
                             )
-                elif is_local_path:
-                    source_path = path_util.normalize(source)
-                    path_util.check_isvalid(source_path, 'upload')
-
-                    if unpack and self._can_unpack_file(source_path):
-                        self._unpack_file(
-                            source_path,
-                            self.zip_util.strip_archive_ext(source_output_path),
-                            remove_source=remove_sources,
-                            simplify_archive=simplify_archives,
-                        )
-                    elif remove_sources:
-                        path_util.rename(source_path, source_output_path)
-                    else:
-                        path_util.copy(
-                            source_path,
-                            source_output_path,
-                            follow_symlinks=follow_symlinks,
-                            exclude_patterns=exclude_patterns,
-                        )
                 elif is_fileobj:
                     if unpack and self.zip_util.path_is_archive(filename):
                         self._unpack_fileobj(
@@ -129,18 +94,18 @@ class UploadManager(object):
             raise
 
     def _interpret_source(self, source):
-        is_url, is_local_path, is_fileobj = False, False, False
+        is_url, is_fileobj = False, False
         if isinstance(source, str):
             if path_util.path_is_url(source):
                 is_url = True
                 source = source.rsplit('?', 1)[0]  # Remove query string from URL, if present
             else:
-                is_local_path = True
+                raise UsageError("Paths must be URLs.")
             filename = os.path.basename(os.path.normpath(source))
         else:
             is_fileobj = True
             filename = source[0]
-        return is_url, is_local_path, is_fileobj, filename
+        return is_url, is_fileobj, filename
 
     def _can_unpack_file(self, path):
         return os.path.isfile(path) and self.zip_util.path_is_archive(path)
@@ -168,13 +133,9 @@ class UploadManager(object):
         if not os.path.isdir(path):
             return
 
-        files = [f for f in os.listdir(path) if not self._ignore_file_in_archive(f)]
+        files = [f for f in os.listdir(path)]
         if len(files) == 1:
             self._simplify_directory(path, files[0])
-
-    def _ignore_file_in_archive(self, filename):
-        matchers = [re.compile(s) for s in self._default_exclude_patterns]
-        return any([matcher.match(filename) for matcher in matchers])
 
     def _simplify_directory(self, path, child_path=None):
         """

--- a/codalab/lib/upload_manager.py
+++ b/codalab/lib/upload_manager.py
@@ -1,11 +1,13 @@
 import os
 import shutil
-from typing import Optional, List, Any
+from typing import Optional, List, Any, Union, Tuple, IO, cast
 
 from codalab.common import UsageError
 from codalab.common import StorageType
 from codalab.lib import crypt_util, file_util, path_util
 from codalab.objects.bundle import Bundle
+
+Source = Union[str, Tuple[str, IO[bytes]]]
 
 
 class UploadManager(object):
@@ -25,7 +27,7 @@ class UploadManager(object):
     def upload_to_bundle_store(
         self,
         bundle: Bundle,
-        sources: List[Any],
+        sources: List[Source],
         git: bool,
         unpack: bool,
         simplify_archives: bool,
@@ -35,7 +37,7 @@ class UploadManager(object):
         Uploads contents for the given bundle to the bundle store.
 
         |sources|: specifies the locations of the contents to upload. Each element is
-                   either a URL, a local path or a tuple (filename, binary file-like object).
+                   either a URL or a tuple (filename, binary file-like object).
         |git|: for URLs, whether |source| is a git repo to clone.
         |unpack|: for each source in |sources|, whether to unpack it if it's an archive.
         |simplify_archives|: whether to simplify unpacked archives so that if they
@@ -80,7 +82,7 @@ class UploadManager(object):
                         )
                     else:
                         with open(source_output_path, 'wb') as out:
-                            shutil.copyfileobj(source[1], out)
+                            shutil.copyfileobj(cast(IO, source[1]), out)
 
             if len(sources) == 1:
                 self._simplify_directory(bundle_path)

--- a/codalab/lib/upload_manager.py
+++ b/codalab/lib/upload_manager.py
@@ -103,7 +103,7 @@ class UploadManager(object):
                 is_url = True
                 source = source.rsplit('?', 1)[0]  # Remove query string from URL, if present
             else:
-                raise UsageError("Paths must be URLs.")
+                raise UsageError("Path must be a URL.")
             filename = os.path.basename(os.path.normpath(source))
         else:
             is_fileobj = True

--- a/codalab/lib/upload_manager.py
+++ b/codalab/lib/upload_manager.py
@@ -22,13 +22,7 @@ class UploadManager(object):
         self.zip_util = zip_util
 
     def upload_to_bundle_store(
-        self,
-        bundle,
-        sources,
-        git,
-        unpack,
-        simplify_archives,
-        use_azure_blob_beta,
+        self, bundle, sources, git, unpack, simplify_archives, use_azure_blob_beta,
     ):
         """
         Uploads contents for the given bundle to the bundle store.

--- a/codalab/lib/upload_manager.py
+++ b/codalab/lib/upload_manager.py
@@ -1,6 +1,6 @@
 import os
 import shutil
-from typing import Optional, List, Any, Union, Tuple, IO, cast
+from typing import Optional, List, Union, Tuple, IO, cast
 
 from codalab.common import UsageError
 from codalab.common import StorageType

--- a/codalab/lib/upload_manager.py
+++ b/codalab/lib/upload_manager.py
@@ -1,9 +1,11 @@
 import os
 import shutil
+from typing import Optional, List, Any
 
 from codalab.common import UsageError
 from codalab.common import StorageType
 from codalab.lib import crypt_util, file_util, path_util
+from codalab.objects.bundle import Bundle
 
 
 class UploadManager(object):
@@ -21,7 +23,13 @@ class UploadManager(object):
         self.zip_util = zip_util
 
     def upload_to_bundle_store(
-        self, bundle, sources, git, unpack, simplify_archives, use_azure_blob_beta,
+        self,
+        bundle: Any,
+        sources: List[Any],
+        git: bool,
+        unpack: bool,
+        simplify_archives: bool,
+        use_azure_blob_beta: bool,
     ):
         """
         Uploads contents for the given bundle to the bundle store.
@@ -117,7 +125,7 @@ class UploadManager(object):
         if simplify_archive:
             self._simplify_archive(dest_path)
 
-    def _simplify_archive(self, path):
+    def _simplify_archive(self, path: str) -> None:
         """
         Modifies |path| in place: If |path| is a directory containing exactly
         one file / directory, then replace |path| with that file / directory.
@@ -129,10 +137,11 @@ class UploadManager(object):
         if len(files) == 1:
             self._simplify_directory(path, files[0])
 
-    def _simplify_directory(self, path, child_path=None):
+    def _simplify_directory(self, path: str, child_path: Optional[str] = None) -> None:
         """
-        Modifies |path| in place: If the |path| directory contains exactly
-        one file / directory, then replace |path| with that file / directory.
+        Modifies |path| in place by replacing |path| with its first child file / directory.
+        This method should only be called after checking to see if the |path| directory
+        contains exactly one file / directory.
         """
         if child_path is None:
             child_path = os.listdir(path)[0]

--- a/codalab/lib/upload_manager.py
+++ b/codalab/lib/upload_manager.py
@@ -60,6 +60,7 @@ class UploadManager(object):
                 is_url, is_fileobj, filename = self._interpret_source(source)
                 source_output_path = os.path.join(bundle_path, filename)
                 if is_url:
+                    assert isinstance(source, str)
                     if git:
                         source_output_path = file_util.strip_git_ext(source_output_path)
                         file_util.git_clone(source, source_output_path)

--- a/codalab/lib/upload_manager.py
+++ b/codalab/lib/upload_manager.py
@@ -1,4 +1,3 @@
-import re
 import os
 import shutil
 

--- a/codalab/lib/upload_manager.py
+++ b/codalab/lib/upload_manager.py
@@ -96,7 +96,7 @@ class UploadManager(object):
                 path_util.remove(bundle_path)
             raise
 
-    def _interpret_source(self, source):
+    def _interpret_source(self, source: Source):
         is_url, is_fileobj = False, False
         if isinstance(source, str):
             if path_util.path_is_url(source):

--- a/codalab/objects/bundle.py
+++ b/codalab/objects/bundle.py
@@ -37,6 +37,18 @@ class Bundle(ORMObject):
     BUNDLE_TYPE: str
     METADATA_SPECS: list
 
+    # Types for columns
+    uuid: str
+    bundle_type: str
+    command: str
+    data_hash: str
+    state: str
+    owner_id: str
+    frozen: bool
+    is_anonymous: bool
+    storage_type: str
+    is_dir: bool
+
     @classmethod
     def construct(cls, *args, **kwargs):
         raise NotImplementedError

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -789,9 +789,6 @@ def _update_bundle_contents_blob(uuid):
             local.upload_manager.upload_to_bundle_store(
                 bundle,
                 sources=sources,
-                follow_symlinks=False,
-                exclude_patterns=None,
-                remove_sources=False,
                 git=query_get_bool('git', default=False),
                 unpack=query_get_bool('unpack', default=True),
                 simplify_archives=query_get_bool('simplify', default=True),

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -837,8 +837,7 @@ def test_upload3(ctx):
         ]
     )
     check_contains(
-        ['codalab-worksheets', 'codalab.github.io'],
-        _run_command([cl, 'cat', uuid + '/codalab.github.io']),
+        ['codalab-worksheets', 'codalab.github.io'], _run_command([cl, 'cat', uuid]),
     )
     check_contains(
         ['README.md', 'codalab', 'scripts'], _run_command([cl, 'cat', uuid + '/codalab-worksheets'])

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -826,6 +826,24 @@ def test_upload3(ctx):
     uuid = _run_command([cl, 'upload', 'https://github.com/codalab/codalab-worksheets', '--git'])
     check_contains(['README.md', 'codalab', 'scripts'], _run_command([cl, 'cat', uuid]))
 
+    # Upload multiple URLs from Git
+    uuid = _run_command(
+        [
+            cl,
+            'upload',
+            'https://github.com/codalab/codalab-worksheets',
+            'https://github.com/codalab/codalab.github.io',
+            '--git',
+        ]
+    )
+    check_contains(
+        ['codalab-worksheets', 'codalab.github.io'],
+        _run_command([cl, 'cat', uuid + '/codalab.github.io']),
+    )
+    check_contains(
+        ['README.md', 'codalab', 'scripts'], _run_command([cl, 'cat', uuid + '/codalab-worksheets'])
+    )
+
 
 @TestModule.register('upload4')
 def test_upload4(ctx):

--- a/tests/unit/lib/upload_manager_test.py
+++ b/tests/unit/lib/upload_manager_test.py
@@ -70,15 +70,27 @@ class UploadManagerTest(unittest.TestCase):
         self.check_file_contains_string(os.path.join(self.bundle_location, 'filename'), 'testing')
 
     def test_fileobj_single_tar_gz_with_dsstore_should_not_simplify_archive(self):
-        """If the user included two files, filename and .DS_Store, in the archive,
+        """If the user included two files, README and .DS_Store, in the archive,
         the archive should not be simplified because we have more than one file in the archive.
         """
         source = os.path.join(self.temp_dir, 'source_dir')
         os.mkdir(source)
-        self.write_string_to_file('testing', os.path.join(source, 'filename'))
+        self.write_string_to_file('testing', os.path.join(source, 'README'))
         self.write_string_to_file('testing', os.path.join(source, '.DS_Store'))
         self.do_upload([('source.tar.gz', tar_gzip_directory(source))])
-        self.assertEqual(['.DS_Store', 'filename'], os.listdir(self.bundle_location))
+        self.assertEqual(['.DS_Store', 'README'], os.listdir(self.bundle_location))
+
+    def test_fileobj_single_tar_gz_with_dsstore_should_not_simplify_archive_2(self):
+        """If the user included three files, README, README2, and .DS_Store, in the archive,
+        the archive should not be simplified because we have more than one file in the archive.
+        """
+        source = os.path.join(self.temp_dir, 'source_dir')
+        os.mkdir(source)
+        self.write_string_to_file('testing', os.path.join(source, 'README'))
+        self.write_string_to_file('testing', os.path.join(source, 'README2'))
+        self.write_string_to_file('testing', os.path.join(source, '.DS_Store'))
+        self.do_upload([('source.tar.gz', tar_gzip_directory(source))])
+        self.assertEqual(['.DS_Store', 'README2', 'README'], os.listdir(self.bundle_location))
 
     def mock_url_sources(self, fileobj, ext=""):
         """Returns a URL that is mocked to return the contents of fileobj.

--- a/tests/unit/lib/upload_manager_test.py
+++ b/tests/unit/lib/upload_manager_test.py
@@ -78,7 +78,7 @@ class UploadManagerTest(unittest.TestCase):
         self.write_string_to_file('testing', os.path.join(source, 'README'))
         self.write_string_to_file('testing', os.path.join(source, '.DS_Store'))
         self.do_upload([('source.tar.gz', tar_gzip_directory(source))])
-        self.assertEqual(['.DS_Store', 'README'], os.listdir(self.bundle_location))
+        self.assertEqual(['.DS_Store', 'README'], sorted(os.listdir(self.bundle_location)))
 
     def test_fileobj_single_tar_gz_with_dsstore_should_not_simplify_archive_2(self):
         """If the user included three files, README, README2, and .DS_Store, in the archive,
@@ -90,7 +90,7 @@ class UploadManagerTest(unittest.TestCase):
         self.write_string_to_file('testing', os.path.join(source, 'README2'))
         self.write_string_to_file('testing', os.path.join(source, '.DS_Store'))
         self.do_upload([('source.tar.gz', tar_gzip_directory(source))])
-        self.assertEqual(['.DS_Store', 'README2', 'README'], os.listdir(self.bundle_location))
+        self.assertEqual(['.DS_Store', 'README', 'README2'], sorted(os.listdir(self.bundle_location)))
 
     def mock_url_sources(self, fileobj, ext=""):
         """Returns a URL that is mocked to return the contents of fileobj.

--- a/tests/unit/lib/upload_manager_test.py
+++ b/tests/unit/lib/upload_manager_test.py
@@ -90,7 +90,9 @@ class UploadManagerTest(unittest.TestCase):
         self.write_string_to_file('testing', os.path.join(source, 'README2'))
         self.write_string_to_file('testing', os.path.join(source, '.DS_Store'))
         self.do_upload([('source.tar.gz', tar_gzip_directory(source))])
-        self.assertEqual(['.DS_Store', 'README', 'README2'], sorted(os.listdir(self.bundle_location)))
+        self.assertEqual(
+            ['.DS_Store', 'README', 'README2'], sorted(os.listdir(self.bundle_location))
+        )
 
     def mock_url_sources(self, fileobj, ext=""):
         """Returns a URL that is mocked to return the contents of fileobj.

--- a/tests/unit/lib/upload_manager_test.py
+++ b/tests/unit/lib/upload_manager_test.py
@@ -69,6 +69,14 @@ class UploadManagerTest(unittest.TestCase):
         self.assertEqual(['filename'], os.listdir(self.bundle_location))
         self.check_file_contains_string(os.path.join(self.bundle_location, 'filename'), 'testing')
 
+    def test_fileobj_single_tar_gz_with_dsstore_should_not_simplify_archive(self):
+        source = os.path.join(self.temp_dir, 'source_dir')
+        os.mkdir(source)
+        self.write_string_to_file('testing', os.path.join(source, 'filename'))
+        self.write_string_to_file('testing', os.path.join(source, '.DS_Store'))
+        self.do_upload([('source.tar.gz', tar_gzip_directory(source))])
+        self.assertEqual(['.DS_Store', 'filename'], os.listdir(self.bundle_location))
+
     def mock_url_sources(self, fileobj, ext=""):
         """Returns a URL that is mocked to return the contents of fileobj.
         The URL will end in the extension "ext", if given.

--- a/tests/unit/lib/upload_manager_test.py
+++ b/tests/unit/lib/upload_manager_test.py
@@ -6,6 +6,11 @@ import unittest
 from codalab.lib.upload_manager import UploadManager
 from codalab.worker.file_util import gzip_bytestring, remove_path, tar_gzip_directory
 
+from unittest.mock import MagicMock
+from urllib.response import addinfourl
+import urllib
+
+urlopen_real = urllib.request.urlopen
 
 class UploadManagerTest(unittest.TestCase):
     def setUp(self):
@@ -23,6 +28,7 @@ class UploadManagerTest(unittest.TestCase):
         self.temp_dir = tempfile.mkdtemp()
         self.bundle_location = os.path.join(self.temp_dir, 'bundle')
         self.manager = UploadManager(MockBundleModel(), MockBundleStore(self.bundle_location))
+        urllib.request.urlopen = urlopen_real
 
     def tearDown(self):
         remove_path(self.temp_dir)
@@ -30,9 +36,6 @@ class UploadManagerTest(unittest.TestCase):
     def do_upload(
         self,
         sources,
-        follow_symlinks=False,
-        exclude_patterns=[],
-        remove_sources=False,
         git=False,
         unpack=True,
         simplify_archives=True,
@@ -46,75 +49,28 @@ class UploadManagerTest(unittest.TestCase):
         self.manager.upload_to_bundle_store(
             FakeBundle(),
             sources,
-            follow_symlinks,
-            exclude_patterns,
-            remove_sources,
             git,
             unpack,
             simplify_archives,
             use_azure_blob_beta,
         )
 
-    def test_single_local_path(self):
-        source = os.path.join(self.temp_dir, 'filename')
-        self.write_string_to_file('testing', source)
-        self.do_upload([source])
-        self.assertTrue(os.path.exists(source))
-        self.check_file_contains_string(self.bundle_location, 'testing')
-
-    def test_ignored_files(self):
-        dsstore_file = os.path.join(self.temp_dir, '.DS_Store')
-        self.write_string_to_file('testing', dsstore_file)
-        source = os.path.join(self.temp_dir, 'filename')
-        self.write_string_to_file('testing', source)
-        self.do_upload([self.temp_dir])
-        self.assertTrue(os.path.exists(os.path.join(self.bundle_location, 'filename')))
-        self.assertFalse(os.path.exists(os.path.join(self.bundle_location, '.DS_Store')))
-        self.assertFalse(os.path.exists(os.path.join(self.bundle_location, '__MACOSX')))
-        self.check_file_contains_string(os.path.join(self.bundle_location, 'filename'), 'testing')
-
-    def test_single_local_gzip_path(self):
-        source = os.path.join(self.temp_dir, 'filename.gz')
-        self.write_bytes_to_file(gzip_bytestring(b'testing'), source)
-        self.do_upload([source], unpack=True)
-        self.assertTrue(os.path.exists(source))
-        self.check_file_contains_string(self.bundle_location, 'testing')
-
-    def test_single_local_tar_gz_path_simplify_archives(self):
-        source_dir = os.path.join(self.temp_dir, 'source_dir')
-        os.mkdir(source_dir)
-        self.write_string_to_file('testing', os.path.join(source_dir, 'filename'))
-        source = os.path.join(self.temp_dir, 'source.tar.gz')
-        with open(source, 'wb') as f:
-            f.write(tar_gzip_directory(source_dir).read())
-        self.do_upload([source], simplify_archives=True)
-        self.assertTrue(os.path.exists(source))
-        self.check_file_contains_string(self.bundle_location, 'testing')
-
-    def test_single_local_path_remove_sources(self):
-        source = os.path.join(self.temp_dir, 'filename')
-        self.write_string_to_file('testing', source)
-        self.do_upload([source], remove_sources=True)
-        self.assertFalse(os.path.exists(source))
-
-    def test_single_local_gzip_path_remove_sources(self):
-        source = os.path.join(self.temp_dir, 'filename.gz')
-        self.write_bytes_to_file(gzip_bytestring(b'testing'), source)
-        self.do_upload([source], remove_sources=True)
-        self.assertFalse(os.path.exists(source))
-
-    def test_single_fileobj(self):
+    def test_fileobj_single(self):
         self.do_upload([('source', BytesIO(b'testing'))])
         self.check_file_contains_string(self.bundle_location, 'testing')
 
-    def test_single_fileobj_tar_gz_simplify_archives(self):
+    def test_fileobj_single_gz(self):
+        self.do_upload([('source.gz', BytesIO(gzip_bytestring(b'testing')))])
+        self.check_file_contains_string(self.bundle_location, 'testing')
+
+    def test_fileobj_single_tar_gz_simplify_archives(self):
         source = os.path.join(self.temp_dir, 'source_dir')
         os.mkdir(source)
         self.write_string_to_file('testing', os.path.join(source, 'filename'))
         self.do_upload([('source.tar.gz', tar_gzip_directory(source))])
         self.check_file_contains_string(self.bundle_location, 'testing')
 
-    def test_single_fileobj_tar_gz_no_simplify_archives(self):
+    def test_fileobj_single_tar_gz_no_simplify_archives(self):
         source = os.path.join(self.temp_dir, 'source_dir')
         os.mkdir(source)
         self.write_string_to_file('testing', os.path.join(source, 'filename'))
@@ -122,11 +78,38 @@ class UploadManagerTest(unittest.TestCase):
         self.assertEqual(['filename'], os.listdir(self.bundle_location))
         self.check_file_contains_string(os.path.join(self.bundle_location, 'filename'), 'testing')
 
+    def mock_url_sources(self, fileobj, ext=""):
+        """Returns a URL that is mocked to return the contents of fileobj.
+        The URL will end in the extension "ext", if given.
+        """
+        url = f"https://codalab/contents{ext}"
+        size = len(fileobj.read())
+        fileobj.seek(0)
+        urllib.request.urlopen = MagicMock()
+        urllib.request.urlopen.return_value = addinfourl(fileobj, {"content-length": size}, url)
+        return [url]
+
+    def test_url_single(self):
+        self.do_upload(self.mock_url_sources(BytesIO(b'hello world')))
+        self.check_file_contains_string(self.bundle_location, 'hello world')
+
+    def test_url_tar_gz(self):
+        source = os.path.join(self.temp_dir, 'source_dir')
+        os.mkdir(source)
+        self.write_string_to_file('testing', os.path.join(source, 'file1'))
+        self.write_string_to_file('testing', os.path.join(source, 'file2'))
+        self.do_upload(self.mock_url_sources(BytesIO(tar_gzip_directory(source).read()), ext=".tar.gz"))
+        self.assertIn('file2', os.listdir(self.bundle_location))
+
     def test_multiple_sources(self):
-        self.do_upload([('source1', BytesIO(b'testing1')), ('source2', BytesIO(b'testing2'))])
-        self.assertEqual(['source1', 'source2'], sorted(os.listdir(self.bundle_location)))
+        self.do_upload([('source1', BytesIO(b'testing1')), ('source2', BytesIO(b'testing2')), 'http://alpha.gnu.org/gnu/bc/bc-1.06.95.tar.bz2'])
+        self.assertEqual(['bc-1.06.95', 'source1', 'source2'], sorted(os.listdir(self.bundle_location)))
         self.check_file_contains_string(os.path.join(self.bundle_location, 'source1'), 'testing1')
         self.check_file_contains_string(os.path.join(self.bundle_location, 'source2'), 'testing2')
+        self.assertIn('README', os.listdir(os.path.join(self.bundle_location, 'bc-1.06.95')))
+    
+    def test_url_git(self):
+        self.do_upload(['https://github.com/codalab/test'], git=True)
 
     def write_string_to_file(self, string, file_path):
         with open(file_path, 'w') as f:

--- a/tests/unit/lib/upload_manager_test.py
+++ b/tests/unit/lib/upload_manager_test.py
@@ -70,6 +70,9 @@ class UploadManagerTest(unittest.TestCase):
         self.check_file_contains_string(os.path.join(self.bundle_location, 'filename'), 'testing')
 
     def test_fileobj_single_tar_gz_with_dsstore_should_not_simplify_archive(self):
+        """If the user included two files, filename and .DS_Store, in the archive,
+        the archive should not be simplified because we have more than one file in the archive.
+        """
         source = os.path.join(self.temp_dir, 'source_dir')
         os.mkdir(source)
         self.write_string_to_file('testing', os.path.join(source, 'filename'))

--- a/tests/unit/lib/upload_manager_test.py
+++ b/tests/unit/lib/upload_manager_test.py
@@ -12,6 +12,7 @@ import urllib
 
 urlopen_real = urllib.request.urlopen
 
+
 class UploadManagerTest(unittest.TestCase):
     def setUp(self):
         class MockBundleStore(object):
@@ -34,12 +35,7 @@ class UploadManagerTest(unittest.TestCase):
         remove_path(self.temp_dir)
 
     def do_upload(
-        self,
-        sources,
-        git=False,
-        unpack=True,
-        simplify_archives=True,
-        use_azure_blob_beta=False,
+        self, sources, git=False, unpack=True, simplify_archives=True, use_azure_blob_beta=False,
     ):
         class FakeBundle(object):
             def __init__(self):
@@ -47,12 +43,7 @@ class UploadManagerTest(unittest.TestCase):
                 self.metadata = object()
 
         self.manager.upload_to_bundle_store(
-            FakeBundle(),
-            sources,
-            git,
-            unpack,
-            simplify_archives,
-            use_azure_blob_beta,
+            FakeBundle(), sources, git, unpack, simplify_archives, use_azure_blob_beta,
         )
 
     def test_fileobj_single(self):
@@ -98,16 +89,26 @@ class UploadManagerTest(unittest.TestCase):
         os.mkdir(source)
         self.write_string_to_file('testing', os.path.join(source, 'file1'))
         self.write_string_to_file('testing', os.path.join(source, 'file2'))
-        self.do_upload(self.mock_url_sources(BytesIO(tar_gzip_directory(source).read()), ext=".tar.gz"))
+        self.do_upload(
+            self.mock_url_sources(BytesIO(tar_gzip_directory(source).read()), ext=".tar.gz")
+        )
         self.assertIn('file2', os.listdir(self.bundle_location))
 
     def test_multiple_sources(self):
-        self.do_upload([('source1', BytesIO(b'testing1')), ('source2', BytesIO(b'testing2')), 'http://alpha.gnu.org/gnu/bc/bc-1.06.95.tar.bz2'])
-        self.assertEqual(['bc-1.06.95', 'source1', 'source2'], sorted(os.listdir(self.bundle_location)))
+        self.do_upload(
+            [
+                ('source1', BytesIO(b'testing1')),
+                ('source2', BytesIO(b'testing2')),
+                'http://alpha.gnu.org/gnu/bc/bc-1.06.95.tar.bz2',
+            ]
+        )
+        self.assertEqual(
+            ['bc-1.06.95', 'source1', 'source2'], sorted(os.listdir(self.bundle_location))
+        )
         self.check_file_contains_string(os.path.join(self.bundle_location, 'source1'), 'testing1')
         self.check_file_contains_string(os.path.join(self.bundle_location, 'source2'), 'testing2')
         self.assertIn('README', os.listdir(os.path.join(self.bundle_location, 'bc-1.06.95')))
-    
+
     def test_url_git(self):
         self.do_upload(['https://github.com/codalab/test'], git=True)
 

--- a/tests/unit/server/upload_download_test.py
+++ b/tests/unit/server/upload_download_test.py
@@ -196,9 +196,6 @@ class RegularBundleStoreTest(BaseUploadDownloadBundleTest, unittest.TestCase):
         self.upload_manager.upload_to_bundle_store(
             bundle,
             sources,
-            follow_symlinks=False,
-            exclude_patterns=None,
-            remove_sources=False,
             git=False,
             unpack=True,
             simplify_archives=True,
@@ -210,9 +207,6 @@ class RegularBundleStoreTest(BaseUploadDownloadBundleTest, unittest.TestCase):
         self.upload_manager.upload_to_bundle_store(
             bundle,
             sources,
-            follow_symlinks=False,
-            exclude_patterns=None,
-            remove_sources=False,
             git=False,
             unpack=False,
             simplify_archives=True,


### PR DESCRIPTION
### Reasons for making this change

- Simplify uploads by removing local path support -- I did this to simplify the amount of changes that need to go into blob storage (#3298 ). From what I can tell, local paths aren't used at all at the moment when uploading (when uploading from the CLI, you either upload strings, URLs, or fileobj's; and workers upload a fileobj directly with BundleServiceClient). Local paths only seem to be used in upload_manager_test.py, so we should be able to safely remove them.
- follow_symlinks, exclude_patterns, and remove_sources have also been removed from UploadManager, because these were only used during local path support. Note that `--follow-symlinks` and `--exclude-patterns` still exist and work properly on the Bundle CLI (they are used when zipping up directories from the CLI). It's just that their existence in UploadManager is no longer functional and can be removed.
- Removed logic around using `_ignore_file_in_archive` to determine whether to simplify archives in UploadManager (see comment below on upload_manager.py).
- I've added additional tests (unit and CLI tests) that exercise more of the functionality of UploadManager.

Although this PR is technically a breaking change by removing functionality, all the removed functionality seems to be either unused / unintentional, and removing them would greatly simplify the implementation of Blob Storage.