### PR TITLE
Andy/multiple bundle location

### DIFF
--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -2943,21 +2943,20 @@ class BundleModel(object):
                 .where(cl_bundle_location.c.bundle_uuid == bundle_uuid)
             ).fetchall()
             rows_data = [{'name': row.name, 'storage_type': row.storage_type, 'storage_format': row.storage_format, 'url': row.url} for row in rows]
-            return BundleLocationListSchema(strict=True, many=True).load(rows_data).data
+            return rows_data
 
-    def add_bundle_location(self, bundle_uuid: str, bundle_store_uuid: str) -> str:
+    def add_bundle_location(self, bundle_uuid: str, bundle_store_uuid: str) -> None:
         """
         adds a new bundle location to the specified bundle and returns SAS URL
         """
-        uuid = spec_util.generate_uuid()
         with self.engine.begin() as connection:
             bundle_location_value = {
-                'id': uuid,
                 'bundle_uuid': bundle_uuid,
                 'bundle_store_uuid': bundle_store_uuid
             }
             connection.execute(cl_bundle_location.insert().values(bundle_location_value))
-        return uuid
+        
+        #return uuid
 
     def get_bundle_location(self, bundle_uuid, location_id):
         """
@@ -2973,4 +2972,4 @@ class BundleModel(object):
                 ).where(and_(cl_bundle_location.c.bundle_uuid == bundle_uuid, cl_bundle_location.c.id == location_id))
             ).fetchone()
             row_data = {'name': row.name, 'storage_type': row.storage_type, 'storage_format': row.storage_format, 'url': row.url}
-            return BundleLocationListSchema(strict=True, many=True).load(row_data).data
+            return row_data

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -2924,7 +2924,7 @@ class BundleModel(object):
             ).fetchall()
             return [{'name': row.name, 'storage_type': row.storage_type, 'storage_format': row.storage_format, 'url': row.url} for row in rows]
 
-    def add_bundle_location(self, bundle_uuid):
+    def add_bundle_location(self, new_location):
         """
         adds a new bundle location to the specified bundle and returns SAS URL
         """
@@ -2933,11 +2933,11 @@ class BundleModel(object):
             bundle_location_value = {
                 'uuid': uuid,
                 'bundle_uuid': bundle_uuid,
-                'bundle_store': # TODO
+                'bundle_store': # TODO - obtain from request
             }
             connection.execute(cl_bundle_location.insert().values(bundle_location_value))
-        
-        # TODO - Return SAS URL
+
+        return uuid # return entire bundle location
 
     def get_bundle_location(self, bundle_uuid, location_id):
         """
@@ -2956,12 +2956,3 @@ class BundleModel(object):
             # Ensure that the specified bundle location exists for the provided bundle
             if row is None:
                 return None
-            
-            # TODO - fetch the SAS URL
-            # target = BundleTarget(location_id, path='')
-            # return local.download_manager.get_target_sas_url(
-            #     target,
-            #     content_type=response.get_header('Content-Type'),
-            #     content_encoding=response.get_header('Content-Encoding'),
-            #     content_disposition=response.get_header('Content-Disposition'),
-            # )

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -61,7 +61,7 @@ from codalab.objects.dependency import Dependency
 from codalab.rest.util import get_group_info
 from codalab.worker.bundle_state import State
 from codalab.worker.worker_run_state import RunStage
-
+from typing import List
 
 logger = logging.getLogger(__name__)
 
@@ -2926,7 +2926,7 @@ class BundleModel(object):
     # Multiple bundle locations methods follow!
     # ===========================================================================
 
-    def get_bundle_locations(self, bundle_uuid):
+    def get_bundle_locations(self, bundle_uuid: str) -> List[dict]:
         """
         returns all bundle locations associated with the specified bundle
         """
@@ -2948,7 +2948,7 @@ class BundleModel(object):
                 )
                 .where(cl_bundle_location.c.bundle_uuid == bundle_uuid)
             ).fetchall()
