### PR TITLE
Fix string cast in logging statement

### DIFF
--- a/codalab/worker/docker_utils.py
+++ b/codalab/worker/docker_utils.py
@@ -119,7 +119,7 @@ def get_nvidia_devices():
     )
     # Get newline delimited gpu-index, gpu-uuid list
     output = output.decode()
-    logger.info("GPUs: " + output.split('\n')[:-1])
+    logger.info("GPUs: " + str(output.split('\n')[:-1]))
     return {gpu.split(',')[0].strip(): gpu.split(',')[1].strip() for gpu in output.split('\n')[:-1]}
 
 


### PR DESCRIPTION
Currently, workers fail with:
```
usage: cl-worker [-h] [--tag TAG] [--server SERVER] [--work-dir WORK_DIR]
                 [--network-prefix NETWORK_PREFIX] [--cpuset CPUSET_STR]
                 [--gpuset GPUSET_STR] [--max-work-dir-size SIZE]
                 [--max-image-cache-size SIZE] [--max-image-size SIZE]
                 [--max-memory SIZE] [--password-file PASSWORD_FILE]
                 [--verbose] [--exit-when-idle] [--idle-seconds IDLE_SECONDS]
                 [--checkin-frequency-seconds CHECKIN_FREQUENCY_SECONDS]
                 [--id ID] [--shared-file-system] [--group GROUP]
                 [--tag-exclusive] [--pass-down-termination]
                 [--delete-work-dir-on-exit]
                 [--exit-after-num-runs EXIT_AFTER_NUM_RUNS]
                 [--exit-on-exception]
cl-worker: error: argument --gpuset: invalid parse_gpuset_args value: 'ALL'
```

because i messed up this string concat :facepalm: 