### PR TITLE
Fix bundle store display in bundle detail page

### DIFF
--- a/frontend/src/components/Bundle/Bundle.js
+++ b/frontend/src/components/Bundle/Bundle.js
@@ -544,14 +544,14 @@ function renderHostWorksheets(bundleInfo) {
 
 function renderStoreInfo(storeInfo) {
     let rows = [];
-    storeInfo.forEach(({ bundle_store_uuid, url }) => {
+    storeInfo.forEach(({ bundle_store_uuid, name, url }) => {
         rows.push(
             <tr>
                 <td>
-                    <a href={`/stores/${bundle_store_uuid}`}>{bundle_store_uuid}</a>
+                    <span>{name}</span>
                 </td>
                 <td>
-                    <span>{url}</span>
+                    <a href={`/stores/${bundle_store_uuid}`}>{bundle_store_uuid}</a>
                 </td>
             </tr>,
         );


### PR DESCRIPTION
### Reasons for making this change

The bundle detail view should show 1) the bundle store id and 2) the bundle store name. Right now, it just shows the ID.

### Related issues

fixes #3977

### Screenshots

![image](https://user-images.githubusercontent.com/29891066/151679325-5b815c60-7e20-488d-85f0-c678e2f649b5.png)

### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
