### PR TITLE
Update size_str formatting to optionally include bytes string.

### DIFF
--- a/codalab/lib/formatting.py
+++ b/codalab/lib/formatting.py
@@ -31,9 +31,10 @@ def verbose_contents_str(input_string):
     return contents_str(input_string, verbose=True)
 
 
-def size_str(size):
+def size_str(size, include_bytes=False):
     """
     size: number of bytes
+    include_bytes: whether or not to include 'bytes' string in the return value
     Return a human-readable string.
     """
     if size is None:
@@ -41,9 +42,15 @@ def size_str(size):
 
     for unit in ('', 'k', 'm', 'g', 't'):
         if size < 100 and size != int(size):
+            if unit == '' and include_bytes:
+                return '%.1f bytes' % size
             return '%.1f%s' % (size, unit)
+
         if size < 1024:
+            if unit == '' and include_bytes:
+                return '%d bytes' % size
             return '%d%s' % (size, unit)
+
         size /= 1024.0
 
 

--- a/codalab/worker/worker_run_state.py
+++ b/codalab/worker/worker_run_state.py
@@ -695,8 +695,8 @@ class RunStateMachine(StateTransitioner):
                 logger.debug('Uploading results for run with UUID %s', run_state.bundle.uuid)
 
                 def progress_callback(bytes_uploaded):
-                    run_status = 'Uploading results: %s bytes uploaded (archived size)' % size_str(
-                        bytes_uploaded
+                    run_status = 'Uploading results: %s uploaded (archived size)' % size_str(
+                        bytes_uploaded, include_bytes=True,
                     )
                     self.uploading[run_state.bundle.uuid]['run_status'] = run_status
                     return True

--- a/tests/unit/lib/formatting_test.py
+++ b/tests/unit/lib/formatting_test.py
@@ -1,0 +1,89 @@
+import unittest
+from codalab.lib.formatting import size_str
+
+
+class SizeStrTest(unittest.TestCase):
+    def test_bytes_formatting(self):
+        """
+        The number of bytes should be returned as a string.
+        If include_bytes is True, 'bytes' should be appended to the return value.
+        """
+        # < 100 bytes
+        size = size_str(99.01)
+        self.assertEqual(size, '99.0')
+        size = size_str(99.01, include_bytes=True)
+        self.assertEqual(size, '99.0 bytes')
+
+        # > 100 bytes
+        size = size_str(700.3)
+        self.assertEqual(size, '700')
+        size = size_str(700.3, include_bytes=True)
+        self.assertEqual(size, '700 bytes')
+
+    def test_kilobytes_formatting(self):
+        """
+        Bytes should be converted to kilobytes (denoted 'k') if possible.
+        The include_bytes flag should have no affect on kilobytes.
+        """
+        # < 100 kilobytes
+        size = size_str(3500)
+        self.assertEqual(size, '3.4k')
+        size = size_str(3500, include_bytes=True)
+        self.assertEqual(size, '3.4k')
+
+        # > 100 kilobytes
+        size = size_str(400000)
+        self.assertEqual(size, '390k')
+        size = size_str(400000, include_bytes=True)
+        self.assertEqual(size, '390k')
+
+    def test_megabytes_formatting(self):
+        """
+        Bytes should be converted to megabytes (denoted 'm') if possible.
+        The include_bytes flag should have no affect on megabytes.
+        """
+        # < 100 megabytes
+        size = size_str(4000000)
+        self.assertEqual(size, '3.8m')
+        size = size_str(4000000, include_bytes=True)
+        self.assertEqual(size, '3.8m')
+
+        # > 100 megabytes
+        size = size_str(400000000)
+        self.assertEqual(size, '381m')
+        size = size_str(400000000, include_bytes=True)
+        self.assertEqual(size, '381m')
+
+    def test_gigabytes_formatting(self):
+        """
+        Bytes should be converted to gigabytes (denoted 'g') if possible.
+        The include_bytes flag should have no affect on gigabytes.
+        """
+        # < 100 gigabytes
+        size = size_str(4000000000)
+        self.assertEqual(size, '3.7g')
+        size = size_str(4000000000, include_bytes=True)
+        self.assertEqual(size, '3.7g')
+
+        # > 100 gigabytes
+        size = size_str(350000000000)
+        self.assertEqual(size, '325g')
+        size = size_str(350000000000, include_bytes=True)
+        self.assertEqual(size, '325g')
+
+    def test_terabytes_formatting(self):
+        """
+        Bytes should be converted to terabytes (denoted 't') if possible.
+        The include_bytes flag should have no affect on terabytes.
+        """
+        # < 100 terabytes
+        size = size_str(3500000000000)
+        self.assertEqual(size, '3.2t')
+        size = size_str(3500000000000, include_bytes=True)
+        self.assertEqual(size, '3.2t')
+
+        # > 100 terabytes
+        size = size_str(450000000000000)
+        self.assertEqual(size, '409t')
+        size = size_str(450000000000000, include_bytes=True)
+        self.assertEqual(size, '409t')


### PR DESCRIPTION
### Reasons for making this change

Currently, we are incorrectly rendering the number of bytes in a bundle's `run_status`, specifically during the uploading step. For example, this is what the uploading `run_status` looks like before this change:

![before](https://user-images.githubusercontent.com/25855750/180881850-064653be-1c17-492a-8aca-e7c1f148f73f.png)

Notice the wording, `120k bytes uploaded`. This is equivalent to saying `120 kilobytes bytes uploaded`, which is inaccurate. 

#### After this Change

This change updates the `size_str` helper to apply the word `bytes` to the result if and only if:
1. The `include_bytes` flag is set to `True`
2. The number being shown to the user is bytes (as opposed to kilobytes, megabytes, gigabytes or terabytes).

This is what the above `run_status` would look like after this change:

![after](https://user-images.githubusercontent.com/25855750/180882000-1116b8ab-7a45-460a-a93c-45096c1d1f58.png)

This is what it would look like if 160 bytes were being uploaded:

![Screen Shot 2022-07-25 at 3 19 58 PM](https://user-images.githubusercontent.com/25855750/180883698-17575f2e-802a-4cd1-83cc-fee7dcce4494.png)

### Related issues

https://github.com/codalab/codalab-worksheets/issues/4114

### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [ ] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
