### PR TITLE
Switch to azurite upstream fork

### DIFF
--- a/docker_config/compose_files/docker-compose.yml
+++ b/docker_config/compose_files/docker-compose.yml
@@ -129,11 +129,7 @@ services:
       - rest-server
 
   azurite:
-    # Use a temporary fork of Azurite that implements rscc, rscd, rsce, rscl, rsct query parameter support
-    # in SAS tokens (https://github.com/Azure/Azurite/pull/998).
-    # TODO (Ashwin): Once this PR is merged and release, use the upstream Microsoft Azurite image again.
-    image: llightex/azurite@sha256:e89a564fde7cb4506b6138bb62e97bce7a305d6493e9899ce6dd227205b72e28
-    # image: mcr.microsoft.com/azure-storage/azurite:3.14.0
+    image: mcr.microsoft.com/azure-storage/azurite:3.14.2
     command: "azurite --blobHost 0.0.0.0"
     networks:
       - rest-server


### PR DESCRIPTION
Switch to the Azurite upstream fork, now that my PR to implement rscc, rscd, rsce, rscl, rsct query parameter support in SAS tokens (https://github.com/Azure/Azurite/pull/998) has been merged and a new release has been made. (release notes: https://github.com/Azure/Azurite/releases/tag/v3.14.2)