### PR TITLE
Bump version to v1.4.2

### DIFF
--- a/codalab/common.py
+++ b/codalab/common.py
@@ -26,7 +26,7 @@ from codalab.lib.beam.filesystems import (
 
 # Increment this on master when ready to cut a release.
 # http://semver.org/
-CODALAB_VERSION = '1.4.1'
+CODALAB_VERSION = '1.4.2'
 BINARY_PLACEHOLDER = '<binary>'
 URLOPEN_TIMEOUT_SECONDS = int(os.environ.get('CODALAB_URLOPEN_TIMEOUT_SECONDS', 5 * 60))
 

--- a/docs/REST-API-Reference.md
+++ b/docs/REST-API-Reference.md
@@ -1,6 +1,6 @@
 # REST API Reference
 
-_version 1.4.1_
+_version 1.4.2_
 
 This reference and the REST API itself is still under heavy development and is
 subject to change at any time. Feedback through our GitHub issues is appreciated!

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -1,5 +1,5 @@
 // Should match codalab/common.py#CODALAB_VERSION
-export const CODALAB_VERSION = '1.4.1';
+export const CODALAB_VERSION = '1.4.2';
 
 // Name Regex to match the backend in spec_utils.py
 export const NAME_REGEX = /^[a-zA-Z_][a-zA-Z0-9_.-]*$/i;

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import sys
 
 
 # should match codalab/common.py#CODALAB_VERSION
-CODALAB_VERSION = "1.4.1"
+CODALAB_VERSION = "1.4.2"
 
 
 class Install(install):


### PR DESCRIPTION
# Release notes

## Frontend

- Don't swallow errors when running interpret worksheet (#3950)
- Fix Bundle Page (#3930)

## Backend

- Recreate deleted networks when starting codalab (#3929)
- Fix building docker files from scratch (#3954)
- Fixed Worker Manager Auth (#3941)
- Update bundle locations endpoint to use schema dump (#3930)
- Only let root add bundle stores (#3945)

## Dev / docs / CI

- Update mergify to get rid of deprecated strict mode (#3942) 
- Added documentation for AWS Batch (#3962)