### PR TITLE
Don't unpack from the bundle CLI when multiple archives are uploaded

### DIFF
--- a/codalab/lib/zip_util.py
+++ b/codalab/lib/zip_util.py
@@ -188,17 +188,8 @@ def pack_files_for_upload(
         return None if should_exclude(tarinfo.name) else tarinfo
 
     for source in sources:
-        if should_unpack and path_is_archive(source):
-            # Unpack archive into scratch space
-            dest_basename = strip_archive_ext(os.path.basename(source))
-            dest_path = os.path.join(scratch_dir, dest_basename)
-            unpack(get_archive_ext(source), source, dest_path)
-
-            # Add file or directory to archive
-            archive.add(dest_path, arcname=dest_basename, recursive=True)
-        else:
-            # Add file to archive, or add files recursively if directory
-            archive.add(source, arcname=os.path.basename(source), recursive=True, filter=filter)
+        # Add file to archive, or add files recursively if directory
+        archive.add(source, arcname=os.path.basename(source), recursive=True, filter=filter)
 
     # Clean up, rewind archive file, and return it
     archive.close()

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -856,10 +856,10 @@ def test_upload4(ctx):
         )
     uuid = _run_command([cl, 'upload'] + archive_exts)
 
-    # Make sure the names do not end with '.tar.gz' after being unpacked.
+    # Make sure the names do with '.tar.gz', because when we upload multiple archives, they
+    # should not get unpacked.
     check_contains(
-        [os.path.basename(archive_paths[0]) + r'\s', os.path.basename(archive_paths[1]) + r'\s'],
-        _run_command([cl, 'cat', uuid]),
+        [os.path.basename(ext) for ext in archive_exts], _run_command([cl, 'cat', uuid]),
     )
 
     # Cleanup

--- a/tests/unit/lib/zip_util_test.py
+++ b/tests/unit/lib/zip_util_test.py
@@ -1,12 +1,36 @@
+import tempfile
+import zipfile
+import tarfile
+import os
+import gzip
+import bz2
 import unittest
+
 from codalab.common import UsageError
-from codalab.lib.zip_util import get_archive_ext, strip_archive_ext, path_is_archive
+from codalab.lib.zip_util import (
+    get_archive_ext,
+    strip_archive_ext,
+    path_is_archive,
+    pack_files_for_upload,
+)
+from codalab.worker.file_util import tar_gzip_directory, zip_directory
+from io import BytesIO
+
+SAMPLE_CONTENTS = b"hello world"
+
+
+def tar_bz2_directory(*args, **kwargs):
+    """Method used for creating a .tar.bz2 archive from a directory.
+    This is just used for tests; it's not performance optimized
+    and should not be used in production code."""
+    output = tar_gzip_directory(*args, **kwargs)
+    return BytesIO(bz2.compress(gzip.decompress(output.read())))
 
 
 class ZipUtilTest(unittest.TestCase):
     """Test for zip util methods."""
 
-    def test_local_file_non_archive(self):
+    def test_strip_archive_ext_local_file_non_archive(self):
         """This local file should be categorized as not an archive."""
         path = "/tmp/file.txt"
         self.assertEqual(path_is_archive(path), False)
@@ -14,7 +38,7 @@ class ZipUtilTest(unittest.TestCase):
         with self.assertRaises(UsageError):
             strip_archive_ext(path)
 
-    def test_url_non_archive(self):
+    def test_strip_archive_ext_url_non_archive(self):
         """This URL should be categorized as not an archive."""
         path = "https://codalab.org/file.txt"
         self.assertEqual(path_is_archive(path), False)
@@ -22,16 +46,166 @@ class ZipUtilTest(unittest.TestCase):
         with self.assertRaises(UsageError):
             strip_archive_ext(path)
 
-    def test_local_file_archive(self):
+    def test_strip_archive_ext_local_file_archive(self):
         """This local should be categorized as an archive."""
         path = "/tmp/file.tar.gz"
         self.assertEqual(path_is_archive(path), True)
         self.assertEqual(get_archive_ext(path), ".tar.gz")
         self.assertEqual(strip_archive_ext(path), "/tmp/file")
 
-    def test_url_archive(self):
+    def test_strip_archive_ext_url_archive(self):
         """This URL should be categorized as an archive."""
         path = "https://codalab.org/file.tar.gz"
         self.assertEqual(path_is_archive(path), True)
         self.assertEqual(get_archive_ext(path), ".tar.gz")
         self.assertEqual(strip_archive_ext(path), "https://codalab.org/file")
