### PR TITLE
Fix SerializationError issue by pinning msrest==0.6.21

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ dataclasses==0.7;python_version<'3.7'
 docker==4.3.0
 marshmallow-jsonapi==0.15.1
 marshmallow==2.15.1
+msrest==0.6.21
 setuptools>=40.0.0
 argcomplete==1.12.3
 indexed_gzip==1.6.3


### PR DESCRIPTION
### Reasons for making this change

Potentially fixes https://github.com/codalab/codalab-worksheets/issues/4143. I'm trying the approach mentioned in https://github.com/Azure/azure-sdk-for-python/issues/24765#issuecomment-1150310498.

Before we merge this, we should see if we can replicate the bug on CI so we can ensure it doesn't regress.