### PR TITLE
Bump v0.5.56

### DIFF
--- a/codalab/common.py
+++ b/codalab/common.py
@@ -17,7 +17,7 @@ from enum import Enum
 
 # Increment this on master when ready to cut a release.
 # http://semver.org/
-CODALAB_VERSION = '0.5.55'
+CODALAB_VERSION = '0.5.56'
 BINARY_PLACEHOLDER = '<binary>'
 URLOPEN_TIMEOUT_SECONDS = int(os.environ.get('CODALAB_URLOPEN_TIMEOUT_SECONDS', 5 * 60))
 

--- a/docs/REST-API-Reference.md
+++ b/docs/REST-API-Reference.md
@@ -1,6 +1,6 @@
 # REST API Reference
 
-_version 0.5.55_
+_version 0.5.56_
 
 This reference and the REST API itself is still under heavy development and is
 subject to change at any time. Feedback through our GitHub issues is appreciated!

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -1,5 +1,5 @@
 // Should match codalab/common.py#CODALAB_VERSION
-export const CODALAB_VERSION = '0.5.55';
+export const CODALAB_VERSION = '0.5.56';
 
 // Name Regex to match the backend in spec_utils.py
 export const NAME_REGEX = /^[a-zA-Z_][a-zA-Z0-9_.-]*$/i;

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import sys
 
 
 # should match codalab/common.py#CODALAB_VERSION
-CODALAB_VERSION = "0.5.55"
+CODALAB_VERSION = "0.5.56"
 
 
 class Install(install):


### PR DESCRIPTION
# Release notes

## Backend

- Fix "python" executable in default-cpu and default-gpu (#3626)
- Blob Storage: fix dependency download for make bundles (#3520) 
- Kubernetes Batch Worker Manager (#3549)