### PR TITLE
Don't install tensorflow-gpu in default-cpu dockerfile

### DIFF
--- a/docker_config/dockerfiles/Dockerfile.default-cpu
+++ b/docker_config/dockerfiles/Dockerfile.default-cpu
@@ -66,7 +66,7 @@ RUN python3 -m pip install -U --no-cache-dir \
       scikit-learn \
       scikit-image \
       nltk \
-      tensorflow-gpu==1.12.0 \
+      tensorflow==1.12.0 \
       tensorboard \
       keras \
       torch==1.1.0 \


### PR DESCRIPTION
Don't install tensorflow-gpu in default-cpu dockerfile. Fixes https://github.com/codalab/codalab-worksheets/issues/2754
