### PR TITLE
Bump version to 1.5.0

### DIFF
--- a/codalab/common.py
+++ b/codalab/common.py
@@ -26,7 +26,7 @@ from codalab.lib.beam.filesystems import (
 
 # Increment this on master when ready to cut a release.
 # http://semver.org/
-CODALAB_VERSION = '1.4.6'
+CODALAB_VERSION = '1.5.0'
 BINARY_PLACEHOLDER = '<binary>'
 URLOPEN_TIMEOUT_SECONDS = int(os.environ.get('CODALAB_URLOPEN_TIMEOUT_SECONDS', 5 * 60))
 

--- a/docs/REST-API-Reference.md
+++ b/docs/REST-API-Reference.md
@@ -1,6 +1,6 @@
 # REST API Reference
 
-_version 1.4.6_
+_version 1.5.0_
 
 This reference and the REST API itself is still under heavy development and is
 subject to change at any time. Feedback through our GitHub issues is appreciated!

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -1,5 +1,5 @@
 // Should match codalab/common.py#CODALAB_VERSION
-export const CODALAB_VERSION = '1.4.6';
+export const CODALAB_VERSION = '1.5.0';
 
 // Name Regex to match the backend in spec_utils.py
 export const NAME_REGEX = /^[a-zA-Z_][a-zA-Z0-9_.-]*$/i;

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import sys
 
 
 # should match codalab/common.py#CODALAB_VERSION
-CODALAB_VERSION = "1.4.6"
+CODALAB_VERSION = "1.5.0"
 
 
 class Install(install):


### PR DESCRIPTION
Bump version to 1.5.0

# Release notes

## Frontend

* Adjust header padding and fix body padding by @leilenah in https://github.com/codalab/codalab-worksheets/pull/4040
* Fix JSON Display by @jzwang43 in https://github.com/codalab/codalab-worksheets/pull/4046
* Bump minimist from 1.2.5 to 1.2.6 in /frontend by @dependabot in https://github.com/codalab/codalab-worksheets/pull/4052

## CLI

None

## Backend

* NFS-safe dependency manager that allows multiple workers to share the same dependency cache #3861
* Support bundle checkpoint / preemptible workers #3882
* Better logging for workers https://github.com/codalab/codalab-worksheets/pull/4022
* Fix bypass of blob storage downloads with custom bundle stores #3991
* Fix/3911-cl-store infer storage type from url by @wwwjn in https://github.com/codalab/codalab-worksheets/pull/4061

## Dev / docs / CI

* Worker manager documentation for Azure Batch and GKE by @teetone in https://github.com/codalab/codalab-worksheets/pull/4002
* Added additional troubleshooting steps to public worker manager doc https://github.com/codalab/codalab-worksheets/pull/4050