### PR TITLE
Ensure image block is a separate block

### DIFF
--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -305,6 +305,7 @@ def _create_bundles():
         if not detached:
             if shadow_parent_uuid is None:
                 items = [worksheet_util.bundle_item(bundle_uuid)]
+                # Add a blank line after the image block in the worksheet source to ensure it is a separate block
                 if after_image:
                     items.insert(0, worksheet_util.markup_item(''))
                 local.model.add_worksheet_items(worksheet_uuid, items, after_sort_key)

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -232,6 +232,7 @@ def _create_bundles():
     shadow_parent_uuid = request.query.get('shadow')
     after_sort_key = request.query.get('after_sort_key')
     detached = query_get_bool('detached', default=False)
+    after_image = query_get_bool('after_image', default=False)
     if not detached and worksheet_uuid is None:
         abort(
             http.client.BAD_REQUEST,
@@ -303,9 +304,10 @@ def _create_bundles():
         # Add as item to worksheet
         if not detached:
             if shadow_parent_uuid is None:
-                local.model.add_worksheet_items(
-                    worksheet_uuid, [worksheet_util.bundle_item(bundle_uuid)], after_sort_key
-                )
+                items = [worksheet_util.bundle_item(bundle_uuid)]
+                if after_image:
+                    items.insert(0, worksheet_util.markup_item(''))
+                local.model.add_worksheet_items(worksheet_uuid, items, after_sort_key)
             else:
                 local.model.add_shadow_worksheet_items(shadow_parent_uuid, bundle_uuid)
 

--- a/frontend/src/components/worksheets/NewUpload/NewUpload.jsx
+++ b/frontend/src/components/worksheets/NewUpload/NewUpload.jsx
@@ -93,6 +93,7 @@ class NewUpload extends React.Component<{
                 url += `&after_sort_key=${after_sort_key}`;
             }
             // current focused item is an image block
+            // pass after_image to the backend to make the backend add a blank line after the image block in the worksheet source to separate the newly uploaded files from the image block
             if(focusedItem.mode==='image_block'){
                 url += `&after_image=1`;
             }
@@ -150,7 +151,7 @@ class NewUpload extends React.Component<{
             return;
         }
 
-        const { worksheetUUID, after_sort_key } = this.props;
+        const { worksheetUUID, after_sort_key, focusedItem } = this.props;
         const { name, description } = this.state;
         const folderNamePos = files[0].webkitRelativePath.indexOf('/');
         let folderName = '';
@@ -165,6 +166,10 @@ class NewUpload extends React.Component<{
         let url = `/rest/bundles?worksheet=${worksheetUUID}`;
         url += `&after_sort_key=${isNaN(after_sort_key) ? -1 : after_sort_key}`;
 
+        if(focusedItem.mode==='image_block'){
+            url += `&after_image=1`;
+        }
+        
         let zip = new JSZip();
         [...files].map((file) => {
             zip.file(file.webkitRelativePath, file);

--- a/frontend/src/components/worksheets/NewUpload/NewUpload.jsx
+++ b/frontend/src/components/worksheets/NewUpload/NewUpload.jsx
@@ -79,7 +79,7 @@ class NewUpload extends React.Component<{
     }
 
     asyncUploadFiles = async (files) => {
-        const { worksheetUUID, after_sort_key } = this.props;
+        const { worksheetUUID, after_sort_key,focusedItem } = this.props;
         const { name, description } = this.state;
         this.setState({
             uploading: true,
@@ -92,7 +92,10 @@ class NewUpload extends React.Component<{
             if (after_sort_key || after_sort_key === 0) {
                 url += `&after_sort_key=${after_sort_key}`;
             }
-
+            // current focused item is an image block
+            if(focusedItem.mode==='image_block'){
+                url += `&after_image=1`;
+            }
             const errorHandler = (error) => {
                 this.clearProgress();
                 alert(createAlertText(url, error.responseText));

--- a/frontend/src/components/worksheets/WorksheetItemList.js
+++ b/frontend/src/components/worksheets/WorksheetItemList.js
@@ -325,6 +325,7 @@ class WorksheetItemList extends React.Component {
                         // (otherwise, chrome will not call onchange on a file input when
                         // the file hasn't changed)
                         onUploadFinish={(e) => this.setState({ newUploadKey: Math.random() + '' })}
+                        focusedItem={focusedItem}
                     />
                     <ImageEditor
                         key={this.state.newUploadKey + 1}


### PR DESCRIPTION
### Reasons for making this change

when focusing on an image block, before uploading a bundle, add a new line to separate the image block and the table block.

### Related issues

fixes #3405 

### Screenshots

![ezgif com-gif-maker (4)](https://user-images.githubusercontent.com/34461466/117447228-13a79300-aef2-11eb-98c2-dc89ad8cb6b0.gif)


### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
