### PR TITLE
Fix "python" executable in default-cpu and default-gpu

### DIFF
--- a/docker_config/dockerfiles/Dockerfile.default-cpu
+++ b/docker_config/dockerfiles/Dockerfile.default-cpu
@@ -28,7 +28,7 @@ RUN apt-get update && apt-get install -y \
     openjdk-8-jdk && \
     rm -rf /var/lib/apt/lists/*
 
-# Set Python3.6 as the default python3 version
+# Set Python3.6 as the default python version
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 1
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.6 1
 

--- a/docker_config/dockerfiles/Dockerfile.default-cpu
+++ b/docker_config/dockerfiles/Dockerfile.default-cpu
@@ -30,6 +30,7 @@ RUN apt-get update && apt-get install -y \
 
 # Set Python3.6 as the default python3 version
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 1
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.6 1
 
 RUN curl https://bootstrap.pypa.io/get-pip.py | python3.6
 

--- a/docker_config/dockerfiles/Dockerfile.default-cpu
+++ b/docker_config/dockerfiles/Dockerfile.default-cpu
@@ -73,3 +73,5 @@ RUN python3 -m pip install -U --no-cache-dir \
 
 RUN python3 -m spacy download en_core_web_sm
 
+# Check to make sure python works from the command line
+RUN python

--- a/docker_config/dockerfiles/Dockerfile.default-gpu
+++ b/docker_config/dockerfiles/Dockerfile.default-gpu
@@ -28,8 +28,9 @@ RUN apt-get update && apt-get install -y \
     openjdk-8-jdk && \
     rm -rf /var/lib/apt/lists/*
 
-# Set Python3.6 as the default python3 version
+# Set Python3.6 as the default python version
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 1
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.6 1
 
 RUN curl https://bootstrap.pypa.io/get-pip.py | python3.6
 
@@ -82,3 +83,6 @@ RUN git clone https://github.com/NVIDIA/apex.git
 WORKDIR /tmp/apex_install/apex
 RUN python3 -m pip install --disable-pip-version-check --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" ./
 WORKDIR /
+
+# Check to make sure python works from the command line
+RUN python


### PR DESCRIPTION
### Reasons for making this change

Fix "python" executable in default-cpu and default-gpu dockerfiles so that it points to Python 3.6.