### PR TITLE
Add Tabs to MainPanel to show both Owned and Shared Worksheets

### DIFF
--- a/frontend/src/components/Dashboard/MainPanel.js
+++ b/frontend/src/components/Dashboard/MainPanel.js
@@ -288,7 +288,7 @@ class MainPanel extends React.Component<{
         const { classes } = this.props;
         const infoMessage = (
             <div className={classes.infoBox}>
-                <div>Display only the first 100 worksheets</div>
+                <div>Note: this page only displays up to the first 100 worksheets.</div>
             </div>
         );
         return (

--- a/frontend/src/components/Dashboard/MainPanel.js
+++ b/frontend/src/components/Dashboard/MainPanel.js
@@ -54,6 +54,14 @@ const styles = ({ palette, spacing, color }) => {
             alignItems: 'center',
             justifyContent: 'space-between',
         },
+        infoBox: {
+            marginLeft: 64,
+            marginRight: 20,
+            marginTop: 20,
+            marginBottom: 40,
+            backgroundColor: '#f1f1f1',
+            alignItems: 'center',
+        },
         wsCard: {
             display: 'flex',
             flexDirection: 'column',
@@ -278,6 +286,11 @@ class MainPanel extends React.Component<{
             warning: WarningIcon,
         }[this.state.snackbarVariant];
         const { classes } = this.props;
+        const infoMessage = (
+            <div className={classes.infoBox}>
+                <div style={{ marginLeft: 16 }}>Display only the first 100 worksheets</div>
+            </div>
+        );
         return (
             <div>
                 <Card elevation={0} style={{ height: '100%', backgroundColor: '#f1f1f1' }}>
@@ -287,22 +300,12 @@ class MainPanel extends React.Component<{
                             onChange={this.handleTabChange}
                             aria-label='mainpanel tabs'
                         >
-                            <Tooltip
-                                title='display only the first 100 worksheets'
-                                placement='top-end'
-                            >
-                                <Tab label='Owned Worksheets' {...this.a11yProps(0)}></Tab>
-                            </Tooltip>
-                            <Tooltip
-                                title='display only the first 100 worksheets'
-                                placement='top-end'
-                            >
-                                <Tab
-                                    label='Shared Worksheets'
-                                    {...this.a11yProps(1)}
-                                    disabled={!this.props.ownDashboard}
-                                ></Tab>
-                            </Tooltip>
+                            <Tab label='Owned Worksheets' {...this.a11yProps(0)}></Tab>
+                            <Tab
+                                label='Shared Worksheets'
+                                {...this.a11yProps(1)}
+                                disabled={!this.props.ownDashboard}
+                            ></Tab>
                             {this.props.ownDashboard ? (
                                 <Tooltip title='New Worksheet'>
                                     <Button
@@ -321,9 +324,11 @@ class MainPanel extends React.Component<{
                     </div>
                     <TabPanel tabIndex={this.state.tabIndex} index={0}>
                         {this.state.worksheets}
+                        {infoMessage}
                     </TabPanel>
                     <TabPanel tabIndex={this.state.tabIndex} index={1}>
                         {this.state.sharedWorksheets}
+                        {infoMessage}
                     </TabPanel>
                 </Card>
                 <Dialog

--- a/frontend/src/components/Dashboard/MainPanel.js
+++ b/frontend/src/components/Dashboard/MainPanel.js
@@ -86,7 +86,7 @@ const styles = ({ palette, spacing, color }) => {
             letterSpacing: 0.15,
             lineHeight: '150%',
             marginBottom: 0,
-            marginLeft: 8,
+            marginLeft: 16,
             float: 'left',
         },
         value: {
@@ -288,24 +288,55 @@ class MainPanel extends React.Component<{
         const { classes } = this.props;
         const infoMessage = (
             <div className={classes.infoBox}>
-                <div style={{ marginLeft: 16 }}>Display only the first 100 worksheets</div>
+                <div>Display only the first 100 worksheets</div>
             </div>
         );
         return (
             <div>
-                <Card elevation={0} style={{ height: '100%', backgroundColor: '#f1f1f1' }}>
-                    <div className={classes.titleBox} display={'flex'} alignItems={'center'}>
-                        <Tabs
-                            value={this.state.tabIndex}
-                            onChange={this.handleTabChange}
-                            aria-label='mainpanel tabs'
-                        >
-                            <Tab label='Owned Worksheets' {...this.a11yProps(0)}></Tab>
-                            <Tab
-                                label='Shared Worksheets'
-                                {...this.a11yProps(1)}
-                                disabled={!this.props.ownDashboard}
-                            ></Tab>
+                {this.props.ownDashboard ? (
+                    <Card elevation={0} style={{ height: '100%', backgroundColor: '#f1f1f1' }}>
+                        <div className={classes.titleBox} display={'flex'} alignItems={'center'}>
+                            <Tabs
+                                value={this.state.tabIndex}
+                                onChange={this.handleTabChange}
+                                aria-label='mainpanel tabs'
+                            >
+                                <Tab label='My Worksheets' {...this.a11yProps(0)}></Tab>
+                                <Tab
+                                    label='Shared Worksheets with Me'
+                                    {...this.a11yProps(1)}
+                                    disabled={!this.props.ownDashboard}
+                                ></Tab>
+                                {this.props.ownDashboard ? (
+                                    <Tooltip title='New Worksheet'>
+                                        <Button
+                                            variant='contained'
+                                            className={classes.button}
+                                            startIcon={<NewWorksheetIcon />}
+                                            onClick={() =>
+                                                this.setState({ newWorksheetShowDialog: true })
+                                            }
+                                        >
+                                            ADD
+                                        </Button>
+                                    </Tooltip>
+                                ) : null}
+                            </Tabs>
+                        </div>
+                        <TabPanel tabIndex={this.state.tabIndex} index={0}>
+                            {this.state.worksheets}
+                            {infoMessage}
+                        </TabPanel>
+                        <TabPanel tabIndex={this.state.tabIndex} index={1}>
+                            {this.state.sharedWorksheets}
+                            {infoMessage}
+                        </TabPanel>
+                    </Card>
+                ) : (
+                    <Card elevation={0} style={{ height: '100%', backgroundColor: '#f1f1f1' }}>
+                        <div className={classes.titleBox} display={'flex'} alignItems={'center'}>
+                            <h3 className={classes.heading}>Worksheets &nbsp;&nbsp;</h3>
+                            &nbsp;&nbsp;&nbsp;&nbsp;
                             {this.props.ownDashboard ? (
                                 <Tooltip title='New Worksheet'>
                                     <Button
@@ -320,17 +351,12 @@ class MainPanel extends React.Component<{
                                     </Button>
                                 </Tooltip>
                             ) : null}
-                        </Tabs>
-                    </div>
-                    <TabPanel tabIndex={this.state.tabIndex} index={0}>
+                        </div>
+
                         {this.state.worksheets}
                         {infoMessage}
-                    </TabPanel>
-                    <TabPanel tabIndex={this.state.tabIndex} index={1}>
-                        {this.state.sharedWorksheets}
-                        {infoMessage}
-                    </TabPanel>
-                </Card>
+                    </Card>
+                )}
                 <Dialog
                     open={this.state.newWorksheetShowDialog}
                     onClose={() => this.resetDialog()}

--- a/frontend/src/components/Dashboard/MainPanel.js
+++ b/frontend/src/components/Dashboard/MainPanel.js
@@ -43,7 +43,12 @@ const styles = ({ palette, spacing, color }) => {
             backgroundColor: 'white',
             alignItems: 'center',
         },
-        titleBox: { margin: 'auto', marginTop: 8, marginBottom: 16, width: '90%' },
+        titleBox: {
+            margin: 'auto',
+            marginTop: 8,
+            marginBottom: 16,
+            width: '90%',
+        },
         wsInlineBox: {
             display: 'flex',
             alignItems: 'center',
@@ -97,7 +102,6 @@ const styles = ({ palette, spacing, color }) => {
             backgroundColor: green[500],
             color: 'white',
             right: 0,
-            marginBottom: 10,
             marginLeft: 'auto',
         },
         snackbarMessage: {

--- a/frontend/src/components/Dashboard/NewDashboard.js
+++ b/frontend/src/components/Dashboard/NewDashboard.js
@@ -87,7 +87,7 @@ class NewDashboard extends React.Component<{
                                 ownDashboard={this.state.ownDashboard}
                             ></SideBar>
                         </Grid>
-                        <Grid item xs>
+                        <Grid item xs style={{ backgroundColor: '#f1f1f1' }}>
                             <MainPanel
                                 userInfo={this.state.userInfo}
                                 ownDashboard={this.state.ownDashboard}


### PR DESCRIPTION
### Reasons for making this change

- Fetch only the first 100 worksheets to avoid overload
- Add a tooltip to remind user only the first 100 worksheets are shown
- Add Tabs to the main panel to show both "Owned Worksheets" and "Shared Worksheets"
- Shared Worksheets Tab is only enabled for the authorized user

### Related issues

fixes #3408 

### Screenshots

<img width="1640" alt="Screen Shot 2021-04-22 at 1 00 22 PM" src="https://user-images.githubusercontent.com/34461466/115778118-01165100-a36b-11eb-9267-22b23bc6922b.png">

![ezgif com-gif-maker (3)](https://user-images.githubusercontent.com/34461466/115777665-6ddd1b80-a36a-11eb-93b1-b834b108265e.gif)


### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
