### PR TITLE
Make wide screen view the default for all users

### DIFF
--- a/frontend/src/__tests__/__snapshots__/Worksheet.test.js.snap
+++ b/frontend/src/__tests__/__snapshots__/Worksheet.test.js.snap
@@ -606,7 +606,7 @@ Object {
           >
             <div
               class="Worksheet-worksheetOuter-2"
-              style="width: 65%;"
+              style="width: 99%;"
             >
               <div
                 class="Worksheet-worksheetDummyHeader-4"
@@ -1441,7 +1441,7 @@ Object {
         >
           <div
             class="Worksheet-worksheetOuter-2"
-            style="width: 65%;"
+            style="width: 99%;"
           >
             <div
               class="Worksheet-worksheetDummyHeader-4"

--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -98,7 +98,7 @@ class Worksheet extends React.Component {
             deleteItemCallback: null,
             copiedBundleIds: '',
             showPasteButton: window.localStorage.getItem('CopiedBundles') !== '',
-            worksheetWidthPercentage: localWorksheetWidthPreference || DEFAULT_WORKSHEET_WIDTH,
+            worksheetWidthPercentage: localWorksheetWidthPreference || EXPANDED_WORKSHEET_WIDTH,
             messagePopover: {
                 showMessage: false,
                 messageContent: null,

--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -16,7 +16,7 @@ import {
     NAVBAR_HEIGHT,
     HEADER_HEIGHT,
     EXPANDED_WORKSHEET_WIDTH,
-    DEFAULT_WORKSHEET_WIDTH,
+    NARROW_WORKSHEET_WIDTH,
     LOCAL_STORAGE_WORKSHEET_WIDTH,
     DIALOG_TYPES,
     AUTO_HIDDEN_DURATION,
@@ -847,9 +847,9 @@ class Worksheet extends React.Component {
     };
     toggleWorksheetSize = () => {
         let newPercentage =
-            this.state.worksheetWidthPercentage === DEFAULT_WORKSHEET_WIDTH
+            this.state.worksheetWidthPercentage === NARROW_WORKSHEET_WIDTH
                 ? EXPANDED_WORKSHEET_WIDTH
-                : DEFAULT_WORKSHEET_WIDTH;
+                : NARROW_WORKSHEET_WIDTH;
         window.localStorage.setItem(LOCAL_STORAGE_WORKSHEET_WIDTH, newPercentage);
         this.setState({ worksheetWidthPercentage: newPercentage });
     };

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -9,7 +9,7 @@ export const HEADER_HEIGHT = 170;
 
 // Worksheet width
 export const EXPANDED_WORKSHEET_WIDTH = '99%';
-export const DEFAULT_WORKSHEET_WIDTH = '65%';
+export const NARROW_WORKSHEET_WIDTH = '65%';
 export const FILE_SIZE_LIMIT_GB = 2;
 export const FILE_SIZE_LIMIT_B = FILE_SIZE_LIMIT_GB * 1024 * 1024 * 1024;
 export const LOCAL_STORAGE_WORKSHEET_WIDTH = 'newWorksheetWidth';

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -12,7 +12,7 @@ export const EXPANDED_WORKSHEET_WIDTH = '99%';
 export const DEFAULT_WORKSHEET_WIDTH = '65%';
 export const FILE_SIZE_LIMIT_GB = 2;
 export const FILE_SIZE_LIMIT_B = FILE_SIZE_LIMIT_GB * 1024 * 1024 * 1024;
-export const LOCAL_STORAGE_WORKSHEET_WIDTH = 'worksheetWidth';
+export const LOCAL_STORAGE_WORKSHEET_WIDTH = 'newWorksheetWidth';
 
 // Dialog constants
 export const DIALOG_TYPES = {


### PR DESCRIPTION
### Reasons for making this change

create a new key `newWorksheetWidth` in localStorage

### Related issues

fixes #3565 

### Screenshots

<img width="540" alt="Screen Shot 2021-05-29 at 12 07 11 AM" src="https://user-images.githubusercontent.com/34461466/120061433-1dfd0e80-c012-11eb-8a22-ab4f39fb65c0.png">


### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
