### PR TITLE
Fix signup error when user is already logged in, fixes #3698

### DIFF
--- a/codalab/rest/account.py
+++ b/codalab/rest/account.py
@@ -2,7 +2,7 @@
 Login and signup views.
 Handles create new user accounts and authenticating users.
 """
-from bottle import request, response, template, local, redirect, default_app, get, post
+from bottle import request, response, template, local, redirect, get, post
 import requests
 import os
 from codalab.lib import crypt_util, spec_util

--- a/codalab/rest/account.py
+++ b/codalab/rest/account.py
@@ -63,11 +63,6 @@ def do_login():
 
 @post('/account/signup')
 def do_signup():
-    if request.user.is_authenticated:
-        return redirect(
-            default_app().get_url('success', message="You are already logged into your account.")
-        )
-
     success_uri = request.forms.get('success_uri')
     error_uri = request.forms.get('error_uri')
     username = request.forms.get('username')

--- a/tests/unit/rest/account_test.py
+++ b/tests/unit/rest/account_test.py
@@ -48,3 +48,25 @@ class UserTest(BaseTestCase):
         response = self.app.post('/rest/account/signup', body)
         self.assertEqual(response.status_int, 302)
         self.assertTrue('error=Google+reCAPTCHA+token+is+missing.' in response.headers["Location"])
+
+    def test_user_signup_fails_when_already_logged_in(self):
+        """User signup should fail when the user is already logged in."""
+        os.environ["CODALAB_TEST_USER"] = "codalab"
+        email = "test@test.com{}".format(random.getrandbits(16))
+        username = "test{}".format((random.getrandbits(16)))
+        body = {
+            'email': email,
+            'username': username,
+            'first_name': "test",
+            'last_name': "test",
+            'affiliation': "None",
+            'password': "testtest",
+            'confirm_password': "testtest",
+            'success_uri': "/account/signup/success",
+            'error_uri': "/account/signup",
+            'token': 'test',
+        }
+        response = self.app.post('/rest/account/signup', body)
+        self.assertEqual(response.status_int, 302)
+        self.assertIn("/account/signup?", response.headers["Location"])
+        self.assertIn("already+logged+in", response.headers["Location"])


### PR DESCRIPTION
Fix signup error when user is already logged in, fixes part of #3698. Removed redundant error-handling code as this error case is already dealt with later on in the file:

https://github.com/codalab/codalab-worksheets/blob/e0a317573c35cf4fd7899d39bf6e9e98bba9ebd4/codalab/rest/account.py#L96-L100

Now, it will show this error:

![image](https://user-images.githubusercontent.com/1689183/124948205-7abef200-dfde-11eb-982c-2ea2fe82f257.png)
