### PR TITLE
Bundle detail ui cleanup

### DIFF
--- a/codalab/bundles/derived_bundle.py
+++ b/codalab/bundles/derived_bundle.py
@@ -15,7 +15,7 @@ class DerivedBundle(NamedBundle):
     # Don't format specs
     # fmt: off
     METADATA_SPECS.append(
-        MetadataSpec('allow_failed_dependencies', bool, 'Whether to allow this bundle to have failed or killed dependencies.', default=False,)
+        MetadataSpec('allow_failed_dependencies', bool, 'Whether to allow this bundle to have failed or killed dependencies (allow_failed_dependencies).', default=False,)
     )
     # fmt: on
 

--- a/codalab/bundles/named_bundle.py
+++ b/codalab/bundles/named_bundle.py
@@ -19,13 +19,13 @@ class NamedBundle(Bundle):
     # fmt: off
     METADATA_SPECS = [
         MetadataSpec('name', str, 'Short name (not necessarily unique), which must start with a letter or underscore '
-                                  'and can only contain letters, digits, underscores, periods, and dashes.', short_key='n'),
-        MetadataSpec('description', str, 'Full description of the bundle.', short_key='d'),
-        MetadataSpec('tags', list, 'Space-separated list of tags used for search (e.g., machine-learning).', metavar='TAG',),
-        MetadataSpec('created', int, 'Time when this bundle was created.', generated=True, formatting='date'),
-        MetadataSpec('data_size', int, 'Size of this bundle (in bytes).', generated=True, formatting='size'),
-        MetadataSpec('failure_message', str, 'Error message if this run bundle failed.', generated=True,),
-        MetadataSpec('error_traceback', str, 'Error traceback if this run bundle failed.', generated=True, hidden=True),
+                                  'and can only contain letters, digits, underscores, periods, and dashes (name).', short_key='n'),
+        MetadataSpec('description', str, 'Full description of the bundle (description).', short_key='d'),
+        MetadataSpec('tags', list, 'Space-separated list of tags used for search, e.g. machine-learning (tags).', metavar='TAG',),
+        MetadataSpec('created', int, 'Time when this bundle was created (created).', generated=True, formatting='date'),
+        MetadataSpec('data_size', int, 'Size of this bundle in bytes (data_size).', generated=True, formatting='size'),
+        MetadataSpec('failure_message', str, 'Error message if this run bundle failed (failure_message).', generated=True,),
+        MetadataSpec('error_traceback', str, 'Error traceback if this run bundle failed (error_traceback).', generated=True, hidden=True),
     ]  # type: List
     # fmt: on
 

--- a/codalab/bundles/run_bundle.py
+++ b/codalab/bundles/run_bundle.py
@@ -25,58 +25,60 @@ class RunBundle(DerivedBundle):
     # Request a machine with this much resources and don't let run exceed these resources
     # Don't format metadata specs
     # fmt: off
