### PR TITLE
Add metadata descriptions to bundle view.

### DIFF
--- a/codalab/lib/worksheet_util.py
+++ b/codalab/lib/worksheet_util.py
@@ -233,8 +233,8 @@ def get_metadata_types(cls):
     Return map from key -> type for the metadata fields in the given bundle class.
     e.g.
        'request_time' -> 'basestring'
-       'time' -> 'duration'
-       'tags' -> 'list'
+       'time'         -> 'duration'
+       'tags'         -> 'list'
 
     Possible types: 'int', 'float', 'list', 'bool', 'duration',
                     'size', 'date', 'basestring'
@@ -246,6 +246,17 @@ def get_metadata_types(cls):
         spec.key: (not issubclass(spec.type, str) and spec.formatting) or spec.type.__name__
         for spec in cls.METADATA_SPECS
     }
+
+
+def get_metadata_descriptions(cls):
+    """
+    Return map from key -> description for the metadata fields in the given bundle class.
+    e.g.
+       'request_time' -> 'Amount of time (e.g., 3, 3m, 3h, 3d)...'
+       'time'         -> 'Amount of wall clock time (seconds)...'
+       'tags'         -> 'Space-separated list of tags...'
+    """
+    return {spec.key: spec.description for spec in cls.METADATA_SPECS}
 
 
 def request_lines(worksheet_info):

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -193,6 +193,7 @@ def build_bundles_document(bundle_uuids):
                         bundle_class
                     ),
                     'metadata_type': worksheet_util.get_metadata_types(bundle_class),
+                    'metadata_descriptions': worksheet_util.get_metadata_descriptions(bundle_class),
                 },
             )
 

--- a/frontend/src/components/Bundle/Bundle.js
+++ b/frontend/src/components/Bundle/Bundle.js
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import SubHeader from '../SubHeader';
 import ContentWrapper from '../ContentWrapper';
+import HelpTooltip from '../HelpTooltip';
 import { JsonApiDataStore } from 'jsonapi-datastore';
 import { renderFormat, renderPermissions, shorten_uuid } from '../../util/worksheet_utils';
 import { BundleEditableField } from '../EditableField';
@@ -70,6 +71,7 @@ class Bundle extends React.Component<
             // Normalize JSON API doc into simpler object
             const bundleInfo = new JsonApiDataStore().sync(response);
             bundleInfo.editableMetadataFields = response.data.meta.editable_metadata_keys;
+            bundleInfo.metadataDescriptions = response.data.meta.metadata_descriptions;
             bundleInfo.metadataType = response.data.meta.metadata_type;
             this.setState({ bundleInfo: bundleInfo });
         };
@@ -245,7 +247,7 @@ function renderDependencies(bundleInfo) {
     );
 }
 
-function createRow(bundleInfo, bundleMetadataChanged, key, value) {
+function createRow(bundleInfo, bundleMetadataChanged, key, value, description) {
     // Return a row corresponding to showing
     //   key: value
     // which can be edited.
@@ -259,7 +261,8 @@ function createRow(bundleInfo, bundleMetadataChanged, key, value) {
         return (
             <tr key={key}>
                 <th>
-                    <span className='editable-key'>{key}</span>
+                    <span>{key}</span>
+                    <HelpTooltip className='bundle-field-tooltip' title={description} />
                 </th>
                 <td>
                     <BundleEditableField
@@ -278,6 +281,7 @@ function createRow(bundleInfo, bundleMetadataChanged, key, value) {
             <tr key={key}>
                 <th>
                     <span>{key}</span>
+                    <HelpTooltip className='bundle-field-tooltip' title={description} />
                 </th>
                 <td>
                     <span>{renderFormat(value, fieldType[key])}</span>
@@ -301,8 +305,12 @@ function renderMetadata(bundleInfo, bundleMetadataChanged) {
     }
     keys.sort();
     for (let i = 0; i < keys.length; i++) {
-        let key = keys[i];
-        metadataListHtml.push(createRow(bundleInfo, bundleMetadataChanged, key, metadata[key]));
+        const key = keys[i];
+        const value = metadata[key];
+        const description = bundleInfo.metadataDescriptions[key];
+        metadataListHtml.push(
+            createRow(bundleInfo, bundleMetadataChanged, key, value, description),
+        );
     }
 
     return (

--- a/frontend/src/components/Bundle/Bundle.scss
+++ b/frontend/src/components/Bundle/Bundle.scss
@@ -190,3 +190,8 @@
   .bundle-state.state-failed[href]:focus {
     background-color: #c9302c;
   }
+  .bundle-field-tooltip {
+    vertical-align: bottom;
+    padding: 4px;
+    font-size: 13px;
+  }

--- a/frontend/src/components/HelpTooltip.js
+++ b/frontend/src/components/HelpTooltip.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import Tooltip from '@material-ui/core/Tooltip';
+import HelpOutlineOutlinedIcon from '@material-ui/icons/HelpOutlineOutlined';
+
+class HelpTooltip extends React.Component {
+    constructor(props) {
+        super(props);
+    }
+
+    render() {
+        if (this.props.title) {
+            return (
+                <Tooltip title={this.props.title}>
+                    <span className={this.props.className}>
+                        <HelpOutlineOutlinedIcon fontSize='inherit' />
+                    </span>
+                </Tooltip>
+            );
+        }
+        return null;
+    }
+}
+
+export default HelpTooltip;


### PR DESCRIPTION
### Reasons for making this change

This change will provide users with info about what each metadata field means.

### Related issues

https://github.com/codalab/codalab-worksheets/issues/4057

### Screenshots

#### Bundle View - metadata 
![Screen Shot 2022-07-04 at 9 48 35 PM](https://user-images.githubusercontent.com/25855750/177252542-d5a9b508-affd-44d7-8c4b-c3fce59d74e4.png)

#### Bundle View - metadata [hover]
https://user-images.githubusercontent.com/25855750/177252407-aeedf52f-c462-4de5-be3a-885bcf79a778.mov


### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [ ] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [ ] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
