### PR TITLE
Have the bundle manager check for unresponsive bundles less frequently

### DIFF
--- a/codalab/bin/bundle_manager.py
+++ b/codalab/bin/bundle_manager.py
@@ -19,9 +19,19 @@ def main():
         type=int,
         default=60,
     )
+    parser.add_argument(
+        '--unresponsive-bundles-check-frequency-hours',
+        help='Number of hours between checks for failing unresponsive bundles.',
+        type=int,
+        default=8,
+    )
     args = parser.parse_args()
 
-    manager = BundleManager(CodaLabManager(), args.worker_timeout_seconds)
+    manager = BundleManager(
+        CodaLabManager(),
+        args.worker_timeout_seconds,
+        args.unresponsive_bundles_check_frequency_hours,
+    )
     # Register a signal handler to ensure safe shutdown.
     for sig in [signal.SIGTERM, signal.SIGINT, signal.SIGHUP]:
         signal.signal(sig, lambda signup, frame: manager.signal())

--- a/codalab_service.py
+++ b/codalab_service.py
@@ -276,6 +276,12 @@ CODALAB_ARGUMENTS = [
         type=int,
         default=60,
     ),
+    CodalabArg(
+        name='bundle_manager_unresponsive_bundles_check_frequency_hours',
+        help='Number of hours between checks for failing unresponsive bundles.',
+        type=int,
+        default=8,
+    ),
     # Worker manager
     CodalabArg(
         name='worker_manager_type',

--- a/docker_config/compose_files/docker-compose.yml
+++ b/docker_config/compose_files/docker-compose.yml
@@ -120,6 +120,7 @@ services:
     command: |
       cl-bundle-manager
       --worker-timeout-seconds ${CODALAB_BUNDLE_MANAGER_WORKER_TIMEOUT_SECONDS}
+      --unresponsive-bundles-check-frequency-hours ${CODALAB_BUNDLE_MANAGER_UNRESPONSIVE_BUNDLES_CHECK_FREQUENCY_HOURS}
     <<: *codalab-base
     <<: *codalab-server
     depends_on:


### PR DESCRIPTION
### Reasons for making this change

The bundle manager checking for unresponsive bundles is quite expensive. This PR simply reduces the number of times we check for unresponsive bundles.

### Related issues

Resolves https://github.com/codalab/codalab-worksheets/issues/3563

### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
