### PR TITLE
Blob Storage: allow downloading from single contents.gz files, improve gzip handling when downloading gzipped files

### DIFF
--- a/codalab/common.py
+++ b/codalab/common.py
@@ -176,7 +176,8 @@ class LinkedBundlePath:
 
         is_archive (bool): Whether this bundle is stored as an indexed archive file (contents.gz / contents.tar.gz + an index.sqlite file. Only done currently by Azure Blob Storage.
 
-        is_archive_dir (bool): Whether this bundle is stored as a contents.tar.gz file (which represents a directory) or a contents.gz file (which represents a single file). Only applicable if is_archive is True.
+        is_archive_dir (bool): Whether this bundle is stored as a contents.tar.gz file (which represents a directory) or
+        a contents.gz file (which represents a single file). Only applicable if is_archive is True.
 
         uses_beam (bool): Whether this bundle's storage type requires using Apache Beam to interact with it.
 

--- a/codalab/common.py
+++ b/codalab/common.py
@@ -174,7 +174,9 @@ class LinkedBundlePath:
 
         bundle_path (str): Path to the bundle contents in that particular storage.
 
-        is_archive (bool): Whether this bundle is stored as a .tar.gz file on this storage medium stores folders. Only done currently by Azure Blob Storage.
+        is_archive (bool): Whether this bundle is stored as an indexed archive file (contents.gz / contents.tar.gz + an index.sqlite file. Only done currently by Azure Blob Storage.
+
+        is_archive_dir (bool): Whether this bundle is stored as a contents.tar.gz file (which represents a directory) or a contents.gz file (which represents a single file). Only applicable if is_archive is True.
 
         uses_beam (bool): Whether this bundle's storage type requires using Apache Beam to interact with it.
 
@@ -186,6 +188,7 @@ class LinkedBundlePath:
     storage_type: StorageType
     bundle_path: str
     is_archive: bool
+    is_archive_dir: bool
     uses_beam: bool
     archive_subpath: str
     bundle_uuid: str
@@ -193,7 +196,7 @@ class LinkedBundlePath:
 
 def parse_linked_bundle_url(url):
     """Parses a linked bundle URL. This bundle URL usually refers to:
-        - an archive file on Blob Storage: "azfs://storageclwsdev0/bundles/uuid/contents.tar.gz"
+        - an archive file on Blob Storage: "azfs://storageclwsdev0/bundles/uuid/contents.tar.gz" (contents.gz for files, contents.tar.gz for directories)
         - a single file that is stored within a subpath of an archive file on Blob Storage: "azfs://storageclwsdev0/bundles/uuid/contents.tar.gz/file1"
 
         Returns a LinkedBundlePath instance to encode this information.
@@ -204,12 +207,14 @@ def parse_linked_bundle_url(url):
         url = url[len(StorageURLScheme.AZURE_BLOB_STORAGE.value) :]
         storage_account, container, bundle_uuid, contents_file, *remainder = url.split("/", 4)
         bundle_path = f"{StorageURLScheme.AZURE_BLOB_STORAGE.value}{storage_account}/{container}/{bundle_uuid}/{contents_file}"
-        is_archive = contents_file.endswith(".tar.gz")
+        is_archive = contents_file.endswith(".gz") or contents_file.endswith(".tar.gz")
+        is_archive_dir = contents_file.endswith(".tar.gz")
         archive_subpath = remainder[0] if is_archive and len(remainder) else None
     else:
         storage_type = StorageType.DISK_STORAGE.value
         bundle_path = url
         is_archive = False
+        is_archive_dir = False
         uses_beam = False
         archive_subpath = None
         bundle_uuid = None
@@ -217,6 +222,7 @@ def parse_linked_bundle_url(url):
         storage_type=storage_type,
         bundle_path=bundle_path,
         is_archive=is_archive,
+        is_archive_dir=is_archive_dir,
         uses_beam=uses_beam,
         archive_subpath=archive_subpath,
         bundle_uuid=bundle_uuid,

--- a/codalab/lib/bundle_store.py
+++ b/codalab/lib/bundle_store.py
@@ -401,11 +401,15 @@ class MultiDiskBundleStore(_MultiDiskBundleStoreBase):
     Storage. Otherwise, the bundle is retrieved from the underlying disk bundle store.
 
     In Blob Storage, each bundle is stored in the format:
-    azfs://{container name}/bundles/{bundle uuid}/contents.tar.gz.
+    azfs://{container name}/bundles/{bundle uuid}/contents.tar.gz if a directory,
+    azfs://{container name}/bundles/{bundle uuid}/contents.gz
 
     If the bundle is a directory, the entire contents of the bundle is stored in the .tar.gz file;
-    otherwise, if the bundle is a single file, the file is stored in the .tar.gz file as an archive
+    otherwise, if the bundle is a single file, the file is stored in the .gz file as an archive
     member with name equal to the bundle uuid and is_dir is set to False in the database.
+
+    See this design doc for more information about Blob Storage design:
+    https://docs.google.com/document/d/1l4kOqi9irBjOApmn4E6vlzsjAXDJbetIyVw8gMRHrpU/edit#
     """
 
     def __init__(self, bundle_model, codalab_home, azure_blob_account_name):
@@ -416,6 +420,7 @@ class MultiDiskBundleStore(_MultiDiskBundleStoreBase):
     def get_bundle_location(self, uuid):
         storage_type, is_dir = self._bundle_model.get_bundle_storage_info(uuid)
         if storage_type == StorageType.AZURE_BLOB_STORAGE.value:
-            return f"azfs://{self._azure_blob_account_name}/bundles/{uuid}/contents.tar.gz"
+            file_name = "contents.tar.gz" if is_dir else "contents.gz"
+            return f"azfs://{self._azure_blob_account_name}/bundles/{uuid}/{file_name}"
         else:
             return _MultiDiskBundleStoreBase.get_bundle_location(self, uuid)

--- a/codalab/worker/download_util.py
+++ b/codalab/worker/download_util.py
@@ -262,12 +262,12 @@ def _compute_target_info_blob(
             # The entry returned by ratarmount for a single .gz file is not technically part of a tar archive
             # and has a name hardcoded as "contents," so we modify the type, name, and permissions of
             # the output accordingly.
-            return dict(
+            return cast(TargetInfo, dict(
                 _get_info("/contents", depth),
                 type="file",
                 name=linked_bundle_path.bundle_uuid,
                 perm=0o755,
-            )
+            ))
         if linked_bundle_path.archive_subpath:
             # Return the contents of a subpath within a directory.
             return _get_info(linked_bundle_path.archive_subpath, depth)

--- a/codalab/worker/download_util.py
+++ b/codalab/worker/download_util.py
@@ -9,7 +9,7 @@ from typing_extensions import TypedDict
 
 from apache_beam.io.filesystems import FileSystems
 from codalab.common import parse_linked_bundle_url
-from codalab.worker.file_util import OpenIndexedTarGzFile
+from codalab.worker.file_util import OpenIndexedArchiveFile
 from codalab.lib.beam.ratarmount import FileInfo
 
 
@@ -188,7 +188,7 @@ def _compute_target_info_blob(
     path: str, depth: Union[int, float], return_generators=False
 ) -> TargetInfo:
     """Computes target info for a file that is externalized on Blob Storage, meaning
-    that it's contained within an indexed .tar.gz file.
+    that it's contained within an indexed archive file.
 
     Args:
         path (str): The path that refers to the specified target.
@@ -208,7 +208,7 @@ def _compute_target_info_blob(
     if not linked_bundle_path.is_archive:
         # Single file
         raise PathException(
-            "Single files on Blob Storage are not supported; only a path within a .tar.gz file is supported."
+            "Single files on Blob Storage are not supported; only a path within an archive file is supported."
         )
 
     # process_contents is used to process the value of the 'contents' key (which is a generator) before it is returned.
@@ -216,7 +216,7 @@ def _compute_target_info_blob(
     # the generator unchanged.
     process_contents = list if return_generators is False else lambda x: x
 
-    with OpenIndexedTarGzFile(linked_bundle_path.bundle_path) as tf:
+    with OpenIndexedArchiveFile(linked_bundle_path.bundle_path) as tf:
         islink = lambda finfo: stat.S_ISLNK(finfo.mode)
         readlink = lambda finfo: finfo.linkname
 
@@ -257,6 +257,17 @@ def _compute_target_info_blob(
                     )
             return result
 
+        if not linked_bundle_path.is_archive_dir:
+            # Return the contents of the single .gz file.
+            # The entry returned by ratarmount for a single .gz file is not technically part of a tar archive
+            # and has a name hardcoded as "contents," so we modify the type, name, and permissions of
+            # the output accordingly.
+            return dict(
+                _get_info("/contents", depth),
+                type="file",
+                name=linked_bundle_path.bundle_uuid,
+                perm=0o755,
+            )
         if linked_bundle_path.archive_subpath:
             # Return the contents of a subpath within a directory.
             return _get_info(linked_bundle_path.archive_subpath, depth)
@@ -291,7 +302,7 @@ def compute_target_info_blob_descendants_flat(path: str) -> Generator[TargetInfo
     Also includes an entry for the specified directory with `name` equal to an empty string.
 
     This function is used by TarSubdirStream in order to determine the list of descendants
-    that exist inside a given subdirectory in a .tar.gz file on Blob Storage.
+    that exist inside a given subdirectory in an archive file on Blob Storage.
     """
     target_info = _compute_target_info_blob(
         path=path, depth=math.inf, return_generators=True

--- a/codalab/worker/download_util.py
+++ b/codalab/worker/download_util.py
@@ -262,12 +262,15 @@ def _compute_target_info_blob(
             # The entry returned by ratarmount for a single .gz file is not technically part of a tar archive
             # and has a name hardcoded as "contents," so we modify the type, name, and permissions of
             # the output accordingly.
-            return cast(TargetInfo, dict(
-                _get_info("/contents", depth),
-                type="file",
-                name=linked_bundle_path.bundle_uuid,
-                perm=0o755,
-            ))
+            return cast(
+                TargetInfo,
+                dict(
+                    _get_info("/contents", depth),
+                    type="file",
+                    name=linked_bundle_path.bundle_uuid,
+                    perm=0o755,
+                ),
+            )
         if linked_bundle_path.archive_subpath:
             # Return the contents of a subpath within a directory.
             return _get_info(linked_bundle_path.archive_subpath, depth)

--- a/codalab/worker/file_util.py
+++ b/codalab/worker/file_util.py
@@ -229,12 +229,12 @@ class OpenFile(object):
     mode: str
     gzipped: bool
 
-    def __init__(self, path: str, mode='r', gzipped=False):
+    def __init__(self, path: str, mode='rb', gzipped=False):
         """Initialize OpenFile.
 
         Args:
             path (str): Path to open; can be a path on disk or a path on Blob Storage.
-            mode (str): Mode with which to open the file. Default is "r".
+            mode (str): Mode with which to open the file. Default is "rb". This is only 
             gzipped (bool): Whether the output should be gzipped. Must be True if downloading a directory;
                 can be True or False if downloading a file.
         """
@@ -248,18 +248,13 @@ class OpenFile(object):
             # Stream an entire, single .gz file from Blob Storage. This is gzipped by default,
             # so if the user requested a gzipped version of the entire file, just read and return it.
             if not linked_bundle_path.is_archive_dir and self.gzipped:
-                return FileSystems.open(
-                    self.path, self.mode, compression_type=CompressionTypes.UNCOMPRESSED
-                )
+                return FileSystems.open(self.path, compression_type=CompressionTypes.UNCOMPRESSED)
             # Stream an entire, single .tar.gz file from Blob Storage. This is gzipped by default,
             # and directories are always gzipped, so just read and return it.
             if linked_bundle_path.is_archive_dir and not linked_bundle_path.archive_subpath:
                 if not self.gzipped:
                     raise IOError("Directories must be gzipped.")
-                fs = FileSystems.open(
-                    self.path, self.mode, compression_type=CompressionTypes.UNCOMPRESSED
-                )
-                return fs
+                return FileSystems.open(self.path, compression_type=CompressionTypes.UNCOMPRESSED)
             # If a file path is specified within an archive file on Blob Storage, open the specified path within the archive.
             with OpenIndexedArchiveFile(linked_bundle_path.bundle_path) as tf:
                 isdir = lambda finfo: finfo.type == tarfile.DIRTYPE

--- a/codalab/worker/file_util.py
+++ b/codalab/worker/file_util.py
@@ -275,7 +275,8 @@ class OpenFile(object):
                     return GzipStream(TarSubdirStream(self.path))
                 else:
                     # Stream a single file from within the archive
-                    return GzipStream(TarFileStream(tf, finfo))
+                    fs = TarFileStream(tf, finfo)
+                    return GzipStream(fs) if self.gzipped else fs
         else:
             # Stream a file from disk storage.
             return open(self.path, self.mode)

--- a/codalab/worker/file_util.py
+++ b/codalab/worker/file_util.py
@@ -8,7 +8,7 @@ import bz2
 
 from codalab.common import BINARY_PLACEHOLDER, UsageError
 from codalab.common import parse_linked_bundle_url
-from codalab.worker.un_gzip_stream import BytesBuffer, un_gzip_stream
+from codalab.worker.un_gzip_stream import BytesBuffer
 from codalab.worker.tar_subdir_stream import TarSubdirStream
 from codalab.worker.tar_file_stream import TarFileStream
 from apache_beam.io.filesystem import CompressionTypes

--- a/codalab/worker/file_util.py
+++ b/codalab/worker/file_util.py
@@ -229,12 +229,12 @@ class OpenFile(object):
     mode: str
     gzipped: bool
 
-    def __init__(self, path: str, mode='r', gzipped=False):
+    def __init__(self, path: str, mode='rb', gzipped=False):
         """Initialize OpenFile.
 
         Args:
             path (str): Path to open; can be a path on disk or a path on Blob Storage.
-            mode (str): Mode with which to open the file. Default is "r".
+            mode (str): Mode with which to open the file. Default is "rb". This is only
             gzipped (bool): Whether the output should be gzipped. Must be True if downloading a directory;
                 can be True or False if downloading a file.
         """
@@ -248,18 +248,13 @@ class OpenFile(object):
             # Stream an entire, single .gz file from Blob Storage. This is gzipped by default,
             # so if the user requested a gzipped version of the entire file, just read and return it.
             if not linked_bundle_path.is_archive_dir and self.gzipped:
-                return FileSystems.open(
-                    self.path, self.mode, compression_type=CompressionTypes.UNCOMPRESSED
-                )
+                return FileSystems.open(self.path, compression_type=CompressionTypes.UNCOMPRESSED)
             # Stream an entire, single .tar.gz file from Blob Storage. This is gzipped by default,
             # and directories are always gzipped, so just read and return it.
             if linked_bundle_path.is_archive_dir and not linked_bundle_path.archive_subpath:
                 if not self.gzipped:
                     raise IOError("Directories must be gzipped.")
-                fs = FileSystems.open(
-                    self.path, self.mode, compression_type=CompressionTypes.UNCOMPRESSED
-                )
-                return fs
+                return FileSystems.open(self.path, compression_type=CompressionTypes.UNCOMPRESSED)
             # If a file path is specified within an archive file on Blob Storage, open the specified path within the archive.
             with OpenIndexedArchiveFile(linked_bundle_path.bundle_path) as tf:
                 isdir = lambda finfo: finfo.type == tarfile.DIRTYPE
@@ -278,11 +273,9 @@ class OpenFile(object):
                     if not self.gzipped:
                         raise IOError("Directories must be gzipped.")
                     return GzipStream(TarSubdirStream(self.path))
-                    return GzipStream(fileobj=fs) if self.gzipped else fs
                 else:
                     # Stream a single file from within the archive
-                    fs = TarFileStream(tf, finfo)
-                    return GzipStream(fs) if self.gzipped else fs
+                    return GzipStream(TarFileStream(tf, finfo))
         else:
             # Stream a file from disk storage.
             return open(self.path, self.mode)

--- a/codalab/worker/tar_subdir_stream.py
+++ b/codalab/worker/tar_subdir_stream.py
@@ -37,7 +37,7 @@ EmptyFileInfo = FileInfo(
 
 
 class TarSubdirStream(BytesIO):
-    """Streams a subdirectory from a tar file stored on Blob Storage, as its own tar archive.
+    """Streams a subdirectory from an indexed archive file stored on Blob Storage, as its own .tar.gz archive.
 
     The general idea is that on initialization, this class will construct a list
     "descendants" that contains all files within the specified subdirectory in the tar file.
@@ -56,15 +56,17 @@ class TarSubdirStream(BytesIO):
         Args:
             path (str): Specified path of the subdirectory on Blob Storage. Must refer to a subdirectory path within a .tar.gz file.
         """
-        from codalab.worker.file_util import OpenIndexedTarGzFile
+        from codalab.worker.file_util import OpenIndexedArchiveFile
         from codalab.worker.download_util import compute_target_info_blob_descendants_flat
 
         self.linked_bundle_path = parse_linked_bundle_url(path)
 
-        # We add OpenIndexedTarGzFile to self._stack so that the context manager remains open and is exited
+        # We add OpenIndexedArchiveFile to self._stack so that the context manager remains open and is exited
         # only in the method self.close().
         with ExitStack() as stack:
-            self.tf = stack.enter_context(OpenIndexedTarGzFile(self.linked_bundle_path.bundle_path))
+            self.tf = stack.enter_context(
+                OpenIndexedArchiveFile(self.linked_bundle_path.bundle_path)
+            )
             self._stack = stack.pop_all()
 
         # Keep track of descendants of the specified subdirectory and the current descendant
@@ -152,7 +154,7 @@ class TarSubdirStream(BytesIO):
         return self._buffer.read(num_bytes)
 
     def close(self):
-        # Close the OpenIndexedTarGzFile context manager that was initialized in __init__.
+        # Close the OpenIndexedArchiveFile context manager that was initialized in __init__.
         self._stack.__exit__(self, None, None)
 
     def __getattr__(self, name):

--- a/tests/unit/lib/path_util_test.py
+++ b/tests/unit/lib/path_util_test.py
@@ -120,14 +120,15 @@ class ParseBundleUrl(unittest.TestCase):
     def test_single_file(self):
         """Parse a URL referring to a single file on Azure."""
         linked_bundle_path = parse_linked_bundle_url(
-            "azfs://storageclwsdev0/bundles/uuid/contents.txt"
+            "azfs://storageclwsdev0/bundles/uuid/contents.gz"
         )
         self.assertEqual(linked_bundle_path.storage_type, StorageType.AZURE_BLOB_STORAGE.value)
         self.assertEqual(linked_bundle_path.uses_beam, True)
         self.assertEqual(
-            linked_bundle_path.bundle_path, "azfs://storageclwsdev0/bundles/uuid/contents.txt"
+            linked_bundle_path.bundle_path, "azfs://storageclwsdev0/bundles/uuid/contents.gz"
         )
-        self.assertEqual(linked_bundle_path.is_archive, False)
+        self.assertEqual(linked_bundle_path.is_archive, True)
+        self.assertEqual(linked_bundle_path.is_archive_dir, False)
         self.assertEqual(linked_bundle_path.archive_subpath, None)
         self.assertEqual(linked_bundle_path.bundle_uuid, "uuid")
 
@@ -141,6 +142,7 @@ class ParseBundleUrl(unittest.TestCase):
             linked_bundle_path.bundle_path, "azfs://storageclwsdev0/bundles/uuid/contents.tar.gz"
         )
         self.assertEqual(linked_bundle_path.is_archive, True)
+        self.assertEqual(linked_bundle_path.is_archive_dir, True)
         self.assertEqual(linked_bundle_path.archive_subpath, None)
         self.assertEqual(linked_bundle_path.bundle_uuid, "uuid")
 
@@ -154,6 +156,7 @@ class ParseBundleUrl(unittest.TestCase):
             linked_bundle_path.bundle_path, "azfs://storageclwsdev0/bundles/uuid/contents.tar.gz"
         )
         self.assertEqual(linked_bundle_path.is_archive, True)
+        self.assertEqual(linked_bundle_path.is_archive_dir, True)
         self.assertEqual(linked_bundle_path.archive_subpath, "a/b.txt")
         self.assertEqual(linked_bundle_path.bundle_uuid, "uuid")
 

--- a/tests/unit/worker/download_util_test.py
+++ b/tests/unit/worker/download_util_test.py
@@ -30,7 +30,7 @@ class AzureBlobTestBase:
         return bundle_uuid, bundle_path
 
     def create_file(self, contents=b"hello world"):
-        """Creates a file on Blob Storage (compressed as .gz) and returns its path."""
+        """Creates a file on Blob (stored as a .gz with an index.sqlite index file) and returns its path."""
         bundle_uuid = str(random.random())
         bundle_path = f"azfs://storageclwsdev0/bundles/{bundle_uuid}/contents.gz"
         compressed_file = BytesIO(gzip.compress(contents))
@@ -41,7 +41,7 @@ class AzureBlobTestBase:
         with tempfile.NamedTemporaryFile(suffix=".sqlite") as tmp_index_file:
             SQLiteIndexedTar(
                 fileObject=compressed_file,
-                tarFileName="contents",
+                tarFileName="contents",  # Later, this file can be accessed by the "/contents" entry in the index.
                 writeIndex=True,
                 clearIndexCache=True,
                 indexFileName=tmp_index_file.name,
@@ -54,7 +54,7 @@ class AzureBlobTestBase:
         return bundle_uuid, bundle_path
 
     def create_directory(self):
-        """Creates a directory and returns its path."""
+        """Creates a directory (stored as a .tar.gz with an index.sqlite index file) and returns its path."""
         bundle_uuid = str(random.random())
         bundle_path = f"azfs://storageclwsdev0/bundles/{bundle_uuid}/contents.tar.gz"
 

--- a/tests/unit/worker/download_util_test.py
+++ b/tests/unit/worker/download_util_test.py
@@ -15,7 +15,6 @@ import tempfile
 from codalab.lib.beam.ratarmount import SQLiteIndexedTar
 import shutil
 import gzip
-from io import BytesIO
 
 
 class AzureBlobTestBase:

--- a/tests/unit/worker/download_util_test.py
+++ b/tests/unit/worker/download_util_test.py
@@ -31,7 +31,7 @@ class AzureBlobTestBase:
         return bundle_uuid, bundle_path
 
     def create_file(self, contents=b"hello world"):
-        """Creates a file on Blob Storage (compressed as .gzip) and returns its path."""
+        """Creates a file on Blob Storage (compressed as .gz) and returns its path."""
         bundle_uuid = str(random.random())
         bundle_path = f"azfs://storageclwsdev0/bundles/{bundle_uuid}/contents.gz"
         compressed_file = BytesIO(gzip.compress(contents))

--- a/tests/unit/worker/download_util_test.py
+++ b/tests/unit/worker/download_util_test.py
@@ -14,18 +14,44 @@ from io import BytesIO
 import tempfile
 from codalab.lib.beam.ratarmount import SQLiteIndexedTar
 import shutil
+import gzip
+from io import BytesIO
 
 
 class AzureBlobTestBase:
     """A helper class that contains convenient methods for creating
     files and/or folders."""
 
-    def create_file(self, contents=b"hello world"):
-        """Creates a file and returns its path."""
+    def create_txt_file(self, contents=b"hello world"):
+        """Creates a txt file and returns its path."""
         bundle_uuid = str(random.random())
         bundle_path = f"azfs://storageclwsdev0/bundles/{bundle_uuid}/test.txt"
         with FileSystems.create(bundle_path, compression_type=CompressionTypes.UNCOMPRESSED) as f:
             f.write(contents)
+        return bundle_uuid, bundle_path
+
+    def create_file(self, contents=b"hello world"):
+        """Creates a file on Blob Storage (compressed as .gzip) and returns its path."""
+        bundle_uuid = str(random.random())
+        bundle_path = f"azfs://storageclwsdev0/bundles/{bundle_uuid}/contents.gz"
+        compressed_file = BytesIO(gzip.compress(contents))
+        # TODO: Unify this code with code in UploadManager.upload_to_bundle_store().
+        with FileSystems.create(bundle_path, compression_type=CompressionTypes.UNCOMPRESSED) as f:
+            shutil.copyfileobj(compressed_file, f)
+        compressed_file.seek(0)
+        with tempfile.NamedTemporaryFile(suffix=".sqlite") as tmp_index_file:
+            SQLiteIndexedTar(
+                fileObject=compressed_file,
+                tarFileName="contents",
+                writeIndex=True,
+                clearIndexCache=True,
+                indexFileName=tmp_index_file.name,
+            )
+            with FileSystems.create(
+                bundle_path.replace("/contents.gz", "/index.sqlite"),
+                compression_type=CompressionTypes.UNCOMPRESSED,
+            ) as out_index_file, open(tmp_index_file.name, "rb") as tif:
+                shutil.copyfileobj(tif, out_index_file)
         return bundle_uuid, bundle_path
 
     def create_directory(self):
@@ -65,7 +91,7 @@ class AzureBlobTestBase:
             with open(tmp_tar_file.name, "rb") as ttf:
                 SQLiteIndexedTar(
                     fileObject=ttf,
-                    tarFileName=bundle_uuid,
+                    tarFileName="contents",
                     writeIndex=True,
                     clearIndexCache=True,
                     indexFileName=tmp_index_file.name,
@@ -80,12 +106,21 @@ class AzureBlobTestBase:
 
 
 class AzureBlobGetTargetInfoTest(AzureBlobTestBase, unittest.TestCase):
-    def test_single_file(self):
-        """Test getting target info of a single file on Azure Blob Storage. As this isn't supported
-        (paths should be specified within existing .tar.gz files), this should throw an exception."""
-        bundle_uuid, bundle_path = self.create_file(b"a")
+    def test_single_txt_file(self):
+        """Test getting target info of a single txt file on Azure Blob Storage. As this isn't supported
+        (paths should be specified within existing .gz / .tar.gz files), this should throw an exception."""
+        bundle_uuid, bundle_path = self.create_txt_file(b"a")
         with self.assertRaises(PathException):
             get_target_info(bundle_path, BundleTarget(bundle_uuid, None), 0)
+
+    def test_single_file(self):
+        """Test getting target info of a single file (compressed as .gz) on Azure Blob Storage."""
+        bundle_uuid, bundle_path = self.create_file(b"a")
+        target_info = get_target_info(bundle_path, BundleTarget(bundle_uuid, None), 0)
+        target_info.pop("resolved_target")
+        self.assertEqual(
+            target_info, {'name': bundle_uuid, 'type': 'file', 'size': 1, 'perm': 0o755}
+        )
 
     def test_nested_directories(self):
         """Test getting target info of different files within a bundle that consists of nested directories, on Azure Blob Storage."""

--- a/tests/unit/worker/file_util_test.py
+++ b/tests/unit/worker/file_util_test.py
@@ -4,6 +4,7 @@ import tarfile
 import tempfile
 import unittest
 import bz2
+import gzip
 
 from codalab.worker.file_util import (
     gzip_file,
@@ -90,12 +91,22 @@ class FileUtilTestAzureBlob(AzureBlobTestBase, unittest.TestCase):
 
     def test_open_file(self):
         _, fname = self.create_file()
+
+        # Read single file (gzipped)
+        with OpenFile(fname, gzipped=True) as f:
+            self.assertEqual(gzip.decompress(f.read()), b"hello world")
+
+        # Read single file (non-gzipped):
         with OpenFile(fname) as f:
             self.assertEqual(f.read(), b"hello world")
 
         _, dirname = self.create_directory()
 
-        # Read single file from directory
+        # Read single file from directory (gzipped):
+        with OpenFile(f"{dirname}/README.md", gzipped=True) as f:
+            self.assertEqual(gzip.decompress(f.read()), b"hello world")
+
+        # Read single file from directory (non-gzipped):
         with OpenFile(f"{dirname}/README.md") as f:
             self.assertEqual(f.read(), b"hello world")
 

--- a/tests/unit/worker/file_util_test.py
+++ b/tests/unit/worker/file_util_test.py
@@ -99,8 +99,8 @@ class FileUtilTestAzureBlob(AzureBlobTestBase, unittest.TestCase):
         with OpenFile(f"{dirname}/README.md") as f:
             self.assertEqual(f.read(), b"hello world")
 
-        # Read entire directory
-        with OpenFile(dirname) as f:
+        # Read entire directory (gzipped)
+        with OpenFile(dirname, gzipped=True) as f:
             self.assertEqual(
                 tarfile.open(fileobj=f, mode='r:gz').getnames(),
                 [
@@ -114,14 +114,24 @@ class FileUtilTestAzureBlob(AzureBlobTestBase, unittest.TestCase):
                 ],
             )
 
-        # Read a subdirectory
-        with OpenFile(f"{dirname}/src") as f:
+        # Read entire directory (non-gzipped)
+        with self.assertRaises(IOError):
+            with OpenFile(dirname, gzipped=False) as f:
+                pass
+
+        # Read a subdirectory (gzipped)
+        with OpenFile(f"{dirname}/src", gzipped=True) as f:
             self.assertEqual(
                 tarfile.open(fileobj=f, mode='r:gz').getnames(), ['.', './test.sh'],
             )
 
+        # Read a subdirectory (non-gzipped)
+        with self.assertRaises(IOError):
+            with OpenFile(f"{dirname}/src") as f:
+                pass
+
         # Read a subdirectory with nested children
-        with OpenFile(f"{dirname}/dist") as f:
+        with OpenFile(f"{dirname}/dist", gzipped=True) as f:
             self.assertEqual(
                 tarfile.open(fileobj=f, mode='r:gz').getnames(),
                 ['.', './a', './a/b', './a/b/test2.sh'],


### PR DESCRIPTION
- Updates the downloading logic to work with "contents.gz" bundles, which represent single files. They can still be read through random access by using the "index.sqlite" index files.
- Improve gzip handling when downloading gzipped files. I do this by adding a `gzipped` kwarg to `OpenFile`. This allows us to directly stream the `contents.gz` / `contents.tar.gz` files if one is requesting a gzipped version of the entire bundle, so that we don't have to un-gzip and then re-gzip these files.

fixes https://github.com/codalab/codalab-worksheets/issues/3440.