### PR TITLE
Fix blob storage download issue by not passing headers on redirect

### DIFF
--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -968,9 +968,11 @@ def _update_bundle_contents_blob(uuid):
     # Get and validate query parameters
     finalize_on_failure = query_get_bool('finalize_on_failure', default=False)
     finalize_on_success = query_get_bool('finalize_on_success', default=True)
-    use_azure_blob_beta = os.getenv("CODALAB_ALWAYS_USE_AZURE_BLOB_BETA") or query_get_bool(
+    use_azure_blob_beta = query_get_bool(
         'use_azure_blob_beta', default=False
     )
+    if os.getenv("CODALAB_ALWAYS_USE_AZURE_BLOB_BETA") == "1":
+        use_azure_blob_beta = True
     store_name = request.query.get('store')
     store = (
         local.model.get_bundle_store(request.user.user_id, name=store_name) if store_name else None

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -968,9 +968,9 @@ def _update_bundle_contents_blob(uuid):
     # Get and validate query parameters
     finalize_on_failure = query_get_bool('finalize_on_failure', default=False)
     finalize_on_success = query_get_bool('finalize_on_success', default=True)
-    use_azure_blob_beta = query_get_bool('use_azure_blob_beta', default=False)
-    if os.getenv("CODALAB_ALWAYS_USE_AZURE_BLOB_BETA") == "1":
-        use_azure_blob_beta = True
+    use_azure_blob_beta = os.getenv("CODALAB_ALWAYS_USE_AZURE_BLOB_BETA") or query_get_bool(
+        'use_azure_blob_beta', default=False
+    )
     store_name = request.query.get('store')
     store = (
         local.model.get_bundle_store(request.user.user_id, name=store_name) if store_name else None

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -968,9 +968,7 @@ def _update_bundle_contents_blob(uuid):
     # Get and validate query parameters
     finalize_on_failure = query_get_bool('finalize_on_failure', default=False)
     finalize_on_success = query_get_bool('finalize_on_success', default=True)
-    use_azure_blob_beta = query_get_bool(
-        'use_azure_blob_beta', default=False
-    )
+    use_azure_blob_beta = query_get_bool('use_azure_blob_beta', default=False)
     if os.getenv("CODALAB_ALWAYS_USE_AZURE_BLOB_BETA") == "1":
         use_azure_blob_beta = True
     store_name = request.query.get('store')

--- a/codalab/server/auth.py
+++ b/codalab/server/auth.py
@@ -56,10 +56,10 @@ class RestOAuthHandler(object):
         }
         headers.update(self._extra_headers)
         request = urllib.request.Request(
-            self._address + '/rest/oauth2/token',
-            headers=headers,
-            data=urllib.parse.urlencode(data).encode('utf-8'),
+            self._address + '/rest/oauth2/token', data=urllib.parse.urlencode(data).encode('utf-8'),
         )
+        for k, v in headers.items():
+            request.add_unredirected_header(k, v)
         try:
             response = urlopen_with_retry(request)
             result = json.loads(response.read().decode())

--- a/codalab/worker/bundle_service_client.py
+++ b/codalab/worker/bundle_service_client.py
@@ -102,8 +102,9 @@ class BundleServiceClient(RestClient):
         request_to_send = urllib.request.Request(
             self._base_url + '/oauth2/token',
             data=urllib.parse.urlencode(request_data).encode('utf-8'),
-            headers=headers,
         )
+        for k, v in headers.items():
+            request_to_send.add_unredirected_header(k, v)
 
         with closing(urlopen_with_retry(request_to_send)) as response:
             response_data = response.read().decode()

--- a/codalab/worker/rest_client.py
+++ b/codalab/worker/rest_client.py
@@ -88,7 +88,9 @@ class RestClient(object):
         request_url = self._base_url + path
 
         # Make the actual request
-        request = urllib.request.Request(request_url, data=data, headers=headers)
+        request = urllib.request.Request(request_url, data=data)
+        for k, v in headers.items():
+            request.add_unredirected_header(k, v)
         request.get_method = lambda: method
         if return_response:
             # Return a file-like object containing the contents of the response


### PR DESCRIPTION
Fixes https://github.com/codalab/codalab-worksheets/issues/3773

Fix blob storage download issue by not passing headers on redirect. The issue was that when the worker downloaded a bundle, it would redirect to Azure Blob Storage, but the Authorization header with CodaLab credentials was passed to Azure Blob Storage, which caused Azure Blob Storage to give an error.

I don't know of a good way to test this locally, because Azurite doesn't have the same behavior.