### PR TITLE
Bump version to 1.4.4

### DIFF
--- a/codalab/common.py
+++ b/codalab/common.py
@@ -26,7 +26,7 @@ from codalab.lib.beam.filesystems import (
 
 # Increment this on master when ready to cut a release.
 # http://semver.org/
-CODALAB_VERSION = '1.4.3'
+CODALAB_VERSION = '1.4.4'
 BINARY_PLACEHOLDER = '<binary>'
 URLOPEN_TIMEOUT_SECONDS = int(os.environ.get('CODALAB_URLOPEN_TIMEOUT_SECONDS', 5 * 60))
 

--- a/docs/REST-API-Reference.md
+++ b/docs/REST-API-Reference.md
@@ -1,6 +1,6 @@
 # REST API Reference
 
-_version 1.4.3_
+_version 1.4.4_
 
 This reference and the REST API itself is still under heavy development and is
 subject to change at any time. Feedback through our GitHub issues is appreciated!

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -1,5 +1,5 @@
 // Should match codalab/common.py#CODALAB_VERSION
-export const CODALAB_VERSION = '1.4.3';
+export const CODALAB_VERSION = '1.4.4';
 
 // Name Regex to match the backend in spec_utils.py
 export const NAME_REGEX = /^[a-zA-Z_][a-zA-Z0-9_.-]*$/i;

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import sys
 
 
 # should match codalab/common.py#CODALAB_VERSION
-CODALAB_VERSION = "1.4.3"
+CODALAB_VERSION = "1.4.4"
 
 
 class Install(install):


### PR DESCRIPTION
# Release notes

## Frontend

- Improve handling if user does not have access to the server (#3993)
 
## Backend

- Support separate GKE cluster for cpu and gpu worker managers (#4005)
- Be able to control seconds between workers for gpu vs cpu worker managers (#4007)
- Bump apache beam to 2.36.0 (https://github.com/codalab/codalab-worksheets/pull/4011)

## Dev / docs / CI

- Support running 2 workers locally (#4003)

Diff:

https://github.com/codalab/codalab-worksheets/compare/v1.4.3...master