### PR TITLE
Stop updating an invalid worksheet name in the frontend

### DIFF
--- a/frontend/src/components/EditableField.js
+++ b/frontend/src/components/EditableField.js
@@ -73,8 +73,14 @@ class EditableFieldBase extends React.Component<{
                 if (this.props.onChange) this.props.onChange(this.state.value);
             })
             .fail(function(response, status, err) {
-                // TODO: this doesn't stop the value from updating in the frontend
-                console.log('Invalid value entered: ', response.responseText);
+                if (this.props.onError)
+                    this.props.onError('Invalid value entered: ' + response.responseText);
+                // Restore the original value
+                this.setState(() => {
+                    return {
+                        value: this.props.value,
+                    };
+                });
             });
     };
 

--- a/frontend/src/components/EditableField.js
+++ b/frontend/src/components/EditableField.js
@@ -76,10 +76,8 @@ class EditableFieldBase extends React.Component<{
                 if (this.props.onError)
                     this.props.onError('Invalid value entered: ' + response.responseText);
                 // Restore the original value
-                this.setState(() => {
-                    return {
-                        value: this.props.value,
-                    };
+                this.setState({
+                    value: this.props.value,
                 });
             });
     };

--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -378,6 +378,13 @@ class Worksheet extends React.Component {
         this.setState({ openedDialog: null, errorDialogMessage: '' });
     };
 
+    openErrorMessageDialog = (message) => {
+        this.setState({
+            openedDialog: DIALOG_TYPES.OPEN_ERROR_DIALOG,
+            errorDialogMessage: message,
+        });
+    };
+
     executeBundleCommand = (cmd_type) => () => {
         this.handleSelectedBundleCommand(cmd_type);
         this.toggleCmdDialogNoEvent(cmd_type);
@@ -1954,6 +1961,7 @@ class Worksheet extends React.Component {
                     toggleCmdDialog={this.toggleCmdDialog}
                     toggleInformationModal={this.toggleInformationModal}
                     toggleCmdDialogNoEvent={this.toggleCmdDialogNoEvent}
+                    openErrorMessageDialog={this.openErrorMessageDialog}
                     copiedBundleIds={this.state.copiedBundleIds}
                     showPasteButton={this.state.showPasteButton}
                     toggleWorksheetSize={this.toggleWorksheetSize}

--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -378,7 +378,7 @@ class Worksheet extends React.Component {
         this.setState({ openedDialog: null, errorDialogMessage: '' });
     };
 
-    openErrorMessageDialog = (message) => {
+    onError = (message) => {
         this.setState({
             openedDialog: DIALOG_TYPES.OPEN_ERROR_DIALOG,
             errorDialogMessage: message,
@@ -1961,7 +1961,7 @@ class Worksheet extends React.Component {
                     toggleCmdDialog={this.toggleCmdDialog}
                     toggleInformationModal={this.toggleInformationModal}
                     toggleCmdDialogNoEvent={this.toggleCmdDialogNoEvent}
-                    openErrorMessageDialog={this.openErrorMessageDialog}
+                    onError={this.onError}
                     copiedBundleIds={this.state.copiedBundleIds}
                     showPasteButton={this.state.showPasteButton}
                     toggleWorksheetSize={this.toggleWorksheetSize}

--- a/frontend/src/components/worksheets/Worksheet/WorksheetHeader.js
+++ b/frontend/src/components/worksheets/Worksheet/WorksheetHeader.js
@@ -40,7 +40,7 @@ export default ({
     toggleCmdDialog,
     toggleCmdDialogNoEvent,
     toggleInformationModal,
-    openErrorMessageDialog,
+    onError,
     copiedBundleIds,
     showPasteButton,
     toggleWorksheetSize,
@@ -79,7 +79,7 @@ export default ({
                                         value={info && info.name}
                                         uuid={info && info.uuid}
                                         onChange={() => reloadWorksheet()}
-                                        onError={(message) => openErrorMessageDialog(message)}
+                                        onError={onError}
                                     />
                                     &nbsp;by&nbsp;
                                     {info.owner_name ? info.owner_name : '<anonymous>'}

--- a/frontend/src/components/worksheets/Worksheet/WorksheetHeader.js
+++ b/frontend/src/components/worksheets/Worksheet/WorksheetHeader.js
@@ -79,7 +79,7 @@ export default ({
                                         value={info && info.name}
                                         uuid={info && info.uuid}
                                         onChange={() => reloadWorksheet()}
-                                        onError={(message) => openErrorMessageDialog(message)}
+                                        onError={openErrorMessageDialog}
                                     />
                                     &nbsp;by&nbsp;
                                     {info.owner_name ? info.owner_name : '<anonymous>'}

--- a/frontend/src/components/worksheets/Worksheet/WorksheetHeader.js
+++ b/frontend/src/components/worksheets/Worksheet/WorksheetHeader.js
@@ -40,6 +40,7 @@ export default ({
     toggleCmdDialog,
     toggleCmdDialogNoEvent,
     toggleInformationModal,
+    openErrorMessageDialog,
     copiedBundleIds,
     showPasteButton,
     toggleWorksheetSize,
@@ -78,6 +79,7 @@ export default ({
                                         value={info && info.name}
                                         uuid={info && info.uuid}
                                         onChange={() => reloadWorksheet()}
+                                        onError={(message) => openErrorMessageDialog(message)}
                                     />
                                     &nbsp;by&nbsp;
                                     {info.owner_name ? info.owner_name : '<anonymous>'}


### PR DESCRIPTION
### Reasons for making this change

Fix the bug of showing no Error Message when changing worksheet name to an invalid one.
resolve a TODO in the code.

### Related issues

fixes #3404 

### Screenshots

![ezgif com-gif-maker (5)](https://user-images.githubusercontent.com/34461466/116180687-335ae200-a6ce-11eb-8eb9-a7c832df10c9.gif)


### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
