### PR TITLE
Fix build by pinning markdown dependency

### DIFF
--- a/requirements.docs.txt
+++ b/requirements.docs.txt
@@ -1,3 +1,4 @@
 tornado<7.0
+markdown==3.3.6
 mkdocs==1.1.2
 mkdocs-material==6.2.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ docker==4.3.0
 marshmallow-jsonapi==0.15.1
 marshmallow==2.15.1
 setuptools>=40.0.0
-argcomplete==1.12.1
+argcomplete==1.12.3
 indexed_gzip==1.6.3
 ratarmountcore==0.1.0
 PyYAML==5.4


### PR DESCRIPTION
- Pin markdown dependency
- Update argcomplete to work with the latest version of markdown