### PR TITLE
Revert "Monitor: Show results of df in human-readable format"

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -251,7 +251,7 @@ def backup_db():
 
 
 def check_disk_space(paths):
-    lines = run_command(['df', '-h'] + paths).split('\n')[1:]
+    lines = run_command(['df'] + paths).split('\n')[1:]
     results = [int(line.split()[3]) for line in lines]
     # Flag an error if disk space running low
     total = sum(results)


### PR DESCRIPTION
Reverts codalab/codalab-worksheets#3610. Fixes https://github.com/codalab/codalab-worksheets/issues/3621 because the code assumes that everything should be ints, not human-formatted.