### PR TITLE
Fix worksheets display limit

### DIFF
--- a/frontend/src/components/Dashboard/MainPanel.js
+++ b/frontend/src/components/Dashboard/MainPanel.js
@@ -189,7 +189,7 @@ class MainPanel extends React.Component<{
 
     componentDidMount() {
         // Fetch worksheets owned by the current user
-        navBarSearch(['owner=' + this.props.userInfo.user_name])
+        navBarSearch(['owner=' + this.props.userInfo.user_name, '.limit=' + 100])
             .then((data) => this.setWorksheets(data))
             .catch(defaultErrorHandler);
         navBarSearch(['.shared', '.notmine', '.limit=' + 100])


### PR DESCRIPTION
### Reasons for making this change

The profile page is only displaying up to 10 worksheets instead of 100 for "my worksheets".

By default the limit is 10, we just need to specify limit to be 100.

### Related issues

fixes #3838 

### Screenshots

![image](https://user-images.githubusercontent.com/29891066/141927983-6cb348bb-e7b2-4737-aefc-15197cba111d.png)

### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
