### PR TITLE
Speed up local reloading by updating Dockerfiles to run "pip install" before copying over code

### DIFF
--- a/docker_config/dockerfiles/Dockerfile.server
+++ b/docker_config/dockerfiles/Dockerfile.server
@@ -46,6 +46,8 @@ RUN python3 -m pip install setuptools --upgrade
 RUN python3 -m pip install --no-cache-dir -r requirements-server.txt
 
 # Install code
+COPY setup.py setup.py
+RUN python3 -m pip install --no-cache-dir -e .
 COPY alembic alembic
 COPY alembic.ini alembic.ini
 COPY codalab codalab
@@ -54,12 +56,9 @@ COPY docs docs
 COPY mkdocs.yml mkdocs.yml
 COPY monitor.py monitor.py
 COPY scripts scripts
-COPY setup.py setup.py
 COPY test_runner.py test_runner.py
 COPY tests tests
 COPY views views
-
-RUN python3 -m pip install --no-cache-dir -e .
 
 # Allow non-root to read everything
 RUN chmod -R og=u-w .

--- a/docker_config/dockerfiles/Dockerfile.worker
+++ b/docker_config/dockerfiles/Dockerfile.worker
@@ -67,7 +67,6 @@ RUN python3 -m pip install --user --upgrade pip==20.3.4; \
     python3 -m pip install --no-cache-dir -r requirements.txt;
 
 # Install code
-
 COPY setup.py setup.py
 RUN python3 -m pip install --no-cache-dir -e .
 COPY codalab/lib codalab/lib

--- a/docker_config/dockerfiles/Dockerfile.worker
+++ b/docker_config/dockerfiles/Dockerfile.worker
@@ -67,13 +67,13 @@ RUN python3 -m pip install --user --upgrade pip==20.3.4; \
     python3 -m pip install --no-cache-dir -r requirements.txt;
 
 # Install code
+
+COPY setup.py setup.py
+RUN python3 -m pip install --no-cache-dir -e .
 COPY codalab/lib codalab/lib
 COPY codalab/worker codalab/worker
 COPY codalab/common.py codalab/common.py
 COPY scripts/detect-ec2-spot-preemption.sh scripts/detect-ec2-spot-preemption.sh
-COPY setup.py setup.py
-
-RUN python3 -m pip install --no-cache-dir -e .
 
 # Allow non-root to read everything
 RUN chmod -R og=u-w .


### PR DESCRIPTION
### Reasons for making this change

Improves experience for https://github.com/codalab/codalab-worksheets/issues/4199, since "pip install" is one of the most time-intensive steps that happen when rebuilding Docker containers locally during development.

### Related issues

<!-- Add a reference to issues resolved, if applicable (for example, "fixes #1"). -->

### Screenshots

<!-- Add screenshots, if necessary. If this is a substantial frontend / user flow change, consider recording
a user flow GIF using a tool such as [LICEcap](https://www.cockos.com/licecap/). -->

### Checklist

* [ ] I've added a screenshot of the changes, if this is a frontend change
* [ ] I've added and/or updated tests, if this is a backend change
* [ ] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [ ] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
