### PR TITLE
Bump version to 1.1.0

### DIFF
--- a/codalab/common.py
+++ b/codalab/common.py
@@ -26,7 +26,7 @@ from codalab.lib.beam.filesystems import (
 
 # Increment this on master when ready to cut a release.
 # http://semver.org/
-CODALAB_VERSION = '1.0.3'
+CODALAB_VERSION = '1.1.0'
 BINARY_PLACEHOLDER = '<binary>'
 URLOPEN_TIMEOUT_SECONDS = int(os.environ.get('CODALAB_URLOPEN_TIMEOUT_SECONDS', 5 * 60))
 

--- a/docker_config/compose_files/docker-compose.yml
+++ b/docker_config/compose_files/docker-compose.yml
@@ -159,13 +159,13 @@ services:
       --sleep-time ${CODALAB_WORKER_MANAGER_SLEEP_TIME_SECONDS}
       --worker-idle-seconds ${CODALAB_WORKER_MANAGER_IDLE_SECONDS}
       --worker-checkin-frequency-seconds ${CODALAB_WORKER_MANAGER_WORKER_CHECKIN_FREQUENCY_SECONDS}
+      --worker-shared-memory-size-gb ${CODALAB_WORKER_MANAGER_CPU_WORKER_SHARED_MEMORY_SIZE_GB}
       ${CODALAB_WORKER_MANAGER_TYPE}
       --job-queue ${CODALAB_WORKER_MANAGER_CPU_AWS_BATCH_QUEUE}
       --region ${CODALAB_WORKER_MANAGER_AWS_REGION}
       --job-definition-name ${CODALAB_WORKER_MANAGER_AWS_BATCH_JOB_DEFINITION_NAME}
       --cpus ${CODALAB_WORKER_MANAGER_CPU_DEFAULT_CPUS}
       --memory-mb ${CODALAB_WORKER_MANAGER_CPU_DEFAULT_MEMORY_MB}
-      --worker-shared-memory-size-gb ${CODALAB_WORKER_MANAGER_CPU_WORKER_SHARED_MEMORY_SIZE_GB}
     <<: *codalab-base
     <<: *codalab-server
     networks:
@@ -186,6 +186,7 @@ services:
       --sleep-time ${CODALAB_WORKER_MANAGER_SLEEP_TIME_SECONDS}
       --worker-idle-seconds ${CODALAB_WORKER_MANAGER_IDLE_SECONDS}
       --worker-checkin-frequency-seconds ${CODALAB_WORKER_MANAGER_WORKER_CHECKIN_FREQUENCY_SECONDS}
+      --worker-shared-memory-size-gb ${CODALAB_WORKER_MANAGER_CPU_WORKER_SHARED_MEMORY_SIZE_GB}
       ${CODALAB_WORKER_MANAGER_TYPE}
       --job-queue ${CODALAB_WORKER_MANAGER_GPU_AWS_BATCH_QUEUE}
       --region ${CODALAB_WORKER_MANAGER_AWS_REGION}
@@ -193,7 +194,6 @@ services:
       --cpus ${CODALAB_WORKER_MANAGER_GPU_DEFAULT_CPUS}
       --gpus ${CODALAB_WORKER_MANAGER_DEFAULT_GPUS}
       --memory-mb ${CODALAB_WORKER_MANAGER_GPU_DEFAULT_MEMORY_MB}
-      --worker-shared-memory-size-gb ${CODALAB_WORKER_MANAGER_GPU_WORKER_SHARED_MEMORY_SIZE_GB}
     <<: *codalab-base
     <<: *codalab-server
     networks:
@@ -214,6 +214,7 @@ services:
       --sleep-time ${CODALAB_WORKER_MANAGER_SLEEP_TIME_SECONDS}
       --worker-idle-seconds ${CODALAB_WORKER_MANAGER_IDLE_SECONDS}
       --worker-checkin-frequency-seconds ${CODALAB_WORKER_MANAGER_WORKER_CHECKIN_FREQUENCY_SECONDS}
+      --worker-shared-memory-size-gb ${CODALAB_WORKER_MANAGER_CPU_WORKER_SHARED_MEMORY_SIZE_GB}
       ${CODALAB_WORKER_MANAGER_TYPE}
       --account-name ${CODALAB_WORKER_MANAGER_AZURE_BATCH_ACCOUNT_NAME}
       --account-key ${CODALAB_WORKER_MANAGER_AZURE_BATCH_ACCOUNT_KEY}
@@ -222,7 +223,6 @@ services:
       --log-container-url ${CODALAB_WORKER_MANAGER_CPU_AZURE_LOG_CONTAINER_URL}
       --cpus ${CODALAB_WORKER_MANAGER_CPU_DEFAULT_CPUS}
       --memory-mb ${CODALAB_WORKER_MANAGER_CPU_DEFAULT_MEMORY_MB}
-      --worker-shared-memory-size-gb ${CODALAB_WORKER_MANAGER_CPU_WORKER_SHARED_MEMORY_SIZE_GB}
     <<: *codalab-base
     <<: *codalab-server
     networks:
@@ -243,6 +243,7 @@ services:
       --sleep-time ${CODALAB_WORKER_MANAGER_SLEEP_TIME_SECONDS}
       --worker-idle-seconds ${CODALAB_WORKER_MANAGER_IDLE_SECONDS}
       --worker-checkin-frequency-seconds ${CODALAB_WORKER_MANAGER_WORKER_CHECKIN_FREQUENCY_SECONDS}
+      --worker-shared-memory-size-gb ${CODALAB_WORKER_MANAGER_CPU_WORKER_SHARED_MEMORY_SIZE_GB}
       ${CODALAB_WORKER_MANAGER_TYPE}
       --account-name ${CODALAB_WORKER_MANAGER_AZURE_BATCH_ACCOUNT_NAME}
       --account-key ${CODALAB_WORKER_MANAGER_AZURE_BATCH_ACCOUNT_KEY}
@@ -252,7 +253,6 @@ services:
       --cpus ${CODALAB_WORKER_MANAGER_GPU_DEFAULT_CPUS}
       --gpus ${CODALAB_WORKER_MANAGER_DEFAULT_GPUS}
       --memory-mb ${CODALAB_WORKER_MANAGER_GPU_DEFAULT_MEMORY_MB}
-      --worker-shared-memory-size-gb ${CODALAB_WORKER_MANAGER_GPU_WORKER_SHARED_MEMORY_SIZE_GB}
     <<: *codalab-base
     <<: *codalab-server
     networks:
@@ -275,13 +275,13 @@ services:
       --worker-checkin-frequency-seconds ${CODALAB_WORKER_MANAGER_WORKER_CHECKIN_FREQUENCY_SECONDS}
       --worker-tag ${CODALAB_WORKER_MANAGER_CPU_TAG}
       --worker-tag-exclusive
+      --worker-shared-memory-size-gb ${CODALAB_WORKER_MANAGER_CPU_WORKER_SHARED_MEMORY_SIZE_GB}
       ${CODALAB_WORKER_MANAGER_TYPE}
       --cluster-host ${CODALAB_WORKER_MANAGER_KUBERNETES_CLUSTER_HOST}
       --auth-token ${CODALAB_WORKER_MANAGER_KUBERNETES_AUTH_TOKEN}
       --cert-path ${CODALAB_WORKER_MANAGER_KUBERNETES_CERT_PATH}
       --cpus ${CODALAB_WORKER_MANAGER_CPU_DEFAULT_CPUS}
       --memory-mb ${CODALAB_WORKER_MANAGER_CPU_DEFAULT_MEMORY_MB}
-      --worker-shared-memory-size-gb ${CODALAB_WORKER_MANAGER_CPU_WORKER_SHARED_MEMORY_SIZE_GB}
     <<: *codalab-base
     <<: *codalab-server
     volumes:
@@ -305,6 +305,7 @@ services:
       --worker-idle-seconds ${CODALAB_WORKER_MANAGER_IDLE_SECONDS}
       --worker-checkin-frequency-seconds ${CODALAB_WORKER_MANAGER_WORKER_CHECKIN_FREQUENCY_SECONDS}
       --worker-tag ${CODALAB_WORKER_MANAGER_GPU_TAG}
+      --worker-shared-memory-size-gb ${CODALAB_WORKER_MANAGER_CPU_WORKER_SHARED_MEMORY_SIZE_GB}
       --worker-tag-exclusive
       ${CODALAB_WORKER_MANAGER_TYPE}
       --cluster-host ${CODALAB_WORKER_MANAGER_KUBERNETES_CLUSTER_HOST}
@@ -313,7 +314,6 @@ services:
       --cpus ${CODALAB_WORKER_MANAGER_GPU_DEFAULT_CPUS}
       --gpus ${CODALAB_WORKER_MANAGER_DEFAULT_GPUS}
       --memory-mb ${CODALAB_WORKER_MANAGER_GPU_DEFAULT_MEMORY_MB}
-      --worker-shared-memory-size-gb ${CODALAB_WORKER_MANAGER_GPU_WORKER_SHARED_MEMORY_SIZE_GB}
     <<: *codalab-base
     <<: *codalab-server
     volumes:

--- a/docs/REST-API-Reference.md
+++ b/docs/REST-API-Reference.md
@@ -1,6 +1,6 @@
 # REST API Reference
 
-_version 1.0.3_
+_version 1.1.0_
 
 This reference and the REST API itself is still under heavy development and is
 subject to change at any time. Feedback through our GitHub issues is appreciated!

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -1,5 +1,5 @@
 // Should match codalab/common.py#CODALAB_VERSION
-export const CODALAB_VERSION = '1.0.3';
+export const CODALAB_VERSION = '1.1.0';
 
 // Name Regex to match the backend in spec_utils.py
 export const NAME_REGEX = /^[a-zA-Z_][a-zA-Z0-9_.-]*$/i;

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import sys
 
 
 # should match codalab/common.py#CODALAB_VERSION
-CODALAB_VERSION = "1.0.3"
+CODALAB_VERSION = "1.1.0"
 
 
 class Install(install):


### PR DESCRIPTION
### Reasons for making this change
Bump new version

Full diff: https://github.com/codalab/codalab-worksheets/compare/v1.0.3...rc1.1.0

# Draft release notes

## Frontend
None

## Backend
- Prevent script failures and better test competitiond.py (#3749)
- make container shared memory configurable (#3748)
- Blob Storage: Use SAS tokens to bypass server when downloading entire bundles through one's browser or the CLI (#3737)

## Dev / docs / CI
None