### PR TITLE
Fix problem that does not copy exclude-patterns when rerun a bundle

### DIFF
--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -1808,6 +1808,7 @@ class BundleCLI(object):
     )
     def do_run_command(self, args):
         client, worksheet_uuid = self.parse_client_worksheet_uuid(args.worksheet_spec)
+        print(args)
         args.target_spec, args.command = desugar_command(args.target_spec, args.command)
         metadata = self.get_missing_metadata(RunBundle, args)
         targets = self.resolve_key_targets(client, worksheet_uuid, args.target_spec)

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -1808,7 +1808,6 @@ class BundleCLI(object):
     )
     def do_run_command(self, args):
         client, worksheet_uuid = self.parse_client_worksheet_uuid(args.worksheet_spec)
-        print(args)
         args.target_spec, args.command = desugar_command(args.target_spec, args.command)
         metadata = self.get_missing_metadata(RunBundle, args)
         targets = self.resolve_key_targets(client, worksheet_uuid, args.target_spec)

--- a/frontend/src/components/worksheets/BundleDetail/BundleActions.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/BundleActions.jsx
@@ -35,6 +35,9 @@ class BundleActions extends React.Component<{
         run.networkAccess = bundleInfo.metadata.request_network;
         run.failedDependencies = bundleInfo.metadata.allow_failed_dependencies;
         run.queue = bundleInfo.metadata.request_queue;
+        console.log(bundleInfo.metadata)
+        run.exclude_patterns = bundleInfo.metadata.exclude_patterns;
+        console.log(bundleInfo.metadata.exclude_patterns)
         this.props.rerunItem(run);
     };
 

--- a/frontend/src/components/worksheets/BundleDetail/BundleActions.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/BundleActions.jsx
@@ -35,9 +35,7 @@ class BundleActions extends React.Component<{
         run.networkAccess = bundleInfo.metadata.request_network;
         run.failedDependencies = bundleInfo.metadata.allow_failed_dependencies;
         run.queue = bundleInfo.metadata.request_queue;
-        console.log(bundleInfo.metadata)
         run.exclude_patterns = bundleInfo.metadata.exclude_patterns;
-        console.log(bundleInfo.metadata.exclude_patterns)
         this.props.rerunItem(run);
     };
 

--- a/frontend/src/components/worksheets/NewRun/NewRun.jsx
+++ b/frontend/src/components/worksheets/NewRun/NewRun.jsx
@@ -273,6 +273,7 @@ class NewRun extends React.Component<
             networkAccess,
             failedDependencies,
             queue,
+            exclude_patterns,
         } = this.state;
         const { after_sort_key } = this.props;
 
@@ -290,6 +291,8 @@ class NewRun extends React.Component<
         if (queue) args.push(`--request-queue=${queue}`);
         if (networkAccess) args.push(`--request-network`);
         if (failedDependencies) args.push(`--allow-failed-dependencies`);
+        console.log(exclude_patterns)
+        if (exclude_patterns) args.push(`--exclude-patterns ${exclude_patterns.join(' ')}`);
 
         for (let dep of dependencies) {
             const key = dep.alias;
@@ -299,6 +302,7 @@ class NewRun extends React.Component<
         }
 
         if (command) args.push(command);
+        console.log(args)
 
         return buildTerminalCommand(args);
     }

--- a/frontend/src/components/worksheets/NewRun/NewRun.jsx
+++ b/frontend/src/components/worksheets/NewRun/NewRun.jsx
@@ -304,9 +304,7 @@ class NewRun extends React.Component<
         // exclude_patterns can take a list of arguments, so put it at the end
         if (exclude_patterns) {
             args.push(`--exclude-patterns`);
-            for (let i = 0; i < exclude_patterns.length; i++) {
-                args.push(`${exclude_patterns[i]}`);
-            }
+            args.push(...exclude_patterns);
         }
 
         return buildTerminalCommand(args);

--- a/frontend/src/components/worksheets/NewRun/NewRun.jsx
+++ b/frontend/src/components/worksheets/NewRun/NewRun.jsx
@@ -291,8 +291,6 @@ class NewRun extends React.Component<
         if (queue) args.push(`--request-queue=${queue}`);
         if (networkAccess) args.push(`--request-network`);
         if (failedDependencies) args.push(`--allow-failed-dependencies`);
-        console.log(exclude_patterns)
-        if (exclude_patterns) args.push(`--exclude-patterns ${exclude_patterns.join(' ')}`);
 
         for (let dep of dependencies) {
             const key = dep.alias;
@@ -302,7 +300,14 @@ class NewRun extends React.Component<
         }
 
         if (command) args.push(command);
-        console.log(args)
+        
+        // exclude_patterns a list of arguments, so put it at the end of commands
+        if (exclude_patterns) {  
+            args.push(`--exclude-patterns`);
+            for (let i = 0; i < exclude_patterns.length; i++) {
+                args.push(`${exclude_patterns[i]}`);
+            }
+        }
 
         return buildTerminalCommand(args);
     }

--- a/frontend/src/components/worksheets/NewRun/NewRun.jsx
+++ b/frontend/src/components/worksheets/NewRun/NewRun.jsx
@@ -300,9 +300,9 @@ class NewRun extends React.Component<
         }
 
         if (command) args.push(command);
-        
+
         // exclude_patterns a list of arguments, so put it at the end of commands
-        if (exclude_patterns) {  
+        if (exclude_patterns) {
             args.push(`--exclude-patterns`);
             for (let i = 0; i < exclude_patterns.length; i++) {
                 args.push(`${exclude_patterns[i]}`);

--- a/frontend/src/components/worksheets/NewRun/NewRun.jsx
+++ b/frontend/src/components/worksheets/NewRun/NewRun.jsx
@@ -301,7 +301,7 @@ class NewRun extends React.Component<
 
         if (command) args.push(command);
 
-        // exclude_patterns a list of arguments, so put it at the end of commands
+        // exclude_patterns can take a list of arguments, so put it at the end
         if (exclude_patterns) {
             args.push(`--exclude-patterns`);
             for (let i = 0; i < exclude_patterns.length; i++) {


### PR DESCRIPTION
### Reasons for making this change
When rerun a bundle, the `exclude-patterns` parameter is not copied.

### Related issues

Fix #3238 

### Screenshots
![test4](https://user-images.githubusercontent.com/40016222/165218223-9b6a6f6d-7640-4a12-96f9-ef4056a8059c.gif)

<!-- Add screenshots, if necessary. If this is a substantial frontend / user flow change, consider recording
a user flow GIF using a tool such as [LICEcap](https://www.cockos.com/licecap/). -->

### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [ ] I've added and/or updated tests, if this is a backend change
* [ ] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [ ] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
