### PR TITLE
Get rid of the the bottom bar of the table

### DIFF
--- a/frontend/src/components/worksheets/items/TableItem/TableItem.js
+++ b/frontend/src/components/worksheets/items/TableItem/TableItem.js
@@ -261,7 +261,7 @@ class TableItem extends React.Component<{
         });
         return (
             <div className='ws-item'>
-                <TableContainer style={{ overflowX: 'auto', overflowY: 'clip' }}>
+                <TableContainer style={{ overflowX: 'auto', overflowY: 'hidden' }}>
                     <Table
                         className={tableClassName}
                         style={{ marginBottom: this.props.focused ? '-20px' : '0' }}

--- a/frontend/src/components/worksheets/items/TableItem/TableItem.js
+++ b/frontend/src/components/worksheets/items/TableItem/TableItem.js
@@ -261,8 +261,11 @@ class TableItem extends React.Component<{
         });
         return (
             <div className='ws-item'>
-                <TableContainer style={{ overflowX: 'auto' }}>
-                    <Table className={tableClassName}>
+                <TableContainer style={{ overflowX: 'auto', overflowY: 'clip' }}>
+                    <Table
+                        className={tableClassName}
+                        style={{ marginBottom: this.props.focused ? '-20px' : '0' }}
+                    >
                         <TableHead>
                             <TableRow
                                 style={{


### PR DESCRIPTION
### Reasons for making this change

remove the redundant bar when focusing on a table

### Related issues

fixes #2948 

### Screenshots

<img width="995" alt="Screen Shot 2021-05-20 at 2 58 41 AM" src="https://user-images.githubusercontent.com/34461466/118959889-94fe1d00-b917-11eb-8042-e92d9090991b.png">


### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
