### PR TITLE
Catch Parsing Error of Datetime

### DIFF
--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -531,7 +531,7 @@ class BundleModel(object):
             elif key in ('.before', '.after'):
                 try:
                     target_datetime = parser.isoparse(value)
-                except Exception:
+                except ValueError:
                     raise UsageError("Unable to parse datatime, please check the format.")
 
                 subclause = None

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -532,7 +532,9 @@ class BundleModel(object):
                 try:
                     target_datetime = parser.isoparse(value)
                 except ValueError:
-                    raise UsageError("Unable to parse datatime, please check the format.")
+                    raise UsageError(
+                        "Unable to parse datetime. Datetime must be specified as an ISO-8601 datetime string such as YYYY-MM-DD."
+                    )
 
                 subclause = None
                 if key == '.before':

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -529,7 +529,10 @@ class BundleModel(object):
                         alias(select([cl_worksheet_item.c.bundle_uuid]).where(condition))
                     )
             elif key in ('.before', '.after'):
-                target_datetime = parser.isoparse(value)
+                try:
+                    target_datetime = parser.isoparse(value)
+                except Exception:
+                    raise UsageError("Unable to parse datatime, please check the format.")
 
                 subclause = None
                 if key == '.before':


### PR DESCRIPTION
### Reasons for making this change

isoparse is throwing an unhandled error if an invalid date is provided, triggering sentry.io

### Related issues

fixes #3483 

### Screenshots

![image](https://user-images.githubusercontent.com/29891066/118328436-d1b2ba00-b4ba-11eb-80e4-8c20cb47179f.png)


<!-- Add screenshots, if necessary -->

### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
