### PR TITLE
Update deleting bundle text to be clearer and close toast when error occurs

### DIFF
--- a/frontend/src/__tests__/Worksheet.test.js
+++ b/frontend/src/__tests__/Worksheet.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import nock from 'nock';
 import { render, waitFor, screen } from '../utils/test-utils';
-import Worksheet from '../components/worksheets/Worksheet/Worksheet';
+import Worksheet, { getToastMsg } from '../components/worksheets/Worksheet/Worksheet';
 
 describe('render simple worksheet', () => {
     beforeEach(() => {
@@ -94,5 +94,14 @@ describe('render simple worksheet', () => {
         await waitFor(() => screen.getByText("Not found: '/worksheets/sample_uuid'"));
         expect(nock.isDone());
         expect(comp).toMatchSnapshot();
+    });
+
+    test('getToastMsg', () => {
+        expect(getToastMsg('rm', 0, 1)).toEqual('Deleting 1 bundle...');
+        expect(getToastMsg('rm', 0, 2)).toEqual('Deleting 2 bundles...');
+        expect(getToastMsg('rm', 1, 1)).toEqual('1 bundle deleted!');
+        expect(getToastMsg('rm', 1, 2)).toEqual('2 bundles deleted!');
+        expect(getToastMsg('random', 0, 2)).toEqual('Executing random command...');
+        expect(getToastMsg('random', 1, 2)).toEqual('random command executed!');
     });
 });

--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -280,27 +280,6 @@ class Worksheet extends React.Component {
         }
     };
 
-    _getToastMsg = (command, state, count) => {
-        // Creates a toast message for a given command.
-        // count is the number of bundles on which this command was performed, if applicable.
-        // state can take the value of 0 or 1
-        // 0 represents the command is being executed
-        // 1 represents the command has already been executed
-        const cmdMsgMap = { rm: ['Deleting', 'deleted'] };
-        const bundleCount = count + (count === 1 ? ' bundle' : ' bundles');
-        const cmdMsg = cmdMsgMap[command] ?? ['Executing', 'Executed'];
-        let toastMsg;
-        if (command in cmdMsgMap) {
-            // We want the toasts to be "Deleting x bundles..." and "x bundles deleted!"
-            toastMsg =
-                state === 0 ? cmdMsg[state] + ' ' + bundleCount : bundleCount + ' ' + cmdMsg[state];
-        } else {
-            // Default text for unrecognized commands.
-            toastMsg = cmdMsg[state] + command + ' command';
-        }
-        toastMsg += state === 0 ? '...' : '!';
-        return toastMsg;
-    };
     handleSelectedBundleCommand = (cmd, worksheet_uuid = this.state.ws.uuid) => {
         // This function runs the command for bulk bundle operations
         // The uuid are recorded by handleCheckBundle
@@ -310,7 +289,7 @@ class Worksheet extends React.Component {
         this.setState({ updating: true });
         const bundleCount: number = Object.keys(this.state.uuidBundlesCheckedCount).length;
         // This toast info is used for showing a message when a command is being performed
-        const toastId = toast.info(this._getToastMsg(cmd, 0, bundleCount), {
+        const toastId = toast.info(getToastMsg(cmd, 0, bundleCount), {
             position: 'top-right',
             hideProgressBar: false,
             closeOnClick: true,
@@ -330,7 +309,7 @@ class Worksheet extends React.Component {
                 this.clearCheckedBundles(() => {
                     // This toast info is used for showing a message when a command has finished executing
                     toast.update(toastId, {
-                        render: this._getToastMsg(cmd, 1, bundleCount),
+                        render: getToastMsg(cmd, 1, bundleCount),
                         type: toast.TYPE.SUCCESS,
                         position: 'top-right',
                         autoClose: 2000,
@@ -2124,6 +2103,31 @@ Mousetrap.stopCallback = function(e, element, combo) {
         element.tagName === 'TEXTAREA' ||
         (element.contentEditable && element.contentEditable === 'true')
     );
+};
+
+export const getToastMsg = (command, state, count) => {
+    // Creates a toast message for a given command.
+    // count is the number of bundles on which this command was performed, if applicable.
+    // state can take the value of 0 or 1
+    // 0 represents the command is being executed
+    // 1 represents the command has already been executed
+    const cmdMsgMap = { rm: ['Deleting', 'deleted'] };
+    const bundleCount = count + (count === 1 ? ' bundle' : ' bundles');
+    const cmdMsg = cmdMsgMap[command] ?? ['Executing', 'executed'];
+    let toastMsg;
+    if (command in cmdMsgMap) {
+        // We want the toasts to be "Deleting x bundles..." and "x bundles deleted!"
+        toastMsg =
+            state === 0 ? cmdMsg[state] + ' ' + bundleCount : bundleCount + ' ' + cmdMsg[state];
+    } else {
+        // Default text for unrecognized commands.
+        toastMsg =
+            state === 0
+                ? cmdMsg[state] + ' ' + command + ' command'
+                : command + ' command' + ' ' + cmdMsg[state];
+    }
+    toastMsg += state === 0 ? '...' : '!';
+    return toastMsg;
 };
 
 export default withStyles(styles)(Worksheet);

--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -293,7 +293,7 @@ class Worksheet extends React.Component {
         if (command in cmdMsgMap) {
             // We want the toasts to be "Deleting x bundles..." and "x bundles deleted!"
             toastMsg =
-                state == 0 ? cmdMsg[state] + ' ' + bundleCount : bundleCount + ' ' + cmdMsg[state];
+                state === 0 ? cmdMsg[state] + ' ' + bundleCount : bundleCount + ' ' + cmdMsg[state];
         } else {
             // Default text for unrecognized commands.
             toastMsg = cmdMsg[state] + command + ' command';

--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -286,12 +286,19 @@ class Worksheet extends React.Component {
         // state can take the value of 0 or 1
         // 0 represents the command is being executed
         // 1 represents the command has already been executed
-        const cmdMsgMap: { string: string } = { rm: ['deleting', 'deleted'] };
-        let toastMsg =
-            (command in cmdMsgMap
-                ? count + (count === 1 ? ' bundle ' : ' bundles ') + cmdMsgMap[command][state]
-                : (state === 0 ? 'Executing ' : 'Executed ') + command + ' command') +
-            (state === 0 ? '...' : '!');
+        const cmdMsgMap = { rm: ['Deleting', 'deleted'] };
+        const bundleCount = count + (count === 1 ? ' bundle' : ' bundles');
+        const cmdMsg = cmdMsgMap[command] ?? ['Executing', 'Executed'];
+        let toastMsg;
+        if (command in cmdMsgMap) {
+            // We want the toasts to be "Deleting x bundles..." and "x bundles deleted!"
+            toastMsg =
+                state == 0 ? cmdMsg[state] + ' ' + bundleCount : bundleCount + ' ' + cmdMsg[state];
+        } else {
+            // Default text for unrecognized commands.
+            toastMsg = cmdMsg[state] + command + ' command';
+        }
+        toastMsg += state === 0 ? '...' : '!';
         return toastMsg;
     };
     handleSelectedBundleCommand = (cmd, worksheet_uuid = this.state.ws.uuid) => {
@@ -339,6 +346,7 @@ class Worksheet extends React.Component {
                 this.reloadWorksheet(undefined, undefined, param);
             })
             .catch((e) => {
+                toast.dismiss();
                 this.setState({
                     openedDialog: DIALOG_TYPES.OPEN_ERROR_DIALOG,
                     errorDialogMessage: e,


### PR DESCRIPTION
### Reasons for making this change

When deleting a bundle, it says “4 bundles deleting…” Should be “Deleting 4 bundles…”

Also, previously the toast does not close if an error occurs, so I added a one-liner to fix it.

### Related issues

Fixes #3834 


### Screenshots
![image](https://user-images.githubusercontent.com/29891066/137445180-2888e8d1-48c0-4b50-b5c9-af092ca4a5d6.png)

![image](https://user-images.githubusercontent.com/29891066/137445614-7db3e532-d965-4f84-83ce-ceed0f8321b2.png)

![image](https://user-images.githubusercontent.com/29891066/137445467-6cf4981d-48c0-40bc-b8d4-bbb451656652.png)

### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
