### PR TITLE
Continuously build default-cpu and default-gpu dockerfiles

### DIFF
--- a/.github/workflows/build_worker_images.yml
+++ b/.github/workflows/build_worker_images.yml
@@ -1,11 +1,11 @@
 name: Build default worker images
 on:
   push:
-    branches: [ master ]
-      paths: ['docker_config/dockerfiles/default-*']
+    branches: [master]
+    paths: ["docker_config/dockerfiles/default-*"]
   release:
     types: [published]
-    paths: ['docker_config/dockerfiles/default-*']
+    paths: ["docker_config/dockerfiles/default-*"]
 
 jobs:
   build_default:

--- a/.github/workflows/build_worker_images.yml
+++ b/.github/workflows/build_worker_images.yml
@@ -5,6 +5,7 @@ on:
       paths: ['docker_config/dockerfiles/default-*']
   release:
     types: [published]
+    paths: ['docker_config/dockerfiles/default-*']
 
 jobs:
   build_default:

--- a/.github/workflows/build_worker_images.yml
+++ b/.github/workflows/build_worker_images.yml
@@ -5,12 +5,12 @@ name: Build default worker images
 on:
   push:
     branches: [master]
-    paths: ["docker_config/dockerfiles/default-*"]
+    paths: ["docker_config/dockerfiles/Dockerfile.default-*"]
   release:
     types: [published]
-    paths: ["docker_config/dockerfiles/default-*"]
+    paths: ["docker_config/dockerfiles/Dockerfile.default-*"]
   pull_request:
-    paths: ["docker_config/dockerfiles/default-*"]
+    paths: ["docker_config/dockerfiles/Dockerfile.default-*"]
 
 jobs:
   build_default:

--- a/.github/workflows/build_worker_images.yml
+++ b/.github/workflows/build_worker_images.yml
@@ -1,4 +1,7 @@
 name: Build default worker images
+# Default images are built and pushed when pushed to master, release, and pull request, 
+# and only when the corresponding dockerfiles are changed.
+# This workflow ensures the worker images are up-to-date on docker hub.
 on:
   push:
     branches: [master]
@@ -32,7 +35,8 @@ jobs:
         env:
           CODALAB_DOCKER_USERNAME: ${{ secrets.CODALAB_DOCKER_USERNAME }}
           CODALAB_DOCKER_PASSWORD: ${{ secrets.CODALAB_DOCKER_PASSWORD }}
-          # Gives us the branch name of the PR if on a pull_request-triggered build,
-          # otherwise, "master" if on a push-triggered build
+          # Set tag to latest if triggered by release,
+          # use the branch name of the PR if triggered by pull request,
+          # "master" if on a push-triggered build
           VERSION: ${{ (github.event_name == 'release' && 'latest') || github.head_ref || 'master' }}
           SERVICE: ${{ matrix.service }}

--- a/.github/workflows/build_worker_images.yml
+++ b/.github/workflows/build_worker_images.yml
@@ -34,5 +34,5 @@ jobs:
           CODALAB_DOCKER_PASSWORD: ${{ secrets.CODALAB_DOCKER_PASSWORD }}
           # Gives us the branch name of the PR if on a pull_request-triggered build,
           # otherwise, "master" if on a push-triggered build
-          VERSION: ${{ github.head_ref || 'master' }}
+          VERSION: ${{ (github.event_name == 'release' && 'latest') || github.head_ref || 'master' }}
           SERVICE: ${{ matrix.service }}

--- a/.github/workflows/build_worker_images.yml
+++ b/.github/workflows/build_worker_images.yml
@@ -1,7 +1,7 @@
 name: Build default worker images
 # Default images are built and pushed when pushed to master, release, and pull request, 
 # and only when the corresponding dockerfiles are changed.
-# This workflow ensures the worker images are up-to-date on docker hub.
+# This workflow ensures the worker images are up-to-date on Docker Hub.
 on:
   push:
     branches: [master]

--- a/.github/workflows/build_worker_images.yml
+++ b/.github/workflows/build_worker_images.yml
@@ -6,6 +6,8 @@ on:
   release:
     types: [published]
     paths: ["docker_config/dockerfiles/default-*"]
+  pull_request:
+    paths: ["docker_config/dockerfiles/default-*"]
 
 jobs:
   build_default:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,33 @@
