### PR TITLE
Bump apache beam to 2.36.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-apache-beam[azure,gcp]==2.32.0
+apache-beam[azure,gcp]==2.36.0
 bottle==0.12.19
 dataclasses==0.7;python_version<'3.7'
 docker==4.3.0


### PR DESCRIPTION
### Reasons for making this change

Bump apache beam to 2.36.0 to fix issues with installing cl on M1 macs.