-            rows_data = [
+            return [
                 {
                     'name': row.name,
                     'storage_type': row.storage_type,
@@ -2957,11 +2957,10 @@ class BundleModel(object):
                 }
                 for row in rows
             ]
-            return rows_data
 
     def add_bundle_location(self, bundle_uuid: str, bundle_store_uuid: str) -> None:
         """
-        adds a new bundle location to the specified bundle and returns SAS URL
+        adds a new bundle location to the specified bundle
         """
         with self.engine.begin() as connection:
             bundle_location_value = {
@@ -2970,9 +2969,9 @@ class BundleModel(object):
             }
             connection.execute(cl_bundle_location.insert().values(bundle_location_value))
 
-    def get_bundle_location(self, bundle_uuid, store_id):
+    def get_bundle_location(self, bundle_uuid: str, bundle_store_uuid: str) -> dict:
         """
-        returns the SAS URL for the specified location associated with the specified bundle
+        returns data about the location associated with the specified bundle and bundle store
         """
         with self.engine.begin() as connection:
             row = connection.execute(
@@ -2993,14 +2992,13 @@ class BundleModel(object):
                 .where(
                     and_(
                         cl_bundle_location.c.bundle_uuid == bundle_uuid,
-                        cl_bundle_location.c.bundle_store_uuid == store_id,
+                        cl_bundle_location.c.bundle_store_uuid == bundle_store_uuid,
                     )
                 )
             ).fetchone()
-            row_data = {
+            return {
                 'name': row.name,
                 'storage_type': row.storage_type,
                 'storage_format': row.storage_format,
                 'url': row.url,
             }
-            return row_data

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -2892,6 +2892,26 @@ class BundleModel(object):
 
         return OAuth2AuthCode(self, **row)
 
+
+    def create_bundle_store(self, user, name, storage_type, storage_format, url, authentication):
+        """
+        create a bundle store
+        """
+        uuid = spec_util.generate_uuid()
+        with self.engine.begin() as connection:
+            bundle_store_value = {
+                'uuid': uuid,
+                'owner_id': user,
+                'name': name,
+                'storage_type': storage_type,
+                'storage_format': storage_format,
+                'url': url,
+                'authentication': authentication,
+            }
+            connection.execute(cl_bundle_store.insert().values(bundle_store_value))
+        return uuid
+
+
     def save_oauth2_auth_code(self, grant):
         with self.engine.begin() as connection:
             result = connection.execute(oauth2_auth_code.insert().values(grant.columns))

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -2892,7 +2892,6 @@ class BundleModel(object):
 
         return OAuth2AuthCode(self, **row)
 
-
     def create_bundle_store(self, user, name, storage_type, storage_format, url, authentication):
         """
         create a bundle store
@@ -2910,7 +2909,6 @@ class BundleModel(object):
             }
             connection.execute(cl_bundle_store.insert().values(bundle_store_value))
         return uuid
-
 
     def save_oauth2_auth_code(self, grant):
         with self.engine.begin() as connection:
@@ -2934,15 +2932,31 @@ class BundleModel(object):
         """
         with self.engine.begin() as connection:
             rows = connection.execute(
-                select([cl_bundle_store.c.name, cl_bundle_store.c.storage_type, cl_bundle_store.c.storage_format, cl_bundle_store.c.url])
+                select(
+                    [
+                        cl_bundle_store.c.name,
+                        cl_bundle_store.c.storage_type,
+                        cl_bundle_store.c.storage_format,
+                        cl_bundle_store.c.url,
+                    ]
+                )
                 .select_from(
                     cl_bundle_location.join(
-                        cl_bundle_store, cl_bundle_store.c.uuid == cl_bundle_location.c.bundle_store_uuid
+                        cl_bundle_store,
+                        cl_bundle_store.c.uuid == cl_bundle_location.c.bundle_store_uuid,
                     )
                 )
                 .where(cl_bundle_location.c.bundle_uuid == bundle_uuid)
             ).fetchall()
-            rows_data = [{'name': row.name, 'storage_type': row.storage_type, 'storage_format': row.storage_format, 'url': row.url} for row in rows]
+            rows_data = [
+                {
+                    'name': row.name,
+                    'storage_type': row.storage_type,
+                    'storage_format': row.storage_format,
+                    'url': row.url,
+                }
+                for row in rows
+            ]
             return rows_data
 
     def add_bundle_location(self, bundle_uuid: str, bundle_store_uuid: str) -> None:
@@ -2952,22 +2966,41 @@ class BundleModel(object):
         with self.engine.begin() as connection:
             bundle_location_value = {
                 'bundle_uuid': bundle_uuid,
-                'bundle_store_uuid': bundle_store_uuid
+                'bundle_store_uuid': bundle_store_uuid,
             }
             connection.execute(cl_bundle_location.insert().values(bundle_location_value))
-        
+
     def get_bundle_location(self, bundle_uuid, store_id):
         """
         returns the SAS URL for the specified location associated with the specified bundle
         """
         with self.engine.begin() as connection:
             row = connection.execute(
-                select([cl_bundle_store.c.name, cl_bundle_store.c.storage_type, cl_bundle_store.c.storage_format, cl_bundle_store.c.url])
+                select(
+                    [
+                        cl_bundle_store.c.name,
+                        cl_bundle_store.c.storage_type,
+                        cl_bundle_store.c.storage_format,
+                        cl_bundle_store.c.url,
+                    ]
+                )
                 .select_from(
                     cl_bundle_location.join(
-                        cl_bundle_store, cl_bundle_store.c.uuid == cl_bundle_location.c.bundle_store_uuid
+                        cl_bundle_store,
+                        cl_bundle_store.c.uuid == cl_bundle_location.c.bundle_store_uuid,
                     )
-                ).where(and_(cl_bundle_location.c.bundle_uuid == bundle_uuid, cl_bundle_location.c.bundle_store_uuid == store_id))
+                )
+                .where(
+                    and_(
+                        cl_bundle_location.c.bundle_uuid == bundle_uuid,
+                        cl_bundle_location.c.bundle_store_uuid == store_id,
+                    )
+                )
             ).fetchone()
-            row_data = {'name': row.name, 'storage_type': row.storage_type, 'storage_format': row.storage_format, 'url': row.url}
+            row_data = {
+                'name': row.name,
+                'storage_type': row.storage_type,
+                'storage_format': row.storage_format,
+                'url': row.url,
+            }
             return row_data

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -2956,8 +2956,6 @@ class BundleModel(object):
             }
             connection.execute(cl_bundle_location.insert().values(bundle_location_value))
         
-        #return uuid
-
     def get_bundle_location(self, bundle_uuid, location_id):
         """
         returns the SAS URL for the specified location associated with the specified bundle

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -2928,7 +2928,13 @@ class BundleModel(object):
 
     def get_bundle_locations(self, bundle_uuid: str) -> List[dict]:
         """
-        returns all bundle locations associated with the specified bundle
+        Returns all bundle locations associated with the specified bundle.
+
+        Args:
+            bundle_uuid (str): The uuid for the bundle whose locations we want to fetch.
+        
+        Returns:
+            A list of bundle locations associated with the specified bundle uuid.
         """
         with self.engine.begin() as connection:
             rows = connection.execute(
@@ -2960,7 +2966,11 @@ class BundleModel(object):
 
     def add_bundle_location(self, bundle_uuid: str, bundle_store_uuid: str) -> None:
         """
-        adds a new bundle location to the specified bundle
+        Adds a new bundle location to the specified bundle.
+
+        Args:
+            bundle_uuid (str): The uuid for the bundle which we want to add a BundleLocation to.
+            bundle_store_uuid (str): The uuid for the bundle store we are associating with the new BundleLocation.
         """
         with self.engine.begin() as connection:
             bundle_location_value = {
@@ -2971,7 +2981,14 @@ class BundleModel(object):
 
     def get_bundle_location(self, bundle_uuid: str, bundle_store_uuid: str) -> dict:
         """
