### PR TITLE
Add test and fix for disappearing dependency issue #3627

### DIFF
--- a/codalab/worker/worker.py
+++ b/codalab/worker/worker.py
@@ -659,6 +659,7 @@ class Worker:
                 is_restaged=False,
                 cpu_usage=0.0,
                 memory_usage=0.0,
+                paths_to_remove=[],
             )
             # Start measuring bundle stats for the initial bundle state.
             self.start_stage_stats(bundle.uuid, RunStage.PREPARING)

--- a/codalab/worker/worker_run_state.py
+++ b/codalab/worker/worker_run_state.py
@@ -355,6 +355,7 @@ class RunStateMachine(StateTransitioner):
                         )
                     )
                     self.paths_to_remove.append(child_path)
+                    logging.info("ADDING PATHS TO REMOVE 1: %s", child_path)
             else:
                 to_mount.append(
                     DependencyToMount(
@@ -367,11 +368,13 @@ class RunStateMachine(StateTransitioner):
                 first_element_of_path = Path(dep.child_path).parts[0]
                 if first_element_of_path == RunStateMachine._ROOT:
                     self.paths_to_remove.append(full_child_path)
+                    logging.info("ADDING PATHS TO REMOVE 2: %s", full_child_path)
                 else:
                     # child_path can be a nested path, so later remove everything from the first element of the path
                     self.paths_to_remove.append(
                         os.path.join(run_state.bundle_path, first_element_of_path)
                     )
+                    logging.info("ADDING PATHS TO REMOVE 3: %s", os.path.join(run_state.bundle_path, first_element_of_path))
             for dependency in to_mount:
                 try:
                     mount_dependency(dependency, self.shared_file_system)
@@ -609,9 +612,9 @@ class RunStateMachine(StateTransitioner):
         # Clean up dependencies paths
         # TODO: This is commented out as a temporary fix for https://github.com/codalab/codalab-worksheets/issues/3627.
         # Let's find a better solution in the future.
-        print("GOING TO REMOVE PATHS", self.paths_to_remove)
-        # for path in self.paths_to_remove:
-        #     remove_path_no_fail(path)
+        logger.info("PATHS TO REMOVE: %s", self.paths_to_remove)
+        for path in self.paths_to_remove:
+            remove_path_no_fail(path)
         self.paths_to_remove = []
 
         if run_state.is_restaged:

--- a/codalab/worker/worker_run_state.py
+++ b/codalab/worker/worker_run_state.py
@@ -607,9 +607,11 @@ class RunStateMachine(StateTransitioner):
                 self.dependency_manager.release(run_state.bundle.uuid, dep_key)
 
         # Clean up dependencies paths
-        for path in self.paths_to_remove:
-            remove_path_no_fail(path)
-        self.paths_to_remove = []
+        # TODO: This is commented out as a temporary fix for https://github.com/codalab/codalab-worksheets/issues/3627.
+        # Let's find a better solution in the future.
+        # for path in self.paths_to_remove:
+        #     remove_path_no_fail(path)
+        # self.paths_to_remove = []
 
         if run_state.is_restaged:
             log_bundle_transition(

--- a/codalab/worker/worker_run_state.py
+++ b/codalab/worker/worker_run_state.py
@@ -609,9 +609,10 @@ class RunStateMachine(StateTransitioner):
         # Clean up dependencies paths
         # TODO: This is commented out as a temporary fix for https://github.com/codalab/codalab-worksheets/issues/3627.
         # Let's find a better solution in the future.
+        print("GOING TO REMOVE PATHS", self.paths_to_remove)
         # for path in self.paths_to_remove:
         #     remove_path_no_fail(path)
-        # self.paths_to_remove = []
+        self.paths_to_remove = []
 
         if run_state.is_restaged:
             log_bundle_transition(

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1507,7 +1507,9 @@ def test_link(ctx):
 
 @TestModule.register('run2')
 def test_run2(ctx):
-    # Test that finishing a bundle (uuid2) with a dependency doesn't delete the dependency for another running bundle (uuid1) dependent on that same dependency; this is the scenario reported in https://github.com/codalab/codalab-worksheets/issues/3627.
+    # Test that finishing a bundle (uuid2) with a dependency doesn't delete the dependency
+    # for another running bundle (uuid1) dependent on that same dependency; this is the
+    # scenario reported in https://github.com/codalab/codalab-worksheets/issues/3627.
     dir3 = _run_command([cl, 'upload', test_path('dir3')])
     uuid1 = _run_command(
         [cl, 'run', 'dir3:%s' % dir3, 'for x in {1..100}; do ls dir3 && sleep 1; done']

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1507,6 +1507,18 @@ def test_link(ctx):
 
 @TestModule.register('run2')
 def test_run2(ctx):
+    # Test that finishing a bundle (uuid2) with a dependency doesn't delete the dependency for another running bundle (uuid1) dependent on that same dependency; this is the scenario reported in https://github.com/codalab/codalab-worksheets/issues/3627.
+    dir3 = _run_command([cl, 'upload', test_path('dir3')])
+    uuid1 = _run_command(
+        [cl, 'run', 'dir3:%s' % dir3, 'for x in {1..100}; do ls dir3 && sleep 1; done']
+    )
+    uuid2 = _run_command(
+        [cl, 'run', 'dir3:%s' % dir3, 'for x in {1..10}; do ls dir3 && sleep 1; done']
+    )
+    wait(uuid2)
+    check_equals(State.RUNNING, get_info(uuid1, 'state'))
+    wait(uuid1)
+
     # Test that content of dependency is mounted at the top when . is specified as the dependency key
     dir3 = _run_command([cl, 'upload', test_path('dir3')])
     uuid = _run_command([cl, 'run', '.:%s' % dir3, 'cat f1'])


### PR DESCRIPTION
Add test that replicates the disappearing dependency issue https://github.com/codalab/codalab-worksheets/issues/3627 and adds a fix for it.

The issue appears to be that finishing a bundle with a dependency deletes the dependency for another running bundle that is dependent on that same dependency.

Here's how I found the issue:

I tested things out on this worksheet on dev: https://worksheets-dev.codalab.org/worksheets/0x5dd52af376db46f4bb57d57efe5a78d9

I noticed that there was a pattern; note that the time 0xac0230 fails is actually right after when 0x72c5c1 is completed.

![image](https://user-images.githubusercontent.com/1689183/124400898-db56e200-dcf3-11eb-826c-1834111d2448.png)
![image](https://user-images.githubusercontent.com/1689183/124400232-f5da8c80-dcee-11eb-9717-bc5eb3cba0aa.png)

In fact, the logs say that 0x72c5c1 changed to "finished" at 20:46:33.

```
2021-07-04 20:46:33,841 Finished run with UUID 0x72c5c18299804510b276262acd95cc0a, exitcode 0, failure_message None /opt/codalab/worker/worker_run_state.py 562
```

Just 3 seconds later is the failure time of the bundle 0xac0230 (20:46:36 = 20:37:40 + 8:56), which is pretty close to 20:46:33.

A similar pattern occurs for the last 3 bundles. Note how the first 2 bundles (which just check for the directory's existence from 1 to 10000 seconds) are working fine, until they fail right when the third bundle finishes after 100 seconds:

![image](https://user-images.githubusercontent.com/1689183/124400305-68e40300-dcef-11eb-9cc2-9cedd2845dfd.png)

When looking at the logic that happens when a bundle is transitioned from cleaning up -> finished, note that dependencies are deleted in this section of code:

https://github.com/codalab/codalab-worksheets/blob/178fa23ecfa5061830d06107e4bb5ba6cc9d69d6/codalab/worker/worker_run_state.py#L610-L612

This, indeed, is the problematic code and I've fixed this issue in this PR. This code was introduced by @teetone in https://github.com/codalab/codalab-worksheets/pull/2295. @nelson-liu did identify that PR as the cause of the issue in https://github.com/codalab/codalab-worksheets/issues/2440#issuecomment-646401762, but I think we probably missed that / further investigating into that issue.