### PR TITLE
Fix login process doesn't remember the worksheets page

### DIFF
--- a/frontend/src/components/NavBar.js
+++ b/frontend/src/components/NavBar.js
@@ -359,7 +359,12 @@ class NavBar extends React.Component<{
                                 <Link to='/account/signup'>
                                     <Button color='inherit'>Sign Up</Button>
                                 </Link>
-                                <Link to='/account/login'>
+                                <Link
+                                    to={{
+                                        pathname: '/account/login',
+                                        state: { from: this.props.location },
+                                    }}
+                                >
                                     <Button color='inherit'>Login</Button>
                                 </Link>
                             </React.Fragment>


### PR DESCRIPTION
### Reasons for making this change

Currently, logging out and back in doesn't bring the user back to the previous worksheet page.

### Related issues

fixes #3892 

### Screenshots

To fix this, we just need to path in the correct props to the login page.

![a](https://user-images.githubusercontent.com/29891066/144033284-6b2ed6f4-342b-430a-b61d-2e02235b69f7.gif)

### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
