### PR TITLE
Fix bundle manager check in transition_bundle_worker_offline

### DIFF
--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -995,8 +995,10 @@ class BundleModel(object):
             # Check that it still exists and is running
             row = connection.execute(
                 cl_bundle.select().where(
-                    cl_bundle.c.id == bundle.id
-                    and (cl_bundle.c.state == State.RUNNING or cl_bundle.c.state == State.PREPARING)
+                    and_(
+                        cl_bundle.c.id == bundle.id,
+                        cl_bundle.c.state.in_((State.RUNNING, State.PREPARING, State.FINALIZING)),
+                    )
                 )
             ).fetchone()
             if not row:
@@ -2551,6 +2553,7 @@ class BundleModel(object):
             connection.execute(cl_user_group.delete().where(cl_user_group.c.user_id == user_id))
 
             # Chat
+            # todo fix
             connection.execute(
                 cl_chat.delete().where(
                     cl_chat.c.sender_user_id == user_id or cl_chat.c.recipient_user_id == user_id

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -2553,7 +2553,6 @@ class BundleModel(object):
             connection.execute(cl_user_group.delete().where(cl_user_group.c.user_id == user_id))
 
             # Chat
-            # todo fix
             connection.execute(
                 cl_chat.delete().where(
                     cl_chat.c.sender_user_id == user_id or cl_chat.c.recipient_user_id == user_id

--- a/tests/unit/model/bundle_model_test.py
+++ b/tests/unit/model/bundle_model_test.py
@@ -1,3 +1,28 @@
+import unittest
+from tests.unit.server.bundle_manager import TestBase
+from codalab.worker.bundle_state import State
+
+
+class BundleModelTest(TestBase, unittest.TestCase):
+    def test_ready_bundle_should_not_transition_worker_offline(self):
+        """transition_bundle_worker_offline should not transition a READY bundle to worker_offline."""
+        bundle = self.create_run_bundle(State.READY)
+        self.save_bundle(bundle)
+        result = self.bundle_manager._model.transition_bundle_worker_offline(bundle)
+        self.assertEqual(result, False)
+        bundle = self.bundle_manager._model.get_bundle(bundle.uuid)
+        self.assertEqual(bundle.state, State.READY)
+
+    def test_finalizing_bundle_should_not_transition_worker_offline(self):
+        """transition_bundle_worker_offline should transition a FINALIZING bundle to worker_offline."""
+        bundle = self.create_run_bundle(State.FINALIZING)
+        self.save_bundle(bundle)
+        result = self.bundle_manager._model.transition_bundle_worker_offline(bundle)
+        self.assertEqual(result, True)
+        bundle = self.bundle_manager._model.get_bundle(bundle.uuid)
+        self.assertEqual(bundle.state, State.WORKER_OFFLINE)
+
+
 def metadata_to_dicts(uuid, metadata):
     return [
         {'bundle_uuid': uuid, 'metadata_key': key, 'metadata_value': value}

--- a/tests/unit/server/bundle_manager/__init__.py
+++ b/tests/unit/server/bundle_manager/__init__.py
@@ -158,8 +158,10 @@ class TestBase:
             uuid=generate_uuid(),
             state=state,
         )
-        bundle.is_frozen = None
+        bundle.frozen = None
         bundle.is_anonymous = False
+        bundle.storage_type = None
+        bundle.is_dir = False
         return bundle
 
     def create_bundle_single_dep(

--- a/tests/unit/server/bundle_manager/schedule_run_bundles_test.py
+++ b/tests/unit/server/bundle_manager/schedule_run_bundles_test.py
@@ -63,7 +63,7 @@ class BundleManagerScheduleRunBundlesTest(BaseBundleManagerTest):
         self.assertEqual(bundle.state, State.WORKER_OFFLINE)
 
     def test_finalizing_bundle_goes_offline_if_no_worker_claims(self):
-        """If no worker claims a FINALIZING bundle, it should go to the WORKER_OFFLINE_STATE."""
+        """If no worker claims a FINALIZING bundle, it should go to the WORKER_OFFLINE state."""
         bundle = self.create_run_bundle(State.FINALIZING)
         self.save_bundle(bundle)
         self.bundle_manager._schedule_run_bundles()


### PR DESCRIPTION
Fixes https://github.com/codalab/codalab-worksheets/pull/4019 by adding the proper `and_` operator in sqlalchemy and also allowing `FINALIZING` bundles to pass the check.