### PR TITLE
bump version to v0.5.50

### DIFF
--- a/codalab/common.py
+++ b/codalab/common.py
@@ -15,7 +15,7 @@ from enum import Enum
 
 # Increment this on master when ready to cut a release.
 # http://semver.org/
-CODALAB_VERSION = '0.5.49'
+CODALAB_VERSION = '0.5.50'
 BINARY_PLACEHOLDER = '<binary>'
 URLOPEN_TIMEOUT_SECONDS = int(os.environ.get('CODALAB_URLOPEN_TIMEOUT_SECONDS', 5 * 60))
 

--- a/docs/REST-API-Reference.md
+++ b/docs/REST-API-Reference.md
@@ -1,6 +1,6 @@
 # REST API Reference
 
-_version 0.5.49_
+_version 0.5.50_
 
 This reference and the REST API itself is still under heavy development and is
 subject to change at any time. Feedback through our GitHub issues is appreciated!

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -1,5 +1,5 @@
 // Should match codalab/common.py#CODALAB_VERSION
-export const CODALAB_VERSION = '0.5.49';
+export const CODALAB_VERSION = '0.5.50';
 
 // Name Regex to match the backend in spec_utils.py
 export const NAME_REGEX = /^[a-zA-Z_][a-zA-Z0-9_.-]*$/i;

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import sys
 
 
 # should match codalab/common.py#CODALAB_VERSION
-CODALAB_VERSION = "0.5.49"
+CODALAB_VERSION = "0.5.50"
 
 
 class Install(install):


### PR DESCRIPTION
# Reasons for making this change
Bump new version

Full diff: [v0.5.49...rc0.5.50](https://github.com/codalab/codalab-worksheets/compare/v0.5.49...rc0.5.50)

# Draft release notes
## Frontend
- Fix delete bundle issue (#3482)
- Add CAPTCHA for Registration (#3463)
- Update developers on "About" page (#3494)
- Ensure image block is a separate block (#3474)
- Only show worksheets not owned by the user (#3469)

## Backend
- Benchmark bundle stages (#3370)
- Blob Storage: allow downloading from single contents.gz files (#3457)
- Redo the stats of docker images (#3272)







