### PR TITLE
Fix dependency resolution issues by pinning fewer GCP requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,14 @@
-apache-beam[azure,gcp]==2.36.0
+apache-beam[azure]==2.36.0
+
+# GCP requirements for apache-beam. Note: when upgrading
+# apache-beam, make sure these requirements are also upgraded
+# accordingly according to Beam's GCP requirements
+# (https://github.com/apache/beam/blob/master/sdks/python/setup.py).
+cachetools>=3.1.0,<5
+google-apitools>=0.5.31,<0.5.32
+google-auth>=1.18.0,<3
+
+# Remaining requirements
 bottle==0.12.20
 dataclasses==0.7;python_version<'3.7'
 docker==4.3.0


### PR DESCRIPTION
### Reasons for making this change

Fixes https://github.com/codalab/codalab-worksheets/issues/4138, in which dependency resolution took very long due to pip's new dependency resolver. There were too many complex requirements from `apache-beam[gcp]` -- see the following for the full list:

https://github.com/apache/beam/blob/release-2.36.0/sdks/python/setup.py#L181-L204

Instead, I've only pulled in the requirements we need, which significantly speeds up the dependency resolver.

### Related issues

Fixes https://github.com/codalab/codalab-worksheets/issues/4138.