### PR TITLE
Bump version to 0.5.51

### DIFF
--- a/codalab/common.py
+++ b/codalab/common.py
@@ -17,7 +17,7 @@ from enum import Enum
 
 # Increment this on master when ready to cut a release.
 # http://semver.org/
-CODALAB_VERSION = '0.5.50'
+CODALAB_VERSION = '0.5.51'
 BINARY_PLACEHOLDER = '<binary>'
 URLOPEN_TIMEOUT_SECONDS = int(os.environ.get('CODALAB_URLOPEN_TIMEOUT_SECONDS', 5 * 60))
 

--- a/docs/REST-API-Reference.md
+++ b/docs/REST-API-Reference.md
@@ -1,6 +1,6 @@
 # REST API Reference
 
-_version 0.5.50_
+_version 0.5.51_
 
 This reference and the REST API itself is still under heavy development and is
 subject to change at any time. Feedback through our GitHub issues is appreciated!

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -1,5 +1,5 @@
 // Should match codalab/common.py#CODALAB_VERSION
-export const CODALAB_VERSION = '0.5.50';
+export const CODALAB_VERSION = '0.5.51';
 
 // Name Regex to match the backend in spec_utils.py
 export const NAME_REGEX = /^[a-zA-Z_][a-zA-Z0-9_.-]*$/i;

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import sys
 
 
 # should match codalab/common.py#CODALAB_VERSION
-CODALAB_VERSION = "0.5.50"
+CODALAB_VERSION = "0.5.51"
 
 
 class Install(install):


### PR DESCRIPTION
# Reasons for making this change
Bump new version.

Full diff: [v0.5.50...rc0.5.51](https://github.com/codalab/codalab-worksheets/compare/v0.5.50...rc0.5.51)

# Draft release notes
## Frontend
- setup sentry for frontend (#3467)
- Fix Schema Deletion Bug (#3464)
- Improve front page doc (#3455)
- Fix upload failure bug when not focusing on an item (#3515)
- remove space below navbar (#3524)
- Fix table bottom hidden issue (#3534) 

## Backend
- Catch parsing error of datetime from CLI (#3504) 
- Make unpacking zip files streaming. Zip files, when uploaded using `cl upload` or through the web UI, are now read in a streaming fashion. Each file's header is read one at a time, and the central directory at the end of the .zip archive is now ignored. (#3485) 
- Added GCPWorkerManager service -- we now support workers on GCP through GKE (#3530) 
