### PR TITLE
Multiline commands rendered with newlines in the bundle tables on a worksheet

### DIFF
--- a/frontend/src/components/worksheets/BundleDetail/BundleDetailSideBar.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/BundleDetailSideBar.jsx
@@ -160,7 +160,7 @@ class BundleDetailSideBar extends React.Component<
                                 </div>        
                         </CopyToClipboard>
                         <div style={{ maxWidth: 300, flexWrap: 'wrap', flexShrink: 1}}>      
-                            {bundleInfo.command}
+                             <pre>{bundleInfo.command} </pre>
                         </div>
                     </Grid>
                 }


### PR DESCRIPTION
### Reasons for making this change

Previously, HTML cannot recognize `\n` as newline character.

### Related issues

fixes #3567

### Screenshots

<img width="1237" alt="Screen Shot 2021-05-28 at 1 53 43 AM" src="https://user-images.githubusercontent.com/34461466/119958485-efbaf880-bf57-11eb-9633-21a4b667d220.png">


### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
