### PR TITLE
fix worker stuck in cleanup issue

### DIFF
--- a/codalab/worker/image_manager.py
+++ b/codalab/worker/image_manager.py
@@ -37,6 +37,7 @@ class ImageManager:
         self._downloading = ThreadDict(
             fields={'success': False, 'status': 'Download starting'}, lock=True
         )
+        self._cleanup_thread = None
 
     def start(self) -> None:
         """

--- a/codalab/worker/image_manager.py
+++ b/codalab/worker/image_manager.py
@@ -3,6 +3,7 @@ import threading
 import time
 import traceback
 from collections import namedtuple
+from typing import Optional
 
 from codalab.lib.formatting import size_str
 from codalab.worker.fsm import DependencyStage
@@ -37,7 +38,7 @@ class ImageManager:
         self._downloading = ThreadDict(
             fields={'success': False, 'status': 'Download starting'}, lock=True
         )
-        self._cleanup_thread = None
+        self._cleanup_thread = None  # type: Optional[threading.Thread]
 
     def start(self) -> None:
         """


### PR DESCRIPTION
this fixes the issue with workers not stopping properly: https://github.com/codalab/codalab-worksheets/issues/3729

`_cleanup_thread` was not initialized in `image_manager.py`. I reproduced it locally, and this fixes it.

cc @epicfaace 