### PR TITLE
Auto focus on the name field when creating new schema

### DIFF
--- a/frontend/src/components/worksheets/items/SchemaItem/SchemaItem.js
+++ b/frontend/src/components/worksheets/items/SchemaItem/SchemaItem.js
@@ -558,6 +558,7 @@ class SchemaItem extends React.Component<{
                     </Tooltip>
                     {(showSchemaDetail || this.props.create) && (
                         <TextField
+                            autoFocus
                             variant='outlined'
                             id='standard-multiline-static'
                             InputProps={{


### PR DESCRIPTION
### Reasons for making this change

When click the add schema button, cursor should focus on the schema name. Easy one-liner.

### Related issue

fixes #3833

<!-- Add a reference to issues resolved, if applicable (for example, "fixes #1"). -->

### Screenshots


![a](https://user-images.githubusercontent.com/29891066/137448841-644b06d8-a12d-467a-b802-5be48fabbe3f.gif)

### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
