### PR TITLE
Remove max-height from stdout and stderr in single-bundle view

### DIFF
--- a/frontend/src/components/CodeSnippet.jsx
+++ b/frontend/src/components/CodeSnippet.jsx
@@ -16,10 +16,11 @@ class CodeSnippet extends React.Component {
     }
 
     render() {
-        const { classes, code, copyMessage, href } = this.props;
+        const { classes, code, copyMessage, expanded, href } = this.props;
+        const maxHeight = expanded ? 'none' : 300;
         return (
             <Grid item xs={12}>
-                <div className={classes.snippet}>
+                <div className={classes.snippet} style={{ maxHeight }}>
                     <div>{code}</div>
                     {copyMessage && <Copy message={copyMessage} text={code} />}
                     {href && <NewWindowLink href={href} />}
@@ -34,7 +35,6 @@ const styles = (theme) => ({
         display: 'flex',
         justifyContent: 'space-between',
         fontFamily: 'monospace',
-        maxHeight: 300,
         padding: 10,
         flexShrink: 1,
         overflow: 'auto',

--- a/frontend/src/components/worksheets/BundleDetail/BundleDetail.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/BundleDetail.jsx
@@ -16,6 +16,7 @@ const BundleDetail = ({
     uuid,
     // Callback on metadata change.
     bundleMetadataChanged,
+    contentExpanded,
     onOpen,
     onUpdate,
     rerunItem,
@@ -246,6 +247,7 @@ const BundleDetail = ({
                 fileContents={fileContents}
                 fetchingContent={fetchingContent}
                 contentType={contentType}
+                expanded={contentExpanded}
             />
         </ConfigurationPanel>
     );

--- a/frontend/src/components/worksheets/BundleDetail/MainContent.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/MainContent.jsx
@@ -60,6 +60,7 @@ class MainContent extends React.Component<{
             bundleInfo,
             classes,
             contentType,
+            expanded,
             fetchingContent,
             fileContents,
             stderr,
@@ -85,7 +86,9 @@ class MainContent extends React.Component<{
                                 collapsed={this.state.showFailureMessage}
                                 onClick={() => this.toggleShowFailureMessage()}
                             />
-                            {this.state.showFailureMessage && <CodeSnippet code={failureMessage} />}
+                            {this.state.showFailureMessage && (
+                                <CodeSnippet code={failureMessage} expanded={expanded} />
+                            )}
                         </Grid>
                     )}
                     {/** Command components ================================================================= */}
@@ -97,7 +100,11 @@ class MainContent extends React.Component<{
                                 onClick={() => this.toggleCommand()}
                             />
                             {this.state.showCommand && (
-                                <CodeSnippet code={command} copyMessage='Command Copied!' />
+                                <CodeSnippet
+                                    code={command}
+                                    expanded={expanded}
+                                    copyMessage='Command Copied!'
+                                />
                             )}
                         </Grid>
                     )}
@@ -115,7 +122,11 @@ class MainContent extends React.Component<{
                                             onClick={() => this.toggleStdOut()}
                                         />
                                         {this.state.showStdOut && (
-                                            <CodeSnippet code={stdout} href={stdoutUrl} />
+                                            <CodeSnippet
+                                                code={stdout}
+                                                href={stdoutUrl}
+                                                expanded={expanded}
+                                            />
                                         )}
                                     </Grid>
                                 )}
@@ -127,7 +138,11 @@ class MainContent extends React.Component<{
                                             onClick={() => this.toggleStdError()}
                                         />
                                         {this.state.showStdError && (
-                                            <CodeSnippet code={stderr} href={stderrUrl} />
+                                            <CodeSnippet
+                                                code={stderr}
+                                                href={stderrUrl}
+                                                expanded={expanded}
+                                            />
                                         )}
                                     </Grid>
                                 )}
@@ -143,19 +158,16 @@ class MainContent extends React.Component<{
                                     {this.state.showFileBrowser && (
                                         <Grid item xs={12}>
                                             {fileContents ? (
-                                                <div
-                                                    className={`${classes.snippet} ${classes.greyBorder}`}
-                                                >
-                                                    {fileContents}
-                                                </div>
+                                                <CodeSnippet
+                                                    code={fileContents}
+                                                    expanded={expanded}
+                                                />
                                             ) : (
-                                                <div className={classes.snippet}>
-                                                    <FileBrowserLite
-                                                        uuid={bundleInfo.uuid}
-                                                        isRunningBundle={this.isRunning()}
-                                                        showBreadcrumbs
-                                                    />
-                                                </div>
+                                                <FileBrowserLite
+                                                    uuid={bundleInfo.uuid}
+                                                    isRunningBundle={this.isRunning()}
+                                                    showBreadcrumbs
+                                                />
                                             )}
                                         </Grid>
                                     )}
@@ -173,20 +185,8 @@ const styles = (theme) => ({
     outter: {
         flex: 1,
     },
-    snippet: {
-        fontFamily: 'monospace',
-        maxHeight: 300,
-        padding: 10,
-        flexWrap: 'wrap',
-        flexShrink: 1,
-        overflow: 'auto',
-        whiteSpace: 'pre-wrap',
-    },
     failureContainer: {
         color: theme.color.red.base,
-    },
-    greyBorder: {
-        border: `1px solid ${theme.color.grey.light}`,
     },
 });
 

--- a/frontend/src/components/worksheets/ConfigPanel/ConfigPanel.jsx
+++ b/frontend/src/components/worksheets/ConfigPanel/ConfigPanel.jsx
@@ -72,7 +72,6 @@ const styles = (theme) => ({
     container: {
         flexGrow: 1,
         flexWrap: 'nowrap',
-        height: '100%',
         maxWidth: '100%',
     },
     content: {

--- a/frontend/src/routes/BundleRoute.js
+++ b/frontend/src/routes/BundleRoute.js
@@ -3,7 +3,7 @@ import { withStyles } from '@material-ui/core';
 import BundleDetail from '../components/worksheets/BundleDetail';
 
 /**
- * This route page displays a bundle's metadata and contents.
+ * This page-level component renders info about a single bundle.
  */
 class BundleRoute extends React.Component {
     constructor(props) {
@@ -28,10 +28,16 @@ class BundleRoute extends React.Component {
     }
 }
 
+const headerHeight = '58px';
+const footerHeight = '25px';
+
 const styles = () => ({
     bundleContainer: {
-        margin: '12px 10px',
-        paddingBottom: 36,
+        // We create our own content viewport to eliminate native auto-scrolling.
+        // Context: https://github.com/codalab/codalab-worksheets/issues/4204
+        height: `calc(100vh - ${headerHeight} - ${footerHeight})`,
+        overflowY: 'scroll',
+        overflowX: 'hidden',
     },
 });
 

--- a/frontend/src/routes/BundleRoute.js
+++ b/frontend/src/routes/BundleRoute.js
@@ -18,6 +18,7 @@ class BundleRoute extends React.Component {
                 <BundleDetail
                     uuid={uuid}
                     onUpdate={() => {}}
+                    contentExpanded
                     sidebarExpanded
                     hideBundlePageLink
                     showBorder

--- a/frontend/src/routes/BundleRoute.js
+++ b/frontend/src/routes/BundleRoute.js
@@ -31,6 +31,7 @@ class BundleRoute extends React.Component {
 const styles = () => ({
     bundleContainer: {
         margin: '12px 10px',
+        paddingBottom: 36,
     },
 });
 


### PR DESCRIPTION
### Reasons for making this change

Currently we apply a max-height of `300px` to bundle info like `stdout`, `stderr` and `fileContents`. We do this so that a bundle row doesn't become too long once it is collapsed in the worksheet view.

This makes sense for the worksheet view, but does not apply to the single-bundle view. Therefore we remove max-hight for bundle content in the single-bundle view only.

This change also fixes an issue with Chrome in which the bundle-view page auto-scrolls downwards sometimes instead of taking the user to the top of the page each time.

### Related issues

https://github.com/codalab/codalab-worksheets/issues/4181
https://github.com/codalab/codalab-worksheets/issues/4204

### Screenshots

https://user-images.githubusercontent.com/25855750/184733006-121592a9-0d6f-4efb-b231-9b2a48a44781.mov


### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [ ] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [ ] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
