### PR TITLE
Recreate deleted networks when starting codalab

### DIFF
--- a/codalab_service.py
+++ b/codalab_service.py
@@ -837,7 +837,7 @@ class CodalabServiceManager(object):
     def bring_up_service(self, service):
         if should_run_service(self.args, service):
             print_header('Bringing up {}'.format(service))
-            self._run_compose_cmd('up -d --no-deps %s' % service)
+            self._run_compose_cmd('up --force-recreate -d --no-deps %s' % service)
 
     def run_service_cmd(self, cmd, root=False, service='rest-server'):
         if root:


### PR DESCRIPTION
Recreate deleted networks when starting codalab. This is needed in order to implement the stanford fix which involves deleting all docker networks first (https://github.com/codalab/deployment/pull/196).