### PR TITLE
Upgrade sqlalchemy to 1.4.39

### DIFF
--- a/codalab/model/mysql_model.py
+++ b/codalab/model/mysql_model.py
@@ -42,11 +42,7 @@ class MySQLModel(BundleModel):
         if not engine_url.startswith('mysql://'):
             raise UsageError('Engine URL should start with mysql://')
         engine = create_engine(
-            engine_url,
-            pool_size=20,
-            max_overflow=100,
-            pool_recycle=3600,
-            encoding='utf-8',
+            engine_url, pool_size=20, max_overflow=100, pool_recycle=3600, encoding='utf-8',
         )
         super(MySQLModel, self).__init__(engine, default_user_info, root_user_id, system_user_id)
 

--- a/codalab/model/mysql_model.py
+++ b/codalab/model/mysql_model.py
@@ -43,7 +43,6 @@ class MySQLModel(BundleModel):
             raise UsageError('Engine URL should start with mysql://')
         engine = create_engine(
             engine_url,
-            strategy='threadlocal',
             pool_size=20,
             max_overflow=100,
             pool_recycle=3600,

--- a/codalab/model/sqlite_model.py
+++ b/codalab/model/sqlite_model.py
@@ -14,7 +14,6 @@ class SQLiteModel(BundleModel):
         # https://docs.sqlalchemy.org/en/13/dialects/sqlite.html#threading-pooling-behavior
         engine = create_engine(
             'sqlite:///:memory:',
-            strategy='threadlocal',
             encoding='utf-8',
             connect_args={'check_same_thread': False},
             poolclass=StaticPool,

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ ratarmountcore==0.1.3
 PyYAML==5.4
 psutil==5.7.2
 six==1.15.0
-SQLAlchemy==1.3.19
+SQLAlchemy==1.4.39
 watchdog>=2.0.0
 fusepy==2.0.4
 pygments>=2.12,<2.13


### PR DESCRIPTION
### Reasons for making this change

Upgrade sqlalchemy to 1.4.39. Removed "threadlocal" as it has been deprecated (see https://docs.sqlalchemy.org/en/13/changelog/migration_13.html#change-4393-threadlocal).