### PR TITLE
Support running 2 workers locally

### DIFF
--- a/codalab_service.py
+++ b/codalab_service.py
@@ -40,7 +40,7 @@ ALL_SERVICES = DEFAULT_SERVICES + [
     'monitor',
     'worker-manager-cpu',
     'worker-manager-gpu',
-    'worker-singularity',
+    'worker2',
 ]
 
 ALL_NO_SERVICES = [
@@ -58,7 +58,7 @@ SERVICE_TO_IMAGE = {
     'worker-manager-gpu': 'server',
     'monitor': 'server',
     'worker': 'worker',
-    'worker-singularity': 'worker',
+    'worker2': 'worker',
 }
 
 # Max timeout in seconds to wait for request to a service to get through
@@ -952,7 +952,7 @@ class CodalabServiceManager(object):
             self.bring_up_service('worker-shared-file-system')
         else:
             self.bring_up_service('worker')
-        self.bring_up_service('worker-singularity')
+        self.bring_up_service('worker2')
 
         self.bring_up_service('monitor')
 

--- a/docker_config/compose_files/docker-compose.yml
+++ b/docker_config/compose_files/docker-compose.yml
@@ -381,24 +381,22 @@ services:
       - rest-server
     shm_size: '500mb'
 
-  worker-singularity:
+  worker2:
     image: codalab/worker:${CODALAB_VERSION}
-    user: ${CODALAB_UID}
     command: |
       cl-worker
       --server http://rest-server:${CODALAB_REST_PORT}
       --work-dir ${CODALAB_WORKER_DIR}
       --network-prefix ${CODALAB_WORKER_NETWORK_PREFIX}
-      --id ${HOSTNAME}
-      --container-runtime singularity
+      --id ${HOSTNAME}-worker2
       --verbose
     <<: *codalab-base
+    <<: *codalab-root  # Not ideal since worker files saved as root, but without it, can't use docker
     depends_on:
       - rest-server
     volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
       - ${CODALAB_WORKER_DIR}:${CODALAB_WORKER_DIR}
-      - ${CODALAB_HOME}:${CODALAB_HOME}
-      - ${CODALAB_BUNDLE_MOUNT}:${CODALAB_BUNDLE_MOUNT}
     networks:
       - service
       - worker

--- a/docs/Server-Setup.md
+++ b/docs/Server-Setup.md
@@ -118,6 +118,13 @@ If you want to delete all the data associated with this, then do:
 
     ./codalab_service.py delete
 
+## Run two workers locally
+
+Sometimes you may want to run two workers locally. In that case, you should run:
+
+    ./codalab_service.py start -bds default worker2
+
+
 ## Azure Blob Storage
 
 To start the server in dev mode with Azurite (an Azure Blob Storage emulator) enabled, run:


### PR DESCRIPTION
### Reasons for making this change

Support running 2 workers locally. Needed for https://github.com/codalab/codalab-worksheets/pull/3861/ and https://github.com/codalab/codalab-worksheets/pull/3882.