-    METADATA_SPECS.append(MetadataSpec('request_docker_image', str, 'Which docker image (either tag or digest, e.g., '
-                                                                    'codalab/default-cpu:latest) we wish to use.', completer=DockerImagesCompleter, hide_when_anonymous=True, default=None))
-    METADATA_SPECS.append(MetadataSpec('request_time', str, 'Amount of time (e.g., 3, 3m, 3h, 3d) allowed for this run. Defaults to user time quota left.', formatting='duration', default=None))
-    METADATA_SPECS.append(MetadataSpec('request_memory', str, 'Amount of memory (e.g., 3, 3k, 3m, 3g, 3t) allowed for this run.', formatting='size', default='2g'))
-    METADATA_SPECS.append(MetadataSpec('request_disk', str, 'Amount of disk space (e.g., 3, 3k, 3m, 3g, 3t) allowed for this run. Defaults to user disk quota left.', formatting='size', default=None))
-    METADATA_SPECS.append(MetadataSpec('request_cpus', int, 'Number of CPUs allowed for this run.', default=1))
-    METADATA_SPECS.append(MetadataSpec('request_gpus', int, 'Number of GPUs allowed for this run.', default=0))
-    METADATA_SPECS.append(MetadataSpec('request_queue', str, 'Submit run to this job queue.', hide_when_anonymous=True, default=None))
-    METADATA_SPECS.append(MetadataSpec('request_priority', int, 'Job priority (higher is more important). Negative '
+    METADATA_SPECS.append(MetadataSpec('request_docker_image', str, 'Which docker image (either tag or digest, e.g., codalab/default-cpu:latest) '
+                                                                    'we wish to use (request_docker_image).', completer=DockerImagesCompleter, hide_when_anonymous=True, default=None))
+    METADATA_SPECS.append(MetadataSpec('request_time', str, 'Amount of time (e.g., 3, 3m, 3h, 3d) allowed for this run (request_time). '
+                                                            'Defaults to user time quota left.', formatting='duration', default=None))
+    METADATA_SPECS.append(MetadataSpec('request_memory', str, 'Amount of memory (e.g., 3, 3k, 3m, 3g, 3t) allowed for this run (request_memory).', formatting='size', default='2g'))
+    METADATA_SPECS.append(MetadataSpec('request_disk', str, 'Amount of disk space (e.g., 3, 3k, 3m, 3g, 3t) allowed for this run (request_disk). '
+                                                            'Defaults to user disk quota left.', formatting='size', default=None))
+    METADATA_SPECS.append(MetadataSpec('request_cpus', int, 'Number of CPUs allowed for this run (request_cpus).', default=1))
+    METADATA_SPECS.append(MetadataSpec('request_gpus', int, 'Number of GPUs allowed for this run (request_gpus).', default=0))
+    METADATA_SPECS.append(MetadataSpec('request_queue', str, 'Submit run to this job queue (request_queue).', hide_when_anonymous=True, default=None))
+    METADATA_SPECS.append(MetadataSpec('request_priority', int, 'Job priority (request_priority). Higher is more important. Negative '
                                                                 'priority bundles are queued behind bundles with no specified priority.', default=None))
-    METADATA_SPECS.append(MetadataSpec('request_network', bool, 'Whether to allow network access.', default=True))
+    METADATA_SPECS.append(MetadataSpec('request_network', bool, 'Whether to allow network access (request_network).', default=True))
+    METADATA_SPECS.append(MetadataSpec('cpu_usage', float, 'Proportion of current CPU usage for a running bundle (cpu_usage). '
+                                                           'This field is only relevant for running bundles. (e.g., 0.24)', default=0.0, generated=True))
     METADATA_SPECS.append(
-        MetadataSpec('cpu_usage', float, 'Proportion of current CPU usage for a running bundle. This field is only relevant for running bundles. (e.g., 0.24)', default=0.0, generated=True))
-    METADATA_SPECS.append(
-        MetadataSpec('memory_usage', float, 'Proportion of current memory usage based on the memory limit.', default=0.0, generated=True))
+        MetadataSpec('memory_usage', float, 'Proportion of current memory usage based on the memory limit (memory_usage).', default=0.0, generated=True))
 
-    METADATA_SPECS.append(MetadataSpec('exclude_patterns', list, 'Exclude these file patterns from being saved into the bundle contents.', default=[]))
+    METADATA_SPECS.append(MetadataSpec('exclude_patterns', list, 'Exclude these file patterns from being saved into the bundle contents (exclude_patterns).', default=[]))
 
-    METADATA_SPECS.append(MetadataSpec('store', str, 'The name of the bundle store where bundle results should be initially uploaded. If unspecified, an optimal '
+    METADATA_SPECS.append(MetadataSpec('store', str, 'The name of the bundle store where bundle results should be initially uploaded (store). If unspecified, an optimal '
                                                      'available bundle store will be chosen.', default=None, hidden=True, optional=True))
 
-    METADATA_SPECS.append(MetadataSpec('actions', list, 'Actions (e.g., kill) that were performed on this run.', generated=True))
+    METADATA_SPECS.append(MetadataSpec('actions', list, 'Actions (e.g., kill) that were performed on this run (actions).', generated=True))
 
-    METADATA_SPECS.append(MetadataSpec('time', float, 'Amount of wall clock time (seconds) used by this run in total. '
+    METADATA_SPECS.append(MetadataSpec('time', float, 'Amount of wall clock time (seconds) used by this run in total (time). '
                                                       '[Runtime of the Docker container excluding CodaLab related '
                                                       'steps such as preparing/uploading results]',
                                        generated=True,
                                        formatting='duration'))
-    METADATA_SPECS.append(MetadataSpec('time_user', float, 'Amount of user time (seconds) used by this run.', generated=True, formatting='duration'))
-    METADATA_SPECS.append(MetadataSpec('time_system', float, 'Amount of system time (seconds) used by this run.', generated=True, formatting='duration'))
-    METADATA_SPECS.append(MetadataSpec('memory', float, 'Amount of memory (bytes) used by this run.', generated=True, formatting='size'))
-    METADATA_SPECS.append(MetadataSpec('memory_max', float, 'Maximum amount of memory (bytes) used by this run at any time during execution.', generated=True, formatting='size'))
+    METADATA_SPECS.append(MetadataSpec('time_user', float, 'Amount of user time (seconds) used by this run (time_user).', generated=True, formatting='duration'))
+    METADATA_SPECS.append(MetadataSpec('time_system', float, 'Amount of system time (seconds) used by this run (time_system).', generated=True, formatting='duration'))
+    METADATA_SPECS.append(MetadataSpec('memory', float, 'Amount of memory (bytes) used by this run (memory).', generated=True, formatting='size'))
+    METADATA_SPECS.append(MetadataSpec('memory_max', float, 'Maximum amount of memory (bytes) used by this run at any time during execution (memory_max).', generated=True, formatting='size'))
 
-    METADATA_SPECS.append(MetadataSpec('started', int, 'Time when this bundle started executing.', generated=True, formatting='date'))
-    METADATA_SPECS.append(MetadataSpec('last_updated', int, 'Time when information about this bundle was last updated.', generated=True, formatting='date'))
-    METADATA_SPECS.append(MetadataSpec('run_status', str, 'Execution status of the bundle.', generated=True))
-    METADATA_SPECS.append(MetadataSpec('staged_status', str, 'Information about the status of the staged bundle.', generated=True))
-    METADATA_SPECS.append(MetadataSpec('time_preparing', float, 'Amount of system time in the PREPARING stage.', generated=True, formatting='duration'))
-    METADATA_SPECS.append(MetadataSpec('time_running', float, 'Amount of system time in the RUNNING stage.', generated=True, formatting='duration'))
-    METADATA_SPECS.append(MetadataSpec('time_cleaning_up', float, 'Amount of system time in the CLEANING_UP stage.', generated=True, formatting='duration'))
-    METADATA_SPECS.append(MetadataSpec('time_uploading_results', float, 'Amount of system time in the UPLOADING_RESULTS stage.', generated=True, formatting='duration'))
+    METADATA_SPECS.append(MetadataSpec('started', int, 'Time when this bundle started executing (started).', generated=True, formatting='date'))
+    METADATA_SPECS.append(MetadataSpec('last_updated', int, 'Time when information about this bundle was last updated (last_updated).', generated=True, formatting='date'))
+    METADATA_SPECS.append(MetadataSpec('run_status', str, 'Execution status of the bundle (run_status).', generated=True))
+    METADATA_SPECS.append(MetadataSpec('staged_status', str, 'Information about the status of the staged bundle (staged_status).', generated=True))
+    METADATA_SPECS.append(MetadataSpec('time_preparing', float, 'Amount of system time in the PREPARING stage (time_preparing).', generated=True, formatting='duration'))
+    METADATA_SPECS.append(MetadataSpec('time_running', float, 'Amount of system time in the RUNNING stage (time_running).', generated=True, formatting='duration'))
+    METADATA_SPECS.append(MetadataSpec('time_cleaning_up', float, 'Amount of system time in the CLEANING_UP stage (time_cleaning_up).', generated=True, formatting='duration'))
+    METADATA_SPECS.append(MetadataSpec('time_uploading_results', float, 'Amount of system time in the UPLOADING_RESULTS stage (time_uploading_results).', generated=True, formatting='duration'))
 
     # Information about running
-    METADATA_SPECS.append(MetadataSpec('docker_image', str, 'Which docker image was used to run the process.', generated=True, hide_when_anonymous=True))
-    METADATA_SPECS.append(MetadataSpec('exitcode', int, 'Exitcode of the process.', generated=True))
-    METADATA_SPECS.append(MetadataSpec('job_handle', str, 'Identifies the job handle (internal).', generated=True, hide_when_anonymous=True))
-    METADATA_SPECS.append(MetadataSpec('remote', str, 'Where this job is/was run (internal).', generated=True, hide_when_anonymous=True))
-    METADATA_SPECS.append(MetadataSpec('remote_history', list, 'All workers where this job has been run (internal); multiple values indicate'
+    METADATA_SPECS.append(MetadataSpec('docker_image', str, 'Which docker image was used to run the process (docker_image).', generated=True, hide_when_anonymous=True))
+    METADATA_SPECS.append(MetadataSpec('exitcode', int, 'Exitcode of the process (exitcode).', generated=True))
+    METADATA_SPECS.append(MetadataSpec('job_handle', str, 'Identifies the job handle (job_handle) [internal].', generated=True, hide_when_anonymous=True))
+    METADATA_SPECS.append(MetadataSpec('remote', str, 'Where this job is/was run (remote) [internal].', generated=True, hide_when_anonymous=True))
+    METADATA_SPECS.append(MetadataSpec('remote_history', list, 'All workers where this job has been run (remote_history) [internal]. Multiple values indicate'
                                        'that the bundle was preempted and moved to a different worker.',
                                        generated=True, hide_when_anonymous=True))
-    METADATA_SPECS.append(MetadataSpec('on_preemptible_worker', bool, 'Whether the bundle is currently running / finished on a preemptible worker.', generated=True, hide_when_anonymous=True,
-                                       default=False))
+    METADATA_SPECS.append(MetadataSpec('on_preemptible_worker', bool, 'Whether the bundle is currently running / finished on a preemptible worker '
+                                                                      '(on_preemptible_worker).', generated=True, hide_when_anonymous=True, default=False))
     # fmt: on
 
     @classmethod

--- a/codalab/bundles/uploaded_bundle.py
+++ b/codalab/bundles/uploaded_bundle.py
@@ -15,21 +15,21 @@ class UploadedBundle(NamedBundle):
     # Don't format specs
     # fmt: off
     METADATA_SPECS.append(
-        MetadataSpec('license', str, 'The license under which this program/dataset is released.')
+        MetadataSpec('license', str, 'The license under which this program/dataset is released (license).')
     )
     METADATA_SPECS.append(
-        MetadataSpec('source_url', str, 'URL corresponding to the original source of this bundle.')
+        MetadataSpec('source_url', str, 'URL corresponding to the original source of this bundle (source_url).')
     )
 
     METADATA_SPECS.append(
-        MetadataSpec('link_url', str, 'Link URL of bundle.', optional=True)
+        MetadataSpec('link_url', str, 'Link URL of bundle (link_url).', optional=True)
     )
     METADATA_SPECS.append(
-        MetadataSpec('link_format', str, 'Link format of bundle. Can be equal to'
+        MetadataSpec('link_format', str, 'Link format of bundle (link_format). Can be equal to'
                                          '"raw" or "zip" (only "raw" is supported as of now).', optional=True)
     )
 
-    METADATA_SPECS.append(MetadataSpec('store', str, 'The name of the bundle store where the bundle should be uploaded to. '
+    METADATA_SPECS.append(MetadataSpec('store', str, 'The name of the bundle store where the bundle should be uploaded to (store). '
                                                      'If unspecified, an optimal available bundle store will be chosen.', default=None, hidden=True, optional=True))
 
     # fmt: on

--- a/docs/CLI-Reference.md
+++ b/docs/CLI-Reference.md
@@ -24,14 +24,14 @@ Usage: `cl <command> <arguments>`
       -i, --ignore               Name of file containing patterns matching files and directories to exclude from upload. This option is currently only supported with the GNU tar library.
       -l, --link                 Makes the path the source of truth of the bundle, meaning that the server will retrieve the bundle directly from the specified path rather than storing its contentsin its own bundle store.
       -a, --use-azure-blob-beta  Use Azure Blob Storage to store files (beta feature).
-      -n, --name                 Short name (not necessarily unique), which must start with a letter or underscore and can only contain letters, digits, underscores, periods, and dashes.
-      -d, --description          Full description of the bundle.
-      --tags                     Space-separated list of tags used for search (e.g., machine-learning).
-      --license                  The license under which this program/dataset is released.
-      --source-url               URL corresponding to the original source of this bundle.
-      --link-url                 Link URL of bundle.
-      --link-format              Link format of bundle. Can be equal to"raw" or "zip" (only "raw" is supported as of now).
-      --store                    The name of the bundle store where the bundle should be uploaded to. If unspecified, an optimal available bundle store will be chosen.
+      -n, --name                 Short name (not necessarily unique), which must start with a letter or underscore and can only contain letters, digits, underscores, periods, and dashes (name).
+      -d, --description          Full description of the bundle (description).
+      --tags                     Space-separated list of tags used for search, e.g. machine-learning (tags).
+      --license                  The license under which this program/dataset is released (license).
+      --source-url               URL corresponding to the original source of this bundle (source_url).
+      --link-url                 Link URL of bundle (link_url).
+      --link-format              Link format of bundle (link_format). Can be equal to"raw" or "zip" (only "raw" is supported as of now).
+      --store                    The name of the bundle store where the bundle should be uploaded to (store). If unspecified, an optimal available bundle store will be chosen.
       -e, --edit                 Show an editor to allow editing of the bundle metadata.
 
 ### make
@@ -41,10 +41,10 @@ Usage: `cl <command> <arguments>`
     Arguments:
       target_spec                  [<key>:][[(<alias>|<address>)::](<uuid>|<name>)//](<uuid>|<name>|^<index>)[/<subpath within bundle>]
       -w, --worksheet-spec         Operate on this worksheet ([(<alias>|<address>)::](<uuid>|<name>)).
-      -n, --name                   Short name (not necessarily unique), which must start with a letter or underscore and can only contain letters, digits, underscores, periods, and dashes.
-      -d, --description            Full description of the bundle.
-      --tags                       Space-separated list of tags used for search (e.g., machine-learning).
-      --allow-failed-dependencies  Whether to allow this bundle to have failed or killed dependencies.
+      -n, --name                   Short name (not necessarily unique), which must start with a letter or underscore and can only contain letters, digits, underscores, periods, and dashes (name).
+      -d, --description            Full description of the bundle (description).
+      --tags                       Space-separated list of tags used for search, e.g. machine-learning (tags).
+      --allow-failed-dependencies  Whether to allow this bundle to have failed or killed dependencies (allow_failed_dependencies).
       -e, --edit                   Show an editor to allow editing of the bundle metadata.
 
 ### run
@@ -56,21 +56,21 @@ Usage: `cl <command> <arguments>`
       -a, --after_sort_key         Insert after this sort_key
       -m, --memoize                If a bundle with the same command and dependencies already exists, return it instead of creating a new one.
       -i, --interactive            Beta feature - Start an interactive session to construct your run command.
-      -n, --name                   Short name (not necessarily unique), which must start with a letter or underscore and can only contain letters, digits, underscores, periods, and dashes.
-      -d, --description            Full description of the bundle.
-      --tags                       Space-separated list of tags used for search (e.g., machine-learning).
-      --allow-failed-dependencies  Whether to allow this bundle to have failed or killed dependencies.
-      --request-docker-image       Which docker image (either tag or digest, e.g., codalab/default-cpu:latest) we wish to use.
-      --request-time               Amount of time (e.g., 3, 3m, 3h, 3d) allowed for this run. Defaults to user time quota left.
-      --request-memory             Amount of memory (e.g., 3, 3k, 3m, 3g, 3t) allowed for this run.
-      --request-disk               Amount of disk space (e.g., 3, 3k, 3m, 3g, 3t) allowed for this run. Defaults to user disk quota left.
-      --request-cpus               Number of CPUs allowed for this run.
-      --request-gpus               Number of GPUs allowed for this run.
-      --request-queue              Submit run to this job queue.
-      --request-priority           Job priority (higher is more important). Negative priority bundles are queued behind bundles with no specified priority.
-      --request-network            Whether to allow network access.
-      --exclude-patterns           Exclude these file patterns from being saved into the bundle contents.
-      --store                      The name of the bundle store where bundle results should be initially uploaded. If unspecified, an optimal available bundle store will be chosen.
+      -n, --name                   Short name (not necessarily unique), which must start with a letter or underscore and can only contain letters, digits, underscores, periods, and dashes (name).
+      -d, --description            Full description of the bundle (description).
+      --tags                       Space-separated list of tags used for search, e.g. machine-learning (tags).
+      --allow-failed-dependencies  Whether to allow this bundle to have failed or killed dependencies (allow_failed_dependencies).
+      --request-docker-image       Which docker image (either tag or digest, e.g., codalab/default-cpu:latest) we wish to use (request_docker_image).
+      --request-time               Amount of time (e.g., 3, 3m, 3h, 3d) allowed for this run (request_time). Defaults to user time quota left.
+      --request-memory             Amount of memory (e.g., 3, 3k, 3m, 3g, 3t) allowed for this run (request_memory).
+      --request-disk               Amount of disk space (e.g., 3, 3k, 3m, 3g, 3t) allowed for this run (request_disk). Defaults to user disk quota left.
+      --request-cpus               Number of CPUs allowed for this run (request_cpus).
+      --request-gpus               Number of GPUs allowed for this run (request_gpus).
+      --request-queue              Submit run to this job queue (request_queue).
+      --request-priority           Job priority (request_priority). Higher is more important. Negative priority bundles are queued behind bundles with no specified priority.
+      --request-network            Whether to allow network access (request_network).
+      --exclude-patterns           Exclude these file patterns from being saved into the bundle contents (exclude_patterns).
+      --store                      The name of the bundle store where bundle results should be initially uploaded (store). If unspecified, an optimal available bundle store will be chosen.
       -e, --edit                   Show an editor to allow editing of the bundle metadata.
       -W, --wait                   Wait until run finishes.
       -t, --tail                   Wait until run finishes, displaying stdout/stderr.
@@ -197,21 +197,21 @@ Usage: `cl <command> <arguments>`
     Any provided metadata arguments will override the original metadata in mimicked bundles.
     Arguments:
       bundles                      Bundles: old_input_1 ... old_input_n old_output new_input_1 ... new_input_n ([[(<alias>|<address>)::](<uuid>|<name>)//](<uuid>|<name>|^<index>)).
-      -n, --name                   Short name (not necessarily unique), which must start with a letter or underscore and can only contain letters, digits, underscores, periods, and dashes. (for makes and runs)
-      -d, --description            Full description of the bundle. (for makes and runs)
-      --tags                       Space-separated list of tags used for search (e.g., machine-learning). (for makes and runs)
-      --allow-failed-dependencies  Whether to allow this bundle to have failed or killed dependencies. (for makes and runs)
-      --request-docker-image       Which docker image (either tag or digest, e.g., codalab/default-cpu:latest) we wish to use. (for runs)
-      --request-time               Amount of time (e.g., 3, 3m, 3h, 3d) allowed for this run. Defaults to user time quota left. (for runs)
-      --request-memory             Amount of memory (e.g., 3, 3k, 3m, 3g, 3t) allowed for this run. (for runs)
-      --request-disk               Amount of disk space (e.g., 3, 3k, 3m, 3g, 3t) allowed for this run. Defaults to user disk quota left. (for runs)
-      --request-cpus               Number of CPUs allowed for this run. (for runs)
-      --request-gpus               Number of GPUs allowed for this run. (for runs)
-      --request-queue              Submit run to this job queue. (for runs)
-      --request-priority           Job priority (higher is more important). Negative priority bundles are queued behind bundles with no specified priority. (for runs)
-      --request-network            Whether to allow network access. (for runs)
-      --exclude-patterns           Exclude these file patterns from being saved into the bundle contents. (for runs)
-      --store                      The name of the bundle store where bundle results should be initially uploaded. If unspecified, an optimal available bundle store will be chosen. (for runs)
+      -n, --name                   Short name (not necessarily unique), which must start with a letter or underscore and can only contain letters, digits, underscores, periods, and dashes (name). (for makes and runs)
+      -d, --description            Full description of the bundle (description). (for makes and runs)
+      --tags                       Space-separated list of tags used for search, e.g. machine-learning (tags). (for makes and runs)
+      --allow-failed-dependencies  Whether to allow this bundle to have failed or killed dependencies (allow_failed_dependencies). (for makes and runs)
+      --request-docker-image       Which docker image (either tag or digest, e.g., codalab/default-cpu:latest) we wish to use (request_docker_image). (for runs)
+      --request-time               Amount of time (e.g., 3, 3m, 3h, 3d) allowed for this run (request_time). Defaults to user time quota left. (for runs)
+      --request-memory             Amount of memory (e.g., 3, 3k, 3m, 3g, 3t) allowed for this run (request_memory). (for runs)
+      --request-disk               Amount of disk space (e.g., 3, 3k, 3m, 3g, 3t) allowed for this run (request_disk). Defaults to user disk quota left. (for runs)
+      --request-cpus               Number of CPUs allowed for this run (request_cpus). (for runs)
+      --request-gpus               Number of GPUs allowed for this run (request_gpus). (for runs)
+      --request-queue              Submit run to this job queue (request_queue). (for runs)
+      --request-priority           Job priority (request_priority). Higher is more important. Negative priority bundles are queued behind bundles with no specified priority. (for runs)
+      --request-network            Whether to allow network access (request_network). (for runs)
+      --exclude-patterns           Exclude these file patterns from being saved into the bundle contents (exclude_patterns). (for runs)
+      --store                      The name of the bundle store where bundle results should be initially uploaded (store). If unspecified, an optimal available bundle store will be chosen. (for runs)
       --depth                      Number of parents to look back from the old output in search of the old input.
       -s, --shadow                 Add the newly created bundles right after the old bundles that are being mimicked.
       -i, --dry-run                Perform a dry run (just show what will be done without doing it)
@@ -227,21 +227,21 @@ Usage: `cl <command> <arguments>`
     Arguments:
       macro_name                   Name of the macro (look for <macro_name>-in1, <macro_name>-in-<name>, ..., and <macro_name>-out bundles).
       bundles                      Bundles: new_input_1 ... new_input_n named_input_name:named_input_bundle other_named_input_name:other_named_input_bundle ([[(<alias>|<address>)::](<uuid>|<name>)//](<uuid>|<name>|^<index>))
-      -n, --name                   Short name (not necessarily unique), which must start with a letter or underscore and can only contain letters, digits, underscores, periods, and dashes. (for makes and runs)
-      -d, --description            Full description of the bundle. (for makes and runs)
-      --tags                       Space-separated list of tags used for search (e.g., machine-learning). (for makes and runs)
-      --allow-failed-dependencies  Whether to allow this bundle to have failed or killed dependencies. (for makes and runs)
-      --request-docker-image       Which docker image (either tag or digest, e.g., codalab/default-cpu:latest) we wish to use. (for runs)
-      --request-time               Amount of time (e.g., 3, 3m, 3h, 3d) allowed for this run. Defaults to user time quota left. (for runs)
-      --request-memory             Amount of memory (e.g., 3, 3k, 3m, 3g, 3t) allowed for this run. (for runs)
-      --request-disk               Amount of disk space (e.g., 3, 3k, 3m, 3g, 3t) allowed for this run. Defaults to user disk quota left. (for runs)
-      --request-cpus               Number of CPUs allowed for this run. (for runs)
-      --request-gpus               Number of GPUs allowed for this run. (for runs)
-      --request-queue              Submit run to this job queue. (for runs)
-      --request-priority           Job priority (higher is more important). Negative priority bundles are queued behind bundles with no specified priority. (for runs)
-      --request-network            Whether to allow network access. (for runs)
-      --exclude-patterns           Exclude these file patterns from being saved into the bundle contents. (for runs)
-      --store                      The name of the bundle store where bundle results should be initially uploaded. If unspecified, an optimal available bundle store will be chosen. (for runs)
+      -n, --name                   Short name (not necessarily unique), which must start with a letter or underscore and can only contain letters, digits, underscores, periods, and dashes (name). (for makes and runs)
+      -d, --description            Full description of the bundle (description). (for makes and runs)
+      --tags                       Space-separated list of tags used for search, e.g. machine-learning (tags). (for makes and runs)
+      --allow-failed-dependencies  Whether to allow this bundle to have failed or killed dependencies (allow_failed_dependencies). (for makes and runs)
+      --request-docker-image       Which docker image (either tag or digest, e.g., codalab/default-cpu:latest) we wish to use (request_docker_image). (for runs)
+      --request-time               Amount of time (e.g., 3, 3m, 3h, 3d) allowed for this run (request_time). Defaults to user time quota left. (for runs)
+      --request-memory             Amount of memory (e.g., 3, 3k, 3m, 3g, 3t) allowed for this run (request_memory). (for runs)
+      --request-disk               Amount of disk space (e.g., 3, 3k, 3m, 3g, 3t) allowed for this run (request_disk). Defaults to user disk quota left. (for runs)
+      --request-cpus               Number of CPUs allowed for this run (request_cpus). (for runs)
+      --request-gpus               Number of GPUs allowed for this run (request_gpus). (for runs)
+      --request-queue              Submit run to this job queue (request_queue). (for runs)
+      --request-priority           Job priority (request_priority). Higher is more important. Negative priority bundles are queued behind bundles with no specified priority. (for runs)
+      --request-network            Whether to allow network access (request_network). (for runs)
+      --exclude-patterns           Exclude these file patterns from being saved into the bundle contents (exclude_patterns). (for runs)
+      --store                      The name of the bundle store where bundle results should be initially uploaded (store). If unspecified, an optimal available bundle store will be chosen. (for runs)
       --depth                      Number of parents to look back from the old output in search of the old input.
       -s, --shadow                 Add the newly created bundles right after the old bundles that are being mimicked.
       -i, --dry-run                Perform a dry run (just show what will be done without doing it)

--- a/frontend/src/__tests__/__snapshots__/Worksheet.test.js.snap
+++ b/frontend/src/__tests__/__snapshots__/Worksheet.test.js.snap
@@ -1664,7 +1664,7 @@ Object {
     <div>
       <div
         class="MuiGrid-container-264 MuiGrid-direction-xs-column-267 MuiGrid-align-items-xs-center-272 MuiGrid-justify-xs-center-281"
-        style="margin-top: 100px;"
+        style="margin: 100px 0px 80px;"
       >
         <div
           class="alert alert-danger alert-dismissable"
@@ -1682,7 +1682,7 @@ Object {
   "container": <div>
     <div
       class="MuiGrid-container-264 MuiGrid-direction-xs-column-267 MuiGrid-align-items-xs-center-272 MuiGrid-justify-xs-center-281"
-      style="margin-top: 100px;"
+      style="margin: 100px 0px 80px;"
     >
       <div
         class="alert alert-danger alert-dismissable"

--- a/frontend/src/components/worksheets/BundleDetail/BundleDetail.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/BundleDetail.jsx
@@ -1,23 +1,21 @@
 // @flow
 import * as React from 'react';
 import { useEffect, useState } from 'react';
-import * as $ from 'jquery';
-// import Drawer from '@material-ui/core/Drawer';
 import { JsonApiDataStore } from 'jsonapi-datastore';
-
-import ConfigurationPanel from '../ConfigPanel';
-import MainContent from './MainContent';
-import BundleDetailSideBar from './BundleDetailSideBar';
-import BundleActions from './BundleActions';
 import { findDOMNode } from 'react-dom';
 import useSWR from 'swr';
 import { apiWrapper, fetchFileSummary } from '../../../util/apiWrapper';
+
+import ConfigurationPanel from '../ConfigPanel';
+import ErrorMessage from '../ErrorMessage';
+import MainContent from './MainContent';
+import BundleDetailSideBar from './BundleDetailSideBar';
+import BundleActions from './BundleActions';
 
 const BundleDetail = ({
     uuid,
     // Callback on metadata change.
     bundleMetadataChanged,
-    onClose,
     onOpen,
     onUpdate,
     rerunItem,
@@ -27,6 +25,7 @@ const BundleDetail = ({
     editPermission,
     sidebarExpanded,
     hideBundlePageLink,
+    showBorder,
 }) => {
     const [errorMessages, setErrorMessages] = useState([]);
     const [bundleInfo, setBundleInfo] = useState(null);
@@ -196,9 +195,18 @@ const BundleDetail = ({
         }
     };
 
+    if (errorMessages.length) {
+        const status = errorMessages[0].response?.status;
+        if (status === 404) {
+            return <ErrorMessage message={`Not found: '/bundles/${uuid}'`} />;
+        }
+        return <ErrorMessage message={`Unable to fetch bundle uuid: ${uuid}.`} />;
+    }
+
     if (!bundleInfo) {
         return <div></div>;
     }
+
     if (bundleInfo.bundle_type === 'private') {
         return <div>Detail not available for this bundle</div>;
     }
@@ -227,6 +235,7 @@ const BundleDetail = ({
                     hidePageLink={hideBundlePageLink}
                 />
             }
+            showBorder={showBorder}
         >
             <MainContent
                 bundleInfo={bundleInfo}

--- a/frontend/src/components/worksheets/BundleDetail/BundleDetail.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/BundleDetail.jsx
@@ -195,15 +195,17 @@ const BundleDetail = ({
         }
     };
 
-    if (errorMessages.length) {
-        const status = errorMessages[0].response?.status;
-        if (status === 404) {
-            return <ErrorMessage message={`Not found: '/bundles/${uuid}'`} />;
-        }
-        return <ErrorMessage message={`Unable to fetch bundle uuid: ${uuid}.`} />;
-    }
-
     if (!bundleInfo) {
+        if (errorMessages.length) {
+            const statuses = errorMessages.map((e) => e.response?.status);
+            if (statuses.includes(404)) {
+                return <ErrorMessage message={`Not found: '/bundles/${uuid}'`} />;
+            }
+            if (statuses.includes(500)) {
+                return <ErrorMessage message='Internal Server Error' />;
+            }
+            return <ErrorMessage message={`Could not fetch: '/bundles/${uuid}'`} />;
+        }
         return <div></div>;
     }
 

--- a/frontend/src/components/worksheets/BundleDetail/BundleDetailSideBar.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/BundleDetailSideBar.jsx
@@ -89,6 +89,7 @@ class BundleDetailSideBar extends React.Component {
                     />
                     <BundleFieldRow label='Created' field={bundle.created} />
                     <BundleFieldRow label='Size' field={bundle.data_size} />
+                    <BundleFieldRow label='Remote' field={bundle.remote} />
                     <BundleFieldRow
                         label='Store'
                         field={bundle.store}

--- a/frontend/src/components/worksheets/BundleDetail/BundleDetailSideBar.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/BundleDetailSideBar.jsx
@@ -67,9 +67,16 @@ class BundleDetailSideBar extends React.Component {
                         field={bundle.tags}
                         onChange={(tags) => onUpdate({ tags })}
                     />
-                    {!isAnonymous && <BundleFieldRow label='Owner' field={bundle.user_name} />}
+                    {!isAnonymous && (
+                        <BundleFieldRow
+                            label='Owner'
+                            description='The user who owns this bundle.'
+                            field={bundle.user_name}
+                        />
+                    )}
                     <BundleFieldRow
                         label='Permissions'
+                        description='Click the right arrow to expand permissions settings.'
                         field={bundle.permission}
                         value={
                             <BundlePermissions

--- a/frontend/src/components/worksheets/BundleDetail/BundleFieldTable/BundleFieldRow.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/BundleFieldTable/BundleFieldRow.jsx
@@ -27,6 +27,12 @@ class BundleFieldRow extends React.Component {
         super(props);
     }
 
+    /**
+     * Returns true if this field should be hidden.
+     * We should only show fields that either have values or are editable.
+     *
+     * @returns {bool}
+     */
     checkHideRow() {
         const field = this.props.field || {};
         const value = this.props.value || field?.value;

--- a/frontend/src/components/worksheets/BundleDetail/BundleFieldTable/BundleFieldRow.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/BundleFieldTable/BundleFieldRow.jsx
@@ -25,6 +25,30 @@ import Copy from '../../../Copy';
 class BundleFieldRow extends React.Component {
     constructor(props) {
         super(props);
+        this.state = {
+            title: this.getTitle(),
+        };
+    }
+
+    getTitle() {
+        const field = this.props.field || {};
+        const description = this.props.description || field.description;
+        if (!description) {
+            return;
+        }
+        const name = field.name;
+        if (!name) {
+            return description;
+        }
+        const title = (
+            <>
+                {description}
+                <br />
+                <br />
+                Search Key: '{name}'
+            </>
+        );
+        return title;
     }
 
     render() {
@@ -37,7 +61,6 @@ class BundleFieldRow extends React.Component {
 
         // allow props to override field values
         const label = this.props.label || field.name;
-        const description = this.props.description || field.description;
         const value = this.props.value || field.value;
         const copyValue = this.props.copyValue || value;
 
@@ -56,9 +79,9 @@ class BundleFieldRow extends React.Component {
                     <Typography variant='subtitle2' inline>
                         {label}
                     </Typography>
-                    {description && (
+                    {this.state.title && (
                         <Tooltip
-                            title={description}
+                            title={this.state.title}
                             classes={{ tooltip: classes.tooltipContainer }}
                         >
                             <span className={classes.tooltipIcon}>

--- a/frontend/src/components/worksheets/BundleDetail/BundleFieldTable/BundleFieldRow.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/BundleFieldTable/BundleFieldRow.jsx
@@ -51,15 +51,7 @@ class BundleFieldRow extends React.Component {
         if (!name) {
             return description;
         }
-        const title = (
-            <>
-                {description}
-                <br />
-                <br />
-                Search Key: '{name}'
-            </>
-        );
-        return title;
+        return `[${name}] ${description}`;
     }
 
     render() {

--- a/frontend/src/components/worksheets/BundleDetail/BundleFieldTable/BundleFieldRow.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/BundleFieldTable/BundleFieldRow.jsx
@@ -25,9 +25,20 @@ import Copy from '../../../Copy';
 class BundleFieldRow extends React.Component {
     constructor(props) {
         super(props);
-        this.state = {
-            title: this.getTitle(),
-        };
+    }
+
+    checkHideRow() {
+        const field = this.props.field || {};
+        const value = this.props.value || field?.value;
+        if (!field.editable) {
+            if (!value) {
+                return true;
+            }
+            if (field.type === 'list' && (!value.length || !value[0])) {
+                return true;
+            }
+        }
+        return false;
     }
 
     getTitle() {
@@ -53,6 +64,8 @@ class BundleFieldRow extends React.Component {
 
     render() {
         const { allowCopy, classes, onChange, noWrap } = this.props;
+        const hideRow = this.checkHideRow();
+        const title = this.getTitle();
         const field = this.props.field || {};
         const name = field.name;
         const dataType = field.type;
@@ -64,13 +77,8 @@ class BundleFieldRow extends React.Component {
         const value = this.props.value || field.value;
         const copyValue = this.props.copyValue || value;
 
-        if (!canEdit) {
-            if (dataType === 'list' && (!value.length || !value[0])) {
-                return null;
-            }
-            if (dataType === 'str' && !value) {
-                return null;
-            }
+        if (hideRow) {
+            return null;
         }
 
         return (
@@ -79,11 +87,8 @@ class BundleFieldRow extends React.Component {
                     <Typography variant='subtitle2' inline>
                         {label}
                     </Typography>
-                    {this.state.title && (
-                        <Tooltip
-                            title={this.state.title}
-                            classes={{ tooltip: classes.tooltipContainer }}
-                        >
+                    {title && (
+                        <Tooltip title={title} classes={{ tooltip: classes.tooltipContainer }}>
                             <span className={classes.tooltipIcon}>
                                 <HelpOutlineOutlinedIcon
                                     fontSize='inherit'

--- a/frontend/src/components/worksheets/BundleDetail/BundleFieldTable/BundleFieldRow.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/BundleFieldTable/BundleFieldRow.jsx
@@ -41,23 +41,9 @@ class BundleFieldRow extends React.Component {
         return false;
     }
 
-    getTitle() {
-        const field = this.props.field || {};
-        const description = this.props.description || field.description;
-        if (!description) {
-            return;
-        }
-        const name = field.name;
-        if (!name) {
-            return description;
-        }
-        return `[${name}] ${description}`;
-    }
-
     render() {
         const { allowCopy, classes, onChange, noWrap } = this.props;
         const hideRow = this.checkHideRow();
-        const title = this.getTitle();
         const field = this.props.field || {};
         const name = field.name;
         const dataType = field.type;
@@ -66,6 +52,7 @@ class BundleFieldRow extends React.Component {
 
         // allow props to override field values
         const label = this.props.label || field.name;
+        const description = this.props.description || field.description;
         const value = this.props.value || field.value;
         const copyValue = this.props.copyValue || value;
 
@@ -79,8 +66,8 @@ class BundleFieldRow extends React.Component {
                     <Typography variant='subtitle2' inline>
                         {label}
                     </Typography>
-                    {title && (
-                        <Tooltip title={title} classes={{ tooltip: classes.tooltipContainer }}>
+                    {description && (
+                        <Tooltip title={description} classes={{ tooltip: classes.tooltip }}>
                             <span className={classes.tooltipIcon}>
                                 <HelpOutlineOutlinedIcon
                                     fontSize='inherit'
@@ -115,9 +102,8 @@ class BundleFieldRow extends React.Component {
 }
 
 const styles = (theme) => ({
-    tooltipContainer: {
+    tooltip: {
         fontSize: 14,
-        padding: `${theme.spacing.large}px ${theme.spacing.larger}px`,
     },
     tooltipIcon: {
         display: 'inline-block',

--- a/frontend/src/components/worksheets/BundleDetail/BundlePermissions.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/BundlePermissions.jsx
@@ -18,8 +18,8 @@ class BundlePermissions extends React.Component {
         const { bundleInfo, classes, showDialog, onClick, onChange } = this.props;
         const { uuid, permission_spec, group_permissions } = bundleInfo;
         const style = {
-            whiteSpace: 'nowrap',
             maxWidth: 168,
+            whiteSpace: 'nowrap',
             overflow: 'hidden',
             textOverflow: 'ellipsis',
         };

--- a/frontend/src/components/worksheets/BundleDetail/BundlePermissions.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/BundlePermissions.jsx
@@ -17,12 +17,18 @@ class BundlePermissions extends React.Component {
     render() {
         const { bundleInfo, classes, showDialog, onClick, onChange } = this.props;
         const { uuid, permission_spec, group_permissions } = bundleInfo;
+        const style = {
+            whiteSpace: 'nowrap',
+            maxWidth: 168,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+        };
 
         return (
             <>
                 <div onClick={onClick} className={classes.permissionsContainer}>
                     <div className={classes.permissions}>
-                        {renderPermissions(bundleInfo)}
+                        {renderPermissions(bundleInfo, style)}
                         {showDialog ? (
                             <KeyboardArrowDownIcon fontSize='small' />
                         ) : (

--- a/frontend/src/components/worksheets/BundleDetail/BundleStateBox.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/BundleStateBox.jsx
@@ -35,7 +35,7 @@ class BundleStateBox extends React.Component {
 
         return (
             <Tooltip
-                classes={{ tooltip: classes.tooltipContainer }}
+                classes={{ tooltip: classes.tooltip }}
                 disableHoverListener={!title}
                 title={title}
             >
@@ -50,9 +50,8 @@ class BundleStateBox extends React.Component {
 }
 
 const styles = (theme) => ({
-    tooltipContainer: {
+    tooltip: {
         fontSize: 14,
-        padding: `${theme.spacing.large}px ${theme.spacing.larger}px`,
     },
     baseState: {
         display: 'inline-block',

--- a/frontend/src/components/worksheets/BundleDetail/BundleStateBox.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/BundleStateBox.jsx
@@ -34,7 +34,11 @@ class BundleStateBox extends React.Component {
         const activeClass = this.getActiveClass(state);
 
         return (
-            <Tooltip title={title} disableHoverListener={!title}>
+            <Tooltip
+                classes={{ tooltip: classes.tooltipContainer }}
+                disableHoverListener={!title}
+                title={title}
+            >
                 <div className={`${classes.baseState} ${activeClass}`}>
                     <Typography inline color='inherit'>
                         {state}
@@ -46,6 +50,10 @@ class BundleStateBox extends React.Component {
 }
 
 const styles = (theme) => ({
+    tooltipContainer: {
+        fontSize: 14,
+        padding: `${theme.spacing.large}px ${theme.spacing.larger}px`,
+    },
     baseState: {
         display: 'inline-block',
         borderRadius: '5px',

--- a/frontend/src/components/worksheets/BundleDetail/MoreDetail.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/MoreDetail.jsx
@@ -74,7 +74,6 @@ class MoreDetail extends React.Component {
                             allowCopy
                             noWrap
                         />
-                        <BundleFieldRow label='Remote' field={bundle.remote} />
                         <BundleFieldRow label='Preemptible' field={bundle.on_preemptible_worker} />
                         <BundleFieldRow
                             label='Queue'

--- a/frontend/src/components/worksheets/BundleDetail/MoreDetail.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/MoreDetail.jsx
@@ -74,6 +74,8 @@ class MoreDetail extends React.Component {
                             allowCopy
                             noWrap
                         />
+                        <BundleFieldRow label='Remote' field={bundle.remote} />
+                        <BundleFieldRow label='Preemptible' field={bundle.on_preemptible_worker} />
                         <BundleFieldRow
                             label='Queue'
                             field={bundle.request_queue}
@@ -89,7 +91,6 @@ class MoreDetail extends React.Component {
                             field={bundle.request_network}
                             onChange={(request_network) => onUpdate({ request_network })}
                         />
-                        <BundleFieldRow label='Preemptible' field={bundle.on_preemptible_worker} />
                     </BundleFieldTable>
                 )}
                 {showTime && (

--- a/frontend/src/components/worksheets/BundleDetail/MoreDetail.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/MoreDetail.jsx
@@ -15,20 +15,14 @@ class MoreDetail extends React.Component {
         super(props);
     }
 
-    getShowSources() {
+    checkSources() {
         const bundle = this.props.bundle;
-        const bundleType = bundle.bundle_type.value;
-        if (bundleType !== 'dataset') {
-            return false;
-        }
-        if (
-            license?.editable ||
-            license?.value ||
-            source_url?.value ||
-            link_url?.value ||
-            link_format?.value
-        ) {
-            return true;
+        const sourceFields = ['license', 'source_url', 'link_url', 'link_format'];
+        for (let i in sourceFields) {
+            const field = sourceFields[i];
+            if (bundle[field]?.editable || bundle[field]?.value) {
+                return true;
+            }
         }
         return false;
     }
@@ -37,11 +31,12 @@ class MoreDetail extends React.Component {
         const { bundle, onUpdate } = this.props;
         const bundleType = bundle.bundle_type.value;
         const exclusions = bundle.exclude_patterns;
-        const showTime = bundle.time?.value || bundle.request_time?.editable;
+
         const showResources = bundleType === 'run';
+        const showSources = bundleType === 'dataset' ? this.checkSources() : false;
         const showExclusions = exclusions?.value.length || exclusions?.editable;
+        const showTime = bundle.time?.value || bundle.request_time?.editable;
         const showDependencies = !!bundle.dependencies?.value?.length;
-        const showSources = this.getShowSources();
 
         return (
             <>

--- a/frontend/src/components/worksheets/BundleDetail/MoreDetail.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/MoreDetail.jsx
@@ -15,96 +15,105 @@ class MoreDetail extends React.Component {
         super(props);
     }
 
+    getShowSources() {
+        const bundle = this.props.bundle;
+        const bundleType = bundle.bundle_type.value;
+        if (bundleType !== 'dataset') {
+            return false;
+        }
+        if (
+            license?.editable ||
+            license?.value ||
+            source_url?.value ||
+            link_url?.value ||
+            link_format?.value
+        ) {
+            return true;
+        }
+        return false;
+    }
+
     render() {
         const { bundle, onUpdate } = this.props;
         const bundleType = bundle.bundle_type.value;
-        const isRunBundle = bundleType === 'run';
-        const isUploadedBundle = bundleType === 'dataset';
-        const hasDependencies = !!bundle.dependencies?.value?.length;
-        const hasExclusions =
-            bundle.exclude_patterns?.value?.length || bundle.exclude_patterns?.editable;
+        const exclusions = bundle.exclude_patterns;
+        const showTime = bundle.time?.value || bundle.request_time?.editable;
+        const showResources = bundleType === 'run';
+        const showExclusions = exclusions?.value.length || exclusions?.editable;
+        const showDependencies = !!bundle.dependencies?.value?.length;
+        const showSources = this.getShowSources();
 
         return (
             <>
-                {isRunBundle && (
-                    <>
-                        <BundleFieldTable title='Resources'>
-                            <BundleFieldRow
-                                label='Disk'
-                                field={bundle.request_disk}
-                                onChange={(request_disk) => onUpdate({ request_disk })}
-                            />
-                            <BundleFieldRow
-                                label='Memory'
-                                field={bundle.request_memory}
-                                onChange={(request_memory) => onUpdate({ request_memory })}
-                            />
-                            <BundleFieldRow
-                                label='CPUs'
-                                field={bundle.request_cpus}
-                                onChange={(request_cpus) => onUpdate({ request_cpus })}
-                            />
-                            <BundleFieldRow
-                                label='GPUs'
-                                field={bundle.request_gpus}
-                                onChange={(request_gpus) => onUpdate({ request_gpus })}
-                            />
-                            <BundleFieldRow
-                                label='Docker Image Requested'
-                                field={bundle.request_docker_image}
-                                onChange={(request_docker_image) =>
-                                    onUpdate({ request_docker_image })
-                                }
-                            />
-                            <BundleFieldRow
-                                label='Docker Image Used'
-                                field={bundle.docker_image}
-                                allowCopy
-                                noWrap
-                            />
-                            <BundleFieldRow
-                                label='Queue'
-                                field={bundle.request_queue}
-                                onChange={(request_queue) => onUpdate({ request_queue })}
-                            />
-                            <BundleFieldRow
-                                label='Priority'
-                                field={bundle.request_priority}
-                                onChange={(request_priority) => onUpdate({ request_priority })}
-                            />
-                            <BundleFieldRow
-                                label='Network'
-                                field={bundle.request_network}
-                                onChange={(request_network) => onUpdate({ request_network })}
-                            />
-                            <BundleFieldRow
-                                label='Preemptible'
-                                field={bundle.on_preemptible_worker}
-                            />
-                        </BundleFieldTable>
-
-                        <BundleFieldTable title='Time'>
-                            <BundleFieldRow
-                                label='Time Allowed'
-                                field={bundle.request_time}
-                                onChange={(request_time) => onUpdate({ request_time })}
-                            />
-                            <BundleFieldRow label='Time Preparing' field={bundle.time_preparing} />
-                            <BundleFieldRow label='Time Running' field={bundle.time_running} />
-                            <BundleFieldRow
-                                label='Time Uploading'
-                                field={bundle.time_uploading_results}
-                            />
-                            <BundleFieldRow
-                                label='Time Cleaning Up'
-                                field={bundle.time_cleaning_up}
-                            />
-                            <BundleFieldRow label='Total Time' field={bundle.time} />
-                        </BundleFieldTable>
-                    </>
+                {showResources && (
+                    <BundleFieldTable title='Resources'>
+                        <BundleFieldRow
+                            label='Disk'
+                            field={bundle.request_disk}
+                            onChange={(request_disk) => onUpdate({ request_disk })}
+                        />
+                        <BundleFieldRow
+                            label='Memory'
+                            field={bundle.request_memory}
+                            onChange={(request_memory) => onUpdate({ request_memory })}
+                        />
+                        <BundleFieldRow
+                            label='CPUs'
+                            field={bundle.request_cpus}
+                            onChange={(request_cpus) => onUpdate({ request_cpus })}
+                        />
+                        <BundleFieldRow
+                            label='GPUs'
+                            field={bundle.request_gpus}
+                            onChange={(request_gpus) => onUpdate({ request_gpus })}
+                        />
+                        <BundleFieldRow
+                            label='Docker Image Requested'
+                            field={bundle.request_docker_image}
+                            onChange={(request_docker_image) => onUpdate({ request_docker_image })}
+                        />
+                        <BundleFieldRow
+                            label='Docker Image Used'
+                            field={bundle.docker_image}
+                            allowCopy
+                            noWrap
+                        />
+                        <BundleFieldRow
+                            label='Queue'
+                            field={bundle.request_queue}
+                            onChange={(request_queue) => onUpdate({ request_queue })}
+                        />
+                        <BundleFieldRow
+                            label='Priority'
+                            field={bundle.request_priority}
+                            onChange={(request_priority) => onUpdate({ request_priority })}
+                        />
+                        <BundleFieldRow
+                            label='Network'
+                            field={bundle.request_network}
+                            onChange={(request_network) => onUpdate({ request_network })}
+                        />
+                        <BundleFieldRow label='Preemptible' field={bundle.on_preemptible_worker} />
+                    </BundleFieldTable>
                 )}
-
-                {isUploadedBundle && (
+                {showTime && (
+                    <BundleFieldTable title='Time'>
+                        <BundleFieldRow
+                            label='Time Allowed'
+                            field={bundle.request_time}
+                            onChange={(request_time) => onUpdate({ request_time })}
+                        />
+                        <BundleFieldRow label='Time Preparing' field={bundle.time_preparing} />
+                        <BundleFieldRow label='Time Running' field={bundle.time_running} />
+                        <BundleFieldRow
+                            label='Time Uploading'
+                            field={bundle.time_uploading_results}
+                        />
+                        <BundleFieldRow label='Time Cleaning Up' field={bundle.time_cleaning_up} />
+                        <BundleFieldRow label='Total Time' field={bundle.time} />
+                    </BundleFieldTable>
+                )}
+                {showSources && (
                     <BundleFieldTable title='Sources'>
                         <BundleFieldRow
                             label='License'
@@ -128,8 +137,7 @@ class MoreDetail extends React.Component {
                         />
                     </BundleFieldTable>
                 )}
-
-                {hasExclusions && (
+                {showExclusions && (
                     <BundleFieldTable title='Contents'>
                         <BundleFieldRow
                             label='Exclude Patterns'
@@ -138,8 +146,7 @@ class MoreDetail extends React.Component {
                         />
                     </BundleFieldTable>
                 )}
-
-                {hasDependencies && (
+                {showDependencies && (
                     <BundleFieldTable title='Dependencies'>
                         <BundleFieldRow
                             label='Failed Dependencies'
@@ -156,10 +163,10 @@ class MoreDetail extends React.Component {
                         />
                     </BundleFieldTable>
                 )}
-
                 <BundleFieldTable title='Worksheets'>
                     <BundleFieldRow
                         label='Host Worksheets'
+                        description='Worksheets associated with this bundle.'
                         field={bundle.host_worksheets}
                         value={<BundleHostWorksheets bundle={bundle} />}
                     />

--- a/frontend/src/components/worksheets/BundleDetail/MoreDetail.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/MoreDetail.jsx
@@ -37,6 +37,7 @@ class MoreDetail extends React.Component {
         const showExclusions = exclusions?.value.length || exclusions?.editable;
         const showTime = bundle.time?.value || bundle.request_time?.editable;
         const showDependencies = !!bundle.dependencies?.value?.length;
+        const showHostWorksheets = !!bundle.host_worksheets?.value.length;
 
         return (
             <>
@@ -158,14 +159,16 @@ class MoreDetail extends React.Component {
                         />
                     </BundleFieldTable>
                 )}
-                <BundleFieldTable title='Worksheets'>
-                    <BundleFieldRow
-                        label='Host Worksheets'
-                        description='Worksheets associated with this bundle.'
-                        field={bundle.host_worksheets}
-                        value={<BundleHostWorksheets bundle={bundle} />}
-                    />
-                </BundleFieldTable>
+                {showHostWorksheets && (
+                    <BundleFieldTable title='Worksheets'>
+                        <BundleFieldRow
+                            label='Host Worksheets'
+                            description='Worksheets associated with this bundle.'
+                            field={bundle.host_worksheets}
+                            value={<BundleHostWorksheets bundle={bundle} />}
+                        />
+                    </BundleFieldTable>
+                )}
             </>
         );
     }

--- a/frontend/src/components/worksheets/ConfigPanel/ConfigLabel.jsx
+++ b/frontend/src/components/worksheets/ConfigPanel/ConfigLabel.jsx
@@ -54,7 +54,6 @@ const styles = (theme) => ({
     },
     tooltipBox: {
         fontSize: 14,
-        padding: `${theme.spacing.large}px ${theme.spacing.larger}px`,
     },
     tooltipIcon: {
         color: theme.color.grey.dark,

--- a/frontend/src/components/worksheets/ConfigPanel/ConfigPanel.jsx
+++ b/frontend/src/components/worksheets/ConfigPanel/ConfigPanel.jsx
@@ -1,7 +1,5 @@
 // @flow
 import * as React from 'react';
-import classNames from 'classnames';
-
 import { withStyles } from '@material-ui/core/styles';
 import Grid from '@material-ui/core/Grid';
 
@@ -24,9 +22,10 @@ class ConfigPanel extends React.Component<{
      * Renderer.
      */
     render() {
-        const { classes, children, sidebar, buttons } = this.props;
+        const { classes, children, sidebar, buttons, showBorder } = this.props;
+        const borderClass = showBorder ? classes.border : '';
         return (
-            <Grid container direction='row' className={classes.container}>
+            <Grid container direction='row' className={`${classes.container} ${borderClass}`}>
                 {/* Column 1: Main content area ================================================ */}
                 <Grid
                     item
@@ -99,6 +98,9 @@ const styles = (theme) => ({
         paddingBottom: theme.spacing.large,
         paddingTop: theme.spacing.larger,
         maxWidth: '90%',
+    },
+    border: {
+        border: `2px solid ${theme.color.grey.light}`,
     },
 });
 

--- a/frontend/src/components/worksheets/ErrorMessage.js
+++ b/frontend/src/components/worksheets/ErrorMessage.js
@@ -9,7 +9,7 @@ class ErrorMessage extends React.Component {
                 direction='column'
                 justify='center'
                 alignItems='center'
-                style={{ marginTop: 100 }}
+                style={{ margin: '100px 0 80px' }}
             >
                 <Grid className='alert alert-danger alert-dismissable'>
                     <Grid item style={{ fontSize: '16px', marginLeft: 10 }}>

--- a/frontend/src/routes/BundleRoute.js
+++ b/frontend/src/routes/BundleRoute.js
@@ -15,16 +15,21 @@ class BundleRoute extends React.Component {
         const { classes } = this.props;
         return (
             <div className={classes.bundleContainer}>
-                <BundleDetail uuid={uuid} onUpdate={() => {}} sidebarExpanded hideBundlePageLink />
+                <BundleDetail
+                    uuid={uuid}
+                    onUpdate={() => {}}
+                    sidebarExpanded
+                    hideBundlePageLink
+                    showBorder
+                />
             </div>
         );
     }
 }
 
-const styles = (theme) => ({
+const styles = () => ({
     bundleContainer: {
         margin: '12px 10px',
-        border: `2px solid ${theme.color.grey.light}`,
     },
 });
 

--- a/frontend/src/util/worksheet_utils.js
+++ b/frontend/src/util/worksheet_utils.js
@@ -66,26 +66,27 @@ export function renderDate(epochSeconds) {
     return dt.toDateString() + ' ' + padInt(hour, 2) + ':' + padInt(min, 2) + ':' + padInt(sec, 2);
 }
 
-export function renderSize(size) {
+export function renderSize(size, includeBytes = false) {
     // size: number of bytes
+    // includeBytes: whether or not to include 'bytes' string in the return value
     // Return a human-readable string.
     var units = ['', 'k', 'm', 'g', 't'];
     for (var i = 0; i < units.length; i++) {
-        var unit = units[i];
+        const unit = includeBytes && units[i] === '' ? ' bytes' : units[i];
         if (size < 100 && size !== Math.floor(size)) return Math.round(size * 10) / 10.0 + unit;
         if (size < 1024) return Math.round(size) + unit;
         size /= 1024.0;
     }
 }
 
-export function renderFormat(value, type) {
+export function renderFormat(value, type, includeBytes = false) {
     switch (type) {
         case 'list':
             return value.join(' ');
         case 'date':
             return renderDate(value);
         case 'size':
-            return renderSize(value);
+            return renderSize(value, includeBytes);
         case 'duration':
             return renderDuration(value);
         case 'bool':
@@ -406,7 +407,7 @@ export function formatBundle(bundle) {
         if (unformattedFields.includes(field)) {
             const value = mergedBundle[field];
             const type = result[field].type;
-            result[field].value = renderFormat(value, type);
+            result[field].value = renderFormat(value, type, true);
         } else {
             result[field].value = mergedBundle[field];
         }

--- a/frontend/src/util/worksheet_utils.js
+++ b/frontend/src/util/worksheet_utils.js
@@ -122,10 +122,11 @@ export function serializeFormat(formatted, type) {
     }
 }
 
-export function renderPermissions(state) {
+export function renderPermissions(state, style = {}) {
     // Render permissions:
     // - state.permission_spec (what user has)
     // - state.group_permissions (what other people have)
+    // - style (optional custom container styles)
     if (!state.permission_spec) return;
 
     function permissionToClass(permission) {
@@ -147,7 +148,7 @@ export function renderPermissions(state) {
     }
 
     return (
-        <div>
+        <div style={style}>
             &#91;you({wrapPermissionInColorSpan(state.permission_spec)})
             {_.map(state.group_permissions || [], function(perm) {
                 return (

--- a/frontend/src/util/worksheet_utils.js
+++ b/frontend/src/util/worksheet_utils.js
@@ -126,7 +126,7 @@ export function renderPermissions(state, style = {}) {
     // Render permissions:
     // - state.permission_spec (what user has)
     // - state.group_permissions (what other people have)
-    // - style (optional custom container styles)
+    // - style (optional container styles)
     if (!state.permission_spec) return;
 
     function permissionToClass(permission) {


### PR DESCRIPTION
### Reasons for making this change

This changes cleans up the bundle detail ui. It introduces the following changes:
1. The user will now see an error message if they try to access a bundle that is no longer available
2. All tooltips in the bundle detail sidebar now use the same font size
3. Field key names have been added to field tooltips
4. The permissions dropdown no longer overflows
5. I have refined the logic that determines what bundle fields to display 

### Related issues

https://github.com/codalab/codalab-worksheets/issues/4169

### Screenshots

#### Fix 1: Bundle Error Handling

![image](https://user-images.githubusercontent.com/25855750/182972199-6e3af36c-3f28-4134-b59d-c610b8bfcbe9.png)

#### Fix 2: Tooltip Font Sizes - prod vs local

https://user-images.githubusercontent.com/25855750/182972475-ef70d106-6001-4036-8565-672cbabc8aa8.mov

#### Fix 3: Field key names in field tooltips

![Screen Shot 2022-08-04 at 5 27 34 PM](https://user-images.githubusercontent.com/25855750/182977204-82c0eba8-f010-4833-b357-5dec8b1d9b9b.png)

#### Fix 4: Permissions overflow -- prod vs local

https://user-images.githubusercontent.com/25855750/182973067-95b09db8-4dbf-47b2-984b-cfe8d9f24516.mov

#### Fix 5: Only display relevant fields -- prod vs local

https://user-images.githubusercontent.com/25855750/182973415-aa47b168-d2ef-496b-9614-b263b3c0b82b.mov

### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [ ] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [ ] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
