### PR TITLE
Normalize worksheet item sort keys during get_worksheet_info.

### DIFF
--- a/codalab/rest/worksheets.py
+++ b/codalab/rest/worksheets.py
@@ -347,17 +347,14 @@ def get_worksheet_info(uuid, fetch_items=False, fetch_permissions=True):
 
     # Create the info by starting out with the metadata.
     result = worksheet.to_dict()
-    items = result.get('items', [])
+    items = result.get('items')
 
     # Update worksheet item sort keys if needed.
-    for item in items:
-        if item['sort_key'] is None:
-            update_worksheet_items(
-                result, [Worksheet.Item.as_tuple(i) for i in items], convert_items=False
-            )
-            worksheet = local.model.get_worksheet(uuid, fetch_items=fetch_items)  # get updated info
-            result = worksheet.to_dict()
-            break
+    if items and any(item['sort_key'] is None for item in items):
+        items = [Worksheet.Item.as_tuple(i) for i in items]  # convert items
+        update_worksheet_items(result, items, convert_items=False)  # update sort keys
+        worksheet = local.model.get_worksheet(uuid, fetch_items=fetch_items)  # get updated info
+        result = worksheet.to_dict()
 
     # Set worksheet permission.
     result['permission'] = permission

--- a/tests/unit/rest/worksheets_test.py
+++ b/tests/unit/rest/worksheets_test.py
@@ -4,10 +4,92 @@ import datetime
 from freezegun import freeze_time
 
 
+TEST_BUNDLE_BODY = {
+    'data': [
+        {
+            'type': 'bundles',
+            'attributes': {
+                'bundle_type': 'run',
+                'command': 'echo TEST',
+                'metadata': {
+                    'name': 'run-echo',
+                    'description': '',
+                    'tags': [''],
+                    'allow_failed_dependencies': False,
+                    'request_docker_image': 'codalab/default-cpu:latest',
+                    'request_time': '',
+                    'request_memory': '4g',
+                    'request_disk': '',
+                    'request_cpus': 1,
+                    'request_gpus': 0,
+                    'request_queue': '',
+                    'request_priority': 0,
+                    'request_network': False,
+                    'exclude_patterns': [],
+                    'store': '',
+                },
+                'dependencies': [],
+            },
+        },
+        {
+            'type': 'bundles',
+            'attributes': {
+                'bundle_type': 'run',
+                'command': 'echo TEST',
+                'metadata': {
+                    'name': 'run-echo',
+                    'description': '',
+                    'tags': [''],
+                    'allow_failed_dependencies': False,
+                    'request_docker_image': 'codalab/default-cpu:latest',
+                    'request_time': '',
+                    'request_memory': '4g',
+                    'request_disk': '',
+                    'request_cpus': 1,
+                    'request_gpus': 0,
+                    'request_queue': '',
+                    'request_priority': 0,
+                    'request_network': False,
+                    'exclude_patterns': [],
+                    'store': '',
+                },
+                'dependencies': [],
+            },
+        },
+        {
+            'type': 'bundles',
+            'attributes': {
+                'bundle_type': 'run',
+                'command': 'echo TEST',
+                'metadata': {
+                    'name': 'run-echo',
+                    'description': '',
+                    'tags': [''],
+                    'allow_failed_dependencies': False,
+                    'request_docker_image': 'codalab/default-cpu:latest',
+                    'request_time': '',
+                    'request_memory': '4g',
+                    'request_disk': '',
+                    'request_cpus': 1,
+                    'request_gpus': 0,
+                    'request_queue': '',
+                    'request_priority': 0,
+                    'request_network': False,
+                    'exclude_patterns': [],
+                    'store': '',
+                },
+                'dependencies': [],
+            },
+        },
+    ]
+}
+
+
 class WorksheetsTest(BaseTestCase):
     @freeze_time("2012-01-14", as_kwarg="frozen_time")
     def test_create(self, frozen_time):
-        """Create a new worksheet, then ensure that the proper fields are returned.
+        """
+        Create a new worksheet, then ensure that the proper fields are returned.
         """
         worksheet_name = f"codalab-{uuid.uuid4()}"
         response = self.app.post_json(
@@ -42,89 +124,11 @@ class WorksheetsTest(BaseTestCase):
         self.assertEqual(current_time, worksheet_info["date_last_modified"])
 
     def test_refresh(self):
-        """Upload 3 bundles to a worksheet, then specify a bundle_uuid to refresh, only the queried bundle info should be returned
+        """
+        Upload 3 bundles to a worksheet, then specify a bundle_uuid to refresh, only the queried bundle info should be returned
         """
         worksheet_id = self.create_worksheet()
