### PR TITLE
Bump version to 1.0.3

### DIFF
--- a/codalab/common.py
+++ b/codalab/common.py
@@ -17,7 +17,7 @@ from enum import Enum
 
 # Increment this on master when ready to cut a release.
 # http://semver.org/
-CODALAB_VERSION = '1.0.2'
+CODALAB_VERSION = '1.0.3'
 BINARY_PLACEHOLDER = '<binary>'
 URLOPEN_TIMEOUT_SECONDS = int(os.environ.get('CODALAB_URLOPEN_TIMEOUT_SECONDS', 5 * 60))
 

--- a/codalab/worker/image_manager.py
+++ b/codalab/worker/image_manager.py
@@ -3,6 +3,7 @@ import threading
 import time
 import traceback
 from collections import namedtuple
+from typing import Optional
 
 from codalab.lib.formatting import size_str
 from codalab.worker.fsm import DependencyStage
@@ -37,6 +38,7 @@ class ImageManager:
         self._downloading = ThreadDict(
             fields={'success': False, 'status': 'Download starting'}, lock=True
         )
+        self._cleanup_thread = None  # type: Optional[threading.Thread]
 
     def start(self) -> None:
         """

--- a/docs/REST-API-Reference.md
+++ b/docs/REST-API-Reference.md
@@ -1,6 +1,6 @@
 # REST API Reference
 
-_version 1.0.2_
+_version 1.0.3_
 
 This reference and the REST API itself is still under heavy development and is
 subject to change at any time. Feedback through our GitHub issues is appreciated!

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -1,5 +1,5 @@
 // Should match codalab/common.py#CODALAB_VERSION
-export const CODALAB_VERSION = '1.0.2';
+export const CODALAB_VERSION = '1.0.3';
 
 // Name Regex to match the backend in spec_utils.py
 export const NAME_REGEX = /^[a-zA-Z_][a-zA-Z0-9_.-]*$/i;

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import sys
 
 
 # should match codalab/common.py#CODALAB_VERSION
-CODALAB_VERSION = "1.0.2"
+CODALAB_VERSION = "1.0.3"
 
 
 class Install(install):


### PR DESCRIPTION
@adiprerepa @teetone I'm going to make this a patch version because even though we added a new feature, it's not an actually usable feature yet -- so the change is effectively a refactoring of DockerImageManager in #3569.

Release notes:


## Backend
- Refactor and abstract docker image manager for future use with singularity (#3569).