### PR TITLE
Properly set finalize_on_failure=1 on file uploads from the web UI

### DIFF
--- a/frontend/src/util/apiWrapper.js
+++ b/frontend/src/util/apiWrapper.js
@@ -133,7 +133,7 @@ export async function createFileBundle(url, data, errorHandler) {
 export function getQueryParams(filename) {
     const formattedFilename = createDefaultBundleName(filename);
     const queryParams = {
-        finalize: 1,
+        finalize_on_failure: 1,
         filename: pathIsArchive(filename)
             ? formattedFilename + getArchiveExt(filename)
             : formattedFilename,


### PR DESCRIPTION
Properly set finalize_on_failure on file uploads from the web UI. Previously, `finalize=1` is set, but finalize has no effect at all when uploading (perhaps it was renamed to finalize_on_failure and we didn't change it on the frontend?)

Additionally, it makes sense to set finalize_on_failure to 1, because in the case of uploads from the web UI, we aren't able to retry uploads (so a single upload failure is final).