### PR TITLE
Bump version to 1.1.2

### DIFF
--- a/codalab/common.py
+++ b/codalab/common.py
@@ -26,7 +26,7 @@ from codalab.lib.beam.filesystems import (
 
 # Increment this on master when ready to cut a release.
 # http://semver.org/
-CODALAB_VERSION = '1.1.1'
+CODALAB_VERSION = '1.1.2'
 BINARY_PLACEHOLDER = '<binary>'
 URLOPEN_TIMEOUT_SECONDS = int(os.environ.get('CODALAB_URLOPEN_TIMEOUT_SECONDS', 5 * 60))
 

--- a/docs/REST-API-Reference.md
+++ b/docs/REST-API-Reference.md
@@ -1,6 +1,6 @@
 # REST API Reference
 
-_version 1.1.1_
+_version 1.1.2_
 
 This reference and the REST API itself is still under heavy development and is
 subject to change at any time. Feedback through our GitHub issues is appreciated!

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -1,5 +1,5 @@
 // Should match codalab/common.py#CODALAB_VERSION
-export const CODALAB_VERSION = '1.1.1';
+export const CODALAB_VERSION = '1.1.2';
 
 // Name Regex to match the backend in spec_utils.py
 export const NAME_REGEX = /^[a-zA-Z_][a-zA-Z0-9_.-]*$/i;

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import sys
 
 
 # should match codalab/common.py#CODALAB_VERSION
-CODALAB_VERSION = "1.1.1"
+CODALAB_VERSION = "1.1.2"
 
 
 class Install(install):


### PR DESCRIPTION
### Reasons for making this change
Bump new version

Full diff: https://github.com/codalab/codalab-worksheets/compare/v1.1.1...rc1.1.2

# Draft release notes

## Frontend
None

## Backend
- Updates apache-beam version to 2.32.0 to support Python 3.9 (#3776)
- fix grammar on bundle deletion (#3785)
- Pin apex version to fix default gpu dockerfile builds (#3777)

## Dev / docs / CI
- Switch to azurite upstream fork (#3781)
- Simplify frontend test running on CI (#3768)
- Test installing codalab CLI on different python versions on CI (#3778)