### PR TITLE
Fix Key Error in Competition Script

### DIFF
--- a/scripts/competitiond.py
+++ b/scripts/competitiond.py
@@ -537,7 +537,7 @@ class Competition(object):
 
     @staticmethod
     def _is_publicly_readable(bundle):
-        for perm in bundle['group_permissions']:
+        for perm in bundle.get('group_permissions', []):
             if perm['group_name'] == 'public':
                 return perm['permission'] >= GROUP_OBJECT_PERMISSION_READ
         # No permissions on public group


### PR DESCRIPTION
### Reasons for making this change

KeyError: 'group_permissions' not found while running competitiond script

### Related issues

fixes #3585 

### Screenshots

<!-- Add screenshots, if necessary -->

### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