-        body = {
-            'data': [
-                {
-                    'type': 'bundles',
-                    'attributes': {
-                        'bundle_type': 'run',
-                        'command': 'echo TEST',
-                        'metadata': {
-                            'name': 'run-echo',
-                            'description': '',
-                            'tags': [''],
-                            'allow_failed_dependencies': False,
-                            'request_docker_image': 'codalab/default-cpu:latest',
-                            'request_time': '',
-                            'request_memory': '4g',
-                            'request_disk': '',
-                            'request_cpus': 1,
-                            'request_gpus': 0,
-                            'request_queue': '',
-                            'request_priority': 0,
-                            'request_network': False,
-                            'exclude_patterns': [],
-                            'store': '',
-                        },
-                        'dependencies': [],
-                    },
-                },
-                {
-                    'type': 'bundles',
-                    'attributes': {
-                        'bundle_type': 'run',
-                        'command': 'echo TEST',
-                        'metadata': {
-                            'name': 'run-echo',
-                            'description': '',
-                            'tags': [''],
-                            'allow_failed_dependencies': False,
-                            'request_docker_image': 'codalab/default-cpu:latest',
-                            'request_time': '',
-                            'request_memory': '4g',
-                            'request_disk': '',
-                            'request_cpus': 1,
-                            'request_gpus': 0,
-                            'request_queue': '',
-                            'request_priority': 0,
-                            'request_network': False,
-                            'exclude_patterns': [],
-                            'store': '',
-                        },
-                        'dependencies': [],
-                    },
-                },
-                {
-                    'type': 'bundles',
-                    'attributes': {
-                        'bundle_type': 'run',
-                        'command': 'echo TEST',
-                        'metadata': {
-                            'name': 'run-echo',
-                            'description': '',
-                            'tags': [''],
-                            'allow_failed_dependencies': False,
-                            'request_docker_image': 'codalab/default-cpu:latest',
-                            'request_time': '',
-                            'request_memory': '4g',
-                            'request_disk': '',
-                            'request_cpus': 1,
-                            'request_gpus': 0,
-                            'request_queue': '',
-                            'request_priority': 0,
-                            'request_network': False,
-                            'exclude_patterns': [],
-                            'store': '',
-                        },
-                        'dependencies': [],
-                    },
-                },
-            ]
-        }
-        response = self.app.post_json(f'/rest/bundles?worksheet={worksheet_id}', body)
+        response = self.app.post_json(f'/rest/bundles?worksheet={worksheet_id}', TEST_BUNDLE_BODY)
         self.assertEqual(response.status_int, 200)
         data = response.json["data"]
         bundle_id = data[0]["id"]
@@ -136,3 +140,28 @@ class WorksheetsTest(BaseTestCase):
         blocks_info = refreshed_bundles["blocks"][0]["bundles_spec"]["bundle_infos"]
         bundles_count = sum(1 for bundle in blocks_info if bundle)
         self.assertEqual(1, bundles_count)
+
+    def test_sort_key_normalization(self):
+        """
+        Confirm that a worksheet contains valid sort keys when worksheet info
+        is fetched via get_worksheet_info.
+        """
+        worksheet_id = self.create_worksheet()
+
+        # Add items with null sort_key to a worksheet.
+        self.app.post_json(f'/rest/bundles?worksheet={worksheet_id}', TEST_BUNDLE_BODY)
+
+        # Get worksheet info, which should normalize sort keys.
+        worksheet_info = self.app.get('/rest/interpret/worksheet/' + worksheet_id).json
+        sort_keys = worksheet_info['blocks'][0]['sort_keys']
+        last_sort_key = None
+
+        for sort_key in sort_keys:
+
+            # Assert that there are no null sort keys.
+            self.assertIsNotNone(sort_key)
+
+            # Assert that sort keys monotonically increase.
+            if last_sort_key is not None:
+                self.assertEqual(sort_key, last_sort_key + 1)
+            last_sort_key = sort_key


### PR DESCRIPTION
### Reasons for making this change

When worksheet items are created via CLI, they are assigned a `null` sort key. When a worksheet item has a `null` sort key, the web UI will always render worksheet items with non-null sort keys above it.

Thus if a user tries to create a new worksheet item directly below a worksheet item that has a `null` sort key, the web UI will render the new item somewhere above the item with the `null` sort key instead of below it as the user intended. 

This change checks worksheet items for `null` sort keys during `get_worksheet_info` and updates those items in the db if needed.

### Related issues

https://github.com/codalab/codalab-worksheets/issues/3989

### Before this Change

https://user-images.githubusercontent.com/10134824/152871649-3a46f325-000f-41e6-853b-421011812961.mov

### After this Change

https://user-images.githubusercontent.com/25855750/182248487-ee2328f4-3e92-4aba-9004-b1d42a0f91a0.mov


### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [ ] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
