### PR TITLE
Provide better space usage for bundle detail info in a worksheet

### DIFF
--- a/frontend/src/components/worksheets/BundleDetail/BundleDetailSideBar.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/BundleDetailSideBar.jsx
@@ -159,7 +159,7 @@ class BundleDetailSideBar extends React.Component<
                                     </span>
                                 </div>        
                         </CopyToClipboard>
-                        <div style={{ maxWidth: 300, flexWrap: 'wrap', flexShrink: 1}}>      
+                        <div style={{  flexWrap: 'wrap', flexShrink: 1}}>
                             {bundleInfo.command}
                         </div>
                     </Grid>
@@ -308,7 +308,6 @@ const styles = (theme) => ({
 		padding: theme.spacing.large,
         borderRadius: theme.spacing.unit,
         wordWrap: 'break-all',
-        maxWidth: 300,
         flexWrap: 'wrap',
     },
     permissions: {
@@ -324,7 +323,6 @@ const styles = (theme) => ({
         paddingLeft: 2,
     },
     wrappableText: {
-        maxWidth: 300, 
         flexWrap: 'wrap', 
         flexShrink: 1,
     },

--- a/frontend/src/components/worksheets/BundleDetail/MainContent.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/MainContent.jsx
@@ -46,7 +46,7 @@ class MainContent extends React.Component<
 
 		return (
             <div className={ classes.outter }>
-    			<Grid container>    
+    			<Grid container>
                     
                     { /** Stdout/stderr components ================================================================= */}
                     <Grid container>
@@ -141,8 +141,7 @@ const styles = (theme) => ({
     },
 	snippet: {
 		fontFamily: 'monospace',
-        maxHeight: 300, 
-        width: 680,
+        maxHeight: 300,
         padding: 10,
         flexWrap: 'wrap', 
         flexShrink: 1,

--- a/frontend/src/components/worksheets/ConfigPanel/ConfigPanel.jsx
+++ b/frontend/src/components/worksheets/ConfigPanel/ConfigPanel.jsx
@@ -30,21 +30,21 @@ class ConfigPanel extends React.Component<{
         return (
             <Grid container direction='row' className={classes.container}>
                 {/* Column 1: Main content area ================================================ */}
-                <Grid item xs={12} md={sidebar ? 8 : 12}
+                <Grid item xs={12} md={sidebar ? 7 : 12}
                       container direction='column' justify='space-between' wrap='nowrap'
                       className={classes.content}>
                     <Grid item container direction='column'>
                         { children }
                     </Grid>
                     { !buttons ? null : (
-                        <Grid item container className={classes.buttons} justify='flex-end'>
+                        <Grid item container className={classes.buttons} justify='flex-start'>
                             { buttons }
                         </Grid>
                     )}
                 </Grid>
                 {/* Column 2: Sidebar ========================================================== */}
                 { !sidebar ? null : (
-                    <Grid item xs={12} md={4}
+                    <Grid item xs={12} md={5}
                           container direction='column'
                           className={classes.sidebar}>
                         { sidebar }
@@ -79,7 +79,8 @@ const styles = (theme) => ({
         padding: theme.spacing.larger,
         maxHeight: '100%',
         overflow: 'auto',
-        maxWidth: 250,
+        maxWidth: '50%',
+        flexGrow: 1,
     },
     buttons: {
         '& button': {
@@ -87,6 +88,7 @@ const styles = (theme) => ({
         },
         paddingBottom: theme.spacing.large,
         paddingTop: theme.spacing.larger,
+        maxWidth: '90%',
     }
 });
 

--- a/frontend/src/components/worksheets/ConfigPanel/ConfigPanel.jsx
+++ b/frontend/src/components/worksheets/ConfigPanel/ConfigPanel.jsx
@@ -30,7 +30,7 @@ class ConfigPanel extends React.Component<{
         return (
             <Grid container direction='row' className={classes.container}>
                 {/* Column 1: Main content area ================================================ */}
-                <Grid item xs={12} md={sidebar ? 7 : 12}
+                <Grid item xs={12} md={sidebar ? 9 : 12}
                       container direction='column' justify='space-between' wrap='nowrap'
                       className={classes.content}>
                     <Grid item container direction='column'>
@@ -44,7 +44,7 @@ class ConfigPanel extends React.Component<{
                 </Grid>
                 {/* Column 2: Sidebar ========================================================== */}
                 { !sidebar ? null : (
-                    <Grid item xs={12} md={5}
+                    <Grid item xs={12} md={3}
                           container direction='column'
                           className={classes.sidebar}>
                         { sidebar }


### PR DESCRIPTION
### Reasons for making this change

File browser of a bundle view in a worksheet matches the size of the screen

### Related issues

fixes #3566 

### Screenshots
![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/34461466/120588887-d2b97600-c3ec-11eb-9d91-e70bd01af33d.gif)

### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
