### PR TITLE
Adjust CollapseButton focus styles.

### DIFF
--- a/frontend/src/components/CollapseButton.jsx
+++ b/frontend/src/components/CollapseButton.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { withStyles } from '@material-ui/core';
 import Button from '@material-ui/core/Button';
 import ChevronRightIcon from '@material-ui/icons/ChevronRight';
 import KeyboardArrowDownIcon from '@material-ui/icons/KeyboardArrowDown';
@@ -23,6 +24,7 @@ class CollapseButton extends React.Component {
 
     render() {
         const {
+            classes,
             containerClass,
             collapsed,
             collapseUp,
@@ -34,7 +36,13 @@ class CollapseButton extends React.Component {
 
         return (
             <div className={containerClass}>
-                <Button onClick={onClick} size='small' color='inherit'>
+                <Button
+                    classes={{ focusVisible: classes.focusVisible }}
+                    onClick={onClick}
+                    size='small'
+                    color='inherit'
+                    disableRipple
+                >
                     {currentLabel}
                     {collapsed ? (
                         collapseUp ? (
@@ -51,4 +59,10 @@ class CollapseButton extends React.Component {
     }
 }
 
-export default CollapseButton;
+const styles = () => ({
+    focusVisible: {
+        backgroundColor: 'rgba(0, 0, 0, 0.08)',
+    },
+});
+
+export default withStyles(styles)(CollapseButton);


### PR DESCRIPTION
### Reasons for making this change

Our `CollapseButton`  component uses Material UI's `Button` component under the hood. MUI adds a ripple effect to `Button` components on `focus` by default. This change disables that ripple effect and applies a more simplistic style to `CollapseButton` on `focus`.

### Related issues

https://github.com/codalab/codalab-worksheets/issues/4191

### Screenshots

#### Before this change

![image](https://user-images.githubusercontent.com/435384/183314827-4062d7ad-a174-4528-9c34-5fce72291fae.png)

#### After this change

![image](https://user-images.githubusercontent.com/25855750/184736530-6576cd12-c81a-4189-b9d5-bee3bf80e987.png)


<!-- Add screenshots, if necessary. If this is a substantial frontend / user flow change, consider recording
a user flow GIF using a tool such as [LICEcap](https://www.cockos.com/licecap/). -->

### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [ ] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [ ] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
