### PR TITLE
print status of bundle disk quota check

### DIFF
--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -1375,7 +1375,7 @@ class BundleCLI(object):
                     'Attempted to upload bundle of size %d with only %d remaining in user\'s disk quota.'
                     % (total_bundle_size, disk_left)
                 )
-            print("Bundle of size %d meets the disk quota requirement of %d, continuing..." % (total_bundle_size, disk_left), file=self.stderr)
+            print("Bundle of size %s meets the disk quota requirement of %s, continuing..." % (FileTransferProgress.format_size(total_bundle_size), FileTransferProgress.format_size(disk_left)), file=self.stderr)
             print("Preparing upload archive...", file=self.stderr)
             if args.ignore:
                 print(

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -1375,7 +1375,7 @@ class BundleCLI(object):
                     'Attempted to upload bundle of size %d with only %d remaining in user\'s disk quota.'
                     % (total_bundle_size, disk_left)
                 )
-
+            print("Bundle of size %d meets the disk quota requirement of %d, continuing..." % (total_bundle_size, disk_left), file=self.stderr)
             print("Preparing upload archive...", file=self.stderr)
             if args.ignore:
                 print(


### PR DESCRIPTION
as requested by @percyliang 

![image](https://user-images.githubusercontent.com/43913660/119784044-aea4e480-be82-11eb-9949-040bcc75721a.png)


A disk quota check is not performed on the server or client for `--link` bundles. You only get a `UsageError: Out of disk quota` whenever the disk quota is *currently* invalid (`disk_use`>`disk_quota`) for all bundles including linked -- but I do not think this is really an issue.