### PR TITLE
Competition script fix: handle dependencies that have been force deleted + update doc

### DIFF
--- a/docs/Competitions.md
+++ b/docs/Competitions.md
@@ -155,6 +155,9 @@ competition organizers, tagging the bundle appropriately, then waiting for the n
 new submissions. The [submission tutorial for the SQuAD competition](https://worksheets.codalab.org/worksheets/0x8403d867f9a3444685c344f4f0bc8d34/) 
 provides a good example.
 
+When submitting a bundle, please ensure none of your submission bundle's dependencies have been deleted. Otherwise,
+your submission bundle will be disregarded as an invalid submission.
+
 ## FAQ / Known issues
 
 * Q: How do I reset the quota for a participant?

--- a/scripts/competitiond.py
+++ b/scripts/competitiond.py
@@ -482,7 +482,7 @@ class Competition(object):
         except NotFoundError:
             logger.info(
                 "Submission {uuid} by {owner[user_name]} has dependencies "
-                "that has been deleted.".format(**submit_bundle)
+                "that have been deleted.".format(**submit_bundle)
             )
             return None
 

--- a/scripts/competitiond.py
+++ b/scripts/competitiond.py
@@ -468,7 +468,7 @@ class Competition(object):
         }
 
         # Do dry run to check if the submission bundle has the right dependencies
-        # and all of its ancestors exists.
+        # and all of its ancestors exist.
         # If the submission bundle is not mimicked (i.e. not in the mimic plan),
         # that means that none of its ancestors are in the set of bundles that
         # we are trying to replace.

--- a/scripts/competitiond.py
+++ b/scripts/competitiond.py
@@ -467,14 +467,22 @@ class Competition(object):
             'skip_prelude': True,
         }
 
-        # Do dry run to check if the submission has the right dependencies.
+        # Do dry run to check if the submission bundle has the right dependencies
+        # and all of its ancestors exists.
         # If the submission bundle is not mimicked (i.e. not in the mimic plan),
         # that means that none of its ancestors are in the set of bundles that
         # we are trying to replace.
-        if find_mimicked(mimic_bundles(dry_run=True, **mimic_args)) is None:
+        try:
+            if find_mimicked(mimic_bundles(dry_run=True, **mimic_args)) is None:
+                logger.info(
+                    "Submission {uuid} by {owner[user_name]} is missing "
+                    "expected dependencies.".format(**submit_bundle)
+                )
+                return None
+        except NotFoundError:
             logger.info(
-                "Submission {uuid} by {owner[user_name]} is missing "
-                "expected dependencies.".format(**submit_bundle)
+                "Submission {uuid} by {owner[user_name]} has dependencies "
+                "that has been deleted.".format(**submit_bundle)
             )
             return None
 


### PR DESCRIPTION
### Reasons for making this change

I was able to reproduce the issue by creating a test competition and force deleting one of my submission bundle's dependencies. We resolve the issue by skipping the problematic submission bundles and printing a message to the competition runner (see screenshot below).

### Related issues

Resolves #3664

### Screenshots

![Screen Shot 2021-07-09 at 10 10 17 AM](https://user-images.githubusercontent.com/16793796/125113777-ec11aa00-e09d-11eb-8b94-40ebbe3c7531.png)

### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
