### PR TITLE
Simplify frontend test running on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -382,12 +382,8 @@ jobs:
       - run: pip install -r requirements.txt
       - name: Setup tests
         run: |
-          sudo ./scripts/test-setup.sh
-          export PATH=$PATH:$PWD/geckodriver
           sudo service mysql stop
           python3 codalab_service.py build services --version ${VERSION} --pull
-          pip install --upgrade diffimg==0.2.3
-          pip install --upgrade selenium==3.141.0
         env:
           VERSION: ${{ github.head_ref || 'master' }}
       - name: Run tests

--- a/tests/ui/README.md
+++ b/tests/ui/README.md
@@ -24,7 +24,7 @@ tests and their respective browsers.
 `docker exec -it codalab_rest-server_1 /bin/bash -c "python3 scripts/create_sample_worksheet.py"`. 
 3. Start the UI tests by running `python tests/ui/ui_tester.py`. You can also pass in an additional argument 
 `--headless`, which will run the tests in headless mode.
-4. If you want to run the UI tests directly within the CodaLab Docker container instead, you should run `python test_runner.py frontend`.
+4. If you want to run the UI tests directly within the CodaLab Docker container instead, you should run `docker exec codalab_rest-server_1 /bin/bash -c "python3 scripts/create_sample_worksheet.py --test-print" && python test_runner.py frontend`.
 
 ### Maintaining the baseline images
 

--- a/tests/ui/README.md
+++ b/tests/ui/README.md
@@ -24,6 +24,7 @@ tests and their respective browsers.
 `docker exec -it codalab_rest-server_1 /bin/bash -c "python3 scripts/create_sample_worksheet.py"`. 
 3. Start the UI tests by running `python tests/ui/ui_tester.py`. You can also pass in an additional argument 
 `--headless`, which will run the tests in headless mode.
+4. If you want to run the UI tests directly within the CodaLab Docker container instead, you should run `python test_runner.py frontend`.
 
 ### Maintaining the baseline images
 


### PR DESCRIPTION
### Reasons for making this change

- Update UI test running instructions to show how to run from Docker, which will replicate the exact conditions through which UI tests are run 
- remove unneeded steps in CI for frontend tests