### PR TITLE
Fix delete bundle issue

### DIFF
--- a/frontend/src/components/Dashboard/MainPanel.js
+++ b/frontend/src/components/Dashboard/MainPanel.js
@@ -238,7 +238,7 @@ class MainPanel extends React.Component<{
             .catch((error) => {
                 this.setState({
                     snackbarShow: true,
-                    snackbarMessage: error.responseText,
+                    snackbarMessage: error,
                     snackbarVariant: 'error',
                 });
             });

--- a/frontend/src/components/Dashboard/MainPanel.js
+++ b/frontend/src/components/Dashboard/MainPanel.js
@@ -235,7 +235,7 @@ class MainPanel extends React.Component<{
                     });
                 }
             })
-            .fail((error) => {
+            .catch((error) => {
                 this.setState({
                     snackbarShow: true,
                     snackbarMessage: error.responseText,

--- a/frontend/src/components/NavBar.js
+++ b/frontend/src/components/NavBar.js
@@ -112,7 +112,7 @@ class NavBar extends React.Component<{
         } catch (error) {
             this.setState({
                 snackbarShow: true,
-                snackbarMessage: error.responseText,
+                snackbarMessage: error,
                 snackbarVariant: 'error',
             });
         }

--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -317,7 +317,7 @@ class Worksheet extends React.Component {
             ]),
             worksheet_uuid,
         )
-            .done(() => {
+            .then(() => {
                 this.clearCheckedBundles(() => {
                     // This toast info is used for showing a message when a command has finished executing
                     toast.update(toastId, {
@@ -336,7 +336,7 @@ class Worksheet extends React.Component {
                 const param = { fromDeleteCommand };
                 this.reloadWorksheet(undefined, undefined, param);
             })
-            .fail((e) => {
+            .catch((e) => {
                 this.setState({
                     openedDialog: DIALOG_TYPES.OPEN_ERROR_DIALOG,
                     errorDialogMessage: e.responseText,

--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -339,7 +339,7 @@ class Worksheet extends React.Component {
             .catch((e) => {
                 this.setState({
                     openedDialog: DIALOG_TYPES.OPEN_ERROR_DIALOG,
-                    errorDialogMessage: e.responseText,
+                    errorDialogMessage: e,
                     forceDelete: false,
                     updating: false,
                 });

--- a/frontend/src/components/worksheets/WorksheetTerminal.js
+++ b/frontend/src/components/worksheets/WorksheetTerminal.js
@@ -179,10 +179,7 @@ class WorksheetTerminal extends React.Component {
                 }
                 return data;
             })
-            .catch(function(error) {
-                // Some exception occurred outside of the CLI
-                const htmlDoc = new DOMParser().parseFromString(error.response.data, 'text/html');
-                const exception = htmlDoc.getElementsByTagName('pre')[0].innerHTML;
+            .catch(function(exception) {
                 return { exception };
             });
     }

--- a/frontend/src/util/apiWrapper.js
+++ b/frontend/src/util/apiWrapper.js
@@ -64,6 +64,10 @@ export const executeCommand = (command, worksheet_uuid) => {
     return post(url, {
         worksheet_uuid: worksheet_uuid || null,
         command: command,
+    }).catch((error) => {
+        const htmlDoc = new DOMParser().parseFromString(error.response.data, 'text/html');
+        const exception = htmlDoc.getElementsByTagName('pre')[0].innerHTML;
+        throw exception;
     });
 };
 


### PR DESCRIPTION
### Reasons for making this change

Delete bundle was not working since we used `done` instead of `then` for an API call. The changes should fix the issue. This pull request also fixes the error display for terminal commands since `error.responseText` was for jquery.

### Related issues

<!-- Add a reference to issues resolved, if applicable (for example, "fixes #1"). -->

### Screenshots

<!-- Add screenshots, if necessary -->

### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
