### PR TITLE
Fix shared worksheet bug due to code refactoring

### DIFF
--- a/frontend/src/components/Dashboard/MainPanel.js
+++ b/frontend/src/components/Dashboard/MainPanel.js
@@ -192,8 +192,8 @@ class MainPanel extends React.Component<{
         navBarSearch(['owner=' + this.props.userInfo.user_name])
             .then((data) => this.setWorksheets(data))
             .catch(defaultErrorHandler);
-        navBarSearch({ keywords: ['.shared', '.limit=' + 100] })
-            .then((data) => this.setWorksheets(data))
+        navBarSearch(['.shared', '.limit=' + 100])
+            .then((data) => this.setWorksheets(data, true))
             .catch(defaultErrorHandler);
     }
 


### PR DESCRIPTION
### Reasons for making this change

We should include this bug fix PR before we deploy the new version; otherwise, the shared worksheet tab on the new profile page will always be empty.

