### PR TITLE
revising docker files to fix fatal issues

### DIFF
--- a/docker_config/dockerfiles/Dockerfile.default-cpu
+++ b/docker_config/dockerfiles/Dockerfile.default-cpu
@@ -32,7 +32,7 @@ RUN apt-get update && apt-get install -y \
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 1
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.6 1
 
-RUN curl https://bootstrap.pypa.io/pip/3.6/get-pip.py | python3.6
+RUN curl https://bootstrap.pypa.io/get-pip.py | python3.6
 
 ### Without this Python thinks we're ASCII and unicode chars fail
 ENV LANG C.UTF-8

--- a/docker_config/dockerfiles/Dockerfile.default-gpu
+++ b/docker_config/dockerfiles/Dockerfile.default-gpu
@@ -32,7 +32,7 @@ RUN apt-get update && apt-get install -y \
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 1
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.6 1
 
-RUN curl https://bootstrap.pypa.io/pip/3.6/get-pip.py | python3.6
+RUN curl https://bootstrap.pypa.io/get-pip.py | python3.6
 
 ### Without this Python thinks we're ASCII and unicode chars fail
 ENV LANG C.UTF-8

--- a/docker_config/dockerfiles/Dockerfile.server
+++ b/docker_config/dockerfiles/Dockerfile.server
@@ -1,11 +1,11 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 MAINTAINER CodaLab Worksheets <codalab.worksheets@gmail.com>
 
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && \
   apt-get install -y --no-install-recommends software-properties-common && \
-  add-apt-repository ppa:fkrull/deadsnakes && \
+  add-apt-repository ppa:deadsnakes/ppa && \
   apt-get update && \
   apt-get install -y --no-install-recommends \
     build-essential \
@@ -20,20 +20,20 @@ RUN apt-get update && \
     python3.6-dev \
     python3-pip \
     python3-setuptools \
-    python-virtualenv \
+    python3-virtualenv \
     python3-software-properties \
     zip \
     unzip \
     rsync && \
     rm -rf /var/lib/apt/lists/*;
-
+ 
 # Set Python3.6 as the default python3 version
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 1
 
 ### Without this Python thinks we're ASCII and unicode chars fail
 ENV LANG C.UTF-8
 
-RUN python3 -m pip install --no-cache-dir --upgrade pip==20.3.4
+RUN python3 -m pip install --no-cache-dir --upgrade pip
 RUN mkdir /opt/codalab-worksheets
 WORKDIR /opt/codalab-worksheets
 

--- a/docker_config/dockerfiles/Dockerfile.worker
+++ b/docker_config/dockerfiles/Dockerfile.worker
@@ -19,13 +19,13 @@ RUN go get -u github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/dock
 WORKDIR /root/go/src/github.com/awslabs/amazon-ecr-credential-helper
 RUN make
 
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 MAINTAINER CodaLab Worksheets <codalab.worksheets@gmail.com>
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && \
   apt-get install -y --no-install-recommends software-properties-common curl && \
-  add-apt-repository ppa:fkrull/deadsnakes && \
+  add-apt-repository ppa:deadsnakes/ppa && \
   apt-get update && \
   apt-get install -y --no-install-recommends \
     build-essential \
@@ -62,7 +62,7 @@ RUN mkdir ${WORKDIR}/scripts
 
 # Install dependencies
 COPY requirements.txt requirements.txt
-RUN python3.6 -m pip install --user --upgrade pip==20.3.4; \
+RUN python3.6 -m pip install --user --upgrade pip; \
     python3.6 -m pip install setuptools --upgrade; \
     python3.6 -m pip install --no-cache-dir -r requirements.txt;
 


### PR DESCRIPTION
### Reasons for making this change

<!-- Add a reason for making this change here. -->

The code to start the CodaLab service 
```
./codalab_service.py start -bd
```
would fail to someone who newly cloned the repo because deadsnakes ppa in the old docker file no longer supports Ubuntu 16.04 for any python version (https://github.com/deadsnakes/issues/issues/195). Therefore, I had to change the Ubuntu version to 20.04 to finish setting up the environment.


