### PR TITLE
Update worksheet refresh toast 

### DIFF
--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -127,7 +127,7 @@ class Worksheet extends React.Component {
             brief: props.brief ? 1 : 0,
         };
 
-        apiWrapper
+        return apiWrapper
             .fetchWorksheet(this.state.ws.uuid, queryParams)
             .then((info) => {
                 info['date_created'] = addUTCTimeZone(info['date_created']);
@@ -879,20 +879,18 @@ class Worksheet extends React.Component {
         }
         if (!(this.state.openedDialog || this.state.BulkBundleDialog)) {
             // Only enable these shortcuts when no dialog is opened
-            Mousetrap.bind(
-                ['shift+r'],
-                function(e) {
-                    this.reloadWorksheet(undefined, undefined);
+            Mousetrap.bind(['shift+r'], () => {
+                this.reloadWorksheet(undefined, undefined, undefined, () => {
                     toast.info('🦄 Worksheet refreshed!', {
                         position: 'top-right',
+                        hideProgressBar: true,
                         autoClose: 1500,
-                        hideProgressBar: false,
                         closeOnClick: true,
                         pauseOnHover: false,
                         draggable: true,
                     });
-                }.bind(this),
-            );
+                });
+            });
 
             // Show/hide web terminal
             Mousetrap.bind(
@@ -1394,6 +1392,7 @@ class Worksheet extends React.Component {
             uploadFiles = false,
             addImage = false, // whether the reload is caused by adding an image
         } = {},
+        afterReload,
     ) => {
         if (partialUpdateItems === undefined) {
             this.setState({ updating: true, showUpdateProgress: true });
@@ -1531,6 +1530,8 @@ class Worksheet extends React.Component {
                     });
                     this.setState({ showUpdateProgress: false, showWorksheetContainer: false });
                 }.bind(this),
+            }).then(() => {
+                afterReload && afterReload();
             });
         } else {
             var ws = _.clone(this.state.ws);


### PR DESCRIPTION
### Reasons for making this change

Original issue: Worksheet refreshed modal has a progress bar that goes from right to left, which is counterintuitive, change it to go from left to right.

After investigating, turns out the progress bar is not tracking anything. I tried to make toast stay only when refreshing, but turns out the refreshing is very fast so there's no point of having a progress bar (it will just be a flash of the toast plus we already have the spinner)

Instead I believe we should just show the 'Worksheet refreshed!' without progress bar **after** the worksheet is refreshed and auto close it.


### Related issues

fixes #3840

### Screenshots
![a](https://user-images.githubusercontent.com/29891066/137670551-fccead16-12d1-45fd-b46b-fdf691156fea.gif)

### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
