### PR TITLE
Remove redundant space between nav bar and image/header below

### DIFF
--- a/frontend/src/css/imports.scss
+++ b/frontend/src/css/imports.scss
@@ -283,7 +283,7 @@ body.ws-interface > .container {
 }
 /* Background for CodaLab logo */
 .page-header {
-  margin: 0 0 20px;
+  margin: -5px 0 20px;
   border: none;
   background: url('../img/splash.png') repeat-x top left;
   min-height: 80px;

--- a/frontend/src/routes/HomePage.js
+++ b/frontend/src/routes/HomePage.js
@@ -78,7 +78,7 @@ class HomePage extends React.Component<{
     render() {
         const { classes, auth } = this.props;
         return (
-            <Grid container style={{ marginTop: -6 }}>
+            <Grid container style={{ marginTop: -30 }}>
                 <Helmet>
                     <meta
                         id='meta-description'


### PR DESCRIPTION
### Reasons for making this change

remove the space for a better UI

### Screenshots

<img width="1522" alt="Screen Shot 2021-05-18 at 4 49 55 AM" src="https://user-images.githubusercontent.com/34461466/118672802-5fd5bb80-b7ad-11eb-92d5-5b3a939cc128.png">
<img width="1294" alt="Screen Shot 2021-05-18 at 5 01 36 AM" src="https://user-images.githubusercontent.com/34461466/118672831-62d0ac00-b7ad-11eb-84c1-585d77ff3940.png">


### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
