### PR TITLE
Bump to version 0.5.48

### DIFF
--- a/codalab/common.py
+++ b/codalab/common.py
@@ -15,7 +15,7 @@ from enum import Enum
 
 # Increment this on master when ready to cut a release.
 # http://semver.org/
-CODALAB_VERSION = '0.5.47'
+CODALAB_VERSION = '0.5.48'
 BINARY_PLACEHOLDER = '<binary>'
 URLOPEN_TIMEOUT_SECONDS = int(os.environ.get('CODALAB_URLOPEN_TIMEOUT_SECONDS', 5 * 60))
 

--- a/docs/REST-API-Reference.md
+++ b/docs/REST-API-Reference.md
@@ -1,6 +1,6 @@
 # REST API Reference
 
-_version 0.5.47_
+_version 0.5.48_
 
 This reference and the REST API itself is still under heavy development and is
 subject to change at any time. Feedback through our GitHub issues is appreciated!

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -1,5 +1,5 @@
 // Should match codalab/common.py#CODALAB_VERSION
-export const CODALAB_VERSION = '0.5.47';
+export const CODALAB_VERSION = '0.5.48';
 
 // Name Regex to match the backend in spec_utils.py
 export const NAME_REGEX = /^[a-zA-Z_][a-zA-Z0-9_.-]*$/i;

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import sys
 
 
 # should match codalab/common.py#CODALAB_VERSION
-CODALAB_VERSION = "0.5.47"
+CODALAB_VERSION = "0.5.48"
 
 
 class Install(install):


### PR DESCRIPTION
### Reasons for making this change

Bump new version

Full diff: https://github.com/codalab/codalab-worksheets/compare/v0.5.47...rc0.5.48

# Draft release notes

## Frontend
- Fix the bug of cannot go back to the profile page after visiting the dashboard (#3448)
- Apply useSwr to FileBrowserLite and BundleDetail for previewing bundles (#3419)
- Stop updating an invalid worksheet name in the frontend (#3450)
- Add Tabs to MainPanel to show both Owned and Shared Worksheets (#3422)

## Backend
- Simplify uploads by removing local path support (#3412) 
- Remove support for uploads of multiple URLs (#3432)
- Don't unpack from the bundle CLI when multiple archives are uploaded (#3449)
