### PR TITLE
When user that is part of a group is deleted, don't crash when running ginfo

### DIFF
--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -3704,11 +3704,17 @@ class BundleCLI(object):
             )
         for member in group['admins']:
             members.append(
-                {'role': 'admin', 'user': '%s(%s)' % (member['user_name'], member['id'])}
+                {
+                    'role': 'admin',
+                    'user': '%s(%s)' % (member.get('user_name', '[deleted user]'), member['id']),
+                }
             )
         for member in group['members']:
             members.append(
-                {'role': 'member', 'user': '%s(%s)' % (member['user_name'], member['id'])}
+                {
+                    'role': 'member',
+                    'user': '%s(%s)' % (member.get('user_name', '[deleted user]'), member['id']),
+                }
             )
 
         print('Members of group %s(%s):' % (group['name'], group['id']), file=self.stdout)

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -2038,9 +2038,20 @@ def test_groups(ctx):
     # Try to relegate yourself to non-admin status
     _run_command([cl, 'uadd', user_name, group_name], expected_exit_code=1)
 
+    # Add a member
+    member_user = random_name()
+    create_user(ctx, member_user)
+    _run_command([cl, 'uadd', user_name, group_name])
+    group_info = _run_command([cl, 'ginfo', group_name])
+    check_contains(user_name, group_info)
+
+    # When member is removed, ginfo should not crash
+    _run_command([cl, 'ufarewell', member_user])
+    group_info = _run_command([cl, 'ginfo', group_name])
+    check_contains('[deleted user]', group_info)
+
     # TODO: Test other group membership semantics:
     # - removing a group
-    # - adding new members
     # - adding an admin
     # - converting member to admin
     # - converting admin to member

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -2041,9 +2041,9 @@ def test_groups(ctx):
     # Add a member
     member_user = random_name()
     create_user(ctx, member_user)
-    _run_command([cl, 'uadd', user_name, group_name])
+    _run_command([cl, 'uadd', member_user, group_name])
     group_info = _run_command([cl, 'ginfo', group_name])
-    check_contains(user_name, group_info)
+    check_contains(member_user, group_info)
 
     # When member is removed, ginfo should not crash
     _run_command([cl, 'ufarewell', member_user])


### PR DESCRIPTION
### Reasons for making this change

Fixes https://github.com/codalab/codalab-worksheets/issues/3310. This issue was happening because the `wilds-admins` group had a deleted user in it.