### PR TITLE
Adjust header padding and fix body padding

### DIFF
--- a/frontend/src/components/NavBar.js
+++ b/frontend/src/components/NavBar.js
@@ -320,7 +320,7 @@ class NavBar extends React.Component<{
 
         return (
             <MuiThemeProvider theme={overrideMedia}>
-                <AppBar id='codalab-app-bar' color='default'>
+                <AppBar id='codalab-app-bar' className={classes.header} color='default'>
                     <Toolbar>
                         <div className={classes.logoContainer}>
                             <Link to='/home'>
@@ -562,6 +562,10 @@ const overrideMedia = createMuiTheme({
 });
 
 const styles = (theme) => ({
+    header: {
+        paddingTop: theme.spacing.large,
+        paddingBottom: theme.spacing.large,
+    },
     logoContainer: {
         marginRight: 40,
     },

--- a/frontend/src/css/imports.scss
+++ b/frontend/src/css/imports.scss
@@ -20,6 +20,10 @@
   font-weight: 600;
   font-style: normal;
 }
+
+$header-height-mobile: 48px;
+$header-height-desktop: 58px;
+
 .btn-secondary {
   color: #fff;
   background-color: #225ea8;
@@ -256,8 +260,11 @@ footer .navbar-nav.navbar-right:last-child {
   margin-right: 0;
 }
 body {
-  padding-top: 48px;
+  padding-top: $header-height-mobile;
   padding-bottom: 25px;
+  @media screen and (min-width: 600px) {
+    padding-top: $header-height-desktop;
+  }
 }
 body > .container {
   padding-bottom: 36px;

--- a/frontend/src/routes/HomePage.js
+++ b/frontend/src/routes/HomePage.js
@@ -78,7 +78,7 @@ class HomePage extends React.Component<{
     render() {
         const { classes, auth } = this.props;
         return (
-            <Grid container style={{ marginTop: -30 }}>
+            <Grid container>
                 <Helmet>
                     <meta
                         id='meta-description'


### PR DESCRIPTION
### Reasons for making this change

## Issue 1

The header appears to be too small when the search bar is present. The search bar takes up the full height of the header, making the header appear visually unbalanced. 

![image](https://user-images.githubusercontent.com/25855750/156674719-c210db87-d2ae-4b72-9023-c249c97bf52f.png)

### Solution

This change adds slight padding to the top and bottom of the header. **Note:** Using `spacing.larger` here might look even better.

![image](https://user-images.githubusercontent.com/25855750/156674783-81c22628-0b2d-4dcb-8b0b-70d2c352e77d.png)

## Issue 2

The hero is currently being pushed up behind the header. The embedded CodaLab YouTube video is calling attention to this stying issue.

![image](https://user-images.githubusercontent.com/25855750/156675203-fdfdfa9c-6b50-4fd0-bdd6-2ace28577cf2.png)

### Solution

I've updated the global `body` styles to resolve this issue.

![image](https://user-images.githubusercontent.com/25855750/156675297-d462b043-c835-427c-ac1d-c1184c504b5d.png)

<!-- Add a reason for making this change here. -->

### Related issues

<!-- Add a reference to issues resolved, if applicable (for example, "fixes #1"). -->

<!-- Add screenshots, if necessary. If this is a substantial frontend / user flow change, consider recording
a user flow GIF using a tool such as [LICEcap](https://www.cockos.com/licecap/). -->

### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [ ] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [ ] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