-        returns data about the location associated with the specified bundle and bundle store
+        Returns data about the location associated with the specified bundle and bundle store.
+
+        Args:
+            bundle_uuid (str): The uuid for the bundle whose location we want to fetch.
+            bundle_store_uuid (str): The uuid for the bundle store whose associated location we want to fetch.
+        
+        Returns:
+            An object representing the specific BundleLocation corresponding to the specified bundle and bundle store.
         """
         with self.engine.begin() as connection:
             row = connection.execute(

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -2952,7 +2952,7 @@ class BundleModel(object):
         uuid = spec_util.generate_uuid()
         with self.engine.begin() as connection:
             bundle_location_value = {
-                'uuid': uuid,
+                'id': uuid,
                 'bundle_uuid': bundle_uuid,
                 'bundle_store_uuid': bundle_store_uuid
             }

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -2915,6 +2915,11 @@ class BundleModel(object):
         with self.engine.begin() as connection:
             rows = connection.execute(
                 select([cl_bundle_store.c.name, cl_bundle_store.c.storage_type, cl_bundle_store.c.storage_format, cl_bundle_store.c.url])
+                .select_from(
+                    cl_bundle_location.join(
+                        cl_bundle_store, cl_bundle_store.c.uuid == cl_bundle_location.c.bundle_store
+                    )
+                )
                 .where(cl_bundle_location.c.bundle_uuid == bundle_uuid)
             ).fetchall()
             return [{'name': row.name, 'storage_type': row.storage_type, 'storage_format': row.storage_format, 'url': row.url} for row in rows]
@@ -2941,7 +2946,11 @@ class BundleModel(object):
         with self.engine.begin() as connection:
             row = connection.execute(
                 select([cl_bundle_store.c.name, cl_bundle_store.c.storage_type, cl_bundle_store.c.storage_format, cl_bundle_store.c.url])
-                .where(and_(cl_bundle_location.c.bundle_uuid == bundle_uuid, cl_bundle_location.c.id == location_id))
+                .select_from(
+                    cl_bundle_location.join(
+                        cl_bundle_store, cl_bundle_store.c.uuid == cl_bundle_location.c.bundle_store
+                    )
+                ).where(and_(cl_bundle_location.c.bundle_uuid == bundle_uuid, cl_bundle_location.c.id == location_id))
             ).fetchone()
             
             # Ensure that the specified bundle location exists for the provided bundle

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -2932,7 +2932,6 @@ class BundleModel(object):
 
         Args:
             bundle_uuid (str): The uuid for the bundle whose locations we want to fetch.
-        
         Returns:
             A list of bundle locations associated with the specified bundle uuid.
         """
@@ -2986,7 +2985,6 @@ class BundleModel(object):
         Args:
             bundle_uuid (str): The uuid for the bundle whose location we want to fetch.
             bundle_store_uuid (str): The uuid for the bundle store whose associated location we want to fetch.
-        
         Returns:
             An object representing the specific BundleLocation corresponding to the specified bundle and bundle store.
         """

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -2956,7 +2956,7 @@ class BundleModel(object):
             }
             connection.execute(cl_bundle_location.insert().values(bundle_location_value))
         
-    def get_bundle_location(self, bundle_uuid, location_id):
+    def get_bundle_location(self, bundle_uuid, store_id):
         """
         returns the SAS URL for the specified location associated with the specified bundle
         """
@@ -2967,7 +2967,7 @@ class BundleModel(object):
                     cl_bundle_location.join(
                         cl_bundle_store, cl_bundle_store.c.uuid == cl_bundle_location.c.bundle_store_uuid
                     )
-                ).where(and_(cl_bundle_location.c.bundle_uuid == bundle_uuid, cl_bundle_location.c.id == location_id))
+                ).where(and_(cl_bundle_location.c.bundle_uuid == bundle_uuid, cl_bundle_location.c.bundle_store_uuid == store_id))
             ).fetchone()
             row_data = {'name': row.name, 'storage_type': row.storage_type, 'storage_format': row.storage_format, 'url': row.url}
             return row_data

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -443,7 +443,7 @@ def _fetch_bundle_locations(bundle_uuid: str):
 @post('/bundles/<bundle_uuid:re:%s>/locations/', apply=AuthenticatedProtectedPlugin())
 def _add_bundle_location(bundle_uuid: str):
     """
-    Adds a new BundleLocation to a bundle
+    Adds a new BundleLocation to a bundle.
 
     Query parameters:
     - `bundle_uuid`: Bundle UUID corresponding to the new location

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -448,13 +448,13 @@ def _add_bundle_location(bundle_uuid: str):
     local.model.add_bundle_location(new_location['bundle_uuid'], new_location['bundle_store_uuid'])
     return BundleLocationSchema(many=False).dump(new_location).data
 
-@get('/bundles/<bundle_uuid:re:%s>/locations/<location_id:re:%s>/', apply=AuthenticatedProtectedPlugin())
-def _fetch_bundle_location(bundle_uuid, location_id):
+@get('/bundles/<bundle_uuid:re:%s>/locations/<store_id:re:%s>/', apply=AuthenticatedProtectedPlugin())
+def _fetch_bundle_location(bundle_uuid, store_id):
     """
     Get info about a specific BundleLocation. This returns a SAS URL that the caller 
     can use to download directly from a bundle location.
     """
-    bundle_location = local.model.get_bundle_location(bundle_uuid, location_id)
+    bundle_location = local.model.get_bundle_location(bundle_uuid, store_id)
     return BundleLocationListSchema(many=False).dump(bundle_location).data
 
 @get('/bundles/<uuid:re:%s>/contents/info/' % spec_util.UUID_STR, name='fetch_bundle_contents_info')

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -431,7 +431,7 @@ def _fetch_locations():
 @get('/bundles/<bundle_uuid:re:%s>/locations/', apply=AuthenticatedProtectedPlugin())
 def _fetch_bundle_locations(bundle_uuid: str):
     """
-    Returns a list of BundleLocations associated with the given bundle
+    Returns a list of BundleLocations associated with the given bundle.
 
     Query parameters:
     - `bundle_uuid`: Bundle UUID to get the locations for
@@ -443,11 +443,10 @@ def _fetch_bundle_locations(bundle_uuid: str):
 @post('/bundles/<bundle_uuid:re:%s>/locations/', apply=AuthenticatedProtectedPlugin())
 def _add_bundle_location(bundle_uuid: str):
     """
