### PR TITLE
Set default for OAUTH2_PROVIDER_TOKEN_EXPIRES_IN to 7 days

### DIFF
--- a/codalab/server/oauth2_provider.py
+++ b/codalab/server/oauth2_provider.py
@@ -151,7 +151,7 @@ class OAuth2Provider(object):
 
             oauth._validator = MyValidator()
         """
-        expires_in = self.app.config.get('OAUTH2_PROVIDER_TOKEN_EXPIRES_IN', parse_duration("30d"))
+        expires_in = self.app.config.get('OAUTH2_PROVIDER_TOKEN_EXPIRES_IN', parse_duration("7d"))
         token_generator = self.app.config.get('OAUTH2_PROVIDER_TOKEN_GENERATOR', None)
         if token_generator and not isinstance(token_generator, collections.Callable):
             token_generator = import_string(token_generator)

--- a/codalab/server/oauth2_provider.py
+++ b/codalab/server/oauth2_provider.py
@@ -55,6 +55,7 @@ from oauthlib import oauth2
 from oauthlib.common import to_unicode
 from oauthlib.oauth2 import RequestValidator, Server
 
+from codalab.lib.formatting import parse_duration
 from codalab.lib.server_util import (
     cached_property,
     create_response,
@@ -150,7 +151,7 @@ class OAuth2Provider(object):
 
             oauth._validator = MyValidator()
         """
-        expires_in = self.app.config.get('OAUTH2_PROVIDER_TOKEN_EXPIRES_IN')
+        expires_in = self.app.config.get('OAUTH2_PROVIDER_TOKEN_EXPIRES_IN', parse_duration("30d"))
         token_generator = self.app.config.get('OAUTH2_PROVIDER_TOKEN_GENERATOR', None)
         if token_generator and not isinstance(token_generator, collections.Callable):
             token_generator = import_string(token_generator)


### PR DESCRIPTION
Resolves https://github.com/codalab/codalab-worksheets/issues/3948

Every token refresh by a user is a request to the server, so now it's a single refresh request every week instead of every day. Also, unless I missed something, the refresh token TTL is undocumented for Flask.