### PR TITLE
Bump version to 1.5.4

### DIFF
--- a/codalab/common.py
+++ b/codalab/common.py
@@ -27,7 +27,7 @@ from codalab.lib.beam.filesystems import (
 
 # Increment this on master when ready to cut a release.
 # http://semver.org/
-CODALAB_VERSION = '1.5.3'
+CODALAB_VERSION = '1.5.4'
 BINARY_PLACEHOLDER = '<binary>'
 URLOPEN_TIMEOUT_SECONDS = int(os.environ.get('CODALAB_URLOPEN_TIMEOUT_SECONDS', 5 * 60))
 

--- a/docs/REST-API-Reference.md
+++ b/docs/REST-API-Reference.md
@@ -1,6 +1,6 @@
 # REST API Reference
 
-_version 1.5.3_
+_version 1.5.4_
 
 This reference and the REST API itself is still under heavy development and is
 subject to change at any time. Feedback through our GitHub issues is appreciated!

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -1,5 +1,5 @@
 // Should match codalab/common.py#CODALAB_VERSION
-export const CODALAB_VERSION = '1.5.3';
+export const CODALAB_VERSION = '1.5.4';
 
 // Name Regex to match the backend in spec_utils.py
 export const NAME_REGEX = /^[a-zA-Z_][a-zA-Z0-9_.-]*$/i;

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import sys
 
 
 # should match codalab/common.py#CODALAB_VERSION
-CODALAB_VERSION = "1.5.3"
+CODALAB_VERSION = "1.5.4"
 
 
 class Install(install):


### PR DESCRIPTION
Bump version to 1.5.4

Diff: https://github.com/codalab/codalab-worksheets/compare/v1.5.3...rc1.5.4

# Release notes

## Frontend

None

## CLI

* Bypass server when uploading to Azure blob storage (#4108)

## Backend

* Read and authenticate with credentials from password file when starting Slurm worker manager (#4125)
* k8s: organize docs, fix version, add CI setup (#4117)
* Bump bottle from 0.12.19 to 0.12.20
* Bump eventsource from 1.0.7 to 1.1.1 in /frontend 
* Refactor kill() and remove() into docker_utils (#4118) 

## Dev / docs / CI

None