### PR TITLE
Simplify frontend test setup

### DIFF
--- a/scripts/test-setup.sh
+++ b/scripts/test-setup.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 
+set -e
+
+rm -rf geckodriver chromedriver
+
 # For testing CodaLab in Chrome
-wget https://chromedriver.storage.googleapis.com/2.41/chromedriver_linux64.zip
+wget https://chromedriver.storage.googleapis.com/92.0.4515.107/chromedriver_linux64.zip
 unzip chromedriver_linux64.zip
 sudo mv chromedriver /usr/bin/chromedriver
 sudo chown root:root /usr/bin/chromedriver
@@ -14,3 +18,5 @@ mkdir geckodriver
 tar -xzf geckodriver-v0.26.0-linux64.tar.gz -C geckodriver
 chmod +x geckodriver/geckodriver
 rm geckodriver-v0.26.0-linux64.tar.gz
+sudo mv geckodriver/geckodriver /usr/bin/geckodriver
+rm -r geckodriver

--- a/tests/ui/README.md
+++ b/tests/ui/README.md
@@ -10,11 +10,10 @@ automation only runs in Chrome and Firefox. We hope to support more browsers in 
 
 1. If you haven't already, install the Python dependencies specified in `requirements.txt`, located in the root of the 
 repository, by running `pip install -r requirements.txt`.
-2. Next, install [ChromeDriver](https://chromedriver.chromium.org/getting-started) (for Chrome) and 
+2. Next, use one of the two below options to install [ChromeDriver](https://chromedriver.chromium.org/getting-started) (for Chrome) and 
 [GeckoDriver](https://github.com/mozilla/geckodriver) (for Firefox). These drivers are the links between the Selenium 
 tests and their respective browsers.
-    1. Run `sudo ./scripts/test-setup.sh` and place the installed GeckoDriver on your path by running 
-    `export PATH=$PATH:/usr/bin/geckodriver`. This is not needed for ChromeDriver.
+    1. If on Linux, run `./scripts/test-setup.sh`.
     2. An alternative is to simply use [Homebrew](https://brew.sh/) and run `brew install geckodriver && brew install 
     --cask chromedriver`. 
 


### PR DESCRIPTION
I had to change some setup instructions to get frontend tests to work locally on my ubuntu machine. I've updated the instructions and also simplified the frontend test setup.