### PR TITLE
Add DB changes for multiple bundle stores (second try); set default database charset to utf8

### DIFF
--- a/alembic/versions/2021102019_create_multi_bundle_store__26a5e6b3bfa5.py
+++ b/alembic/versions/2021102019_create_multi_bundle_store__26a5e6b3bfa5.py
@@ -1,0 +1,24 @@
+"""create multi bundle store tables
+
+Revision ID: 26a5e6b3bfa5
+Revises: 6c013a88862f
+Create Date: 2021-10-20 19:30:20.877152
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '26a5e6b3bfa5'
+down_revision = '6c013a88862f'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+def upgrade():
+    # tables automatically added
+    pass
+
+
+def downgrade():
+    op.drop_table('bundle_location')
+    op.drop_table('bundle_store')

--- a/codalab/common.py
+++ b/codalab/common.py
@@ -184,6 +184,20 @@ class StorageURLScheme(Enum):
     AZURE_BLOB_STORAGE = "azfs://"
 
 
+class StorageFormat(Enum):
+    """Possible storage formats for bundles.
+    When updating this enum, sync it with with the enum in the storage_format column
+    in codalab.model.tables and add the appropriate migrations to reflect the column change.
+    """
+
+    # Currently how disk storage stores bundles, just uncompressed.
+    UNCOMPRESSED = "uncompressed"
+
+    # Uses ratarmount to construct a single index.sqlite file along with a .tar.gz / .gz
+    # version of the bundle.
+    COMPRESSED_V1 = "compressed_v1"
+
+
 @dataclass(frozen=True)
 class LinkedBundlePath:
     """A LinkedBundlePath refers to a path that points to the location of a linked bundle within a specific storage location.

--- a/codalab/model/mysql_model.py
+++ b/codalab/model/mysql_model.py
@@ -48,6 +48,7 @@ class MySQLModel(BundleModel):
             max_overflow=100,
             pool_recycle=3600,
             encoding='utf-8',
+            charset='utf8'
         )
         super(MySQLModel, self).__init__(engine, default_user_info, root_user_id, system_user_id)
 

--- a/codalab/model/mysql_model.py
+++ b/codalab/model/mysql_model.py
@@ -42,13 +42,13 @@ class MySQLModel(BundleModel):
         if not engine_url.startswith('mysql://'):
             raise UsageError('Engine URL should start with mysql://')
         engine = create_engine(
-            engine_url,
+            # Set the charset to utf8, so that it does not use latin1 by default.
+            engine_url + "?charset=utf8",
             strategy='threadlocal',
             pool_size=20,
             max_overflow=100,
             pool_recycle=3600,
             encoding='utf-8',
-            charset='utf8',
         )
         super(MySQLModel, self).__init__(engine, default_user_info, root_user_id, system_user_id)
 

--- a/codalab/model/mysql_model.py
+++ b/codalab/model/mysql_model.py
@@ -48,7 +48,7 @@ class MySQLModel(BundleModel):
             max_overflow=100,
             pool_recycle=3600,
             encoding='utf-8',
-            charset='utf8'
+            charset='utf8',
         )
         super(MySQLModel, self).__init__(engine, default_user_info, root_user_id, system_user_id)
 

