### PR TITLE
Fix JSON Display

### DIFF
--- a/frontend/src/components/Bundle/Bundle.js
+++ b/frontend/src/components/Bundle/Bundle.js
@@ -494,7 +494,7 @@ function renderContents(bundleInfo, fileContents, stdout, stderr) {
                     </span>
                 </div>
                 <div className='collapsible-content bundle-meta'>
-                    <pre>{JSON.stringify(fileContents, null, 2)}</pre>
+                    <pre>{fileContents}</pre>
                 </div>
             </div>
         );

--- a/frontend/src/components/Bundle/Bundle.js
+++ b/frontend/src/components/Bundle/Bundle.js
@@ -102,7 +102,12 @@ class Bundle extends React.Component<
             if (!info) return;
             if (info.type === 'file' || info.type === 'link') {
                 return fetchFileSummary(this.props.uuid, '/').then((blob) => {
-                    this.setState({ fileContents: blob, stdout: null, stderr: null });
+                    this.setState({
+                        fileContents:
+                            typeof blob === 'object' ? JSON.stringify(blob, null, 2) : blob,
+                        stdout: null,
+                        stderr: null,
+                    });
                 });
             } else if (info.type === 'directory') {
                 // Get stdout/stderr (important to set things to null).
@@ -494,7 +499,7 @@ function renderContents(bundleInfo, fileContents, stdout, stderr) {
                     </span>
                 </div>
                 <div className='collapsible-content bundle-meta'>
-                    <pre>{JSON.stringify(fileContents, null, 2)}</pre>
+                    <pre>{fileContents}</pre>
                 </div>
             </div>
         );

--- a/frontend/src/components/Bundle/Bundle.js
+++ b/frontend/src/components/Bundle/Bundle.js
@@ -494,7 +494,7 @@ function renderContents(bundleInfo, fileContents, stdout, stderr) {
                     </span>
                 </div>
                 <div className='collapsible-content bundle-meta'>
-                    <pre>{fileContents}</pre>
+                    <pre>{JSON.stringify(fileContents, null, 2)}</pre>
                 </div>
             </div>
         );

--- a/frontend/src/components/Bundle/Bundle.js
+++ b/frontend/src/components/Bundle/Bundle.js
@@ -102,12 +102,7 @@ class Bundle extends React.Component<
             if (!info) return;
             if (info.type === 'file' || info.type === 'link') {
                 return fetchFileSummary(this.props.uuid, '/').then((blob) => {
-                    this.setState({
-                        fileContents:
-                            typeof blob === 'object' ? JSON.stringify(blob, null, 2) : blob,
-                        stdout: null,
-                        stderr: null,
-                    });
+                    this.setState({ fileContents: blob, stdout: null, stderr: null });
                 });
             } else if (info.type === 'directory') {
                 // Get stdout/stderr (important to set things to null).
@@ -499,7 +494,7 @@ function renderContents(bundleInfo, fileContents, stdout, stderr) {
                     </span>
                 </div>
                 <div className='collapsible-content bundle-meta'>
-                    <pre>{fileContents}</pre>
+                    <pre>{JSON.stringify(fileContents, null, 2)}</pre>
                 </div>
             </div>
         );

--- a/frontend/src/util/apiWrapper.js
+++ b/frontend/src/util/apiWrapper.js
@@ -135,7 +135,7 @@ export const fetchFileSummary = (uuid, path) => {
         {
             headers: { Accept: 'text/plain' },
         },
-        // need to define transformResponse to prevent json being parsed due to the issue discussed in: https://github.com/axios/axios/issues/811
+        // Get the raw text response and don't parse JSON. Need to define transformResponse to prevent JSON being parsed due to the issue discussed in: https://github.com/axios/axios/issues/811
         { responseType: 'text', transformResponse: (data) => data },
     );
 };

--- a/frontend/src/util/apiWrapper.js
+++ b/frontend/src/util/apiWrapper.js
@@ -2,7 +2,7 @@ import { Semaphore } from 'await-semaphore';
 import axios from 'axios';
 import { createDefaultBundleName, pathIsArchive, getArchiveExt } from './worksheet_utils';
 
-export const get = (url, params, options) => {
+export const get = (url, params, options = {}) => {
     const requestOptions = {
         params,
         ...options,

--- a/frontend/src/util/apiWrapper.js
+++ b/frontend/src/util/apiWrapper.js
@@ -135,7 +135,7 @@ export const fetchFileSummary = (uuid, path) => {
         {
             headers: { Accept: 'text/plain' },
         },
-        // need to define transformResponse due to the issue discussed in: https://github.com/axios/axios/issues/811
+        // need to define transformResponse to prevent json being parsed due to the issue discussed in: https://github.com/axios/axios/issues/811
         { responseType: 'text', transformResponse: (data) => data },
     );
 };

--- a/frontend/src/util/apiWrapper.js
+++ b/frontend/src/util/apiWrapper.js
@@ -135,6 +135,7 @@ export const fetchFileSummary = (uuid, path) => {
         {
             headers: { Accept: 'text/plain' },
         },
+        // need to define transformResponse due to the issue discussed in: https://github.com/axios/axios/issues/811
         { responseType: 'text', transformResponse: (data) => data },
     );
 };

--- a/frontend/src/util/apiWrapper.js
+++ b/frontend/src/util/apiWrapper.js
@@ -2,9 +2,10 @@ import { Semaphore } from 'await-semaphore';
 import axios from 'axios';
 import { createDefaultBundleName, pathIsArchive, getArchiveExt } from './worksheet_utils';
 
-export const get = (url, params) => {
+export const get = (url, params, options) => {
     const requestOptions = {
         params,
+        ...options,
     };
     return axios.get(url, requestOptions).then((res) => res.data);
 };
@@ -129,7 +130,13 @@ export const fetchFileSummary = (uuid, path) => {
     };
     const url =
         '/rest/bundles/' + uuid + '/contents/blob' + path + '?' + new URLSearchParams(params);
-    return get(url, { headers: { Accept: 'text/plain' } });
+    return get(
+        url,
+        {
+            headers: { Accept: 'text/plain' },
+        },
+        { responseType: 'text', transformResponse: (data) => data },
+    );
 };
 
 export async function createFileBundle(url, data, errorHandler) {


### PR DESCRIPTION
### Reasons for making this change

Bundle detail screen goes blank sometimes if the file is JSON.

### Related issues

Fixes #4037 

### Screenshots

![image](https://user-images.githubusercontent.com/29891066/157104266-6d025c82-703f-4079-af84-bde2a5af901e.png)

### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
