### PR TITLE
Version 1.1.3 (October 6, 2021)

### DIFF
--- a/codalab/common.py
+++ b/codalab/common.py
@@ -26,7 +26,7 @@ from codalab.lib.beam.filesystems import (
 
 # Increment this on master when ready to cut a release.
 # http://semver.org/
-CODALAB_VERSION = '1.1.2'
+CODALAB_VERSION = '1.1.3'
 BINARY_PLACEHOLDER = '<binary>'
 URLOPEN_TIMEOUT_SECONDS = int(os.environ.get('CODALAB_URLOPEN_TIMEOUT_SECONDS', 5 * 60))
 

--- a/docs/REST-API-Reference.md
+++ b/docs/REST-API-Reference.md
@@ -1,6 +1,6 @@
 # REST API Reference
 
-_version 1.1.2_
+_version 1.1.3_
 
 This reference and the REST API itself is still under heavy development and is
 subject to change at any time. Feedback through our GitHub issues is appreciated!

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -1,5 +1,5 @@
 // Should match codalab/common.py#CODALAB_VERSION
-export const CODALAB_VERSION = '1.1.2';
+export const CODALAB_VERSION = '1.1.3';
 
 // Name Regex to match the backend in spec_utils.py
 export const NAME_REGEX = /^[a-zA-Z_][a-zA-Z0-9_.-]*$/i;

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import sys
 
 
 # should match codalab/common.py#CODALAB_VERSION
-CODALAB_VERSION = "1.1.2"
+CODALAB_VERSION = "1.1.3"
 
 
 class Install(install):


### PR DESCRIPTION
## Frontend
- Fix typeError (#3807)
- Provide default type for schema fields (#3808) 
- Fix error message (#3819) 
## Backend
None

## Dev / docs / CI
- Update README.md (#3788)
- When user that is part of a group is deleted, don't crash when running ginfo (#3789)
