### PR TITLE
Fix blob upload issue for large files

### DIFF
--- a/codalab/lib/beam/blobstorageuploader.py
+++ b/codalab/lib/beam/blobstorageuploader.py
@@ -51,8 +51,6 @@ class BlobStorageUploader(Uploader):
     self.block_number = self.block_number + 1
 
   def finish(self):
-    while len(self.buffer) > 0:
-      # Take the first chunk off the buffer and write it to Blob Storage
-      chunk = self.buffer.read(BlobStorageUploader.MAX_WRITE_SIZE)
-      self._write_to_blob(chunk)
+    # The buffer will have a size smaller than MIN_WRITE_SIZE, so its contents can fit into memory.
+    self._write_to_blob(self.buffer.read())
     self._blob_to_upload.commit_block_list(self.block_list, content_settings=self._content_settings)

--- a/codalab/lib/beam/blobstorageuploader.py
+++ b/codalab/lib/beam/blobstorageuploader.py
@@ -12,6 +12,15 @@ class BlobStorageUploader(Uploader):
   that handles multipart streaming (block-by-block) uploads.
   TODO (Ashwin): contribute this back upstream to Apache Beam (https://github.com/codalab/codalab-worksheets/issues/3475).
   """
+  # Note that Blob Storage currently can hold a maximum of 100,000 uncommitted blocks.
+  # This means that with this current implementation, we can upload a file with a maximum
+  # size of 10 TiB to Blob Storage. To exceed that limit, we must either increase MIN_WRITE_SIZE
+  # or modify the implementation of this class to call commit_block_list more often (and not
+  # just at the end of the upload). 
+  MIN_WRITE_SIZE = 100 * 1024 * 1024
+  # Maximum block size is 4000 MiB (https://docs.microsoft.com/en-us/rest/api/storageservices/put-block#remarks).
+  MAX_WRITE_SIZE = 4000 * 1024 * 1024
+
   def __init__(self, client, path, mime_type='application/octet-stream'):
     self._client = client
     self._path = path
@@ -26,20 +35,11 @@ class BlobStorageUploader(Uploader):
     self.block_list = []
 
   def put(self, data):
-    # Note that Blob Storage currently can hold a maximum of 100,000 uncommitted blocks.
-    # This means that with this current implementation, we can upload a file with a maximum
-    # size of 10 TiB to Blob Storage. To exceed that limit, we must either increase MIN_WRITE_SIZE
-    # or modify the implementation of this class to call commit_block_list more often (and not
-    # just at the end of the upload). 
-    MIN_WRITE_SIZE = 100 * 1024 * 1024
-    # Maximum block size is 4000 MiB (https://docs.microsoft.com/en-us/rest/api/storageservices/put-block#remarks).
-    MAX_WRITE_SIZE = 4000 * 1024 * 1024
-
     self.buffer.write(data.tobytes())
 
-    while len(self.buffer) >= MIN_WRITE_SIZE:
+    while len(self.buffer) >= BlobStorageUploader.MIN_WRITE_SIZE:
       # Take the first chunk off the buffer and write it to Blob Storage
-      chunk = self.buffer.read(MAX_WRITE_SIZE)
+      chunk = self.buffer.read(BlobStorageUploader.MAX_WRITE_SIZE)
       self._write_to_blob(chunk)
 
   def _write_to_blob(self, data):
@@ -51,5 +51,8 @@ class BlobStorageUploader(Uploader):
     self.block_number = self.block_number + 1
 
   def finish(self):
-    self._write_to_blob(self.buffer)
+    while len(self.buffer) > 0:
+      # Take the first chunk off the buffer and write it to Blob Storage
+      chunk = self.buffer.read(BlobStorageUploader.MAX_WRITE_SIZE)
+      self._write_to_blob(chunk)
     self._blob_to_upload.commit_block_list(self.block_list, content_settings=self._content_settings)


### PR DESCRIPTION
Fixes #3665. The problem was that upon `finish()` being called on the BlobStorageUploader, we were calling _write_to_blob (and thus stage_block) directly with the BytesBuffer `self.buffer` as the argument. This has two problems:
- I don't think Blob Storage plays well with us directly passing in a custom class to stage_block. It really just expects a bytestring instead.
- If self.buffer is longer than the maximum block size, then this will cause an error.

Thus, the solution is to split it into chunks, similar to the logic in `put` that periodically calls `_write_to_blob`.