### PR TITLE
Add license to ratarmount code

### DIFF
--- a/codalab/lib/beam/ratarmount.py
+++ b/codalab/lib/beam/ratarmount.py
@@ -10,6 +10,28 @@ This fork is the same code as what is found here: https://github.com/codalab/rat
 
 TODO (Ashwin): Merge changes made in this library upstream, so that we can eventually just use the
 ratarmount library from pip.
+
+MIT License
+
+Copyright (c) 2019 Maximilian K.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 """
 
 import argparse


### PR DESCRIPTION
Realized that because ratarmount is licensed under the MIT license, we need to include a copy of it.