### PR TITLE
Fix error with folder upload

### DIFF
--- a/frontend/src/components/worksheets/NewUpload/NewUpload.jsx
+++ b/frontend/src/components/worksheets/NewUpload/NewUpload.jsx
@@ -165,7 +165,7 @@ class NewUpload extends React.Component<{
         let url = `/rest/bundles?worksheet=${worksheetUUID}`;
         url += `&after_sort_key=${isNaN(after_sort_key) ? -1 : after_sort_key}`;
 
-        if (focusedItem.mode === 'image_block') {
+        if (focusedItem && focusedItem.mode === 'image_block') {
             url += `&after_image=1`;
         }
 


### PR DESCRIPTION
The error was due to `focusedItem` being null / undefined in this line:

![image](https://user-images.githubusercontent.com/1689183/130792507-c3268c56-1b87-45f7-8376-208412b9d139.png)


Fixes https://github.com/codalab/codalab-worksheets/issues/3762