### PR TITLE
Add blank bundle size to detail sidebar.

### DIFF
--- a/frontend/src/components/worksheets/BundleDetail/BundleDetail.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/BundleDetail.jsx
@@ -29,12 +29,12 @@ const BundleDetail = ({
     showBorder,
 }) => {
     const [bundleInfo, setBundleInfo] = useState(null);
+    const [contentType, setContentType] = useState(null);
     const [fileContents, setFileContents] = useState(null);
     const [stdout, setStdout] = useState(null);
     const [stderr, setStderr] = useState(null);
     const [prevUuid, setPrevUuid] = useState(uuid);
     const [open, setOpen] = useState(true);
-    const [contentType, setContentType] = useState('');
     const [fetchingContent, setFetchingContent] = useState(false);
     const [fetchingMetadata, setFetchingMetadata] = useState(false);
     const [contentErrors, setContentErrors] = useState([]);
@@ -80,6 +80,7 @@ const BundleDetail = ({
                 .then((r) => r.json())
                 .catch((error) => {
                     setBundleInfo(null);
+                    setContentType(null);
                     setFileContents(null);
                     setStderr(null);
                     setStdout(null);
@@ -119,6 +120,7 @@ const BundleDetail = ({
             setFetchingContent(true);
             return apiWrapper.get(url).catch((error) => {
                 // If contents aren't available yet, then also clear stdout and stderr.
+                setContentType(null);
                 setFileContents(null);
                 setStderr(null);
                 setStdout(null);
@@ -138,6 +140,7 @@ const BundleDetail = ({
             setPendingFileSummaryFetches((f) => f + 1);
             return fetchFileSummary(uuid, '/')
                 .then(function(blob) {
+                    setContentType(info.type);
                     setFileContents(blob);
                     setStderr(null);
                     setStdout(null);
@@ -171,6 +174,7 @@ const BundleDetail = ({
             });
             Promise.all(fetchRequests)
                 .then((r) => {
+                    setContentType(info.type);
                     setFileContents(stateUpdate['fileContents']);
                     if ('stdout' in stateUpdate) {
                         setStdout(stateUpdate['stdout']);
@@ -190,7 +194,6 @@ const BundleDetail = ({
         onSuccess: (response) => {
             updateBundleDetail(response);
             setContentErrors([]);
-            setContentType(response.data?.type);
         },
     });
 

--- a/frontend/src/components/worksheets/BundleDetail/BundleDetailSideBar.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/BundleDetailSideBar.jsx
@@ -117,7 +117,11 @@ class BundleDetailSideBar extends React.Component {
                         }
                     />
                     <BundleFieldRow label='Created' field={bundle.created} />
-                    <BundleFieldRow label='Size' field={bundle.data_size} />
+                    <BundleFieldRow
+                        label='Size'
+                        description='Size of this bundle in bytes (data_size).'
+                        value={bundle.data_size?.value || '--'}
+                    />
                     <BundleFieldRow label='Remote' field={bundle.remote} />
                     <BundleFieldRow
                         label='Store'

--- a/frontend/src/components/worksheets/BundleDetail/MainContent.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/MainContent.jsx
@@ -55,13 +55,25 @@ class MainContent extends React.Component<{
         return runStates.includes(bundleInfo.state);
     }
 
+    isLoading() {
+        const { bundleInfo, fetchingContent, contentType, stderr, stdout } = this.props;
+        const state = bundleInfo.state;
+        const inFinalState = FINAL_BUNDLE_STATES.includes(state);
+        if (!inFinalState) {
+            return true;
+        }
+        if (state === 'killed') {
+            return false;
+        }
+        return !stderr && !stdout && !contentType && fetchingContent;
+    }
+
     render() {
         const {
             bundleInfo,
             classes,
             contentType,
             expanded,
-            fetchingContent,
             fileContents,
             stderr,
             stdout,
@@ -71,9 +83,7 @@ class MainContent extends React.Component<{
         const stderrUrl = '/rest/bundles/' + uuid + '/contents/blob/stderr';
         const command = bundleInfo.command;
         const failureMessage = bundleInfo.metadata.failure_message;
-        const state = bundleInfo.state;
-        const inFinalState = FINAL_BUNDLE_STATES.includes(state);
-        const isLoading = !inFinalState || fetchingContent;
+        const isLoading = this.isLoading();
 
         return (
             <div className={classes.outter}>


### PR DESCRIPTION
### Reasons for making this change

Adds `--` placeholder while we wait for `data_size`. This prevents the bundle sidebar from jumping for running bundles.

### Related issues

<!-- Add a reference to issues resolved, if applicable (for example, "fixes #1"). -->

### Screenshots

![image](https://user-images.githubusercontent.com/25855750/185001864-6bd026e2-10da-461e-8fa0-7c21c41dcb61.png)


### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [ ] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [ ] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
