### PR TITLE
Filter out non-cl-worker pods

### DIFF
--- a/codalab/worker_manager/kubernetes_worker_manager.py
+++ b/codalab/worker_manager/kubernetes_worker_manager.py
@@ -91,7 +91,7 @@ class KubernetesWorkerManager(WorkerManager):
                 'default', field_selector='status.phase==Running'
             )
             logger.debug(pods.items)
-            return [WorkerJob(True) for _ in pods.items]
+            return [WorkerJob(True) for pod in pods.items if 'cl-worker' in pod.metadata.name]
         except (client.ApiException, MaxRetryError, NewConnectionError) as e:
             logger.error(f'Exception when calling Kubernetes CoreV1Api->list_namespaced_pod: {e}')
             return []


### PR DESCRIPTION
Related to https://github.com/codalab/codalab-worksheets/issues/3900

The previous logic used to work because `cl-worker` pods were the only running pods in the `default` namespace. The change in https://github.com/codalab/deployment/pull/194 moves some daemonsets out to the `default` namespace, so we should filter out non-cl-worker pods when returning running worker jobs.

![Screen Shot 2021-12-07 at 9 20 20 PM](https://user-images.githubusercontent.com/16793796/145152727-03bc6213-6d5d-48ea-b951-4cad1e5dc18b.png)