### PR TITLE
Better logging when unzip or file uploads fail, fix zip file upload error

### DIFF
--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -836,6 +836,11 @@ def _update_bundle_contents_blob(uuid):
                     'metadata': {'failure_message': msg, 'error_traceback': traceback.format_exc()},
                 },
             )
+        else:
+            local.model.update_bundle(
+                bundle,
+                {'metadata': {'failure_message': msg, 'error_traceback': traceback.format_exc()},},
+            )
 
         abort(http.client.INTERNAL_SERVER_ERROR, msg)
 

--- a/codalab/worker/file_util.py
+++ b/codalab/worker/file_util.py
@@ -171,9 +171,17 @@ def unzip_directory(fileobj: IO[bytes], directory_path: str, force: bool = False
     #         zf.extract(member, directory_path)
 
     def do_unzip(filename):
-        exitcode = subprocess.call(['unzip', '-q', filename, '-d', directory_path])
+        exitcode = subprocess.Popen(
+            ['unzip', '-q', filename, '-d', directory_path], stdout=subprocess.PIPE
+        )
+        exitcode = proc.wait()
         if exitcode != 0:
-            raise UsageError('Invalid archive upload. ')
+            logging.error(
+                "Invalid archive upload: failed to unzip .zip file. stderr: <%s>. stdout: <%s>.",
+                proc.stderr(),
+                proc.stdout(),
+            )
+            raise UsageError('Invalid archive upload: failed to unzip .zip file.')
 
     # We have to save fileobj to a temporary file, because unzip doesn't accept input from standard input.
     with tempfile.NamedTemporaryFile() as f:

--- a/codalab/worker/file_util.py
+++ b/codalab/worker/file_util.py
@@ -179,8 +179,8 @@ def unzip_directory(fileobj: IO[bytes], directory_path: str, force: bool = False
         if exitcode != 0:
             logging.error(
                 "Invalid archive upload: failed to unzip .zip file. stderr: <%s>. stdout: <%s>.",
-                proc.stderr(),
-                proc.stdout(),
+                proc.stderr.read(),
+                proc.stdout.read(),
             )
             raise UsageError('Invalid archive upload: failed to unzip .zip file.')
 

--- a/codalab/worker/file_util.py
+++ b/codalab/worker/file_util.py
@@ -173,7 +173,9 @@ def unzip_directory(fileobj: IO[bytes], directory_path: str, force: bool = False
 
     def do_unzip(filename):
         proc = subprocess.Popen(
-            ['unzip', '-q', filename, '-d', directory_path], stdout=subprocess.PIPE
+            ['unzip', '-q', filename, '-d', directory_path],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
         )
         exitcode = proc.wait()
         if exitcode != 0:

--- a/codalab/worker/file_util.py
+++ b/codalab/worker/file_util.py
@@ -189,7 +189,7 @@ def unzip_directory(fileobj: IO[bytes], directory_path: str, force: bool = False
     # We have to save fileobj to a temporary file, because unzip doesn't accept input from standard input.
     with tempfile.NamedTemporaryFile() as f:
         shutil.copyfileobj(fileobj, f)
-        f.seek(0)
+        f.flush()
         do_unzip(f.name)
 
 

--- a/codalab/worker/file_util.py
+++ b/codalab/worker/file_util.py
@@ -1,6 +1,7 @@
 from contextlib import closing
 from io import BytesIO, TextIOWrapper
 import gzip
+import logging
 import os
 import shutil
 import subprocess

--- a/codalab/worker/file_util.py
+++ b/codalab/worker/file_util.py
@@ -171,7 +171,7 @@ def unzip_directory(fileobj: IO[bytes], directory_path: str, force: bool = False
     #         zf.extract(member, directory_path)
 
     def do_unzip(filename):
-        exitcode = subprocess.Popen(
+        proc = subprocess.Popen(
             ['unzip', '-q', filename, '-d', directory_path], stdout=subprocess.PIPE
         )
         exitcode = proc.wait()


### PR DESCRIPTION
- Better logging when unzip fails. We don't have any logging when the unzip command fails, so it's hard to investigate failures like https://github.com/codalab/codalab-worksheets/issues/3579.
- Store upload errors in error_traceback even when finalize_on_failure is 0.
- Fixes https://github.com/codalab/codalab-worksheets/issues/3579 zip uploading issue