### PR TITLE
Add Delete Account Option for non-root user

### DIFF
--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -4123,7 +4123,7 @@ class BundleCLI(object):
     @Commands.command(
         'ufarewell',
         help=[
-            'Delete user permanently. Root user only.',
+            'Delete user permanently. Only root user can delete other users. Non-root user can delete his/her own account.',
             'To be safe, you can only delete a user if user does not own any bundles, worksheets, or groups.',
         ],
         arguments=(Commands.Argument('user_spec', help='Username or id of user to delete.'),),

--- a/codalab/rest/users.py
+++ b/codalab/rest/users.py
@@ -101,10 +101,7 @@ def delete_user():
 
     request_user_id = request.user.user_id
 
-    if not (
-        request_user_id == local.model.root_user_id
-        or (user_ids == [request_user_id])
-    ):
+    if not (request_user_id == local.model.root_user_id or (user_ids == [request_user_id])):
         abort(http.client.UNAUTHORIZED, 'As a non-root user, you can only delete your own account.')
 
     for user_id in user_ids:

--- a/codalab/rest/users.py
+++ b/codalab/rest/users.py
@@ -103,7 +103,7 @@ def delete_user():
 
     if not (
         request_user_id == local.model.root_user_id
-        or (len(user_ids) == 1 and request_user_id == user_ids[0])
+        or (user_ids == [request_user_id])
     ):
         abort(http.client.UNAUTHORIZED, 'As a non-root user, you can only delete your own account.')
 

--- a/codalab/rest/users.py
+++ b/codalab/rest/users.py
@@ -101,8 +101,11 @@ def delete_user():
 
     request_user_id = request.user.user_id
 
-    if request_user_id != local.model.root_user_id:
-        abort(http.client.UNAUTHORIZED, 'Only root user can delete other users.')
+    if not (
+        request_user_id == local.model.root_user_id
+        or (len(user_ids) == 1 and request_user_id == user_ids[0])
+    ):
+        abort(http.client.UNAUTHORIZED, 'As a non-root user, you can only delete your own account.')
 
     for user_id in user_ids:
         if user_id == local.model.root_user_id:
@@ -135,7 +138,7 @@ def delete_user():
 
         groups = local.model.batch_get_groups(owner_id=user_id)
         if groups is not None and len(groups) > 0:
-            group_uuids = [group.uuid for group in groups]
+            group_uuids = [group['uuid'] for group in groups]
             error_messages.append(
                 'User %s owns groups, can\'t delete. UUIDs: %s\n' % (user_id, ','.join(group_uuids))
             )

--- a/docs/CLI-Reference.md
+++ b/docs/CLI-Reference.md
@@ -442,7 +442,7 @@ Usage: `cl <command> <arguments>`
       --remove-access           Remove the user's access if the CodaLab instance is in protected mode
 
 ### ufarewell
-    Delete user permanently. Root user only.
+    Delete user permanently. Only root user can delete other users. Non-root user can delete his/her own account.
     To be safe, you can only delete a user if user does not own any bundles, worksheets, or groups.
     Arguments:
       user_spec  Username or id of user to delete.

--- a/frontend/src/components/UserInfo.js
+++ b/frontend/src/components/UserInfo.js
@@ -5,7 +5,17 @@ import _ from 'underscore';
 import { renderSize, renderDuration } from '../util/worksheet_utils';
 import SubHeader from './SubHeader';
 import ContentWrapper from './ContentWrapper';
-import { defaultErrorHandler, getUser, updateUser } from '../util/apiWrapper';
+import { apiWrapper, defaultErrorHandler, getUser, updateUser } from '../util/apiWrapper';
+import DeleteIcon from '@material-ui/icons/Delete';
+import Button from '@material-ui/core/Button';
+import TextField from '@material-ui/core/TextField';
+import Dialog from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogContentText from '@material-ui/core/DialogContentText';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import Divider from '@material-ui/core/Divider';
+
 /**
  * This stateful component ___.
  */
@@ -208,6 +218,7 @@ class UserInfo extends React.Component {
                                 title='Send me general updates about new features (once a month).'
                                 fieldKey='2'
                             />
+                            <DeleteAccountDialog user={this.state.user} />
                         </form>
                     )}
                 </ContentWrapper>
@@ -340,6 +351,85 @@ class AccountProfileField extends React.Component {
             </div>
         );
     }
+}
+
+function DeleteAccountDialog(user) {
+    const [open, setOpen] = React.useState(false);
+    const [message, setMessage] = React.useState('');
+
+    const handleClickOpen = () => {
+        setOpen(true);
+    };
+
+    const handleClose = () => {
+        setOpen(false);
+    };
+
+    const deleteAccount = () => {
+        if (message !== 'Delete my account') {
+            alert(
+                'Please type "Delete my account" to verify your intention to delete your account. Case sensitive.',
+            );
+            return;
+        }
+        setOpen(false);
+        apiWrapper
+            .executeCommand('ufarewell ' + user.user.id)
+            .then((data) => {
+                window.location.href = 'https://worksheets.codalab.org';
+            })
+            .catch((error) => alert(error));
+    };
+
+    return (
+        <div>
+            <Divider style={{ marginBottom: '30px' }} />
+            <h2 style={{ color: '#bc3638' }}>Delete account</h2>
+            <p>
+                To be safe, you can only delete your account if you do not own any bundles,
+                worksheets, or groups.
+            </p>
+            <Button
+                variant='contained'
+                startIcon={<DeleteIcon />}
+                onClick={handleClickOpen}
+                style={{ backgroundColor: '#bc3638', color: 'white' }}
+            >
+                Delete your account
+            </Button>
+            <Dialog open={open} onClose={handleClose} aria-labelledby='delete-account-title'>
+                <DialogTitle id='delete-account-title'>
+                    {' '}
+                    Are you sure you want to delete your account?
+                </DialogTitle>
+                <DialogContent>
+                    <DialogContentText>
+                        <p>Once you delete your account, you can not return back.</p>
+                        <p>
+                            Please ensure that you do not own any bundles, worksheets, or groups
+                            before deleting your account; otherwise the deletion will fail.
+                        </p>
+                        <br />
+                    </DialogContentText>
+                    <TextField
+                        autoFocus
+                        id='message'
+                        label='To verify, type "Delete my account" below:'
+                        onChange={(e) => setMessage(e.target.value)}
+                        fullWidth
+                    />
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={handleClose} color='primary'>
+                        Cancel
+                    </Button>
+                    <Button onClick={deleteAccount} style={{ color: 'red' }}>
+                        Confirm
+                    </Button>
+                </DialogActions>
+            </Dialog>
+        </div>
+    );
 }
 
 export default UserInfo;


### PR DESCRIPTION
### Reasons for making this change

The user can use `ufarewell` cmd or the `Delete your account` button on the account page to delete his own account if the user does not own any bundles, worksheets, or groups.

Provide a delete account dialog to avoid unintentional deletion.

### Related issues

fixes #3459

### Screenshots

![ezgif com-gif-maker (5)](https://user-images.githubusercontent.com/34461466/118061625-208d1200-b34a-11eb-98f7-4b47fe8d057b.gif)


### Checklist

* [ ] I've added a screenshot of the changes, if this is a frontend change
* [ ] I've added and/or updated tests, if this is a backend change
* [ ] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [ ] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
