### PR TITLE
Provide default type for schema fields 

### DIFF
--- a/frontend/src/components/worksheets/items/SchemaItem/SchemaItem.js
+++ b/frontend/src/components/worksheets/items/SchemaItem/SchemaItem.js
@@ -116,7 +116,9 @@ class SchemaItem extends React.Component<{
         const schemaHeaders = schemaItem.header;
         let newRow = { from_schema_name: schemaItem.schema_name };
         schemaHeaders.forEach((header) => {
-            newRow[header] = '';
+            // Set post-processor to null for new rows so we can tell if a row has been autofilled.
+            // This also makes new row default values consistent with the first row.
+            newRow[header] = header === 'post-processor' ? null : '';
         });
         let curRow = [...this.state.rows];
         curRow.splice(idx + 1, 0, newRow);

--- a/frontend/src/components/worksheets/items/SchemaItem/SchemaItem.js
+++ b/frontend/src/components/worksheets/items/SchemaItem/SchemaItem.js
@@ -118,7 +118,6 @@ class SchemaItem extends React.Component<{
         let newRow = { from_schema_name: schemaItem.schema_name };
         schemaHeaders.forEach((header) => {
             // Set post-processor to null for new, unedited rows to indicate that the row can be autofilled.
-            // This also makes new row default values consistent with the first row.
             newRow[header] = header === 'post-processor' ? null : '';
         });
         let curRow = [...this.state.rows];

--- a/frontend/src/components/worksheets/items/SchemaItem/SchemaItem.js
+++ b/frontend/src/components/worksheets/items/SchemaItem/SchemaItem.js
@@ -143,7 +143,7 @@ class SchemaItem extends React.Component<{
     };
 
     autofillTypes = (row) => {
-        // Only autofill if how to render is null.
+        // Only autofill if the post-processor is null.
         // Null means the post-processor has never been manually changed or autofilled.
         if (row['post-processor'] !== null) {
             return row;

--- a/frontend/src/components/worksheets/items/SchemaItem/SchemaItem.js
+++ b/frontend/src/components/worksheets/items/SchemaItem/SchemaItem.js
@@ -117,7 +117,7 @@ class SchemaItem extends React.Component<{
         const schemaHeaders = schemaItem.header;
         let newRow = { from_schema_name: schemaItem.schema_name };
         schemaHeaders.forEach((header) => {
-            // Set post-processor to null for new rows so we can tell if a row has been autofilled.
+            // Set post-processor to null for new, unedited rows to indicate that the row can be autofilled.
             // This also makes new row default values consistent with the first row.
             newRow[header] = header === 'post-processor' ? null : '';
         });

--- a/frontend/src/components/worksheets/items/SchemaItem/SchemaItem.js
+++ b/frontend/src/components/worksheets/items/SchemaItem/SchemaItem.js
@@ -143,7 +143,8 @@ class SchemaItem extends React.Component<{
     };
 
     autofillTypes = (row) => {
-        // Do not fill if how to render is defined.
+        // Only autofill if how to render is null.
+        // Null means the post-processor has never been manually changed or autofilled.
         if (row['post-processor'] !== null) {
             return row;
         }

--- a/frontend/src/components/worksheets/items/SchemaItem/SchemaItem.js
+++ b/frontend/src/components/worksheets/items/SchemaItem/SchemaItem.js
@@ -25,6 +25,7 @@ import HelpOutlineOutlinedIcon from '@material-ui/icons/HelpOutlineOutlined';
 import { getAfterSortKey } from '../../../../util/worksheet_utils';
 import DeleteForeverIcon from '@material-ui/icons/DeleteForever';
 import Grid from '@material-ui/core/Grid';
+import { DEFAULT_POST_PROCESSOR } from '../../../../constants';
 
 class SchemaItem extends React.Component<{
     worksheetUUID: string,
@@ -147,17 +148,8 @@ class SchemaItem extends React.Component<{
             return row;
         }
 
-        switch (row['generalized-path'].toLowerCase()) {
-            case 'time':
-                row['post-processor'] = 'duration';
-                break;
-            case 'size':
-                row['post-processor'] = 'size';
-                break;
-            case 'date':
-                row['post-processor'] = 'date';
-                break;
-        }
+        row['post-processor'] =
+            DEFAULT_POST_PROCESSOR[row['generalized-path'].toLowerCase()] ?? row['post-processor'];
 
         return row;
     };

--- a/frontend/src/components/worksheets/items/SchemaItem/SchemaItem.js
+++ b/frontend/src/components/worksheets/items/SchemaItem/SchemaItem.js
@@ -128,11 +128,36 @@ class SchemaItem extends React.Component<{
         const { rows } = this.state;
         let copiedRows = [...rows];
         // replace new line with space, remove single quotes since we use that to quote fields with space when saving
-        copiedRows.splice(idx, 1, {
-            ...rows[idx],
-            [key]: e.target.value.replace(/\n/g, ' ').replace("'", ''),
-        });
+        copiedRows.splice(
+            idx,
+            1,
+            this.autofillTypes({
+                ...rows[idx],
+                [key]: e.target.value.replace(/\n/g, ' ').replace("'", ''),
+            }),
+        );
         this.setState({ rows: [...copiedRows] });
+    };
+
+    autofillTypes = (row) => {
+        // Do not fill if how to render is defined.
+        if (row['post-processor'] !== null) {
+            return row;
+        }
+
+        switch (row['generalized-path'].toLowerCase()) {
+            case 'time':
+                row['post-processor'] = 'duration';
+                break;
+            case 'size':
+                row['post-processor'] = 'size';
+                break;
+            case 'date':
+                row['post-processor'] = 'date';
+                break;
+        }
+
+        return row;
     };
 
     changeSchemaName = (e) => {

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -53,3 +53,10 @@ export const BUNDLE_STATES: String[] = [
     'killed',
     'worker_offline',
 ];
+
+// Autofill types for schemas.
+export const DEFAULT_POST_PROCESSOR = {
+    time: 'duration',
+    size: 'size',
+    date: 'date',
+};


### PR DESCRIPTION
### Reasons for making this change

Provide default types for some schema paths so it's easier to use.

### Related issues

#3599 

### Screenshots



![test](https://user-images.githubusercontent.com/29891066/133947541-19a19699-6365-4cfc-9824-2bd39837124b.gif)
### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