+name: Push Default
+on:
+  push:
+    branches: [ master ]
+    paths: ['docker_config/dockerfiles/default-*']
+
+jobs:
+  build_default:
+    name: Build Default Images
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        service: [default-cpu, default-gpu]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v1
+        with:
+          python-version: 3.6
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: pip-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            pip-
+      - run: pip install -r requirements.txt
+      - run: python3 codalab_service.py build --pull --version ${VERSION} -s ${SERVICE} $([ -z "${CODALAB_DOCKER_USERNAME}" ] || echo "--push")
+        env:
+          CODALAB_DOCKER_USERNAME: ${{ secrets.CODALAB_DOCKER_USERNAME }}
+          CODALAB_DOCKER_PASSWORD: ${{ secrets.CODALAB_DOCKER_PASSWORD }}
+          # Gives us the branch name of the PR if on a pull_request-triggered build,
+          # otherwise, "master" if on a push-triggered build
+          VERSION: ${{ github.head_ref || 'master' }}
+          SERVICE: ${{ matrix.service }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,14 +1,14 @@
-name: Push Default
+name: Build default worker images
 on:
-  # push:
-  #   branches: [ master ]
   push:
-    branches: [ auto-build ]
-    # paths: ['docker_config/dockerfiles/default-*']
+    branches: [ master ]
+      paths: ['docker_config/dockerfiles/default-*']
+  release:
+    types: [published]
 
 jobs:
   build_default:
-    name: Build Default Images
+    name: Build and push default worker images
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,7 +24,7 @@ jobs:
           restore-keys: |
             pip-
       - run: pip install -r requirements.txt
-      - run: python3 codalab_service.py build --pull --version ${VERSION} -s ${SERVICE} $([ -z "${CODALAB_DOCKER_USERNAME}" ] || echo "--push")
+      - run: python3 codalab_service.py build ${SERVICE} $([ -z "${CODALAB_DOCKER_USERNAME}" ] || echo "--push")
         env:
           CODALAB_DOCKER_USERNAME: ${{ secrets.CODALAB_DOCKER_USERNAME }}
           CODALAB_DOCKER_PASSWORD: ${{ secrets.CODALAB_DOCKER_PASSWORD }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,6 +3,7 @@ on:
   # push:
   #   branches: [ master ]
   pull_request:
+    branches: [ auto-build ]
     # paths: ['docker_config/dockerfiles/default-*']
 
 jobs:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,8 +1,9 @@
 name: Push Default
 on:
-  push:
-    branches: [ master ]
-    paths: ['docker_config/dockerfiles/default-*']
+  # push:
+  #   branches: [ master ]
+  pull_request:
+    # paths: ['docker_config/dockerfiles/default-*']
 
 jobs:
   build_default:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,7 @@ name: Push Default
 on:
   # push:
   #   branches: [ master ]
-  pull_request:
+  push:
     branches: [ auto-build ]
     # paths: ['docker_config/dockerfiles/default-*']
 

--- a/docker_config/dockerfiles/Dockerfile.default-cpu
+++ b/docker_config/dockerfiles/Dockerfile.default-cpu
@@ -1,7 +1,10 @@
 FROM ubuntu:xenial
 MAINTAINER CodaLab Team "codalab.worksheets@gmail.com"
 
+RUN apt-get update && apt-get install -y \
+    software-properties-common
 RUN add-apt-repository ppa:deadsnakes/ppa 
+ENV DEBIAN_FRONTEND=noninteractive
 
 ############################################################
 # Common steps (must be the same in the CPU and GPU images)

--- a/docker_config/dockerfiles/Dockerfile.default-cpu
+++ b/docker_config/dockerfiles/Dockerfile.default-cpu
@@ -65,7 +65,7 @@ RUN wget http://scala-lang.org/files/archive/scala-$SCALA_VERSION.deb && \
 ENV SCALA_HOME /usr/share/java
 
 ## Python packages
-
+# Newer pip dropped the support for python 2 so we need to specify the version.
 RUN python -m pip install --upgrade "pip < 21.0"
 RUN pip3 install -U pip
 RUN pip2 install -U setuptools 

--- a/docker_config/dockerfiles/Dockerfile.default-cpu
+++ b/docker_config/dockerfiles/Dockerfile.default-cpu
@@ -15,8 +15,7 @@ RUN apt-get update && apt-get install -y \
     git \
     python2.7 \	
     python-pip \	
-    python-dev \	
-    python-software-properties \	
+    python-dev \		
     python-tk \
     build-essential \
     cmake \

--- a/docker_config/dockerfiles/Dockerfile.default-cpu
+++ b/docker_config/dockerfiles/Dockerfile.default-cpu
@@ -67,9 +67,9 @@ ENV SCALA_HOME /usr/share/java
 
 ## Python packages
 
-RUN pip2 install -U pip
+RUN python -m pip install --upgrade "pip < 21.0"
 RUN pip3 install -U pip
-
+RUN pip2 install -U setuptools 
 RUN pip2 install -U \
       numpy \
       scipy \

--- a/docker_config/dockerfiles/Dockerfile.default-cpu
+++ b/docker_config/dockerfiles/Dockerfile.default-cpu
@@ -18,7 +18,6 @@ RUN apt-get update && apt-get install -y \
     python-dev \	
     python-software-properties \	
     python-tk \
-    software-properties-common \
     build-essential \
     cmake \
     libhdf5-dev \

--- a/docker_config/dockerfiles/Dockerfile.default-gpu
+++ b/docker_config/dockerfiles/Dockerfile.default-gpu
@@ -65,7 +65,7 @@ RUN wget http://scala-lang.org/files/archive/scala-$SCALA_VERSION.deb && \
 ENV SCALA_HOME /usr/share/java
 
 ## Python packages
-
+# Newer pip dropped the support for python 2 so we need to specify the version.
 RUN python -m pip install --upgrade "pip < 21.0"
 RUN pip3 install -U pip
 RUN pip2 install -U setuptools 

--- a/docker_config/dockerfiles/Dockerfile.default-gpu
+++ b/docker_config/dockerfiles/Dockerfile.default-gpu
@@ -15,8 +15,7 @@ RUN apt-get update && apt-get install -y \
     git \
     python2.7 \	
     python-pip \	
-    python-dev \	
-    python-software-properties \	
+    python-dev \		
     python-tk \
     build-essential \
     cmake \

--- a/docker_config/dockerfiles/Dockerfile.default-gpu
+++ b/docker_config/dockerfiles/Dockerfile.default-gpu
@@ -1,6 +1,11 @@
 FROM nvidia/cuda:9.2-cudnn7-devel
 MAINTAINER CodaLab Team "codalab.worksheets@gmail.com"
 
+RUN apt-get update && apt-get install -y \
+    software-properties-common
+RUN add-apt-repository ppa:deadsnakes/ppa 
+ENV DEBIAN_FRONTEND=noninteractive
+
 ############################################################
 # Common steps (must be the same in the CPU and GPU images)
 
@@ -10,8 +15,7 @@ RUN apt-get update && apt-get install -y \
     git \
     python2.7 \	
     python-pip \	
-    python-dev \	
-    python-software-properties \	
+    python-dev \		
     python-tk \
     software-properties-common \
     build-essential \

--- a/docker_config/dockerfiles/Dockerfile.default-gpu
+++ b/docker_config/dockerfiles/Dockerfile.default-gpu
@@ -66,9 +66,9 @@ ENV SCALA_HOME /usr/share/java
 
 ## Python packages
 
-RUN pip2 install -U pip
+RUN python -m pip install --upgrade "pip < 21.0"
 RUN pip3 install -U pip
-
+RUN pip2 install -U setuptools 
 RUN pip2 install -U \
       numpy \
       scipy \

--- a/docker_config/dockerfiles/Dockerfile.default-gpu
+++ b/docker_config/dockerfiles/Dockerfile.default-gpu
@@ -15,9 +15,9 @@ RUN apt-get update && apt-get install -y \
     git \
     python2.7 \	
     python-pip \	
-    python-dev \		
+    python-dev \	
+    python-software-properties \	
     python-tk \
-    software-properties-common \
     build-essential \
     cmake \
     libhdf5-dev \


### PR DESCRIPTION
### Reasons for making this change

Add a GHA workflow that runs on master whenever the default-cpu/gpu dockerfiles are changed. This should build and push the images to docker hub.

### Related issues

fixes #2753 

### Screenshots

<!-- Add screenshots, if necessary -->

### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