--- a/codalab/model/mysql_model.py
+++ b/codalab/model/mysql_model.py
@@ -42,9 +42,7 @@ class MySQLModel(BundleModel):
         if not engine_url.startswith('mysql://'):
             raise UsageError('Engine URL should start with mysql://')
         engine = create_engine(
-            # Set the charset to utf8, so that it does not use latin1 by default.
-            # TODO: Migrate to utf8mb4 (https://github.com/codalab/codalab-worksheets/issues/3849)
-            engine_url + "?charset=utf8",
+            engine_url,
             strategy='threadlocal',
             pool_size=20,
             max_overflow=100,

--- a/codalab/model/mysql_model.py
+++ b/codalab/model/mysql_model.py
@@ -43,6 +43,7 @@ class MySQLModel(BundleModel):
             raise UsageError('Engine URL should start with mysql://')
         engine = create_engine(
             # Set the charset to utf8, so that it does not use latin1 by default.
+            # TODO: Migrate to utf8mb4 (https://github.com/codalab/codalab-worksheets/issues/3849)
             engine_url + "?charset=utf8",
             strategy='threadlocal',
             pool_size=20,

--- a/codalab/model/tables.py
+++ b/codalab/model/tables.py
@@ -105,36 +105,27 @@ bundle_store = Table(
         autoincrement=True,
     ),
     Column('uuid', String(63), nullable=False),
-
     # Usually root. For BYO bundle stores (not yet supported),
     # it is the user who created the bundle store.
     Column('owner_id', String(255), nullable=True),
-
     # Name used to refer to this bundle store from the CLI.
     Column('name', String(255), nullable=True),
-
     # Storage type. This is usually redundant with information already in the url column, but set for efficiency reasons. When updating this column, sync it with codalab.common.StorageType.
     Column(
         'storage_type',
         Enum(StorageType.DISK_STORAGE.value, StorageType.AZURE_BLOB_STORAGE.value),
         nullable=True,
     ),
-
     # The format through which the bundle is stored.
     Column(
-        'storage_format',
-        Enum(StorageFormat.UNCOMPRESSED.value, StorageFormat.COMPRESSED_V1.value)
+        'storage_format', Enum(StorageFormat.UNCOMPRESSED.value, StorageFormat.COMPRESSED_V1.value)
     ),
-
     # URL that uniquely identifies the bundle store.
     Column('url', String(255), nullable=True),
-    
     # Authentication / password to access the bundle store.
     Column('authentication', String(255), nullable=True),
-
     # Name of environment variable through which the authentication variable from above can be passed to codalab-service to access the bundle store.
     Column('authentication_env', String(255), nullable=True),
-
     UniqueConstraint('uuid', name='uix_1'),
     Index('bundle_store_name_index', 'name'),
     Index('bundle_store_owner_index', 'owner_id'),
@@ -153,10 +144,8 @@ bundle_location = Table(
         nullable=False,
         autoincrement=True,
     ),
-
     # Which bundle this location contains the contents of.
     Column('bundle_uuid', String(63), ForeignKey(bundle.c.uuid), nullable=False),
-
     # Which bundle store this location is on.
     Column('bundle_store_uuid', String(63), ForeignKey(bundle_store.c.uuid), nullable=False),
 )

--- a/codalab/model/tables.py
+++ b/codalab/model/tables.py
@@ -59,7 +59,7 @@ bundle = Table(
     UniqueConstraint('uuid', name='uix_1'),
     Index('bundle_data_hash_index', 'data_hash'),
     Index('state_index', 'state'),  # Needed for the bundle manager.
-    mysql_charset=TABLE_DEFAULT_CHARSET
+    mysql_charset=TABLE_DEFAULT_CHARSET,
 )
 
 # Includes things like name, description, etc.
@@ -77,7 +77,7 @@ bundle_metadata = Table(
     Column('metadata_key', String(63), nullable=False),
     Column('metadata_value', Text, nullable=False),
     Index('metadata_kv_index', 'metadata_key', 'metadata_value', mysql_length=63),
-    mysql_charset=TABLE_DEFAULT_CHARSET
+    mysql_charset=TABLE_DEFAULT_CHARSET,
 )
 
 # For each child_uuid, we have: key = child_path, target = (parent_uuid, parent_path)
@@ -97,7 +97,7 @@ bundle_dependency = Table(
     # dependencies to bundles not (yet) in the system.
     Column('parent_uuid', String(63), nullable=False),
     Column('parent_path', Text, nullable=False),
-    mysql_charset=TABLE_DEFAULT_CHARSET
+    mysql_charset=TABLE_DEFAULT_CHARSET,
 )
 
 # Storage location for bundles.
@@ -136,7 +136,7 @@ bundle_store = Table(
     UniqueConstraint('uuid', name='uix_1'),
     Index('bundle_store_name_index', 'name'),
     Index('bundle_store_owner_index', 'owner_id'),
-    mysql_charset=TABLE_DEFAULT_CHARSET
+    mysql_charset=TABLE_DEFAULT_CHARSET,
 )
 
 
@@ -156,7 +156,7 @@ bundle_location = Table(
     Column('bundle_uuid', String(63), ForeignKey(bundle.c.uuid), nullable=False),
     # Which bundle store this location is on.
     Column('bundle_store_uuid', String(63), ForeignKey(bundle_store.c.uuid), nullable=False),
-    mysql_charset=TABLE_DEFAULT_CHARSET
+    mysql_charset=TABLE_DEFAULT_CHARSET,
 )
 
 
@@ -189,7 +189,7 @@ worksheet = Table(
     UniqueConstraint('uuid', name='uix_1'),
     Index('worksheet_name_index', 'name'),
     Index('worksheet_owner_index', 'owner_id'),
-    mysql_charset=TABLE_DEFAULT_CHARSET
+    mysql_charset=TABLE_DEFAULT_CHARSET,
 )
 
 worksheet_item = Table(
@@ -218,7 +218,7 @@ worksheet_item = Table(
     Index('worksheet_item_worksheet_uuid_index', 'worksheet_uuid'),
     Index('worksheet_item_bundle_uuid_index', 'bundle_uuid'),
     Index('worksheet_item_subworksheet_uuid_index', 'subworksheet_uuid'),
-    mysql_charset=TABLE_DEFAULT_CHARSET
+    mysql_charset=TABLE_DEFAULT_CHARSET,
 )
 
 # Worksheet tags
@@ -236,7 +236,7 @@ worksheet_tag = Table(
     Column('tag', String(63), nullable=False),
     Index('worksheet_tag_worksheet_uuid_index', 'worksheet_uuid'),
     Index('worksheet_tag_tag_index', 'tag'),
-    mysql_charset=TABLE_DEFAULT_CHARSET
+    mysql_charset=TABLE_DEFAULT_CHARSET,
 )
 
 group = Table(
@@ -256,7 +256,7 @@ group = Table(
     UniqueConstraint('uuid', name='uix_1'),
     Index('group_name_index', 'name'),
     Index('group_owner_id_index', 'owner_id'),
-    mysql_charset=TABLE_DEFAULT_CHARSET
+    mysql_charset=TABLE_DEFAULT_CHARSET,
 )
 
 user_group = Table(
@@ -275,7 +275,7 @@ user_group = Table(
     Column('is_admin', Boolean),
     Index('group_uuid_index', 'group_uuid'),
     Index('user_id_index', 'user_id'),
-    mysql_charset=TABLE_DEFAULT_CHARSET
+    mysql_charset=TABLE_DEFAULT_CHARSET,
 )
 
 # Permissions for bundles
@@ -294,7 +294,7 @@ group_bundle_permission = Table(
     Column('object_uuid', String(63), ForeignKey(bundle.c.uuid), nullable=False),
     # Permissions encoded as integer (see below)
     Column('permission', Integer, nullable=False),
-    mysql_charset=TABLE_DEFAULT_CHARSET
+    mysql_charset=TABLE_DEFAULT_CHARSET,
 )
 
 # Permissions for worksheets
@@ -313,7 +313,7 @@ group_object_permission = Table(
     Column('object_uuid', String(63), ForeignKey(worksheet.c.uuid), nullable=False),
     # Permissions encoded as integer (see below)
     Column('permission', Integer, nullable=False),
-    mysql_charset=TABLE_DEFAULT_CHARSET
+    mysql_charset=TABLE_DEFAULT_CHARSET,
 )
 
 # A permission value is one of the following: none (0), read (1), or all (2).
@@ -372,7 +372,7 @@ user = Table(
     Index('user_user_id_index', 'user_id'),
     Index('user_user_name_index', 'user_name'),
     UniqueConstraint('user_id', name='uix_1'),
-    mysql_charset=TABLE_DEFAULT_CHARSET
+    mysql_charset=TABLE_DEFAULT_CHARSET,
 )
 
 # Stores (email) verification keys
@@ -390,7 +390,7 @@ user_verification = Table(
     Column('date_created', DateTime, nullable=False),
     Column('date_sent', DateTime, nullable=True),
     Column('key', String(64), nullable=False),
-    mysql_charset=TABLE_DEFAULT_CHARSET
+    mysql_charset=TABLE_DEFAULT_CHARSET,
 )
 
 # Stores password reset codes
@@ -407,7 +407,7 @@ user_reset_code = Table(
     Column('user_id', String(63), ForeignKey(user.c.user_id), nullable=False),
     Column('date_created', DateTime, nullable=False),
     Column('code', String(64), nullable=False),
-    mysql_charset=TABLE_DEFAULT_CHARSET
+    mysql_charset=TABLE_DEFAULT_CHARSET,
 )
 
 # OAuth2 Tables
@@ -435,7 +435,7 @@ oauth2_client = Table(
     Column('scopes', Text, nullable=False),  # comma-separated list of allowed scopes
     Column('redirect_uris', Text, nullable=False),  # comma-separated list of allowed redirect URIs
     UniqueConstraint('client_id', name='uix_1'),
-    mysql_charset=TABLE_DEFAULT_CHARSET
+    mysql_charset=TABLE_DEFAULT_CHARSET,
 )
 
 oauth2_token = Table(
@@ -454,7 +454,7 @@ oauth2_token = Table(
     Column('access_token', String(255), unique=True),
     Column('refresh_token', String(255), unique=True),
     Column('expires', DateTime, nullable=False),
-    mysql_charset=TABLE_DEFAULT_CHARSET
+    mysql_charset=TABLE_DEFAULT_CHARSET,
 )
 
 oauth2_auth_code = Table(
@@ -473,7 +473,7 @@ oauth2_auth_code = Table(
     Column('code', String(100), nullable=False),
     Column('expires', DateTime, nullable=False),
     Column('redirect_uri', String(255), nullable=False),
-    mysql_charset=TABLE_DEFAULT_CHARSET
+    mysql_charset=TABLE_DEFAULT_CHARSET,
 )
 
 # Store information about users' questions or feedback.
@@ -497,7 +497,7 @@ chat = Table(
     Column(
         'bundle_uuid', String(63), nullable=True
     ),  # What is the id of the bundle that the sender is on?
-    mysql_charset=TABLE_DEFAULT_CHARSET
+    mysql_charset=TABLE_DEFAULT_CHARSET,
 )
 
 # Store information about workers.
@@ -526,7 +526,7 @@ worker = Table(
         'exit_after_num_runs', Integer, nullable=False
     ),  # Number of jobs allowed to run on worker.
     Column('is_terminating', Boolean, nullable=False),
-    mysql_charset=TABLE_DEFAULT_CHARSET
+    mysql_charset=TABLE_DEFAULT_CHARSET,
 )
 
 # Store information about all sockets currently allocated to each worker.
@@ -538,7 +538,7 @@ worker_socket = Table(
     # No foreign key constraint on the worker table so that we can create a socket
     # for the worker before adding the worker to the worker table.
     Column('socket_id', Integer, primary_key=True, nullable=False),
-    mysql_charset=TABLE_DEFAULT_CHARSET
+    mysql_charset=TABLE_DEFAULT_CHARSET,
 )
 
 # Store information about the bundles currently running on each worker.
@@ -550,7 +550,7 @@ worker_run = Table(
     ForeignKeyConstraint(['user_id', 'worker_id'], ['worker.user_id', 'worker.worker_id']),
     Column('run_uuid', String(63), ForeignKey(bundle.c.uuid), nullable=False),
     Index('uuid_index', 'run_uuid'),
-    mysql_charset=TABLE_DEFAULT_CHARSET
+    mysql_charset=TABLE_DEFAULT_CHARSET,
 )
 
 # Store information about the dependencies available on each worker.
@@ -563,5 +563,5 @@ worker_dependency = Table(
     # Serialized list of dependencies for the user/worker combination.
     # See WorkerModel for the serialization method.
     Column('dependencies', LargeBinary, nullable=False),
-    mysql_charset=TABLE_DEFAULT_CHARSET
+    mysql_charset=TABLE_DEFAULT_CHARSET,
 )

--- a/codalab/model/tables.py
+++ b/codalab/model/tables.py
@@ -135,7 +135,7 @@ bundle_store = Table(
     # Name of environment variable through which the authentication variable from above can be passed to codalab-service to access the bundle store.
     Column('authentication_env', String(255), nullable=True),
 
-    UniqueConstraint('uuid', 'owner_id', name='uix_1'),
+    UniqueConstraint('uuid', name='uix_1'),
 )
 
 

--- a/codalab/model/tables.py
+++ b/codalab/model/tables.py
@@ -109,7 +109,7 @@ bundle_store = Table(
     # it is the user who created the bundle store.
     Column('owner_id', String(255), nullable=True),
     # Name used to refer to this bundle store from the CLI.
-    Column('name', String(255), nullable=True),
+    Column('name', String(255), nullable=False),
     # Storage type. This is usually redundant with information already in the url column, but set for efficiency reasons. When updating this column, sync it with codalab.common.StorageType.
     Column(
         'storage_type',

--- a/codalab/model/tables.py
+++ b/codalab/model/tables.py
@@ -147,7 +147,7 @@ bundle_location = Table(
     # Which bundle this location contains the contents of.
     Column('bundle_uuid', String(63), ForeignKey(bundle.c.uuid), nullable=False),
     # Which bundle store this location is on.
-    Column('bundle_store_uuid', String(63), ForeignKey(bundle_store.c.uuid), nullable=False),
+    # Column('bundle_store_uuid', String(63), ForeignKey(bundle_store.c.uuid), nullable=False),
 )
 
 

--- a/codalab/model/tables.py
+++ b/codalab/model/tables.py
@@ -23,6 +23,10 @@ from codalab.common import StorageType, StorageFormat
 
 db_metadata = MetaData()
 
+# Set the table's charset to utf8, so that it is not set to latin1 by default.
+# TODO: Migrate to utf8mb4 (https://github.com/codalab/codalab-worksheets/issues/3849)
+TABLE_DEFAULT_CHARSET = 'utf8'
+
 bundle = Table(
     'bundle',
     db_metadata,
@@ -55,7 +59,7 @@ bundle = Table(
     UniqueConstraint('uuid', name='uix_1'),
     Index('bundle_data_hash_index', 'data_hash'),
     Index('state_index', 'state'),  # Needed for the bundle manager.
-    mysql_charset='utf8'
+    mysql_charset=TABLE_DEFAULT_CHARSET
 )
 
 # Includes things like name, description, etc.
@@ -73,7 +77,7 @@ bundle_metadata = Table(
     Column('metadata_key', String(63), nullable=False),
     Column('metadata_value', Text, nullable=False),
     Index('metadata_kv_index', 'metadata_key', 'metadata_value', mysql_length=63),
-    mysql_charset='utf8'
+    mysql_charset=TABLE_DEFAULT_CHARSET
 )
 
 # For each child_uuid, we have: key = child_path, target = (parent_uuid, parent_path)
@@ -93,7 +97,7 @@ bundle_dependency = Table(
     # dependencies to bundles not (yet) in the system.
     Column('parent_uuid', String(63), nullable=False),
     Column('parent_path', Text, nullable=False),
-    mysql_charset='utf8'
+    mysql_charset=TABLE_DEFAULT_CHARSET
 )
 
 # Storage location for bundles.
@@ -132,7 +136,7 @@ bundle_store = Table(
     UniqueConstraint('uuid', name='uix_1'),
     Index('bundle_store_name_index', 'name'),
     Index('bundle_store_owner_index', 'owner_id'),
-    mysql_charset='utf8'
+    mysql_charset=TABLE_DEFAULT_CHARSET
 )
 
 
@@ -152,7 +156,7 @@ bundle_location = Table(
     Column('bundle_uuid', String(63), ForeignKey(bundle.c.uuid), nullable=False),
     # Which bundle store this location is on.
     Column('bundle_store_uuid', String(63), ForeignKey(bundle_store.c.uuid), nullable=False),
-    mysql_charset='utf8'
+    mysql_charset=TABLE_DEFAULT_CHARSET
 )
 
 
@@ -185,7 +189,7 @@ worksheet = Table(
     UniqueConstraint('uuid', name='uix_1'),
     Index('worksheet_name_index', 'name'),
     Index('worksheet_owner_index', 'owner_id'),
-    mysql_charset='utf8'
+    mysql_charset=TABLE_DEFAULT_CHARSET
 )
 
 worksheet_item = Table(
@@ -214,7 +218,7 @@ worksheet_item = Table(
     Index('worksheet_item_worksheet_uuid_index', 'worksheet_uuid'),
     Index('worksheet_item_bundle_uuid_index', 'bundle_uuid'),
     Index('worksheet_item_subworksheet_uuid_index', 'subworksheet_uuid'),
-    mysql_charset='utf8'
+    mysql_charset=TABLE_DEFAULT_CHARSET
 )
 
 # Worksheet tags
@@ -232,7 +236,7 @@ worksheet_tag = Table(
     Column('tag', String(63), nullable=False),
     Index('worksheet_tag_worksheet_uuid_index', 'worksheet_uuid'),
     Index('worksheet_tag_tag_index', 'tag'),
-    mysql_charset='utf8'
+    mysql_charset=TABLE_DEFAULT_CHARSET
 )
 
 group = Table(
@@ -252,7 +256,7 @@ group = Table(
     UniqueConstraint('uuid', name='uix_1'),
     Index('group_name_index', 'name'),
     Index('group_owner_id_index', 'owner_id'),
-    mysql_charset='utf8'
+    mysql_charset=TABLE_DEFAULT_CHARSET
 )
 
 user_group = Table(
@@ -271,7 +275,7 @@ user_group = Table(
     Column('is_admin', Boolean),
     Index('group_uuid_index', 'group_uuid'),
     Index('user_id_index', 'user_id'),
-    mysql_charset='utf8'
+    mysql_charset=TABLE_DEFAULT_CHARSET
 )
 
 # Permissions for bundles
@@ -290,7 +294,7 @@ group_bundle_permission = Table(
     Column('object_uuid', String(63), ForeignKey(bundle.c.uuid), nullable=False),
     # Permissions encoded as integer (see below)
     Column('permission', Integer, nullable=False),
-    mysql_charset='utf8'
+    mysql_charset=TABLE_DEFAULT_CHARSET
 )
 
 # Permissions for worksheets
@@ -309,7 +313,7 @@ group_object_permission = Table(
     Column('object_uuid', String(63), ForeignKey(worksheet.c.uuid), nullable=False),
     # Permissions encoded as integer (see below)
     Column('permission', Integer, nullable=False),
-    mysql_charset='utf8'
+    mysql_charset=TABLE_DEFAULT_CHARSET
 )
 
 # A permission value is one of the following: none (0), read (1), or all (2).
@@ -368,7 +372,7 @@ user = Table(
     Index('user_user_id_index', 'user_id'),
     Index('user_user_name_index', 'user_name'),
     UniqueConstraint('user_id', name='uix_1'),
-    mysql_charset='utf8'
+    mysql_charset=TABLE_DEFAULT_CHARSET
 )
 
 # Stores (email) verification keys
@@ -386,7 +390,7 @@ user_verification = Table(
     Column('date_created', DateTime, nullable=False),
     Column('date_sent', DateTime, nullable=True),
     Column('key', String(64), nullable=False),
-    mysql_charset='utf8'
+    mysql_charset=TABLE_DEFAULT_CHARSET
 )
 
 # Stores password reset codes
@@ -403,7 +407,7 @@ user_reset_code = Table(
     Column('user_id', String(63), ForeignKey(user.c.user_id), nullable=False),
     Column('date_created', DateTime, nullable=False),
     Column('code', String(64), nullable=False),
-    mysql_charset='utf8'
+    mysql_charset=TABLE_DEFAULT_CHARSET
 )
 
 # OAuth2 Tables
@@ -431,7 +435,7 @@ oauth2_client = Table(
     Column('scopes', Text, nullable=False),  # comma-separated list of allowed scopes
     Column('redirect_uris', Text, nullable=False),  # comma-separated list of allowed redirect URIs
     UniqueConstraint('client_id', name='uix_1'),
-    mysql_charset='utf8'
+    mysql_charset=TABLE_DEFAULT_CHARSET
 )
 
 oauth2_token = Table(
@@ -450,7 +454,7 @@ oauth2_token = Table(
     Column('access_token', String(255), unique=True),
     Column('refresh_token', String(255), unique=True),
     Column('expires', DateTime, nullable=False),
-    mysql_charset='utf8'
+    mysql_charset=TABLE_DEFAULT_CHARSET
 )
 
 oauth2_auth_code = Table(
@@ -469,7 +473,7 @@ oauth2_auth_code = Table(
     Column('code', String(100), nullable=False),
     Column('expires', DateTime, nullable=False),
     Column('redirect_uri', String(255), nullable=False),
-    mysql_charset='utf8'
+    mysql_charset=TABLE_DEFAULT_CHARSET
 )
 
 # Store information about users' questions or feedback.
@@ -493,7 +497,7 @@ chat = Table(
     Column(
         'bundle_uuid', String(63), nullable=True
     ),  # What is the id of the bundle that the sender is on?
-    mysql_charset='utf8'
+    mysql_charset=TABLE_DEFAULT_CHARSET
 )
 
 # Store information about workers.
@@ -522,7 +526,7 @@ worker = Table(
         'exit_after_num_runs', Integer, nullable=False
     ),  # Number of jobs allowed to run on worker.
     Column('is_terminating', Boolean, nullable=False),
-    mysql_charset='utf8'
+    mysql_charset=TABLE_DEFAULT_CHARSET
 )
 
 # Store information about all sockets currently allocated to each worker.
@@ -534,7 +538,7 @@ worker_socket = Table(
     # No foreign key constraint on the worker table so that we can create a socket
     # for the worker before adding the worker to the worker table.
     Column('socket_id', Integer, primary_key=True, nullable=False),
-    mysql_charset='utf8'
+    mysql_charset=TABLE_DEFAULT_CHARSET
 )
 
 # Store information about the bundles currently running on each worker.
@@ -546,7 +550,7 @@ worker_run = Table(
     ForeignKeyConstraint(['user_id', 'worker_id'], ['worker.user_id', 'worker.worker_id']),
     Column('run_uuid', String(63), ForeignKey(bundle.c.uuid), nullable=False),
     Index('uuid_index', 'run_uuid'),
-    mysql_charset='utf8'
+    mysql_charset=TABLE_DEFAULT_CHARSET
 )
 
 # Store information about the dependencies available on each worker.
@@ -559,5 +563,5 @@ worker_dependency = Table(
     # Serialized list of dependencies for the user/worker combination.
     # See WorkerModel for the serialization method.
     Column('dependencies', LargeBinary, nullable=False),
-    mysql_charset='utf8'
+    mysql_charset=TABLE_DEFAULT_CHARSET
 )

--- a/codalab/model/tables.py
+++ b/codalab/model/tables.py
@@ -145,9 +145,9 @@ bundle_location = Table(
         autoincrement=True,
     ),
     # Which bundle this location contains the contents of.
-    Column('bundle_uuid', String(63), ForeignKey(bundle.c.uuid), nullable=False),
+    # Column('bundle_uuid', String(63), ForeignKey(bundle.c.uuid), nullable=False),
     # Which bundle store this location is on.
-    # Column('bundle_store_uuid', String(63), ForeignKey(bundle_store.c.uuid), nullable=False),
+    Column('bundle_store_uuid', String(63), ForeignKey(bundle_store.c.uuid), nullable=False),
 )
 
 

--- a/codalab/model/tables.py
+++ b/codalab/model/tables.py
@@ -136,6 +136,8 @@ bundle_store = Table(
     Column('authentication_env', String(255), nullable=True),
 
     UniqueConstraint('uuid', name='uix_1'),
+    Index('bundle_store_name_index', 'name'),
+    Index('bundle_store_owner_index', 'owner_id'),
 )
 
 

--- a/codalab/model/tables.py
+++ b/codalab/model/tables.py
@@ -145,7 +145,7 @@ bundle_location = Table(
         autoincrement=True,
     ),
     # Which bundle this location contains the contents of.
-    # Column('bundle_uuid', String(63), ForeignKey(bundle.c.uuid), nullable=False),
+    Column('bundle_uuid', String(63), ForeignKey(bundle.c.uuid), nullable=False),
     # Which bundle store this location is on.
     Column('bundle_store_uuid', String(63), ForeignKey(bundle_store.c.uuid), nullable=False),
 )

--- a/codalab/model/tables.py
+++ b/codalab/model/tables.py
@@ -19,7 +19,7 @@ from sqlalchemy.types import (
     Unicode,
 )
 from sqlalchemy.sql.schema import ForeignKeyConstraint
-from codalab.common import StorageType
+from codalab.common import StorageType, StorageFormat
 
 db_metadata = MetaData()
 
@@ -92,6 +92,73 @@ bundle_dependency = Table(
     Column('parent_uuid', String(63), nullable=False),
     Column('parent_path', Text, nullable=False),
 )
+
+# Storage location for bundles.
+bundle_store = Table(
+    'bundle_store',
+    db_metadata,
+    Column(
+        'id',
+        BigInteger().with_variant(Integer, "sqlite"),
+        primary_key=True,
+        nullable=False,
+        autoincrement=True,
+    ),
+    Column('uuid', String(63), nullable=False),
+
+    # Usually root. For BYO bundle stores (not yet supported),
+    # it is the user who created the bundle store.
+    Column('owner_id', String(255), nullable=True),
+
+    # Name used to refer to this bundle store from the CLI.
+    Column('name', String(255), nullable=True),
+
+    # Storage type. This is usually redundant with information already in the url column, but set for efficiency reasons. When updating this column, sync it with codalab.common.StorageType.
+    Column(
+        'storage_type',
+        Enum(StorageType.DISK_STORAGE.value, StorageType.AZURE_BLOB_STORAGE.value),
+        nullable=True,
+    ),
+
+    # The format through which the bundle is stored.
+    Column(
+        'storage_format',
+        Enum(StorageFormat.UNCOMPRESSED.value, StorageFormat.COMPRESSED_V1.value)
+    ),
+
+    # URL that uniquely identifies the bundle store.
+    Column('url', String(255), nullable=True),
+    
+    # Authentication / password to access the bundle store.
+    Column('authentication', String(255), nullable=True),
+
+    # Name of environment variable through which the authentication variable from above can be passed to codalab-service to access the bundle store.
+    Column('authentication_env', String(255), nullable=True),
+
+    UniqueConstraint('uuid', 'owner_id', name='uix_1'),
+)
+
+
+# Location where the contents of a bundle is stored. Multiple
+# BundleLocations can be associated with a single Bundle.
+bundle_location = Table(
+    'bundle_location',
+    db_metadata,
+    Column(
+        'id',
+        BigInteger().with_variant(Integer, "sqlite"),
+        primary_key=True,
+        nullable=False,
+        autoincrement=True,
+    ),
+
+    # Which bundle this location contains the contents of.
+    Column('bundle_uuid', String(63), ForeignKey(bundle.c.uuid), nullable=False),
+
+    # Which bundle store this location is on.
+    Column('bundle_store_uuid', String(63), ForeignKey(bundle_store.c.uuid), nullable=False),
+)
+
 
 # The worksheet table does not have many columns now, but it will eventually
 # include columns for owner, group, permissions, etc.

--- a/codalab/model/tables.py
+++ b/codalab/model/tables.py
@@ -55,6 +55,7 @@ bundle = Table(
     UniqueConstraint('uuid', name='uix_1'),
     Index('bundle_data_hash_index', 'data_hash'),
     Index('state_index', 'state'),  # Needed for the bundle manager.
+    mysql_charset='utf8'
 )
 
 # Includes things like name, description, etc.
@@ -72,6 +73,7 @@ bundle_metadata = Table(
     Column('metadata_key', String(63), nullable=False),
     Column('metadata_value', Text, nullable=False),
     Index('metadata_kv_index', 'metadata_key', 'metadata_value', mysql_length=63),
+    mysql_charset='utf8'
 )
 
 # For each child_uuid, we have: key = child_path, target = (parent_uuid, parent_path)
@@ -91,6 +93,7 @@ bundle_dependency = Table(
     # dependencies to bundles not (yet) in the system.
     Column('parent_uuid', String(63), nullable=False),
     Column('parent_path', Text, nullable=False),
+    mysql_charset='utf8'
 )
 
 # Storage location for bundles.
@@ -129,6 +132,7 @@ bundle_store = Table(
     UniqueConstraint('uuid', name='uix_1'),
     Index('bundle_store_name_index', 'name'),
     Index('bundle_store_owner_index', 'owner_id'),
+    mysql_charset='utf8'
 )
 
 
@@ -148,6 +152,7 @@ bundle_location = Table(
     Column('bundle_uuid', String(63), ForeignKey(bundle.c.uuid), nullable=False),
     # Which bundle store this location is on.
     Column('bundle_store_uuid', String(63), ForeignKey(bundle_store.c.uuid), nullable=False),
+    mysql_charset='utf8'
 )
 
 
@@ -180,6 +185,7 @@ worksheet = Table(
     UniqueConstraint('uuid', name='uix_1'),
     Index('worksheet_name_index', 'name'),
     Index('worksheet_owner_index', 'owner_id'),
+    mysql_charset='utf8'
 )
 
 worksheet_item = Table(
@@ -208,6 +214,7 @@ worksheet_item = Table(
     Index('worksheet_item_worksheet_uuid_index', 'worksheet_uuid'),
     Index('worksheet_item_bundle_uuid_index', 'bundle_uuid'),
     Index('worksheet_item_subworksheet_uuid_index', 'subworksheet_uuid'),
+    mysql_charset='utf8'
 )
 
 # Worksheet tags
@@ -225,6 +232,7 @@ worksheet_tag = Table(
     Column('tag', String(63), nullable=False),
     Index('worksheet_tag_worksheet_uuid_index', 'worksheet_uuid'),
     Index('worksheet_tag_tag_index', 'tag'),
+    mysql_charset='utf8'
 )
 
 group = Table(
@@ -244,6 +252,7 @@ group = Table(
     UniqueConstraint('uuid', name='uix_1'),
     Index('group_name_index', 'name'),
     Index('group_owner_id_index', 'owner_id'),
+    mysql_charset='utf8'
 )
 
 user_group = Table(
@@ -262,6 +271,7 @@ user_group = Table(
     Column('is_admin', Boolean),
     Index('group_uuid_index', 'group_uuid'),
     Index('user_id_index', 'user_id'),
+    mysql_charset='utf8'
 )
 
 # Permissions for bundles
@@ -280,6 +290,7 @@ group_bundle_permission = Table(
     Column('object_uuid', String(63), ForeignKey(bundle.c.uuid), nullable=False),
     # Permissions encoded as integer (see below)
     Column('permission', Integer, nullable=False),
+    mysql_charset='utf8'
 )
 
 # Permissions for worksheets
@@ -298,6 +309,7 @@ group_object_permission = Table(
     Column('object_uuid', String(63), ForeignKey(worksheet.c.uuid), nullable=False),
     # Permissions encoded as integer (see below)
     Column('permission', Integer, nullable=False),
+    mysql_charset='utf8'
 )
 
 # A permission value is one of the following: none (0), read (1), or all (2).
@@ -356,6 +368,7 @@ user = Table(
     Index('user_user_id_index', 'user_id'),
     Index('user_user_name_index', 'user_name'),
     UniqueConstraint('user_id', name='uix_1'),
+    mysql_charset='utf8'
 )
 
 # Stores (email) verification keys
@@ -373,6 +386,7 @@ user_verification = Table(
     Column('date_created', DateTime, nullable=False),
     Column('date_sent', DateTime, nullable=True),
     Column('key', String(64), nullable=False),
+    mysql_charset='utf8'
 )
 
 # Stores password reset codes
@@ -389,6 +403,7 @@ user_reset_code = Table(
     Column('user_id', String(63), ForeignKey(user.c.user_id), nullable=False),
     Column('date_created', DateTime, nullable=False),
     Column('code', String(64), nullable=False),
+    mysql_charset='utf8'
 )
 
 # OAuth2 Tables
@@ -416,6 +431,7 @@ oauth2_client = Table(
     Column('scopes', Text, nullable=False),  # comma-separated list of allowed scopes
     Column('redirect_uris', Text, nullable=False),  # comma-separated list of allowed redirect URIs
     UniqueConstraint('client_id', name='uix_1'),
+    mysql_charset='utf8'
 )
 
 oauth2_token = Table(
@@ -434,6 +450,7 @@ oauth2_token = Table(
     Column('access_token', String(255), unique=True),
     Column('refresh_token', String(255), unique=True),
     Column('expires', DateTime, nullable=False),
+    mysql_charset='utf8'
 )
 
 oauth2_auth_code = Table(
@@ -452,6 +469,7 @@ oauth2_auth_code = Table(
     Column('code', String(100), nullable=False),
     Column('expires', DateTime, nullable=False),
     Column('redirect_uri', String(255), nullable=False),
+    mysql_charset='utf8'
 )
 
 # Store information about users' questions or feedback.
@@ -475,6 +493,7 @@ chat = Table(
     Column(
         'bundle_uuid', String(63), nullable=True
     ),  # What is the id of the bundle that the sender is on?
+    mysql_charset='utf8'
 )
 
 # Store information about workers.
@@ -503,6 +522,7 @@ worker = Table(
         'exit_after_num_runs', Integer, nullable=False
     ),  # Number of jobs allowed to run on worker.
     Column('is_terminating', Boolean, nullable=False),
+    mysql_charset='utf8'
 )
 
 # Store information about all sockets currently allocated to each worker.
@@ -514,6 +534,7 @@ worker_socket = Table(
     # No foreign key constraint on the worker table so that we can create a socket
     # for the worker before adding the worker to the worker table.
     Column('socket_id', Integer, primary_key=True, nullable=False),
+    mysql_charset='utf8'
 )
 
 # Store information about the bundles currently running on each worker.
@@ -525,6 +546,7 @@ worker_run = Table(
     ForeignKeyConstraint(['user_id', 'worker_id'], ['worker.user_id', 'worker.worker_id']),
     Column('run_uuid', String(63), ForeignKey(bundle.c.uuid), nullable=False),
     Index('uuid_index', 'run_uuid'),
+    mysql_charset='utf8'
 )
 
 # Store information about the dependencies available on each worker.
@@ -537,4 +559,5 @@ worker_dependency = Table(
     # Serialized list of dependencies for the user/worker combination.
     # See WorkerModel for the serialization method.
     Column('dependencies', LargeBinary, nullable=False),
+    mysql_charset='utf8'
 )

--- a/codalab/model/tables.py
+++ b/codalab/model/tables.py
@@ -23,7 +23,7 @@ from codalab.common import StorageType, StorageFormat
 
 db_metadata = MetaData()
 
-# Set the table's charset to utf8, so that it is not set to latin1 by default.
+# Set tables' charset to utf8, so that it is not set to latin1 by default upon creation.
 # TODO: Migrate to utf8mb4 (https://github.com/codalab/codalab-worksheets/issues/3849)
 TABLE_DEFAULT_CHARSET = 'utf8'
 


### PR DESCRIPTION
Second try for https://github.com/codalab/codalab-worksheets/pull/3818.

## Problem

The problem was that when we created all our existing tables on dev earlier, SQLAlchemy would pick the `utf8_general_ci` collation by default for these tables. Sometime later, though, once we upgraded SQLAlchemy, it changed the default collation to `latin1_swedish_ci`. What this means is that when we added these two new tables (bundle_location and bundle_store) they are the only tables with a `latin1_swedish_ci` collation:

```mysql> select table_name, TABLE_COLLATION, ENGINE from information_schema.TABLES;
+---------------------------------------+-------------------+--------+
| table_name                            | TABLE_COLLATION   | ENGINE |
+---------------------------------------+-------------------+--------+
| alembic_version                       | utf8_general_ci   | InnoDB |
| bundle                                | utf8_general_ci   | InnoDB |
| bundle_dependency                     | utf8_general_ci   | InnoDB |
| bundle_location                       | latin1_swedish_ci | InnoDB |
| bundle_metadata                       | utf8_general_ci   | InnoDB |
| bundle_store                          | latin1_swedish_ci | InnoDB |
| chat                                  | utf8_general_ci   | InnoDB |
| group                                 | utf8_general_ci   | InnoDB |
| group_bundle_permission               | utf8_general_ci   | InnoDB |
| group_object_permission               | utf8_general_ci   | InnoDB |
| oauth2_auth_code                      | utf8_general_ci   | InnoDB |
| oauth2_client                         | utf8_general_ci   | InnoDB |
| oauth2_token                          | utf8_general_ci   | InnoDB |
| user                                  | utf8_general_ci   | InnoDB |
| user_group                            | utf8_general_ci   | InnoDB |
| user_reset_code                       | utf8_general_ci   | InnoDB |
| user_verification                     | utf8_general_ci   | InnoDB |
| worker                                | utf8_general_ci   | InnoDB |
| worker_dependency                     | utf8_general_ci   | InnoDB |
| worker_run                            | utf8_general_ci   | InnoDB |
| worker_socket                         | utf8_general_ci   | InnoDB |
| worksheet                             | utf8_general_ci   | InnoDB |
| worksheet_item                        | utf8_general_ci   | InnoDB |
| worksheet_tag                         | utf8_general_ci   | InnoDB |
+---------------------------------------+-------------------+--------+
64 rows in set (0.01 sec)
```

Moreover, the `bundle_store.bundle_uuid` column is a ForeignKey to the `bundle.uuid` column, which means that both columns must have the same collation. Because these collations don't match, it wasn't able to add these tables.

## Solution

This PR explicitly sets the charset for all tables to utf8, meaning that they will use the `utf8_general_ci` collation by default.

If (which is likely) your local database tables were created with a newer version of SQLAlchemy, you will need to run the following commands to fix the collation first before deploying:

You may need to log in to the database:

docker exec -it codalab_mysql_1 /bin/bash
mysql -ucodalab -p
(password is codalab)

Then run:

```
SET foreign_key_checks=0;
ALTER TABLE  alembic_version           CONVERT TO CHARACTER SET utf8;
ALTER TABLE  bundle                    CONVERT TO CHARACTER SET utf8;
ALTER TABLE  bundle_dependency         CONVERT TO CHARACTER SET utf8;
ALTER TABLE  bundle_metadata           CONVERT TO CHARACTER SET utf8;
ALTER TABLE  chat                      CONVERT TO CHARACTER SET utf8;
ALTER TABLE  group                     CONVERT TO CHARACTER SET utf8;
ALTER TABLE  group_bundle_permission   CONVERT TO CHARACTER SET utf8;
ALTER TABLE  group_object_permission   CONVERT TO CHARACTER SET utf8;
ALTER TABLE  oauth2_auth_code          CONVERT TO CHARACTER SET utf8;
ALTER TABLE  oauth2_client             CONVERT TO CHARACTER SET utf8;
ALTER TABLE  oauth2_token              CONVERT TO CHARACTER SET utf8;
ALTER TABLE  user                      CONVERT TO CHARACTER SET utf8;
ALTER TABLE  user_group                CONVERT TO CHARACTER SET utf8;
ALTER TABLE  user_reset_code           CONVERT TO CHARACTER SET utf8;
ALTER TABLE  user_verification         CONVERT TO CHARACTER SET utf8;
ALTER TABLE  worker                    CONVERT TO CHARACTER SET utf8;
ALTER TABLE  worker_dependency         CONVERT TO CHARACTER SET utf8;
ALTER TABLE  worker_run                CONVERT TO CHARACTER SET utf8;
ALTER TABLE  worker_socket             CONVERT TO CHARACTER SET utf8;
ALTER TABLE  worksheet                 CONVERT TO CHARACTER SET utf8;
ALTER TABLE  worksheet_item            CONVERT TO CHARACTER SET utf8;
ALTER TABLE  worksheet_tag             CONVERT TO CHARACTER SET utf8;
ALTER TABLE  alembic_version           CHARACTER SET utf8 COLLATE utf8_general_ci;
ALTER TABLE  bundle                    CHARACTER SET utf8 COLLATE utf8_general_ci;
ALTER TABLE  bundle_dependency         CHARACTER SET utf8 COLLATE utf8_general_ci;
ALTER TABLE  bundle_metadata           CHARACTER SET utf8 COLLATE utf8_general_ci;
ALTER TABLE  chat                      CHARACTER SET utf8 COLLATE utf8_general_ci;
ALTER TABLE  group                     CHARACTER SET utf8 COLLATE utf8_general_ci;
ALTER TABLE  group_bundle_permission   CHARACTER SET utf8 COLLATE utf8_general_ci;
ALTER TABLE  group_object_permission   CHARACTER SET utf8 COLLATE utf8_general_ci;
ALTER TABLE  oauth2_auth_code          CHARACTER SET utf8 COLLATE utf8_general_ci;
ALTER TABLE  oauth2_client             CHARACTER SET utf8 COLLATE utf8_general_ci;
ALTER TABLE  oauth2_token              CHARACTER SET utf8 COLLATE utf8_general_ci;
ALTER TABLE  user                      CHARACTER SET utf8 COLLATE utf8_general_ci;
ALTER TABLE  user_group                CHARACTER SET utf8 COLLATE utf8_general_ci;
ALTER TABLE  user_reset_code           CHARACTER SET utf8 COLLATE utf8_general_ci;
ALTER TABLE  user_verification         CHARACTER SET utf8 COLLATE utf8_general_ci;
ALTER TABLE  worker                    CHARACTER SET utf8 COLLATE utf8_general_ci;
ALTER TABLE  worker_dependency         CHARACTER SET utf8 COLLATE utf8_general_ci;
ALTER TABLE  worker_run                CHARACTER SET utf8 COLLATE utf8_general_ci;
ALTER TABLE  worker_socket             CHARACTER SET utf8 COLLATE utf8_general_ci;
ALTER TABLE  worksheet                 CHARACTER SET utf8 COLLATE utf8_general_ci;
ALTER TABLE  worksheet_item            CHARACTER SET utf8 COLLATE utf8_general_ci;
ALTER TABLE  worksheet_tag             CHARACTER SET utf8 COLLATE utf8_general_ci;
SET foreign_key_checks=1;
```

We'll need to do this on codalab.stanford.edu, as all the tables currently use latin1_swedish_ci (you can check by running the `select table_name, TABLE_COLLATION, ENGINE from information_schema.TABLES;` command from above).

## Future steps

We should convert to utf8mb4 because utf8 is being deprecated -- see https://github.com/codalab/codalab-worksheets/issues/3849.