### PR TITLE
Don't silently swallow socket errors

### DIFF
--- a/codalab/model/worker_model.py
+++ b/codalab/model/worker_model.py
@@ -342,7 +342,7 @@ class WorkerModel(object):
                     sock.connect(self._socket_path(socket_id))
                     success = sock.recv(len(WorkerModel.ACK)) == WorkerModel.ACK
                 except socket.error:
-                    pass
+                    logging.exception("socket error when calling send_stream")
 
                 if not success:
                     # Shouldn't be too expensive just to keep retrying.
@@ -390,7 +390,7 @@ class WorkerModel(object):
                     else:
                         success = True
                 except socket.error:
-                    pass
+                    logging.exception("socket error when calling send_json_message")
 
                 if not success:
                     # Shouldn't be too expensive just to keep retrying.


### PR DESCRIPTION
Don't silently swallow socket errors -- log them instead. Without this change, it was very difficult to debug communication between the worker and the server through the sockets.