### PR TITLE
Improve handling if user does not have access to the server v2

### DIFF
--- a/codalab/rest/users.py
+++ b/codalab/rest/users.py
@@ -43,6 +43,9 @@ def fetch_authenticated_user():
     user_info['data']['attributes']['is_root_user'] = (
         request.user.user_id == local.model.root_user_id
     )
+    user_info['data']['attributes']['protected_mode'] = (
+        os.environ.get('CODALAB_PROTECTED_MODE') == 'True'
+    )
     return user_info
 
 

--- a/frontend/src/components/Dashboard/NewDashboard.js
+++ b/frontend/src/components/Dashboard/NewDashboard.js
@@ -68,7 +68,7 @@ class NewDashboard extends React.Component<{
 
     /** Renderer. */
     render() {
-        // If the ser is in protected mode and the user does not have access, show error message.
+        // If the server is in protected mode and the user does not have access, show error message.
         if (
             this.state.userInfo &&
             this.state.userInfo.protected_mode &&

--- a/frontend/src/components/Dashboard/NewDashboard.js
+++ b/frontend/src/components/Dashboard/NewDashboard.js
@@ -68,7 +68,12 @@ class NewDashboard extends React.Component<{
 
     /** Renderer. */
     render() {
-        if (this.state.userInfo && !this.state.userInfo.has_access) {
+        // If the ser is in protected mode and the user does not have access, show error message.
+        if (
+            this.state.userInfo &&
+            this.state.userInfo.protected_mode &&
+            !this.state.userInfo.has_access
+        ) {
             return (
                 <ErrorMessage
                     message={'No access to this server, please contact the administrators.'}

--- a/tests/unit/rest/user_test.py
+++ b/tests/unit/rest/user_test.py
@@ -39,6 +39,7 @@ class UserTest(BaseTestCase):
                     "user_name": "codalab",
                     "url": None,
                     "parallel_run_quota": 100,
+                    'protected_mode': False,
                     "avatar_id": None,
                     "is_root_user": True,
                 },


### PR DESCRIPTION
### Reasons for making this change


    User creates an account on cs324.codalab.org
    User gets ugly experience (can't create worksheets, etc.)


### Related issues

Fixes #3961 

### Screenshots

Shows alert if user doesn't have access to the server:
![image](https://user-images.githubusercontent.com/29891066/152636114-5e0df078-65ff-4f88-91bd-6973faa04979.png)



### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
