### PR TITLE
Pin apex version to fix default gpu dockerfile builds

### DIFF
--- a/.github/workflows/build_worker_images.yml
+++ b/.github/workflows/build_worker_images.yml
@@ -5,7 +5,7 @@ name: Build default worker images
 on:
   push:
     branches: [master, build]
-    paths: ["docker_config/dockerfiles/Dockerfile.default-*"]
+#     paths: ["docker_config/dockerfiles/Dockerfile.default-*"]
   release:
     types: [published]
     paths: ["docker_config/dockerfiles/Dockerfile.default-*"]

--- a/.github/workflows/build_worker_images.yml
+++ b/.github/workflows/build_worker_images.yml
@@ -4,8 +4,8 @@ name: Build default worker images
 # This workflow ensures the worker images are up-to-date on Docker Hub.
 on:
   push:
-    branches: [master, build]
-#     paths: ["docker_config/dockerfiles/Dockerfile.default-*"]
+    branches: [master]
+    paths: ["docker_config/dockerfiles/Dockerfile.default-*"]
   release:
     types: [published]
     paths: ["docker_config/dockerfiles/Dockerfile.default-*"]
@@ -40,8 +40,8 @@ jobs:
           df -h
       - run: python3 codalab_service.py build --version ${VERSION} ${SERVICE} $([ -z "${CODALAB_DOCKER_USERNAME}" ] || echo "--push")
         env:
-          # CODALAB_DOCKER_USERNAME: ${{ secrets.CODALAB_DOCKER_USERNAME }}
-          # CODALAB_DOCKER_PASSWORD: ${{ secrets.CODALAB_DOCKER_PASSWORD }}
+          CODALAB_DOCKER_USERNAME: ${{ secrets.CODALAB_DOCKER_USERNAME }}
+          CODALAB_DOCKER_PASSWORD: ${{ secrets.CODALAB_DOCKER_PASSWORD }}
           # Set tag to latest if triggered by release,
           # use the branch name of the PR if triggered by pull request,
           # "master" if on a push-triggered build

--- a/.github/workflows/build_worker_images.yml
+++ b/.github/workflows/build_worker_images.yml
@@ -4,7 +4,7 @@ name: Build default worker images
 # This workflow ensures the worker images are up-to-date on Docker Hub.
 on:
   push:
-    branches: [master]
+    branches: [master, build]
     paths: ["docker_config/dockerfiles/Dockerfile.default-*"]
   release:
     types: [published]
@@ -40,8 +40,8 @@ jobs:
           df -h
       - run: python3 codalab_service.py build --version ${VERSION} ${SERVICE} $([ -z "${CODALAB_DOCKER_USERNAME}" ] || echo "--push")
         env:
-          CODALAB_DOCKER_USERNAME: ${{ secrets.CODALAB_DOCKER_USERNAME }}
-          CODALAB_DOCKER_PASSWORD: ${{ secrets.CODALAB_DOCKER_PASSWORD }}
+          # CODALAB_DOCKER_USERNAME: ${{ secrets.CODALAB_DOCKER_USERNAME }}
+          # CODALAB_DOCKER_PASSWORD: ${{ secrets.CODALAB_DOCKER_PASSWORD }}
           # Set tag to latest if triggered by release,
           # use the branch name of the PR if triggered by pull request,
           # "master" if on a push-triggered build

--- a/docker_config/dockerfiles/Dockerfile.default-gpu
+++ b/docker_config/dockerfiles/Dockerfile.default-gpu
@@ -65,7 +65,7 @@ RUN python3 -m pip install --no-cache-dir \
 
 # Install apex
 WORKDIR /tmp/apex_install
-RUN git clone https://github.com/NVIDIA/apex.git
+RUN git clone https://github.com/NVIDIA/apex.git && git checkout 0c2c6eea6556b208d1a8711197efc94899e754e1
 WORKDIR /tmp/apex_install/apex
 RUN python3 -m pip install --disable-pip-version-check --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" ./
 WORKDIR /

--- a/docker_config/dockerfiles/Dockerfile.default-gpu
+++ b/docker_config/dockerfiles/Dockerfile.default-gpu
@@ -65,7 +65,7 @@ RUN python3 -m pip install --no-cache-dir \
 
 # Install apex
 WORKDIR /tmp/apex_install
-RUN git clone https://github.com/NVIDIA/apex.git && git checkout 0c2c6eea6556b208d1a8711197efc94899e754e1
+RUN git clone https://github.com/NVIDIA/apex.git && cd apex && git checkout 0c2c6eea6556b208d1a8711197efc94899e754e1
 WORKDIR /tmp/apex_install/apex
 RUN python3 -m pip install --disable-pip-version-check --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" ./
 WORKDIR /


### PR DESCRIPTION
Pin apex version to fix default gpu dockerfile build.

Fixes the issue @teetone faced with v1.1.1 (see https://github.com/codalab/codalab-worksheets/runs/3500957811?check_suite_focus=true).