-    Adds a new BundleLocation to a bundle
+    Adds a new BundleLocation to a bundle. Request body must contain the fields in BundleLocationSchema.
 
     Query parameters:
     - `bundle_uuid`: Bundle UUID corresponding to the new location
-    - `bundle_store_uuid`: Bundle Store UUID corresponding to the new location
     """
     new_location = BundleLocationSchema(many=False).load(request.json).data
     local.model.add_bundle_location(new_location['bundle_uuid'], new_location['bundle_store_uuid'])
@@ -460,7 +459,7 @@ def _add_bundle_location(bundle_uuid: str):
 )
 def _fetch_bundle_location(bundle_uuid: str, bundle_store_uuid: str):
     """
-    Get info about a specific BundleLocation
+    Get info about a specific BundleLocation.
 
     Query parameters:
     - `bundle_uuid`: Bundle UUID to get the location for

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -445,7 +445,7 @@ def _add_bundle_location(bundle_uuid: str):
     Validates the user input against the BundleLocation schema
     """
     new_location = BundleLocationSchema(many=False).load(request.json).data
-    new_location['uuid'] = local.model.add_bundle_location(new_location['bundle_uuid'], new_location['bundle_store_uuid'])
+    local.model.add_bundle_location(new_location['bundle_uuid'], new_location['bundle_store_uuid'])
     return BundleLocationSchema(many=False).dump(new_location).data
 
 @get('/bundles/<bundle_uuid:re:%s>/locations/<location_id:re:%s>/', apply=AuthenticatedProtectedPlugin())

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -425,6 +425,7 @@ def _fetch_locations():
     }
     return dict(data=uuids_to_locations)
 
+
 @get('/bundles/<bundle_uuid:re:%s>/locations/', apply=AuthenticatedProtectedPlugin())
 def _fetch_bundle_locations(bundle_uuid):
     """
@@ -435,7 +436,8 @@ def _fetch_bundle_locations(bundle_uuid):
     """
     bundle_locations = local.model.get_bundle_locations(bundle_uuid)
     return BundleLocationListSchema(many=True).dump(bundle_locations).data
-    
+
+
 @post('/bundles/<bundle_uuid:re:%s>/locations/', apply=AuthenticatedProtectedPlugin())
 def _add_bundle_location(bundle_uuid: str):
     """
@@ -448,7 +450,10 @@ def _add_bundle_location(bundle_uuid: str):
     local.model.add_bundle_location(new_location['bundle_uuid'], new_location['bundle_store_uuid'])
     return BundleLocationSchema(many=False).dump(new_location).data
 
-@get('/bundles/<bundle_uuid:re:%s>/locations/<store_id:re:%s>/', apply=AuthenticatedProtectedPlugin())
+
+@get(
+    '/bundles/<bundle_uuid:re:%s>/locations/<store_id:re:%s>/', apply=AuthenticatedProtectedPlugin()
+)
 def _fetch_bundle_location(bundle_uuid, store_id):
     """
     Get info about a specific BundleLocation. This returns a SAS URL that the caller 
@@ -456,6 +461,7 @@ def _fetch_bundle_location(bundle_uuid, store_id):
     """
     bundle_location = local.model.get_bundle_location(bundle_uuid, store_id)
     return BundleLocationListSchema(many=False).dump(bundle_location).data
