### PR TITLE
Update developers on "About" page

### DIFF
--- a/docs/About.md
+++ b/docs/About.md
@@ -13,11 +13,11 @@ provided by Microsoft Azure.
 ## Current Developers
 
 - Percy Liang
-- Jane Ge
 - Ashwin Ramaswami
-- Levi Lian
-- Yipeng He
 - Tony Lee
+- Yuqi Jin
+- Aditya Prerepa
+- Yuqi Jin
 
 ## Former Developers
 
@@ -37,3 +37,6 @@ provided by Microsoft Azure.
 - Dennis Jeong
 - Nikhil Bhattasali
 - Hao Wu
+- Jane Ge
+- Levi Lian
+- Yipeng He

--- a/docs/About.md
+++ b/docs/About.md
@@ -17,7 +17,7 @@ provided by Microsoft Azure.
 - Tony Lee
 - Yuqi Jin
 - Aditya Prerepa
-- Yuqi Jin
+- Jizhen Wang
 
 ## Former Developers
 


### PR DESCRIPTION
### Reasons for making this change

Update developers on "About" page, as they were outdated.