### PR TITLE
Update mergify to get rid of deprecated strict mode

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,3 +1,8 @@
+queue_rules:
+  - name: default
+    conditions:
+      - check-success=All CI tasks complete
+
 pull_request_rules:
   - name: Automatic merge on approval
     conditions:
@@ -6,6 +11,5 @@ pull_request_rules:
       - label=ready-to-merge
       - check-success=All CI tasks complete
     actions:
-      merge:
-        method: squash
-        strict: true
+      queue:
+        name: default


### PR DESCRIPTION
Mergify no longer works because strict mode has been deprecated -- following instructions here (https://blog.mergify.com/strict-mode-deprecation/) to get the same functionality.

Strict mode just makes sure that each PR is merged serially and that each PR must be up-to-date and have CI passing before being merged.