### PR TITLE
Use shallow clones for git, for speed

### DIFF
--- a/codalab/lib/file_util.py
+++ b/codalab/lib/file_util.py
@@ -55,8 +55,8 @@ def strip_git_ext(path):
     return path
 
 
-def git_clone(source_url, target_path):
-    return subprocess.call(['git', 'clone', source_url, target_path])
+def git_clone(source_url: str, target_path: str) -> int:
+    return subprocess.call(['git', 'clone', '--depth', '1', source_url, target_path])
 
 
 def download_url(source_url, target_path, print_status=False):


### PR DESCRIPTION
Use shallow clones when uploading git repos, for speed. We only need shallow clones, because we're just zipping up the default branch, rather than using any other branches / information about the repo's history.

Timing stats:
`git clone https://github.com/codalab/codalab-worksheets` - took 43 seconds
`git clone --depth 1 https://github.com/codalab/codalab-worksheets` - took 12 seconds
