### PR TITLE
Bump version to v0.5.49

### DIFF
--- a/codalab/common.py
+++ b/codalab/common.py
@@ -15,7 +15,7 @@ from enum import Enum
 
 # Increment this on master when ready to cut a release.
 # http://semver.org/
-CODALAB_VERSION = '0.5.48'
+CODALAB_VERSION = '0.5.49'
 BINARY_PLACEHOLDER = '<binary>'
 URLOPEN_TIMEOUT_SECONDS = int(os.environ.get('CODALAB_URLOPEN_TIMEOUT_SECONDS', 5 * 60))
 

--- a/docs/REST-API-Reference.md
+++ b/docs/REST-API-Reference.md
@@ -1,6 +1,6 @@
 # REST API Reference
 
-_version 0.5.48_
+_version 0.5.49_
 
 This reference and the REST API itself is still under heavy development and is
 subject to change at any time. Feedback through our GitHub issues is appreciated!

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -1,5 +1,5 @@
 // Should match codalab/common.py#CODALAB_VERSION
-export const CODALAB_VERSION = '0.5.48';
+export const CODALAB_VERSION = '0.5.49';
 
 // Name Regex to match the backend in spec_utils.py
 export const NAME_REGEX = /^[a-zA-Z_][a-zA-Z0-9_.-]*$/i;

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import sys
 
 
 # should match codalab/common.py#CODALAB_VERSION
-CODALAB_VERSION = "0.5.48"
+CODALAB_VERSION = "0.5.49"
 
 
 class Install(install):


### PR DESCRIPTION
# Reasons for making this change
Bump new version

Full diff: [v0.5.48...v0.5.49](https://github.com/codalab/codalab-worksheets/compare/v0.5.48...rc0.5.49)

# Draft release notes
## Frontend
- A More Central Place for Ajax Calls (#3400)
- Fix shared worksheet bug due to code refactoring (#3468)

## Backend
- Make docker image status more granular with the percentage done (#3382)
- Simplify uploads by extracting directly to bundle_path, streaming downloaded URLs (#3434)
- Setup Sentry on dev and prod docker-compose.yml (#3444)
- Remove simplify_archive (#3435)
- Fix disk quota enforcement error for non-root users by using correct endpoint (#3454)
