### PR TITLE
Feature/4133 optimize bundle cl info

### DIFF
--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -2405,6 +2405,9 @@ class BundleCLI(object):
                 # Display basic info
                 self.print_basic_info(info)
 
+                # Display bundle locations
+                self.print_bundle_locations(client, info, args.raw)
+
                 # Display verbose info
                 if args.verbose:
                     self.print_line()
@@ -2463,10 +2466,24 @@ class BundleCLI(object):
         lines.append(self.key_value_str('Created', info.get('created')))
         lines.append(self.key_value_str('Size', info.get('data_size')))
 
-        if 'store' in info:
-            lines.append(self.key_value_str('Store', info.get('store')))
-
         print('\n'.join(lines), file=self.stdout)
+
+    def print_bundle_locations(self, client, info, raw):
+        """
+        print >>self.stdout - bundle stores
+        """
+        bundle_locations = client.get_bundle_locations((info['uuid']))
+        if len(bundle_locations) > 0:
+            lines = []
+            if raw:
+                bundle_locations = str(bundle_locations)
+                lines.append(self.key_value_str('Stores', bundle_locations))
+            else:
+                bundle_locations = [
+                    location.get('attributes').get('name') for location in bundle_locations
+                ]
+                lines.append(self.key_value_str('Stores', ','.join(bundle_locations)))
+            print('\n'.join(lines), file=self.stdout)
 
     def print_resource_info(self, info):
         """

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -2364,6 +2364,7 @@ class BundleCLI(object):
     def do_info_command(self, args):
         args.bundle_spec = spec_util.expand_specs(args.bundle_spec)
         client, worksheet_uuid = self.parse_client_worksheet_uuid(args.worksheet_spec)
+
         bundles = client.fetch(
             'bundles',
             params={
@@ -2373,6 +2374,7 @@ class BundleCLI(object):
                 + (['children', 'group_permissions', 'host_worksheets'] if args.verbose else []),
             },
         )
+
         for i, info in enumerate(bundles):
             if args.field:
                 # Display individual fields (arbitrary genpath)

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -2416,8 +2416,7 @@ class BundleCLI(object):
                         self.print_time_info(info)
                     if bundle_type == 'dataset':
                         self.print_source_info(info)
-                    if info.get('dependencies'):
-                        self.print_dependencies(info)
+                    self.print_dependencies(info)
                     self.print_host_worksheets(info)
                     self.print_contents(client, info)
 
@@ -2442,30 +2441,29 @@ class BundleCLI(object):
         """
         print >>self.stdout - the basic information for a bundle (key/value pairs).
         """
+        keys = [
+            'state',
+            'uuid',
+            'name',
+            'description',
+            'tags',
+            'owner',
+            'permission',
+            'group_permissions',
+            'created',
+            'data_size',
+        ]
         lines = []
-        lines.append(self.key_value_str('State', info.get('state')))
-        lines.append(self.key_value_str('UUID', info.get('uuid')))
-        lines.append(self.key_value_str('Name', info.get('name')))
-
-        if 'description' in info:
-            lines.append(self.key_value_str('Description', info.get('description')))
-
-        if 'tags' in info:
-            lines.append(self.key_value_str('Tags', info.get('tags')))
-
-        lines.append(self.key_value_str('Owner', self.simple_user_str(info['owner'])))
-        lines.append(self.key_value_str('Permissions', permission_str(info['permission'])))
-
-        if 'group_permissions' in info:
-            lines.append(
-                self.key_value_str(
-                    'Group Permissions', group_permissions_str(info['group_permissions'])
-                )
-            )
-
-        lines.append(self.key_value_str('Created', info.get('created')))
-        lines.append(self.key_value_str('Size', info.get('data_size')))
-
+        for key in keys:
+            if key in info:
+                value = info[key]
+                if key == 'owner':
+                    value = self.simple_user_str(value)
+                if key == 'permission':
+                    value = permission_str(value)
+                if key == 'group_permissions':
+                    value = group_permissions_str(value)
+                lines.append(self.key_value_str(key, value))
         print('\n'.join(lines), file=self.stdout)
 
     def print_bundle_locations(self, client, info, raw):
@@ -2477,31 +2475,36 @@ class BundleCLI(object):
             lines = []
             if raw:
                 bundle_locations = str(bundle_locations)
-                lines.append(self.key_value_str('Stores', bundle_locations))
+                lines.append(self.key_value_str('store', bundle_locations))
             else:
                 bundle_locations = [
                     location.get('attributes').get('name') for location in bundle_locations
                 ]
-                lines.append(self.key_value_str('Stores', ','.join(bundle_locations)))
+                lines.append(self.key_value_str('store', ','.join(bundle_locations)))
             print('\n'.join(lines), file=self.stdout)
 
     def print_resource_info(self, info):
         """
         print >>self.stdout - run bundle resource information
         """
+        keys = [
+            'request_disk',
+            'request_memory',
+            'request_cpus',
+            'request_gpus',
+            'request_docker_image',
+            'docker_image',
+            'request_queue',
+            'request_priority',
+            'request_network',
+            'on_preemptible_worker',
+        ]
         lines = []
-        lines.append(self.key_value_str('Disk', info.get('request_disk')))
-        lines.append(self.key_value_str('Memory', info.get('request_memory')))
-        lines.append(self.key_value_str('CPUs', info.get('request_cpus')))
-        lines.append(self.key_value_str('GPUs', info.get('request_gpus')))
-        lines.append(self.key_value_str('Docker Image Requested', info.get('request_docker_image')))
-        lines.append(self.key_value_str('Docker Image Used', info.get('docker_image')))
-        lines.append(self.key_value_str('Queue', info.get('request_queue')))
-        lines.append(self.key_value_str('Priority', info.get('request_priority')))
-        lines.append(self.key_value_str('Network', info.get('request_network')))
-        lines.append(self.key_value_str('Preemptible', info.get('on_preemptible_worker')))
+        for key in keys:
+            if key in info:
+                lines.append(self.key_value_str(key, info[key]))
 
-        print('RESOURCES', file=self.stdout)
+        print('Resources', file=self.stdout)
         print('\n'.join(lines), file=self.stdout)
         self.print_line()
 
@@ -2509,15 +2512,20 @@ class BundleCLI(object):
         """
         print >>self.stdout - run bundle time information
         """
+        keys = [
+            'request_time',
+            'time_preparing',
+            'time_running',
+            'time_uploading_results',
+            'time_cleaning_up',
+            'time',
+        ]
         lines = []
-        lines.append(self.key_value_str('Time Allowed', info.get('request_time')))
-        lines.append(self.key_value_str('Time Preparing', info.get('time_preparing')))
-        lines.append(self.key_value_str('Time Running', info.get('time_running')))
-        lines.append(self.key_value_str('Time Uploading', info.get('time_uploading_results')))
-        lines.append(self.key_value_str('Time Cleaning Up', info.get('time_cleaning_up')))
-        lines.append(self.key_value_str('Total Time', info.get('time')))
+        for key in keys:
+            if key in info:
+                lines.append(self.key_value_str(key, info[key]))
 
-        print('TIME', file=self.stdout)
+        print('Time', file=self.stdout)
         print('\n'.join(lines), file=self.stdout)
         self.print_line()
 
@@ -2525,13 +2533,23 @@ class BundleCLI(object):
         """
         print >>self.stdout - uploaded bundle source information
         """
+        keys = [
+            'license',
+            'source_url',
+            'link_url',
+            'link_format',
+        ]
         lines = []
-        lines.append(self.key_value_str('License', info.get('license')))
-        lines.append(self.key_value_str('Source URL', info.get('source_url')))
-        lines.append(self.key_value_str('Link URL', info.get('link_url')))
-        lines.append(self.key_value_str('Link Format', info.get('link_format')))
+        has_source_info = False
+        for key in keys:
+            if key in info:
+                has_source_info = True
+                lines.append(self.key_value_str(key, info[key]))
 
-        print('SOURCES', file=self.stdout)
+        if not has_source_info:
+            return
+
+        print('Sources', file=self.stdout)
         print('\n'.join(lines), file=self.stdout)
         self.print_line()
 
@@ -2539,10 +2557,16 @@ class BundleCLI(object):
         """
         print >>self.stdout - bundle dependency information
         """
-        lines = []
-        lines.append(self.key_value_str('Allow Failed', info.get('allow_failed_dependencies')))
+        dependencies = info.get('dependencies')
+        if not dependencies:
+            return
 
-        for dep in info['dependencies']:
+        lines = []
+        lines.append(
+            self.key_value_str('allow_failed_dependencies', info.get('allow_failed_dependencies'))
+        )
+
+        for dep in dependencies:
             child = dep['child_path']
             parent = path_util.safe_join(
                 contents_str(dep['parent_name']) + '(' + dep['parent_uuid'] + ')',
@@ -2550,7 +2574,7 @@ class BundleCLI(object):
             )
             lines.append(self.key_value_str(child, parent))
 
-        print('DEPENDENCIES', file=self.stdout)
+        print('Dependencies', file=self.stdout)
         print('\n'.join(lines), file=self.stdout)
         self.print_line()
 
@@ -2558,7 +2582,7 @@ class BundleCLI(object):
         """
         print >>self.stdout - list of host worksheets
         """
-        print('HOST WORKSHEETS', file=self.stdout)
+        print('Host Worksheets', file=self.stdout)
         for host_worksheet_info in info['host_worksheets']:
             print(self.worksheet_url_and_name(host_worksheet_info), file=self.stdout)
         self.print_line()
@@ -2567,11 +2591,10 @@ class BundleCLI(object):
         """
         print >>self.stdout - contents previews including stderr and stdout
         """
-        print('CONTENTS', file=self.stdout)
+        print('Contents', file=self.stdout)
 
-        exclude_patterns = info.get('exclude_patterns')
-        if exclude_patterns:
-            print(self.key_value_str('Exclude Patterns', exclude_patterns))
+        if 'exclude_patterns' in info:
+            print(self.key_value_str('exclude_patterns', info['exclude_patterns']))
             self.print_line()
 
         def wrap(string):

--- a/codalab/lib/worksheet_util.py
+++ b/codalab/lib/worksheet_util.py
@@ -189,7 +189,7 @@ def get_worksheet_lines(worksheet_info):
 def get_formatted_metadata(cls, metadata, raw=False, show_hidden=False):
     """
     Input:
