### PR TITLE
Fix installation of "cl" command with git dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,14 @@ jobs:
           restore-keys: |
             pip-
       - run: ./pre-commit.sh && git diff --exit-code
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: pip-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            pip-
+      - name: Ensure the "cl" command can be properly installed.
+      - run: pip install -e . && cl --help
 
   test_frontend:
     name: Test Frontend

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ psutil==5.7.2
 # Use a forked version of ratarmount that works with file objects.
 # TODO (Ashwin): integrate these changes upstream so we can use the standard ratarmount package.
 # For a full diff, see https://github.com/epicfaace/ratarmount/pull/1.
-git+https://github.com/epicfaace/ratarmount.git@83d310d8efdf34351650ee98e7f44cf1c00dbf6e#egg=ratarmount
+ratarmount @ git+https://github.com/epicfaace/ratarmount.git@83d310d8efdf34351650ee98e7f44cf1c00dbf6e#egg=ratarmount
 
 six==1.15.0
 SQLAlchemy==1.3.19

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ psutil==5.7.2
 # Use a forked version of ratarmount that works with file objects.
 # TODO (Ashwin): integrate these changes upstream so we can use the standard ratarmount package.
 # For a full diff, see https://github.com/epicfaace/ratarmount/pull/1.
-ratarmount @ git+https://github.com/epicfaace/ratarmount.git@83d310d8efdf34351650ee98e7f44cf1c00dbf6e#egg=ratarmount
+ratarmount @ git+https://github.com/codalab/ratarmount.git@83d310d8efdf34351650ee98e7f44cf1c00dbf6e#egg=ratarmount
 
 six==1.15.0
 SQLAlchemy==1.3.19

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ def get_requirements(*requirements_file_paths):
     for requirements_file_path in requirements_file_paths:
         with open(requirements_file_path) as requirements_file:
             for line in requirements_file:
-                if line[0:2] != '-r' and line.find('git') == -1:
+                if line[0:2] != '-r':
                     requirements.append(line.strip())
     return requirements
 


### PR DESCRIPTION
### Reasons for making this change

Stress tests were failing for the rc0.5.45 release because the git dependency (fork of ratarmount) was not properly added to setup.py.

I've also added a check in CI to ensure this doesn't regress in the future.