### PR TITLE
Update Dockerfile.default-cpu

### DIFF
--- a/docker_config/dockerfiles/Dockerfile.default-cpu
+++ b/docker_config/dockerfiles/Dockerfile.default-cpu
@@ -6,7 +6,6 @@ RUN apt-get update && apt-get install -y \
     software-properties-common
 RUN add-apt-repository ppa:deadsnakes/ppa 
 
-
 ############################################################
 # Common steps (must be the same in the CPU and GPU images)
 


### PR DESCRIPTION
Testing CI because CI failed earlier (https://github.com/codalab/codalab-worksheets/actions/runs/1006344735) with a similar issue to https://github.com/actions/runner/issues/932.