-        cls: bundle subclass (e.g. DatasetBundle, RuunBundle, ProgramBundle)
+        cls: bundle subclass (e.g. DatasetBundle, RunBundle, ProgramBundle)
         metadata: bundle metadata
         raw: boolean value indicating if the raw value needs to be returned
     Return an object containing the key and formatted value of metadata.

--- a/codalab/lib/worksheet_util.py
+++ b/codalab/lib/worksheet_util.py
@@ -192,9 +192,9 @@ def get_formatted_metadata(cls, metadata, raw=False, show_hidden=False):
         cls: bundle subclass (e.g. DatasetBundle, RuunBundle, ProgramBundle)
         metadata: bundle metadata
         raw: boolean value indicating if the raw value needs to be returned
-    Return a list of tuples containing the key and formatted value of metadata.
+    Return an object containing the key and formatted value of metadata.
     """
-    result = []
+    result = {}
     for spec in cls.METADATA_SPECS:
         if spec.hidden and not show_hidden:
             continue
@@ -202,14 +202,14 @@ def get_formatted_metadata(cls, metadata, raw=False, show_hidden=False):
         if not raw:
             if key not in metadata:
                 continue
-            if metadata[key] == '' or metadata[key] == []:
+            if metadata[key] == '' or metadata[key] == [] or metadata[key] == ['']:
                 continue
             value = apply_func(spec.formatting, metadata.get(key))
             if isinstance(value, list):
                 value = ' '.join(value)
         else:
             value = metadata.get(key)
-        result.append((key, value))
+        result[key] = value
     return result
 
 

--- a/frontend/src/components/worksheets/BundleDetail/MoreDetail.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/MoreDetail.jsx
@@ -142,7 +142,7 @@ class MoreDetail extends React.Component {
                 {hasDependencies && (
                     <BundleFieldTable title='Dependencies'>
                         <BundleFieldRow
-                            label='Failed Dependencies'
+                            label='Allow Failed'
                             field={bundle.allow_failed_dependencies}
                             onChange={(allow_failed_dependencies) =>
                                 onUpdate({ allow_failed_dependencies })

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -661,11 +661,11 @@ def test_basic(ctx):
 
     # info
     check_contains(
-        ['State', 'UUID', 'Name', 'Owner', 'Permissions', 'Created', 'Size',],
+        ['state', 'uuid', 'name', 'owner', 'permission', 'created', 'data_size',],
         _run_command([cl, 'info', uuid]),
     )
-    check_contains('License', _run_command([cl, 'info', '--raw', '--verbose', uuid]))
-    check_contains(['HOST WORKSHEETS', 'CONTENTS'], _run_command([cl, 'info', '--verbose', uuid]))
+    check_contains('license', _run_command([cl, 'info', '--raw', '--verbose', uuid]))
+    check_contains(['Host Worksheets', 'Contents'], _run_command([cl, 'info', '--verbose', uuid]))
 
     # test interpret_file_genpath
     check_equals(' '.join(test_path_contents('a.txt').splitlines(False)), get_info(uuid, '/'))

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -656,11 +656,17 @@ def test_basic(ctx):
     check_equals('a2.txt', get_info(uuid, 'name'))
     check_contains(['c', 'd', 'e'], get_info(uuid, 'tags'))
 
-    # cat, info
+    # cat
     check_equals(test_path_contents('a.txt'), _run_command([cl, 'cat', uuid]))
-    check_contains(['bundle_type', 'uuid', 'owner', 'created'], _run_command([cl, 'info', uuid]))
-    check_contains('license', _run_command([cl, 'info', '--raw', uuid]))
-    check_contains(['host_worksheets', 'contents'], _run_command([cl, 'info', '--verbose', uuid]))
+
+    # info
+    check_contains(
+        ['State', 'UUID', 'Name', 'Owner', 'Permissions', 'Created', 'Size',],
+        _run_command([cl, 'info', uuid]),
+    )
+    check_contains('License', _run_command([cl, 'info', '--raw', '--verbose', uuid]))
+    check_contains(['HOST WORKSHEETS', 'CONTENTS'], _run_command([cl, 'info', '--verbose', uuid]))
+
     # test interpret_file_genpath
     check_equals(' '.join(test_path_contents('a.txt').splitlines(False)), get_info(uuid, '/'))
 
@@ -1315,7 +1321,7 @@ def test_make(ctx):
     # make
     uuid3 = _run_command([cl, 'make', 'dep1:' + uuid1, 'dep2:' + uuid2])
     wait(uuid3)
-    check_contains(['dep1', uuid1, 'dep2', uuid2], _run_command([cl, 'info', uuid3]))
+    check_contains(['dep1', uuid1, 'dep2', uuid2], _run_command([cl, 'info', '-v', uuid3]))
     # anonymous make
     uuid4 = _run_command([cl, 'make', uuid3, '--name', 'foo'])
     wait(uuid4)

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1144,7 +1144,7 @@ def test_upload_default_bundle_store(ctx):
     )
     # Upload a bundle, which should output to bundle store by default
     uuid = _run_command([cl, 'upload', '-c', 'hello'])
-    check_contains(bundle_store_name, _run_command([cl, "info", uuid]))
+    check_contains(bundle_store_name, _run_command([cl, "info", "-f", "store", uuid]))
 
 
 @TestModule.register('store_add')

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1144,7 +1144,7 @@ def test_upload_default_bundle_store(ctx):
     )
     # Upload a bundle, which should output to bundle store by default
     uuid = _run_command([cl, 'upload', '-c', 'hello'])
-    check_contains(bundle_store_name, _run_command([cl, "info", "-f", "store", uuid]))
+    check_contains(bundle_store_name, _run_command([cl, "info", uuid]))
 
 
 @TestModule.register('store_add')


### PR DESCRIPTION
### Reasons for making this change

Bundle details were recently updated in https://github.com/codalab/codalab-worksheets/pull/4150 to look like this:

![image](https://user-images.githubusercontent.com/25855750/181141088-0d67fcfb-cbf9-4f28-ac5e-838b166ae6cd.png)

When details are expanded, the sidebar looks like this:

![image](https://user-images.githubusercontent.com/25855750/181140911-75376c6c-2f66-43a4-94fe-c1862d0e6ed1.png)

The goal of these changes are to align the `cl info <bundle_uuid>` command output with the way we group / display bundle details in the newly redesigned bundle ui.

When a user runs `cl info <bundle_uuid>`, we will display all of the fields that we display by default in the bundle UI:

![image](https://user-images.githubusercontent.com/25855750/181362582-5517d2f0-36cf-4c6f-8dd1-5eb4d96fe665.png)

When a user adds the `--verbose` or `-v` flag, we will display the rest of the bundle fields underneath the default fields. The groupings and labels mimic the newly redesigned bundle ui:

![image](https://user-images.githubusercontent.com/25855750/181362777-4e3dbc52-b886-4946-89ff-0f8786b03332.png)


### Related issues
https://github.com/codalab/codalab-worksheets/issues/4133

### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [ ] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed