### PR TITLE
Fix link to REST API reference on https://worksheets.codalab.org/

### DIFF
--- a/frontend/src/routes/HomePage.js
+++ b/frontend/src/routes/HomePage.js
@@ -270,7 +270,7 @@ class HomePage extends React.Component<{
                                         {this.renderTableItem(
                                             'REST API Reference',
                                             'Develop your own application against our REST API.',
-                                            'https://github.com/codalab/codalab-worksheets/blob/master/docs/rest.md',
+                                            'https://codalab-worksheets.readthedocs.io/en/latest/REST-API-Reference',
                                         )}
                                         {this.renderTableItem(
                                             'Execution',


### PR DESCRIPTION
The previous link was broken.