### PR TITLE
Fix TypeError: Cannot read properties of undefined (reading 'status')

### DIFF
--- a/frontend/src/components/Bundle/Bundle.js
+++ b/frontend/src/components/Bundle/Bundle.js
@@ -69,7 +69,7 @@ class Bundle extends React.Component<
         };
 
         let errorHandler = (error) => {
-            if (error.response.status === 404) {
+            if (error.response && error.response.status === 404) {
                 this.setState({
                     fileContents: null,
                     stdout: null,


### PR DESCRIPTION
### Reasons for making this change

Fix sentry.io error when `error.response` is undefined.

### Related issues

#3795 

### Screenshots

N/A

### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
