### PR TITLE
Bump ratarmountcore version to 0.1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ marshmallow==2.15.1
 setuptools>=40.0.0
 argcomplete==1.12.3
 indexed_gzip==1.6.3
-ratarmountcore==0.1.0
+ratarmountcore==0.1.1
 PyYAML==5.4
 psutil==5.7.2
 six==1.15.0


### PR DESCRIPTION
Fixes error:

```
 File "/Users/tonyhlee/research/codalab/codalab-worksheets/codalab/worker/tar_subdir_stream.py", line 5, in <module>
    from ratarmountcore import FileInfo
  File "/Users/tonyhlee/research/codalab/codalab-worksheets/venv/lib/python3.8/site-packages/ratarmountcore/__init__.py", line 53, in <module>
    from .ZipMountSource import ZipMountSource
  File "/Users/tonyhlee/research/codalab/codalab-worksheets/venv/lib/python3.8/site-packages/ratarmountcore/ZipMountSource.py", line 11, in <module>
    from .compressions import zipfile
ImportError: cannot import name 'zipfile' from 'ratarmountcore.compressions'
```