+
 
 @get('/bundles/<uuid:re:%s>/contents/info/' % spec_util.UUID_STR, name='fetch_bundle_contents_info')
 @get(

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -34,6 +34,8 @@ from codalab.objects.permission import (
 from codalab.rest.schemas import (
     BundleSchema,
     BundlePermissionSchema,
+    BundleLocationSchema,
+    BundleLocationListSchema,
     BUNDLE_CREATE_RESTRICTED_FIELDS,
     BUNDLE_UPDATE_RESTRICTED_FIELDS,
     WorksheetSchema,

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -430,6 +430,8 @@ def _fetch_bundle_locations(bundle_uuid):
     """
     Returns a list of BundleLocations associated with the given bundle in the format 
     [{name, storage_type, storage_format, url}]
+
+    TODO: Use schema to return output (look into `dump` function. See lines 407-409)
     """
     return dict(data=local.model.get_bundle_locations(bundle_uuid))
     
@@ -438,8 +440,14 @@ def _add_bundle_location(bundle_uuid):
     """
     Add a new BundleLocation to a bundle. Returns a SAS URL that the caller can then 
     use to upload directly to a bundle location
+
+    Validates the user input against the BundleLocation schema
     """
-    return dict(data=local.model.add_bundle_location(bundle_uuid))
+    new_location = BundleLocationSchema(strict=True, many=False).load(request.json).data
+    new_location = local.model.add_bundle_location(new_location)
+    return BundleLocationSchema(many=True).dump(new_location).data
+
+    # return dict(data=local.model.add_bundle_location(bundle_uuid))
 
 @get('/bundles/<bundle_uuid:re:%s>/locations/<location_id:re:%s>/', apply=AuthenticatedProtectedPlugin())
 def _fetch_bundle_location(bundle_uuid, location_id):

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -425,6 +425,29 @@ def _fetch_locations():
     }
     return dict(data=uuids_to_locations)
 
+@get('/bundles/<bundle_uuid:re:%s>/locations/', apply=AuthenticatedProtectedPlugin())
+def _fetch_bundle_locations(bundle_uuid):
+    """
+    Returns a list of BundleLocations associated with the given bundle in the format 
+    [{name, storage_type, storage_format, url}]
+    """
+    return dict(data=local.model.get_bundle_locations(bundle_uuid))
+    
+@post('/bundles/<bundle_uuid:re:%s>/locations/', apply=AuthenticatedProtectedPlugin())
+def _add_bundle_location(bundle_uuid):
+    """
+    Add a new BundleLocation to a bundle. Returns a SAS URL that the caller can then 
+    use to upload directly to a bundle location
+    """
+    return dict(data=local.model.add_bundle_location(bundle_uuid))
+
+@get('/bundles/<bundle_uuid:re:%s>/locations/<location_id:re:%s>/', apply=AuthenticatedProtectedPlugin())
+def _fetch_bundle_location(bundle_uuid, location_id):
+    """
+    Get info about a specific BundleLocation. This returns a SAS URL that the caller 
+    can use to download directly from a bundle location.
+    """
+    return dict(data=local.model.get_bundle_location(bundle_uuid, location_id))
 
 @get('/bundles/<uuid:re:%s>/contents/info/' % spec_util.UUID_STR, name='fetch_bundle_contents_info')
 @get(

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -429,12 +429,12 @@ def _fetch_locations():
 
 
 @get('/bundles/<bundle_uuid:re:%s>/locations/', apply=AuthenticatedProtectedPlugin())
-def _fetch_bundle_locations(bundle_uuid):
+def _fetch_bundle_locations(bundle_uuid: str):
     """
-    Returns a list of BundleLocations associated with the given bundle in the format 
-    [{name, storage_type, storage_format, url}]
+    Returns a list of BundleLocations associated with the given bundle
 
-    TODO: Use schema to return output (look into `dump` function. See lines 407-409)
+    Query parameters:
+    - `bundle_uuid`: Bundle UUID to get the locations for
     """
     bundle_locations = local.model.get_bundle_locations(bundle_uuid)
     return BundleLocationListSchema(many=True).dump(bundle_locations).data
@@ -443,10 +443,11 @@ def _fetch_bundle_locations(bundle_uuid):
 @post('/bundles/<bundle_uuid:re:%s>/locations/', apply=AuthenticatedProtectedPlugin())
 def _add_bundle_location(bundle_uuid: str):
     """
-    Add a new BundleLocation to a bundle. Returns a SAS URL that the caller can then 
-    use to upload directly to a bundle location
+    Adds a new BundleLocation to a bundle
 
-    Validates the user input against the BundleLocation schema
+    Query parameters:
+    - `bundle_uuid`: Bundle UUID corresponding to the new location
+    - `bundle_store_uuid`: Bundle Store UUID corresponding to the new location
     """
     new_location = BundleLocationSchema(many=False).load(request.json).data
     local.model.add_bundle_location(new_location['bundle_uuid'], new_location['bundle_store_uuid'])
@@ -454,14 +455,18 @@ def _add_bundle_location(bundle_uuid: str):
 
 
 @get(
-    '/bundles/<bundle_uuid:re:%s>/locations/<store_id:re:%s>/', apply=AuthenticatedProtectedPlugin()
+    '/bundles/<bundle_uuid:re:%s>/locations/<bundle_store_uuid:re:%s>/',
+    apply=AuthenticatedProtectedPlugin(),
 )
-def _fetch_bundle_location(bundle_uuid, store_id):
+def _fetch_bundle_location(bundle_uuid: str, bundle_store_uuid: str):
     """
-    Get info about a specific BundleLocation. This returns a SAS URL that the caller 
-    can use to download directly from a bundle location.
+    Get info about a specific BundleLocation
+
+    Query parameters:
+    - `bundle_uuid`: Bundle UUID to get the location for
+    - `bundle_store_uuid`: Bundle Store UUID to get the location for
     """
-    bundle_location = local.model.get_bundle_location(bundle_uuid, store_id)
+    bundle_location = local.model.get_bundle_location(bundle_uuid, bundle_store_uuid)
     return BundleLocationListSchema(many=False).dump(bundle_location).data
 
 

--- a/codalab/rest/schemas.py
+++ b/codalab/rest/schemas.py
@@ -221,7 +221,6 @@ class BundleSchema(Schema):
         type_ = 'bundles'
 
 class BundleLocationSchema(Schema):
-    # id = fields.String(validate=validate_uuid, attribute='uuid', required=False)
     bundle_uuid = fields.String(validate=validate_uuid, attribute='uuid')
     bundle_store_uuid = fields.String(validate=validate_uuid, attribute='uuid')
     class Meta:

--- a/codalab/rest/schemas.py
+++ b/codalab/rest/schemas.py
@@ -220,11 +220,14 @@ class BundleSchema(Schema):
     class Meta:
         type_ = 'bundles'
 
+
 class BundleLocationSchema(Schema):
     bundle_uuid = fields.String(validate=validate_uuid, attribute='uuid')
     bundle_store_uuid = fields.String(validate=validate_uuid, attribute='uuid')
+
     class Meta:
         type_ = 'bundle-location'
+
 
 class BundleLocationListSchema(Schema):
     # Used only for bundle locations GET endpoint
@@ -232,8 +235,10 @@ class BundleLocationListSchema(Schema):
     storage_type = fields.String()
     storage_format = fields.String()
     url = fields.Url(allow_none=True)
+
     class Meta:
         type_ = 'bundle-location-list'
+
 
 # Field-update restrictions are specified as lists below because the
 # restrictions differ depending on the action

--- a/codalab/rest/schemas.py
+++ b/codalab/rest/schemas.py
@@ -221,7 +221,7 @@ class BundleSchema(Schema):
         type_ = 'bundles'
 
 class BundleLocationSchema(Schema):
-    id = fields.String(validate=validate_uuid, attribute='uuid', required=False)
+    # id = fields.String(validate=validate_uuid, attribute='uuid', required=False)
     bundle_uuid = fields.String(validate=validate_uuid, attribute='uuid')
     bundle_store_uuid = fields.String(validate=validate_uuid, attribute='uuid')
     class Meta:

--- a/codalab/rest/schemas.py
+++ b/codalab/rest/schemas.py
@@ -220,6 +220,12 @@ class BundleSchema(Schema):
     class Meta:
         type_ = 'bundles'
 
+class BundleLocationSchema(Schema):
+    id = fields.String(validate=validate_uuid, attribute='uuid')
+    bundle_uuid = fields.Nested(BundleSchema, many=True)
+    bundle_store = fields.Nested(BundleStoreSchema, many=False)
+    class Meta:
+        type_ = 'bundle-location'
 
 # Field-update restrictions are specified as lists below because the
 # restrictions differ depending on the action

--- a/codalab/rest/schemas.py
+++ b/codalab/rest/schemas.py
@@ -230,7 +230,6 @@ class BundleLocationSchema(Schema):
 
 
 class BundleLocationListSchema(Schema):
-    # Used only for bundle locations GET endpoint
     name = fields.String()
     storage_type = fields.String()
     storage_format = fields.String()

--- a/codalab/rest/schemas.py
+++ b/codalab/rest/schemas.py
@@ -221,9 +221,9 @@ class BundleSchema(Schema):
         type_ = 'bundles'
 
 class BundleLocationSchema(Schema):
-    id = fields.String(validate=validate_uuid, attribute='uuid', required=False) # make optional, only for output (ignore if user inputs id)
-    bundle_uuid = fields.Nested(BundleSchema, many=True)
-    bundle_store = fields.Nested(BundleStoreSchema, many=False)
+    id = fields.String(validate=validate_uuid, attribute='uuid', required=False)
+    bundle_uuid = fields.String(validate=validate_uuid, attribute='uuid')
+    bundle_store_uuid = fields.String(validate=validate_uuid, attribute='uuid')
     class Meta:
         type_ = 'bundle-location'
 
@@ -232,6 +232,7 @@ class BundleLocationListSchema(Schema):
     name = fields.String()
     storage_type = fields.String()
     storage_format = fields.String()
+    url = fields.Url(allow_none=True)
     class Meta:
         type_ = 'bundle-location-list'
 

--- a/codalab/rest/schemas.py
+++ b/codalab/rest/schemas.py
@@ -221,11 +221,19 @@ class BundleSchema(Schema):
         type_ = 'bundles'
 
 class BundleLocationSchema(Schema):
-    id = fields.String(validate=validate_uuid, attribute='uuid')
+    id = fields.String(validate=validate_uuid, attribute='uuid', required=False) # make optional, only for output (ignore if user inputs id)
     bundle_uuid = fields.Nested(BundleSchema, many=True)
     bundle_store = fields.Nested(BundleStoreSchema, many=False)
     class Meta:
         type_ = 'bundle-location'
+
+class BundleLocationListSchema(Schema):
+    # Used only for bundle locations GET endpoint
+    name = fields.String()
+    storage_type = fields.String()
+    storage_format = fields.String()
+    class Meta:
+        type_ = 'bundle-location-list'
 
 # Field-update restrictions are specified as lists below because the
 # restrictions differ depending on the action

--- a/docs/REST-API-Reference.md
+++ b/docs/REST-API-Reference.md
@@ -454,22 +454,21 @@ Query parameters:
 
 ### `GET /bundles/<bundle_uuid:re:%s>/locations/`
 
-Returns a list of BundleLocations associated with the given bundle
+Returns a list of BundleLocations associated with the given bundle.
 
 Query parameters:
 - `bundle_uuid`: Bundle UUID to get the locations for
 
 ### `POST /bundles/<bundle_uuid:re:%s>/locations/`
 
-Adds a new BundleLocation to a bundle
+Adds a new BundleLocation to a bundle. Request body must contain the fields in BundleLocationSchema.
 
 Query parameters:
 - `bundle_uuid`: Bundle UUID corresponding to the new location
-- `bundle_store_uuid`: Bundle Store UUID corresponding to the new location
 
 ### `GET /bundles/<bundle_uuid:re:%s>/locations/<bundle_store_uuid:re:%s>/`
 
-Get info about a specific BundleLocation
+Get info about a specific BundleLocation.
 
 Query parameters:
 - `bundle_uuid`: Bundle UUID to get the location for

--- a/docs/REST-API-Reference.md
+++ b/docs/REST-API-Reference.md
@@ -195,6 +195,24 @@ Name | Type
 `parent_path` | String
 `parent_name` | Method
 
+## bundle-location-list
+
+
+Name | Type
+--- | ---
+`name` | String
+`storage_type` | String
+`storage_format` | String
+`url` | Url
+
+## bundle-location
+
+
+Name | Type
+--- | ---
+`bundle_uuid` | String
+`bundle_store_uuid` | String
+
 ## bundle-permissions
 
 
@@ -433,6 +451,25 @@ Fetch locations of bundles.
 
 Query parameters:
 - `uuids`: List of bundle UUID's to get the locations for
+
+### `GET /bundles/<bundle_uuid:re:%s>/locations/`
+
+Returns a list of BundleLocations associated with the given bundle in the format 
+[{name, storage_type, storage_format, url}]
+
+TODO: Use schema to return output (look into `dump` function. See lines 407-409)
+
+### `POST /bundles/<bundle_uuid:re:%s>/locations/`
+
+Add a new BundleLocation to a bundle. Returns a SAS URL that the caller can then 
+use to upload directly to a bundle location
+
+Validates the user input against the BundleLocation schema
+
+### `GET /bundles/<bundle_uuid:re:%s>/locations/<store_id:re:%s>/`
+
+Get info about a specific BundleLocation. This returns a SAS URL that the caller 
+can use to download directly from a bundle location.
 
 ### `GET /bundles/<uuid:re:0x[0-9a-f]{32}>/contents/info/<path:path>`
 

--- a/docs/REST-API-Reference.md
+++ b/docs/REST-API-Reference.md
@@ -454,22 +454,26 @@ Query parameters:
 
 ### `GET /bundles/<bundle_uuid:re:%s>/locations/`
 
-Returns a list of BundleLocations associated with the given bundle in the format 
-[{name, storage_type, storage_format, url}]
+Returns a list of BundleLocations associated with the given bundle
 
-TODO: Use schema to return output (look into `dump` function. See lines 407-409)
+Query parameters:
+- `bundle_uuid`: Bundle UUID to get the locations for
 
 ### `POST /bundles/<bundle_uuid:re:%s>/locations/`
 
-Add a new BundleLocation to a bundle. Returns a SAS URL that the caller can then 
-use to upload directly to a bundle location
+Adds a new BundleLocation to a bundle
 
-Validates the user input against the BundleLocation schema
+Query parameters:
+- `bundle_uuid`: Bundle UUID corresponding to the new location
+- `bundle_store_uuid`: Bundle Store UUID corresponding to the new location
 
-### `GET /bundles/<bundle_uuid:re:%s>/locations/<store_id:re:%s>/`
+### `GET /bundles/<bundle_uuid:re:%s>/locations/<bundle_store_uuid:re:%s>/`
 
-Get info about a specific BundleLocation. This returns a SAS URL that the caller 
-can use to download directly from a bundle location.
+Get info about a specific BundleLocation
+
+Query parameters:
+- `bundle_uuid`: Bundle UUID to get the location for
+- `bundle_store_uuid`: Bundle Store UUID to get the location for
 
 ### `GET /bundles/<uuid:re:0x[0-9a-f]{32}>/contents/info/<path:path>`
 

--- a/tests/unit/server/bundle_store_test.py
+++ b/tests/unit/server/bundle_store_test.py
@@ -26,13 +26,33 @@ class BundleStoreTest(BaseBundleManagerTest):
 
         # Call get_bundle_locations
         bundle_locations = self.bundle_manager._model.get_bundle_locations(bundle.uuid)
-        self.assertEqual(bundle_locations, [{'name': 'store1', 'storage_type': 'disk', 'storage_format': 'uncompressed', 'url': 'http://url'}])
-        
-        # Call get_bundle_location
-        bundle_location = self.bundle_manager._model.get_bundle_location(bundle.uuid, bundle_store_uuid)
-        self.assertEqual(bundle_location, {'name': 'store1', 'storage_type': 'disk', 'storage_format': 'uncompressed', 'url': 'http://url'})
+        self.assertEqual(
+            bundle_locations,
+            [
+                {
+                    'name': 'store1',
+                    'storage_type': 'disk',
+                    'storage_format': 'uncompressed',
+                    'url': 'http://url',
+                }
+            ],
+        )
 
-        # Create second bundle store 
+        # Call get_bundle_location
+        bundle_location = self.bundle_manager._model.get_bundle_location(
+            bundle.uuid, bundle_store_uuid
+        )
+        self.assertEqual(
+            bundle_location,
+            {
+                'name': 'store1',
+                'storage_type': 'disk',
+                'storage_format': 'uncompressed',
+                'url': 'http://url',
+            },
+        )
+
+        # Create second bundle store
         bundle_store_uuid_2 = self.bundle_manager._model.create_bundle_store(
             user=self.user_id,
             name="store2",
@@ -49,8 +69,34 @@ class BundleStoreTest(BaseBundleManagerTest):
 
         # Call get_bundle_locations
         bundle_locations_2 = self.bundle_manager._model.get_bundle_locations(bundle.uuid)
-        self.assertEqual(bundle_locations_2, [{'name': 'store1', 'storage_type': 'disk', 'storage_format': 'uncompressed', 'url': 'http://url'}, {'name': 'store2', 'storage_type': 'disk', 'storage_format': 'uncompressed', 'url': 'http://url2'}])
+        self.assertEqual(
+            bundle_locations_2,
+            [
+                {
+                    'name': 'store1',
+                    'storage_type': 'disk',
+                    'storage_format': 'uncompressed',
+                    'url': 'http://url',
+                },
+                {
+                    'name': 'store2',
+                    'storage_type': 'disk',
+                    'storage_format': 'uncompressed',
+                    'url': 'http://url2',
+                },
+            ],
+        )
 
         # Call get_bundle_location
-        bundle_location_2 = self.bundle_manager._model.get_bundle_location(bundle.uuid, bundle_store_uuid_2)
-        self.assertEqual(bundle_location_2, {'name': 'store2', 'storage_type': 'disk', 'storage_format': 'uncompressed', 'url': 'http://url2'})
+        bundle_location_2 = self.bundle_manager._model.get_bundle_location(
+            bundle.uuid, bundle_store_uuid_2
+        )
+        self.assertEqual(
+            bundle_location_2,
+            {
+                'name': 'store2',
+                'storage_type': 'disk',
+                'storage_format': 'uncompressed',
+                'url': 'http://url2',
+            },
+        )

--- a/tests/unit/server/bundle_store_test.py
+++ b/tests/unit/server/bundle_store_test.py
@@ -9,7 +9,7 @@ class BundleStoreTest(BaseBundleManagerTest):
         bundle = self.create_run_bundle()
         self.save_bundle(bundle)
 
-        # Create bundle store
+        # Create first bundle store
         bundle_store_uuid = self.bundle_manager._model.create_bundle_store(
             user=self.user_id,
             name="store1",
@@ -19,7 +19,7 @@ class BundleStoreTest(BaseBundleManagerTest):
             authentication="authentication",
         )
 
-        # Calls add_bundle_location to add a bundle location ot the bundle
+        # Calls add_bundle_location to add first bundle location to the bundle
         bundle_location_uuid = self.bundle_manager._model.add_bundle_location(
             bundle.uuid, bundle_store_uuid
         )
@@ -27,3 +27,30 @@ class BundleStoreTest(BaseBundleManagerTest):
         # Call get_bundle_locations
         bundle_locations = self.bundle_manager._model.get_bundle_locations(bundle.uuid)
         self.assertEqual(bundle_locations, [{'name': 'store1', 'storage_type': 'disk', 'storage_format': 'uncompressed', 'url': 'http://url'}])
+        
+        # Call get_bundle_location
+        bundle_location = self.bundle_manager._model.get_bundle_location(bundle.uuid, bundle_store_uuid)
+        self.assertEqual(bundle_location, {'name': 'store1', 'storage_type': 'disk', 'storage_format': 'uncompressed', 'url': 'http://url'})
+
+        # Create second bundle store 
+        bundle_store_uuid_2 = self.bundle_manager._model.create_bundle_store(
+            user=self.user_id,
+            name="store2",
+            storage_type=StorageType.DISK_STORAGE.value,
+            storage_format=StorageFormat.UNCOMPRESSED.value,
+            url="http://url2",
+            authentication="authentication2",
+        )
+
+        # Add second bundle store to the bundle
+        bundle_location_uuid_2 = self.bundle_manager._model.add_bundle_location(
+            bundle.uuid, bundle_store_uuid_2
+        )
+
+        # Call get_bundle_locations
+        bundle_locations_2 = self.bundle_manager._model.get_bundle_locations(bundle.uuid)
+        self.assertEqual(bundle_locations_2, [{'name': 'store1', 'storage_type': 'disk', 'storage_format': 'uncompressed', 'url': 'http://url'}, {'name': 'store2', 'storage_type': 'disk', 'storage_format': 'uncompressed', 'url': 'http://url2'}])
+
+        # Call get_bundle_location
+        bundle_location_2 = self.bundle_manager._model.get_bundle_location(bundle.uuid, bundle_store_uuid_2)
+        self.assertEqual(bundle_location_2, {'name': 'store2', 'storage_type': 'disk', 'storage_format': 'uncompressed', 'url': 'http://url2'})

--- a/tests/unit/server/bundle_store_test.py
+++ b/tests/unit/server/bundle_store_test.py
@@ -1,0 +1,30 @@
+from codalab.common import StorageType, StorageFormat
+from tests.unit.server.bundle_manager import BaseBundleManagerTest
+
+
+class BundleStoreTest(BaseBundleManagerTest):
+    def test_add_bundle_location(self):
+        """Create a bundle location for a bundle store."""
+        # Create bundle
+        bundle = self.create_run_bundle()
+        self.save_bundle(bundle)
+
+        # Create bundle store
+        bundle_store_uuid = self.bundle_manager._model.create_bundle_store(
+            user=self.user_id,
+            name="store1",
+            storage_type=StorageType.DISK_STORAGE.value,
+            storage_format=StorageFormat.UNCOMPRESSED.value,
+            url="http://url",
+            authentication="authentication",
+        )
+
+        # Calls add_bundle_location to add a bundle location ot the bundle
+        bundle_location_uuid = self.bundle_manager._model.add_bundle_location(
+            bundle.uuid, bundle_store_uuid
+        )
+
+        # Call get_bundle_locations
+        bundle_locations = self.bundle_manager._model.get_bundle_locations(bundle.uuid)
+
+        self.assertEqual(bundle_locations, [1, 2])

--- a/tests/unit/server/bundle_store_test.py
+++ b/tests/unit/server/bundle_store_test.py
@@ -5,8 +5,7 @@ from tests.unit.server.bundle_manager import BaseBundleManagerTest
 class BundleStoreTest(BaseBundleManagerTest):
     def test_add_bundle_location(self):
         """
-        Creates a new bundle and multiple associated bundle stores and bundle locations to 
-        test the get_bundle_locations, get_bundle_location, and add_bundle_location functions
+        Creates a new bundle and multiple associated bundle stores and bundle locations to test the get_bundle_locations, get_bundle_location, and add_bundle_location functions
         """
         # Create bundle
         bundle = self.create_run_bundle()

--- a/tests/unit/server/bundle_store_test.py
+++ b/tests/unit/server/bundle_store_test.py
@@ -4,7 +4,10 @@ from tests.unit.server.bundle_manager import BaseBundleManagerTest
 
 class BundleStoreTest(BaseBundleManagerTest):
     def test_add_bundle_location(self):
-        """Create a bundle location for a bundle store."""
+        """
+        Creates a new bundle and multiple associated bundle stores and bundle locations to 
+        test the get_bundle_locations, get_bundle_location, and add_bundle_location functions
+        """
         # Create bundle
         bundle = self.create_run_bundle()
         self.save_bundle(bundle)

--- a/tests/unit/server/bundle_store_test.py
+++ b/tests/unit/server/bundle_store_test.py
@@ -26,5 +26,4 @@ class BundleStoreTest(BaseBundleManagerTest):
 
         # Call get_bundle_locations
         bundle_locations = self.bundle_manager._model.get_bundle_locations(bundle.uuid)
-
-        self.assertEqual(bundle_locations, [1, 2])
+        self.assertEqual(bundle_locations, [{'name': 'store1', 'storage_type': 'disk', 'storage_format': 'uncompressed', 'url': 'http://url'}])

--- a/tests/unit/server/bundle_store_test.py
+++ b/tests/unit/server/bundle_store_test.py
@@ -20,9 +20,7 @@ class BundleStoreTest(BaseBundleManagerTest):
         )
 
         # Calls add_bundle_location to add first bundle location to the bundle
-        bundle_location_uuid = self.bundle_manager._model.add_bundle_location(
-            bundle.uuid, bundle_store_uuid
-        )
+        self.bundle_manager._model.add_bundle_location(bundle.uuid, bundle_store_uuid)
 
         # Call get_bundle_locations
         bundle_locations = self.bundle_manager._model.get_bundle_locations(bundle.uuid)
@@ -63,9 +61,7 @@ class BundleStoreTest(BaseBundleManagerTest):
         )
 
         # Add second bundle store to the bundle
-        bundle_location_uuid_2 = self.bundle_manager._model.add_bundle_location(
-            bundle.uuid, bundle_store_uuid_2
-        )
+        self.bundle_manager._model.add_bundle_location(bundle.uuid, bundle_store_uuid_2)
 
         # Call get_bundle_locations
         bundle_locations_2 = self.bundle_manager._model.get_bundle_locations(bundle.uuid)


### PR DESCRIPTION
### Reasons for making this change

Adding REST API endpoints to help support multiple bundle locations. Added 2 GET endpoints (one to fetch all BundleLocations associated with a given bundle, and another to fetch a specific BundleLocation), as well as 1 POST endpoint to add a new BundleLocation to a bundle

Design doc: https://docs.google.com/document/d/1TOsO4gnxUm1XMmlGUb7BJ4Z6y_olFbv9APbx0-IEy6M/edit#

### Related issues

Fixes #3801, which is part of multi-bundle store megaissue #3799

### Screenshots

<!-- Add screenshots, if necessary. If this is a substantial frontend / user flow change, consider recording
a user flow GIF using a tool such as [LICEcap](https://www.cockos.com/licecap/). -->

### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
