### PR TITLE
Black and flake8 speed improvements

### DIFF
--- a/codalab/lib/beam/filesystems.py
+++ b/codalab/lib/beam/filesystems.py
@@ -2,9 +2,11 @@ import os
 from azure.storage.blob import BlobServiceClient
 
 # Test connection string for Azurite (local development)
-TEST_CONN_STR = ("DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;"
-"AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;"
-"BlobEndpoint=http://azurite:10000/devstoreaccount1;")
+TEST_CONN_STR = (
+    "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;"
+    "AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;"
+    "BlobEndpoint=http://azurite:10000/devstoreaccount1;"
+)
 
 # The Apache beam BlobStorageFileSystem expects the AZURE_STORAGE_CONNECTION_STRING environment variable
 # to be set to the correct Azure Blob Storage connection string.

--- a/codalab/lib/beam/mockblobstoragefilesystem.py
+++ b/codalab/lib/beam/mockblobstoragefilesystem.py
@@ -6,7 +6,7 @@ This is used only for unit tests for speed, so that unit tests do not need to de
 a Blob Storage container / Azurite running in the background.
 """
 
-from apache_beam.io.filesystem import FileSystem
+from apache_beam.io.filesystem import FileSystem  # noqa: F401
 from apache_beam.io.localfilesystem import LocalFileSystem
 import os
 from io import BytesIO
@@ -15,75 +15,78 @@ __all__ = ['MockBlobStorageFileSystem']
 
 
 class MockBlobStorageFileSystem(LocalFileSystem):
-  AZFS_MOCK_LOCATION = "/tmp/codalab/azfs-mock/"
+    AZFS_MOCK_LOCATION = "/tmp/codalab/azfs-mock/"
 
-  def __init__(self, *args, **kwargs):
-    os.makedirs(MockBlobStorageFileSystem.AZFS_MOCK_LOCATION, exist_ok=True)
-    super().__init__(*args, **kwargs)
+    def __init__(self, *args, **kwargs):
+        os.makedirs(MockBlobStorageFileSystem.AZFS_MOCK_LOCATION, exist_ok=True)
+        super().__init__(*args, **kwargs)
 
-  @classmethod
-  def scheme(cls):
-    """URI scheme for the FileSystem
+    @classmethod
+    def scheme(cls):
+        """URI scheme for the FileSystem
     """
-    return 'azfs'
+        return 'azfs'
 
-  def _local_to_azfs(self, path):
-      return "azfs://" + path[len(MockBlobStorageFileSystem.AZFS_MOCK_LOCATION):]
+    def _local_to_azfs(self, path):
+        return "azfs://" + path[len(MockBlobStorageFileSystem.AZFS_MOCK_LOCATION) :]
 
-  def _azfs_to_local(self, path):
-      if not path.startswith("azfs://"):
+    def _azfs_to_local(self, path):
+        if not path.startswith("azfs://"):
+            return path
+        path = MockBlobStorageFileSystem.AZFS_MOCK_LOCATION + path[len("azfs://") :]
+        os.makedirs(os.path.dirname(path), exist_ok=True)
         return path
-      path = MockBlobStorageFileSystem.AZFS_MOCK_LOCATION + path[len("azfs://"):]
-      os.makedirs(os.path.dirname(path), exist_ok=True)
-      return path
 
-  def join(self, basepath, *paths):
-    return super().join(basepath, *paths)
+    def join(self, basepath, *paths):
+        return super().join(basepath, *paths)
 
-  def split(self, path):
-    return super().split(path)
+    def split(self, path):
+        return super().split(path)
 
-  def mkdirs(self, path):
-    return super().mkdirs(self._azfs_to_local(path))
+    def mkdirs(self, path):
+        return super().mkdirs(self._azfs_to_local(path))
 
-  def has_dirs(self):
-    return super().has_dirs()
+    def has_dirs(self):
+        return super().has_dirs()
 
-  def _list(self, dir_or_prefix):
-    for file_metadata in super()._list(self._azfs_to_local(dir_or_prefix)):
-      file_metadata.path = self._local_to_azfs(file_metadata.path)
-      yield file_metadata
-  
-  def create(
-      self,
-      path,
-      *args, **kwargs):
-    return super().create(self._azfs_to_local(path), *args, **kwargs)
-  
-  def open(
-      self,
-      path,
-      *args, **kwargs):
-    return BytesIO(super().open(self._azfs_to_local(path), *args, **kwargs).read())
+    def _list(self, dir_or_prefix):
+        for file_metadata in super()._list(self._azfs_to_local(dir_or_prefix)):
+            file_metadata.path = self._local_to_azfs(file_metadata.path)
+            yield file_metadata
 
-  def copy(self, source_file_names, destination_file_names):
-    return super().copy([self._azfs_to_local(p) for p in source_file_names], [self._azfs_to_local(p) for p in destination_file_names])
+    def create(self, path, *args, **kwargs):
+        return super().create(self._azfs_to_local(path), *args, **kwargs)
 
-  def rename(self, source_file_names, destination_file_names):
-    print([self._azfs_to_local(p) for p in source_file_names], [self._azfs_to_local(p) for p in destination_file_names])
-    return super().rename([self._azfs_to_local(p) for p in source_file_names], [self._azfs_to_local(p) for p in destination_file_names])
-  
-  def exists(self, path):
-    return super().exists(self._azfs_to_local(path))
+    def open(self, path, *args, **kwargs):
+        return BytesIO(super().open(self._azfs_to_local(path), *args, **kwargs).read())
 
-  def size(self, path):
-    return super().size(self._azfs_to_local(path))
+    def copy(self, source_file_names, destination_file_names):
+        return super().copy(
+            [self._azfs_to_local(p) for p in source_file_names],
+            [self._azfs_to_local(p) for p in destination_file_names],
+        )
 
-  def last_updated(self, path):
-    return super().last_updated(self._azfs_to_local(path))
+    def rename(self, source_file_names, destination_file_names):
+        print(
+            [self._azfs_to_local(p) for p in source_file_names],
+            [self._azfs_to_local(p) for p in destination_file_names],
+        )
+        return super().rename(
+            [self._azfs_to_local(p) for p in source_file_names],
+            [self._azfs_to_local(p) for p in destination_file_names],
+        )
 
-  def checksum(self, path):
-    return super().checksum(self._azfs_to_local(path))
+    def exists(self, path):
+        return super().exists(self._azfs_to_local(path))
 
-  def delete(self, paths):
-    return super().delete([self._azfs_to_local(path) for path in paths])
+    def size(self, path):
+        return super().size(self._azfs_to_local(path))
+
+    def last_updated(self, path):
+        return super().last_updated(self._azfs_to_local(path))
+
+    def checksum(self, path):
+        return super().checksum(self._azfs_to_local(path))
+
+    def delete(self, paths):
+        return super().delete([self._azfs_to_local(path) for path in paths])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,6 @@ exclude = '''
    | dist
    | build
    | frontend
-   | codalab/lib/beam
+   | var
 )/
 '''

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ ignore_missing_imports = True
 
 [flake8]
 max-line-length = 200
-exclude = venv/*,var/*,codalab/lib/beam/*,alembic/*
+exclude = venv/*,var/*,alembic/*,frontend/*
 
 # Ignore completely:
 # E203 - White space before ':', (conflicts with black)


### PR DESCRIPTION
### Reasons for making this change

- ignore additional large directories (such as var, frontend) for black / flake8 to make them run faster
- enable black and flake8 on codalab/lib/beam (this directory no longer contains vendor code, but has our own code, so we should run black and flake8 on it).