+
+    def test_pack_single_file(self):
+        """Pack a single file."""
+        with tempfile.NamedTemporaryFile() as f:
+            f.write(SAMPLE_CONTENTS)
+            f.flush()
+            packed = pack_files_for_upload(
+                sources=[f.name], should_unpack=False, follow_symlinks=False
+            )
+            self.assertEqual(packed.pop("fileobj").read(), SAMPLE_CONTENTS)
+            self.assertEqual(
+                packed,
+                {
+                    "filename": os.path.basename(f.name),
+                    "filesize": len(SAMPLE_CONTENTS),
+                    "should_simplify": False,
+                    "should_unpack": False,
+                },
+            )
+
+    def test_pack_single_file_force_compression(self):
+        """Pack a single file with force_compression set to True."""
+        with tempfile.NamedTemporaryFile() as f:
+            f.write(SAMPLE_CONTENTS)
+            f.flush()
+            packed = pack_files_for_upload(
+                sources=[f.name], should_unpack=False, follow_symlinks=False, force_compression=True
+            )
+            self.assertEqual(gzip.decompress(packed.pop("fileobj").read()), SAMPLE_CONTENTS)
+            self.assertEqual(
+                packed,
+                {
+                    "filename": os.path.basename(f.name) + '.gz',
+                    "filesize": None,
+                    "should_simplify": False,
+                    "should_unpack": True,
+                },
+            )
+
+    def test_pack_directory(self):
+        """Pack a single directory."""
+        with tempfile.TemporaryDirectory() as tmpdir, open(
+            os.path.join(tmpdir, "file.txt"), "wb"
+        ) as f:
+            f.write(SAMPLE_CONTENTS)
+            f.seek(0)
+            packed = pack_files_for_upload(
+                sources=[tmpdir], should_unpack=False, follow_symlinks=False
+            )
+            tf = tarfile.open(fileobj=packed.pop("fileobj"), mode="r:gz")
+            self.assertEqual(tf.getnames(), ['.', './file.txt'])
+            self.assertEqual(tf.extractfile('./file.txt').read(), SAMPLE_CONTENTS)
+            self.assertEqual(
+                packed,
+                {
+                    "filename": os.path.basename(tmpdir) + '.tar.gz',
+                    "filesize": None,
+                    "should_simplify": False,
+                    "should_unpack": True,
+                },
+            )
+
+    def test_pack_single_archive(self):
+        """Pack a single archive that is a .tar.gz / .tar.bz2 file."""
+        for (compress_fn, extension, mode) in [
+            (tar_gzip_directory, ".tar.gz", "r:gz"),
+            (tar_bz2_directory, ".tar.bz2", "r:bz2"),
+        ]:
+            with self.subTest(extension=extension), tempfile.TemporaryDirectory() as tmpdir, open(
+                os.path.join(tmpdir, "file.txt"), "wb"
+            ) as f, tempfile.NamedTemporaryFile(suffix=extension) as out_archive:
+                f.write(SAMPLE_CONTENTS)
+                f.flush()
+                out_archive.write(compress_fn(tmpdir).read())
+                out_archive_size = out_archive.tell()
+                out_archive.flush()
+                packed = pack_files_for_upload(
+                    sources=[out_archive.name], should_unpack=False, follow_symlinks=False
+                )
+                tf = tarfile.open(fileobj=packed.pop("fileobj"), mode=mode)
+                self.assertEqual(tf.getnames(), ['.', './file.txt'])
+                self.assertEqual(tf.extractfile('./file.txt').read(), SAMPLE_CONTENTS)
+                self.assertEqual(
+                    packed,
+                    {
+                        "filename": os.path.basename(out_archive.name),
+                        "filesize": out_archive_size,
+                        "should_simplify": True,
+                        "should_unpack": False,
+                    },
+                )
+
+    def test_pack_single_archive_zip(self):
+        """Pack a single archive that is a .zip file."""
+        with tempfile.TemporaryDirectory() as tmpdir, open(
+            os.path.join(tmpdir, "file.txt"), "wb"
+        ) as f, tempfile.NamedTemporaryFile(suffix=".zip") as out_archive:
+            f.write(SAMPLE_CONTENTS)
+            f.flush()
+            out_archive.write(zip_directory(tmpdir).read())
+            out_archive_size = out_archive.tell()
+            out_archive.flush()
+            packed = pack_files_for_upload(
+                sources=[out_archive.name], should_unpack=False, follow_symlinks=False
+            )
+            zf = zipfile.ZipFile(packed.pop("fileobj"), mode="r")
+            self.assertEqual(zf.namelist(), ['file.txt'])
+            self.assertEqual(zf.open('file.txt').read(), SAMPLE_CONTENTS)
+            self.assertEqual(
+                packed,
+                {
+                    "filename": os.path.basename(out_archive.name),
+                    "filesize": out_archive_size,
+                    "should_simplify": True,
+                    "should_unpack": False,
+                },
+            )
+
+    def test_pack_files_and_directories(self):
+        """Pack a combination of files and directories."""
+        with tempfile.NamedTemporaryFile() as f1, tempfile.TemporaryDirectory() as tmpdir, open(
+            os.path.join(tmpdir, "file.txt"), "wb"
+        ) as f2:
+            f1.write(SAMPLE_CONTENTS)
+            f1.seek(0)
+            f2.write(SAMPLE_CONTENTS)
+            f2.seek(0)
+            packed = pack_files_for_upload(
+                sources=[f1.name, tmpdir], should_unpack=False, follow_symlinks=False
+            )
+            fileobj = packed.pop("fileobj")
+            tf = tarfile.open(fileobj=fileobj, mode="r:gz")
+            expected_names = [
+                os.path.basename(f1.name),
+                os.path.basename(tmpdir),
+                os.path.join(os.path.basename(tmpdir), "file.txt"),
+            ]
+            self.assertEqual(tf.getnames(), expected_names)
+            self.assertEqual(tf.extractfile(expected_names[0]).read(), SAMPLE_CONTENTS)
+            self.assertEqual(tf.extractfile(expected_names[2]).read(), SAMPLE_CONTENTS)
+            fileobj.seek(0, os.SEEK_END)
+            self.assertEqual(
+                packed,
+                {
+                    "filename": 'contents.tar.gz',
+                    "filesize": fileobj.tell(),
+                    "should_simplify": False,
+                    "should_unpack": True,
+                },
+            )


### PR DESCRIPTION
### Reasons for making this change

For https://github.com/codalab/codalab-worksheets/issues/3439. Don't unpack from the bundle CLI when multiple archives are uploaded.

**This is a breaking change.** This means that running, for example, `cl upload item.gz dir.tar.gz` will not unpack the each individual archive file; rather, these files will just be added as usual to the entire bundle directory.

I've also added unit tests that exercise all of the functionality of `zip_util.pack_file_for_upload`, as we'll be changing this function later for streaming (https://github.com/codalab/codalab-worksheets/issues/3437).