### PR TITLE
Fix blank screen for frontend errors

### DIFF
--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -1219,10 +1219,10 @@ class Worksheet extends React.Component {
                     startTime = endTime;
                 }
             })
-            .catch((error) => {
+            .catch(() => {
                 this.setState({
                     openedDialog: DIALOG_TYPES.OPEN_ERROR_DIALOG,
-                    errorDialogMessage: error,
+                    errorDialogMessage: 'Failed to update run bundles.',
                     showWorksheetContainer: false,
                 });
             });
@@ -1587,11 +1587,12 @@ class Worksheet extends React.Component {
                 this.setState({ updating: false });
                 this.reloadWorksheet(undefined, rawIndex);
             }.bind(this),
-            error: function(error) {
+            error: function() {
                 this.setState({ updating: false, showUpdateProgress: false });
                 this.setState({
                     openedDialog: DIALOG_TYPES.OPEN_ERROR_DIALOG,
-                    errorDialogMessage: error,
+                    errorDialogMessage:
+                        'Failed to save and update the worksheet, please check the syntax and try again.',
                 });
                 if (fromRaw) {
                     this.toggleSourceEditMode(true);


### PR DESCRIPTION
### Reasons for making this change

Blank screen show after edit source and then click save.

This is because error is an object and cannot be directly rendered. Because the error message is just error 404, I added clearer message to explain the error to user.

### Related issues

#3651 

### Screenshots


![a](https://user-images.githubusercontent.com/29891066/134846465-a0da2054-e54d-4827-ac15-30a87c271b8b.gif)

### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
