### PR TITLE
Fix issue where `container` is None

### DIFF
--- a/codalab/worker/docker_utils.py
+++ b/codalab/worker/docker_utils.py
@@ -337,6 +337,9 @@ def container_exists(container):
     try:
         client.containers.get(container.id)
         return True
+    except AttributeError:
+        # container is None
+        return False
     except docker.errors.NotFound:
         return False
 


### PR DESCRIPTION
Fix issue where `container` is None (https://github.com/codalab/codalab-worksheets/issues/4015). The docker stats function should not throw an error on `container_exists`, but rather just treat the result of `container_exists` as False.