### PR TITLE
Add --store validation during cl upload.

### DIFF
--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -1372,6 +1372,26 @@ class BundleCLI(object):
             'metadata': metadata,
         }
 
+        # Validate store metadata.
+        store = metadata.get('store') or ''
+        if store != '':
+            print('Validating store...')
+            bundle_stores = client.fetch('bundle_stores')
+            if len(bundle_stores) == 0:
+                raise UsageError(f'{store} is not a valid store. No stores have been added.')
+
+            store_is_valid = False
+            for store_data in bundle_stores:
+                if store_data['name'] == store:
+                    store_is_valid = True
+                    break
+
+            if not store_is_valid:
+                print('Available Stores:\n')
+                self.print_table(['id', 'name', 'storage_type', 'storage_format'], bundle_stores)
+                print(' ')
+                raise UsageError(f' {store} is not a valid store.')
+
         # Option 1: --link
         if args.link:
             if len(args.path) != 1:
@@ -1399,7 +1419,7 @@ class BundleCLI(object):
                     'state_on_success': State.READY,
                     'finalize_on_success': True,
                     'use_azure_blob_beta': args.use_azure_blob_beta,
-                    'store': metadata.get('store') or '',
+                    'store': store,
                 },
             )
 
@@ -1420,7 +1440,7 @@ class BundleCLI(object):
                     'state_on_success': State.READY,
                     'finalize_on_success': True,
                     'use_azure_blob_beta': args.use_azure_blob_beta,
-                    'store': metadata.get('store') or '',
+                    'store': store,
                 },
             )
 
@@ -1486,7 +1506,7 @@ class BundleCLI(object):
                         'state_on_success': State.READY,
                         'finalize_on_success': True,
                         'use_azure_blob_beta': args.use_azure_blob_beta,
-                        'store': metadata.get('store') or '',
+                        'store': store,
                     },
                     progress_callback=progress.update,
                 )

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -923,6 +923,9 @@ def test_upload3(ctx):
     check_equals('hello', _run_command([cl, 'cat', uuid]))
     check_contains(bundle_store_name, _run_command([cl, 'info', uuid]))
 
+    # Check that we raise an error if the user specifies an invalid store.
+    _run_command([cl, 'upload', '--store', 'nonexistent_store'], expected_exit_code=1)
+
     # Check that uuid_run finished and uploaded results properly.
     wait(uuid_run)
     check_equals('hello', _run_command([cl, 'cat', f'{uuid_run}/stdout']))


### PR DESCRIPTION
### Reasons for making this change

If the user types in a store that doesn't exist during `cl upload --store`, we currently show them a general `500: Internal Server Error`.

This change will let the user know that they entered in a store name that doesn't exist, as well as show them a list of valid stores.

### Related issues

https://github.com/codalab/codalab-worksheets/issues/4062

### Screenshots

https://user-images.githubusercontent.com/25855750/175749113-f4ed237b-dd9d-451f-b86e-709ad9647f57.mov

### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [ ] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
