### PR TITLE
Only show file names and line numbers in worker logs when --verbose is set

### DIFF
--- a/codalab/worker/main.py
+++ b/codalab/worker/main.py
@@ -238,10 +238,13 @@ def main():
         )
 
     # Configure logging
-    logging.basicConfig(
-        format='%(asctime)s %(message)s %(pathname)s %(lineno)d',
-        level=(logging.DEBUG if args.verbose else logging.INFO),
-    )
+    log_format: str = '%(asctime)s %(message)s'
+    if args.verbose:
+        log_format += ' %(pathname)s %(lineno)d'
+        log_level = logging.DEBUG
+    else:
+        log_level = logging.INFO
+    logging.basicConfig(format=log_format, level=log_level)
 
     logging.getLogger('urllib3').setLevel(logging.INFO)
     # Initialize sentry logging


### PR DESCRIPTION
### Reasons for making this change

Only show file names and line numbers in worker logs when --verbose is set

Without `--verbose`:

```
(tonyhlee_wilds) tonyhlee@john0:~/codalab/codalab-worksheets$ cl-worker
2021-10-28 10:51:37,415 Connecting to https://worksheets.codalab.org
2021-10-28 10:51:43,650 Loaded 0 dependencies, 0 paths from cache.
2021-10-28 10:51:46,349 Cannot initialize NVIDIA runtime, no GPU support: Problem getting NVIDIA devices: 500 Server Error: Internal Server Error ("OCI runtime create failed: container_linux.go:367: starting container process caused: process_linux.go:495: container init caused: Running hook #1:: error running hook: exit status 1, stdout: , stderr: nvidia-container-cli: initialization error: driver error: failed to process request: unknown")
2021-10-28 10:51:46,768 Worker started!
2021-10-28 10:51:46,771 Starting image manager
2021-10-28 10:51:46,771 Starting local dependency manager
2021-10-28 10:51:50,233 Connected! Successful check in
```

With `--verbose`:

```
...
2021-10-28 10:53:22,903 Worker started! /sailhome/tonyhlee/codalab/codalab-worksheets/codalab/worker/main.py 336
2021-10-28 10:53:22,904 Starting image manager /sailhome/tonyhlee/codalab/codalab-worksheets/codalab/worker/image_manager.py 52
2021-10-28 10:53:22,904 Starting local dependency manager /sailhome/tonyhlee/codalab/codalab-worksheets/codalab/worker/dependency_manager.py 173
2021-10-28 10:53:26,366 Connected! Successful check in! /sailhome/tonyhlee/codalab/codalab-worksheets/codalab/worker/worker.py 429
```

### Related issues

Resolves #3867