### PR TITLE
Read and authenticate with credentials from password file when starting Slurm worker manager

### DIFF
--- a/codalab/worker_manager/slurm_batch_worker_manager.py
+++ b/codalab/worker_manager/slurm_batch_worker_manager.py
@@ -109,6 +109,10 @@ class SlurmBatchWorkerManager(WorkerManager):
         # A set of newly submitted job id to keep tracking worker status, as worker might not be created right away.
         self.submitted_jobs = self.load_worker_jobs()
 
+        # We're using a temporary CodaLabManager for the worker and worker managers by default,
+        # so we don't write out the state to state.json when users log in.
+        # If we always read from the password file, we can both leave state.json untouched,
+        # and users can always start the worker manager without logging in.
         if args.password_file:
             logger.info(
                 f"--password-file specified. Reading credentials from {args.password_file}..."

--- a/codalab/worker_manager/slurm_batch_worker_manager.py
+++ b/codalab/worker_manager/slurm_batch_worker_manager.py
@@ -2,6 +2,7 @@ import logging
 import uuid
 import subprocess
 import getpass
+import os
 import re
 import sys
 import textwrap
@@ -107,6 +108,14 @@ class SlurmBatchWorkerManager(WorkerManager):
         self.num_failed = 0
         # A set of newly submitted job id to keep tracking worker status, as worker might not be created right away.
         self.submitted_jobs = self.load_worker_jobs()
+
+        if args.password_file:
+            logger.info(
+                f"--password-file specified. Reading credentials from {args.password_file}..."
+            )
+            with open(args.password_file) as f:
+                os.environ["CODALAB_USERNAME"] = f.readline().strip()
+                os.environ["CODALAB_PASSWORD"] = f.readline().strip()
 
     def load_worker_jobs(self):
         """


### PR DESCRIPTION
Resolves https://github.com/codalab/codalab-worksheets/issues/4066
