### PR TITLE
Remove simplify_archive

### DIFF
--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -1415,7 +1415,6 @@ class BundleCLI(object):
                     params={
                         'filename': packed['filename'],
                         'unpack': packed['should_unpack'],
-                        'simplify': packed['should_simplify'],
                         'state_on_success': State.READY,
                         'finalize_on_success': True,
                         'use_azure_blob_beta': args.use_azure_blob_beta,
@@ -1621,7 +1620,6 @@ class BundleCLI(object):
                 params={
                     'filename': filename,
                     'unpack': unpack,
-                    'simplify': False,  # retain original bundle verbatim
                     'state_on_success': source_info['state'],  # copy bundle state
                     'finalize_on_success': True,
                 },

--- a/codalab/lib/zip_util.py
+++ b/codalab/lib/zip_util.py
@@ -112,8 +112,7 @@ def pack_files_for_upload(
         'fileobj': <file object of archive>,
         'filename': <name of archive file>,
         'filesize': <size of archive in bytes, or None if unknown>,
-        'should_unpack': <True iff archive should be unpacked at server>,
-        'should_simplify': <True iff directory should be 'simplified' at server>
+        'should_unpack': <True iff archive should be unpacked at server>
         }
     """
     exclude_patterns = exclude_patterns or []
@@ -147,7 +146,6 @@ def pack_files_for_upload(
                 'filename': filename + '.tar.gz',
                 'filesize': None,
                 'should_unpack': True,
-                'should_simplify': False,
             }
         elif path_is_archive(source):
             return {
@@ -155,7 +153,6 @@ def pack_files_for_upload(
                 'filename': filename,
                 'filesize': os.path.getsize(source),
                 'should_unpack': should_unpack,
-                'should_simplify': True,
             }
         elif force_compression:
             return {
@@ -163,7 +160,6 @@ def pack_files_for_upload(
                 'filename': filename + '.gz',
                 'filesize': None,
                 'should_unpack': True,
-                'should_simplify': False,
             }
         else:
             return {
@@ -171,7 +167,6 @@ def pack_files_for_upload(
                 'filename': filename,
                 'filesize': os.path.getsize(source),
                 'should_unpack': False,
-                'should_simplify': False,
             }
 
     # Build archive file incrementally from all sources
@@ -205,5 +200,4 @@ def pack_files_for_upload(
         'filename': 'contents.tar.gz',
         'filesize': filesize,
         'should_unpack': True,
-        'should_simplify': False,
     }

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -734,8 +734,6 @@ def _update_bundle_contents_blob(uuid):
       whether or not it is an archive, default is 'contents'
     - `unpack`: (optional) 1 if the uploaded file should be unpacked if it is
       an archive, or 0 otherwise, default is 1
-    - `simplify`: (optional) 1 if the uploaded file should be 'simplified' if
-      it is an archive, or 0 otherwise, default is 1.
     - `finalize_on_failure`: (optional) 1 if bundle state should be set
       to 'failed' in the case of a failure during upload, or 0 if the bundle
       state should not change on failure. Default is 0.
@@ -794,9 +792,8 @@ def _update_bundle_contents_blob(uuid):
                 source=source,
                 git=query_get_bool('git', default=False),
                 unpack=query_get_bool('unpack', default=True),
-                simplify_archives=query_get_bool('simplify', default=True),
                 use_azure_blob_beta=use_azure_blob_beta,
-            )  # See UploadManager for full explanation of 'simplify'
+            )
             bundle_link_url = getattr(bundle.metadata, "link_url", None)
             bundle_location = bundle_link_url or local.bundle_store.get_bundle_location(bundle.uuid)
             local.model.update_disk_metadata(bundle, bundle_location, enforce_disk_quota=True)

--- a/docs/REST-API-Reference.md
+++ b/docs/REST-API-Reference.md
@@ -617,8 +617,6 @@ Query parameters:
   whether or not it is an archive, default is 'contents'
 - `unpack`: (optional) 1 if the uploaded file should be unpacked if it is
   an archive, or 0 otherwise, default is 1
-- `simplify`: (optional) 1 if the uploaded file should be 'simplified' if
-  it is an archive, or 0 otherwise, default is 1.
 - `finalize_on_failure`: (optional) 1 if bundle state should be set
   to 'failed' in the case of a failure during upload, or 0 if the bundle
   state should not change on failure. Default is 0.

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -788,7 +788,7 @@ def test_upload2(ctx):
         # Upload it and unpack
         uuid = _run_command([cl, 'upload', archive_path])
         check_equals(os.path.basename(archive_path).replace(suffix, ''), get_info(uuid, 'name'))
-        check_equals(test_path_contents('dir1/f1'), _run_command([cl, 'cat', uuid + '/f1']))
+        check_equals(test_path_contents('dir1/f1'), _run_command([cl, 'cat', uuid + '/dir1/f1']))
 
         # Upload it but don't unpack
         uuid = _run_command([cl, 'upload', archive_path, '--pack'])
@@ -816,11 +816,11 @@ def test_upload3(ctx):
 
     # Upload URL that's an archive
     uuid = _run_command([cl, 'upload', 'http://alpha.gnu.org/gnu/bc/bc-1.06.95.tar.bz2'])
-    check_contains(['README', 'INSTALL', 'FAQ'], _run_command([cl, 'cat', uuid]))
+    check_contains(['bc-1.06.95'], _run_command([cl, 'cat', uuid]))
 
     # Upload URL with a query string, that's an archive
     uuid = _run_command([cl, 'upload', 'http://alpha.gnu.org/gnu/bc/bc-1.06.95.tar.bz2?a=b'])
-    check_contains(['README', 'INSTALL', 'FAQ'], _run_command([cl, 'cat', uuid]))
+    check_contains(['bc-1.06.95'], _run_command([cl, 'cat', uuid]))
 
     # Upload URL from Git
     uuid = _run_command([cl, 'upload', 'https://github.com/codalab/codalab-worksheets', '--git'])

--- a/tests/unit/lib/upload_manager_test.py
+++ b/tests/unit/lib/upload_manager_test.py
@@ -35,7 +35,7 @@ class UploadManagerTest(unittest.TestCase):
         remove_path(self.temp_dir)
 
     def do_upload(
-        self, source, git=False, unpack=True, simplify_archives=True, use_azure_blob_beta=False,
+        self, source, git=False, unpack=True, use_azure_blob_beta=False,
     ):
         class FakeBundle(object):
             def __init__(self):
@@ -43,7 +43,7 @@ class UploadManagerTest(unittest.TestCase):
                 self.metadata = object()
 
         self.manager.upload_to_bundle_store(
-            FakeBundle(), source, git, unpack, simplify_archives, use_azure_blob_beta,
+            FakeBundle(), source, git, unpack, use_azure_blob_beta,
         )
 
     def test_fileobj(self):
@@ -54,18 +54,11 @@ class UploadManagerTest(unittest.TestCase):
         self.do_upload(('source.gz', BytesIO(gzip_bytestring(b'testing'))))
         self.check_file_contains_string(self.bundle_location, 'testing')
 
-    def test_fileobj_tar_gz_simplify_archives(self):
+    def test_fileobj_tar_gz_should_not_simplify_archives(self):
         source = os.path.join(self.temp_dir, 'source_dir')
         os.mkdir(source)
         self.write_string_to_file('testing', os.path.join(source, 'filename'))
         self.do_upload(('source.tar.gz', tar_gzip_directory(source)))
-        self.check_file_contains_string(self.bundle_location, 'testing')
-
-    def test_fileobj_tar_gz_no_simplify_archives(self):
-        source = os.path.join(self.temp_dir, 'source_dir')
-        os.mkdir(source)
-        self.write_string_to_file('testing', os.path.join(source, 'filename'))
-        self.do_upload(('source.tar.gz', tar_gzip_directory(source)), simplify_archives=False)
         self.assertEqual(['filename'], os.listdir(self.bundle_location))
         self.check_file_contains_string(os.path.join(self.bundle_location, 'filename'), 'testing')
 
@@ -119,22 +112,12 @@ class UploadManagerTest(unittest.TestCase):
         )
         self.assertIn('file2', os.listdir(self.bundle_location))
 
-    def test_url_tar_gz_simplify_archives(self):
+    def test_url_tar_gz_should_not_simplify_archives(self):
         source = os.path.join(self.temp_dir, 'source_dir')
         os.mkdir(source)
         self.write_string_to_file('testing', os.path.join(source, 'filename'))
         self.do_upload(
             self.mock_url_source(BytesIO(tar_gzip_directory(source).read()), ext=".tar.gz")
-        )
-        self.check_file_contains_string(self.bundle_location, 'testing')
-
-    def test_url_tar_gz_no_simplify_archives(self):
-        source = os.path.join(self.temp_dir, 'source_dir')
-        os.mkdir(source)
-        self.write_string_to_file('testing', os.path.join(source, 'filename'))
-        self.do_upload(
-            self.mock_url_source(BytesIO(tar_gzip_directory(source).read()), ext=".tar.gz"),
-            simplify_archives=False,
         )
         self.check_file_contains_string(os.path.join(self.bundle_location, 'filename'), 'testing')
 

--- a/tests/unit/lib/zip_util_test.py
+++ b/tests/unit/lib/zip_util_test.py
@@ -74,7 +74,6 @@ class ZipUtilTest(unittest.TestCase):
                 {
                     "filename": os.path.basename(f.name),
                     "filesize": len(SAMPLE_CONTENTS),
-                    "should_simplify": False,
                     "should_unpack": False,
                 },
             )
@@ -93,7 +92,6 @@ class ZipUtilTest(unittest.TestCase):
                 {
                     "filename": os.path.basename(f.name) + '.gz',
                     "filesize": None,
-                    "should_simplify": False,
                     "should_unpack": True,
                 },
             )
@@ -116,7 +114,6 @@ class ZipUtilTest(unittest.TestCase):
                 {
                     "filename": os.path.basename(tmpdir) + '.tar.gz',
                     "filesize": None,
-                    "should_simplify": False,
                     "should_unpack": True,
                 },
             )
@@ -146,7 +143,6 @@ class ZipUtilTest(unittest.TestCase):
                     {
                         "filename": os.path.basename(out_archive.name),
                         "filesize": out_archive_size,
-                        "should_simplify": True,
                         "should_unpack": False,
                     },
                 )
@@ -172,7 +168,6 @@ class ZipUtilTest(unittest.TestCase):
                 {
                     "filename": os.path.basename(out_archive.name),
                     "filesize": out_archive_size,
-                    "should_simplify": True,
                     "should_unpack": False,
                 },
             )
@@ -202,10 +197,5 @@ class ZipUtilTest(unittest.TestCase):
             fileobj.seek(0, os.SEEK_END)
             self.assertEqual(
                 packed,
-                {
-                    "filename": 'contents.tar.gz',
-                    "filesize": fileobj.tell(),
-                    "should_simplify": False,
-                    "should_unpack": True,
-                },
+                {"filename": 'contents.tar.gz', "filesize": fileobj.tell(), "should_unpack": True,},
             )

--- a/tests/unit/server/upload_download_test.py
+++ b/tests/unit/server/upload_download_test.py
@@ -197,7 +197,6 @@ class RegularBundleStoreTest(BaseUploadDownloadBundleTest, unittest.TestCase):
             source=["contents.tar.gz", f],
             git=False,
             unpack=True,
-            simplify_archives=True,
             use_azure_blob_beta=False,
         )
 
@@ -207,7 +206,6 @@ class RegularBundleStoreTest(BaseUploadDownloadBundleTest, unittest.TestCase):
             source=["contents", BytesIO(contents)],
             git=False,
             unpack=False,
-            simplify_archives=True,
             use_azure_blob_beta=False,
         )
 


### PR DESCRIPTION
### Reasons for making this change

Merge this only after https://github.com/codalab/codalab-worksheets/pull/3434 is merged. This is a **breaking change** that removes the simplify_archive functionality -- this simplifies the upload process even further in preparation for usage with Blob Storage.

The simplify archives functionality essentially meant that if an archive that was unpacked to create a bundle just had a single file, the bundle would just be that single file rather than that extracted folder with one item.

Practically, this change only affects the following workflows:

- If someone creates a file `a.tar.gz` with one file / folder `X` in it, running `cl upload a.tar.gz` previously would create a bundle with just `X` at the top-level of it. Now, the bundle will be a directory bundle with `X` in it.
- The same as above applies to URLs, such as `https://a.tar.gz`.

The "worker uploading bundle results" workflow is not affected, because these archives will always have greater than one file (they'll at least have stdout and stderr), so the archives are never simplified anyway.

For example, consider the archive. This archive contains all its files within a single "bc-1.06.95" directory:

![image](https://user-images.githubusercontent.com/1689183/116019794-009fe380-a613-11eb-8e5c-9901a3486e5d.png)

Previously when running `cl upload http://alpha.gnu.org/gnu/bc/bc-1.06.95.tar.bz2`, it would simplify the archive by default and the bundle contents would look like this:

![image](https://user-images.githubusercontent.com/1689183/116019930-4bb9f680-a613-11eb-87b0-38d5536f502d.png)

With this PR, running `cl upload http://alpha.gnu.org/gnu/bc/bc-1.06.95.tar.bz2` will give a different output, with the bundle contents all included within the "bc-1.06.95" directory:

![image](https://user-images.githubusercontent.com/1689183/116019952-570d2200-a613-11eb-93b1-14cacdd1d3d1.png)
