### PR TITLE
Test installing codalab CLI on different python versions on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10-dev]
+        python-version: [3.6, 3.7, 3.8, 3.9]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,15 +30,28 @@ jobs:
           restore-keys: |
             pip-
       - run: ./pre-commit.sh && git diff --exit-code
+
+  install:
+    name: Install
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10-dev]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
       - uses: actions/cache@v2
         with:
           path: ~/.cache/pip
-          key: pip-${{ hashFiles('requirements.txt') }}
+          key: pip-${{ hashFiles('requirements.txt') }}-${{ matrix.python-version }}
           restore-keys: |
             pip-
-      - name: Ensure the "cl" command can be properly installed.
-        run: pip install -e . && cl
-
+      - run: pip install -e .
+      - run: cl
+  
   test_frontend:
     name: Test Frontend
     runs-on: ubuntu-latest
@@ -419,7 +432,7 @@ jobs:
   ci:
     name: All CI tasks complete
     runs-on: ubuntu-latest
-    needs: [format, test_frontend, build, test_backend, test_backend_on_worker_restart, test_backend_sharedfs, test_backend_protected_mode, test_ui]
+    needs: [format, install, test_frontend, build, test_backend, test_backend_on_worker_restart, test_backend_sharedfs, test_backend_protected_mode, test_ui]
     steps:
       - uses: actions/checkout@v2
       - run: echo Done


### PR DESCRIPTION
### Reasons for making this change

Test running codalab on different python versions on CI. This will help us catch issues such as https://github.com/codalab/codalab-worksheets/issues/3775, https://github.com/codalab/codalab-worksheets/issues/3034, https://github.com/codalab/codalab-worksheets/issues/3029 and ensure support for Python versions doesn't regress.