### PR TITLE
Fix the bug of cannot go back to profile page after visiting dashboard

### DIFF
--- a/frontend/src/components/Dashboard/SideBar.js
+++ b/frontend/src/components/Dashboard/SideBar.js
@@ -171,7 +171,7 @@ class SideBar extends React.Component {
             contentType: 'application/json; charset=utf-8',
             success: (data) => {
                 const uuid = data.response[0].uuid;
-                window.location = '/worksheets/' + uuid;
+                window.location.href = '/worksheets/' + uuid;
             },
             error: (xhr, status, err) => {
                 console.error(xhr.responseText);

--- a/frontend/src/components/Dashboard/SideBar.js
+++ b/frontend/src/components/Dashboard/SideBar.js
@@ -160,6 +160,24 @@ class SideBar extends React.Component {
         fetchBundles(0, {});
     }
 
+    viewDashboard() {
+        const url = '/rest/interpret/wsearch';
+        $.ajax({
+            url: url,
+            dataType: 'json',
+            type: 'POST',
+            cache: false,
+            data: JSON.stringify({ keywords: ['name=dashboard'] }),
+            contentType: 'application/json; charset=utf-8',
+            success: (data) => {
+                const uuid = data.response[0].uuid;
+                window.location.href = '/worksheets/' + uuid;
+            },
+            error: (xhr, status, err) => {
+                console.error(xhr.responseText);
+            },
+        });
+    }
     render() {
         const { classes, userInfo } = this.props;
         if (!userInfo) {
@@ -240,7 +258,9 @@ class SideBar extends React.Component {
                         <Button
                             variant='contained'
                             color='primary'
-                            onClick={() => (window.location.href = '/worksheets?name=dashboard')}
+                            onClick={() => {
+                                this.viewDashboard();
+                            }}
                         >
                             View Dashboard
                         </Button>

--- a/frontend/src/components/Dashboard/SideBar.js
+++ b/frontend/src/components/Dashboard/SideBar.js
@@ -171,7 +171,7 @@ class SideBar extends React.Component {
             contentType: 'application/json; charset=utf-8',
             success: (data) => {
                 const uuid = data.response[0].uuid;
-                window.location.href = '/worksheets/' + uuid;
+                window.location = '/worksheets/' + uuid;
             },
             error: (xhr, status, err) => {
                 console.error(xhr.responseText);

--- a/frontend/src/components/Dashboard/SideBar.js
+++ b/frontend/src/components/Dashboard/SideBar.js
@@ -160,24 +160,6 @@ class SideBar extends React.Component {
         fetchBundles(0, {});
     }
 
-    viewDashboard() {
-        const url = '/rest/interpret/wsearch';
-        $.ajax({
-            url: url,
-            dataType: 'json',
-            type: 'POST',
-            cache: false,
-            data: JSON.stringify({ keywords: ['name=dashboard'] }),
-            contentType: 'application/json; charset=utf-8',
-            success: (data) => {
-                const uuid = data.response[0].uuid;
-                window.location.href = '/worksheets/' + uuid;
-            },
-            error: (xhr, status, err) => {
-                console.error(xhr.responseText);
-            },
-        });
-    }
     render() {
         const { classes, userInfo } = this.props;
         if (!userInfo) {
@@ -258,9 +240,7 @@ class SideBar extends React.Component {
                         <Button
                             variant='contained'
                             color='primary'
-                            onClick={() => {
-                                this.viewDashboard();
-                            }}
+                            onClick={() => (window.location.href = '/worksheets?name=dashboard')}
                         >
                             View Dashboard
                         </Button>

--- a/frontend/src/components/VerifySuccess.js
+++ b/frontend/src/components/VerifySuccess.js
@@ -14,8 +14,8 @@ const VerifySuccess = (props) => {
                         {props.auth.isAuthenticated && (
                             <p className='user-authenticated'>
                                 Check out your{' '}
-                                <NavLink to='/users' tabIndex={2}>
-                                    profile
+                                <NavLink to='/worksheets?name=dashboard' tabIndex={2}>
+                                    dashboard
                                 </NavLink>{' '}
                                 to get started.
                             </p>
@@ -23,7 +23,10 @@ const VerifySuccess = (props) => {
                         {!props.auth.isAuthenticated && (
                             <p className='user-not-authenticated'>
                                 <a
-                                    href={'/account/login?next=' + encodeURIComponent('/users')}
+                                    href={
+                                        '/account/login?next=' +
+                                        encodeURIComponent('/rest/worksheets/?name=dashboard')
+                                    }
                                     target='_self'
                                 >
                                     Sign In

--- a/frontend/src/components/VerifySuccess.js
+++ b/frontend/src/components/VerifySuccess.js
@@ -14,8 +14,8 @@ const VerifySuccess = (props) => {
                         {props.auth.isAuthenticated && (
                             <p className='user-authenticated'>
                                 Check out your{' '}
-                                <NavLink to='/worksheets?name=dashboard' tabIndex={2}>
-                                    dashboard
+                                <NavLink to='/users' tabIndex={2}>
+                                    profile
                                 </NavLink>{' '}
                                 to get started.
                             </p>
@@ -23,10 +23,7 @@ const VerifySuccess = (props) => {
                         {!props.auth.isAuthenticated && (
                             <p className='user-not-authenticated'>
                                 <a
-                                    href={
-                                        '/account/login?next=' +
-                                        encodeURIComponent('/rest/worksheets/?name=dashboard')
-                                    }
+                                    href={'/account/login?next=' + encodeURIComponent('/users')}
                                     target='_self'
                                 >
                                     Sign In

--- a/frontend/src/components/VerifySuccess.js
+++ b/frontend/src/components/VerifySuccess.js
@@ -14,7 +14,7 @@ const VerifySuccess = (props) => {
                         {props.auth.isAuthenticated && (
                             <p className='user-authenticated'>
                                 Check out your{' '}
-                                <NavLink to='/worksheets?name=dashboard' tabIndex={2}>
+                                <NavLink to='/users' tabIndex={2}>
                                     dashboard
                                 </NavLink>{' '}
                                 to get started.
@@ -23,10 +23,7 @@ const VerifySuccess = (props) => {
                         {!props.auth.isAuthenticated && (
                             <p className='user-not-authenticated'>
                                 <a
-                                    href={
-                                        '/account/login?next=' +
-                                        encodeURIComponent('/rest/worksheets/?name=dashboard')
-                                    }
+                                    href={'/account/login?next=' + encodeURIComponent('/users')}
                                     target='_self'
                                 >
                                     Sign In

--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -1627,7 +1627,7 @@ class Worksheet extends React.Component {
         this.deleteWorksheet({
             success: function(data) {
                 this.setState({ updating: false });
-                window.location = '/rest/worksheets/?name=dashboard';
+                window.location = '/users';
             }.bind(this),
             error: function(xhr, status, err) {
                 this.setState({ updating: false });

--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -1627,7 +1627,7 @@ class Worksheet extends React.Component {
         this.deleteWorksheet({
             success: function(data) {
                 this.setState({ updating: false });
-                window.location = '/users';
+                window.location = '/rest/worksheets/?name=dashboard';
             }.bind(this),
             error: function(xhr, status, err) {
                 this.setState({ updating: false });

--- a/frontend/src/components/worksheets/WorksheetNameSearch.js
+++ b/frontend/src/components/worksheets/WorksheetNameSearch.js
@@ -21,7 +21,7 @@ export default class extends React.Component {
         try {
             const response = await fetch(`/rest/worksheets?specs=${name}`).then((e) => e.json());
             const uuid = response.data[0].id;
-            this.props.history.push(`/worksheets/${uuid}/`);
+            this.props.history.replace(`/worksheets/${uuid}/`);
         } catch (e) {
             // Error shouldn't happen anymore, keeping just in case
             console.error(e);


### PR DESCRIPTION
### Reasons for making this change

The bug is due to previously I used `/worksheets?name=dashboard` to visit the dashboard, which actually will first make a request to interpret the URL into the /worksheets/<uuid> format. 
Also, update the default page for VerifySuccess & DeleteWorksheet.

### Related issues

fixes #3427 

### Screenshots

![ezgif com-gif-maker (4)](https://user-images.githubusercontent.com/34461466/116146901-e22dfc80-a693-11eb-8cd3-be4ab9fac9b1.gif)


### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
