### PR TITLE
Fix (frontend): Don't swallow errors when running interpret worksheet

### DIFF
--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -1203,7 +1203,8 @@ class Worksheet extends React.Component {
                     startTime = endTime;
                 }
             })
-            .catch(() => {
+            .catch((e) => {
+                console.error(e);
                 this.setState({
                     openedDialog: DIALOG_TYPES.OPEN_ERROR_DIALOG,
                     errorDialogMessage: 'Failed to update run bundles.',


### PR DESCRIPTION
### Reasons for making this change

Don't swallow errors when running interpret worksheet -- I kept getting this error locally but wasn't able to debug because we didn't print the error to the console.