### PR TITLE
refactor: ensure `use_azure_blob_beta` is always a boolean type

### DIFF
--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -968,9 +968,9 @@ def _update_bundle_contents_blob(uuid):
     # Get and validate query parameters
     finalize_on_failure = query_get_bool('finalize_on_failure', default=False)
     finalize_on_success = query_get_bool('finalize_on_success', default=True)
-    use_azure_blob_beta = os.getenv("CODALAB_ALWAYS_USE_AZURE_BLOB_BETA") or query_get_bool(
-        'use_azure_blob_beta', default=False
-    )
+    use_azure_blob_beta = query_get_bool('use_azure_blob_beta', default=False)
+    if os.getenv("CODALAB_ALWAYS_USE_AZURE_BLOB_BETA") == "1":
+        use_azure_blob_beta = True
     store_name = request.query.get('store')
     store = (
         local.model.get_bundle_store(request.user.user_id, name=store_name) if store_name else None


### PR DESCRIPTION
### Reasons for making this change

This PR doesn't change any functionality, but just makes sure that `use_azure_blob_beta` is always a boolean type. Previously, `use_azure_blob_beta` could be equal to `"1"` (which evaluates to `True`), but with this PR it will always be either True or False.