### PR TITLE
Show bundle `run_status` in `preparing` state

### DIFF
--- a/codalab/lib/bundle_util.py
+++ b/codalab/lib/bundle_util.py
@@ -371,9 +371,9 @@ def get_bundle_state_details(bundle):
     See Bundle-Lifecycle.md for public bundle state documentation.
     """
     metadata = bundle.get('metadata', {})
-    run_status = metadata.get('run_status', '')
-    type = bundle.get('bundle_type')
+    run_status = metadata.get('run_status')
     state = bundle.get('state')
+    type = bundle.get('bundle_type')
     state_details_by_type = {
         'dataset': {
             'created': 'Bundle has been created but its contents have not been uploaded yet.',
@@ -398,8 +398,6 @@ def get_bundle_state_details(bundle):
             'worker_offline': 'The worker where the bundle is running on is offline, and the worker might or might not come back online.',
         },
     }
-
-    # TODO: make sure preparing always has a status
 
     if state == 'preparing' or state == 'running':
         return run_status

--- a/codalab/lib/bundle_util.py
+++ b/codalab/lib/bundle_util.py
@@ -366,13 +366,14 @@ def get_bundle_state_details(bundle):
 
     If the bundle is currently running, its `run_status` will be returned.
     Otherwise, a description of the `state` is returned.
+
+    See bundle_state.py for details on the State class.
+    See Bundle-Lifecycle.md for public bundle state documentation.
     """
+    metadata = bundle.get('metadata', {})
+    run_status = metadata.get('run_status', '')
     type = bundle.get('bundle_type')
     state = bundle.get('state')
-    metadata = bundle.get('metadata', {})
-
-    # see bundle_state.py for details on the State class
-    # see Bundle-Lifecycle.md for public bundle state documentation
     state_details_by_type = {
         'dataset': {
             'created': 'Bundle has been created but its contents have not been uploaded yet.',
@@ -389,8 +390,7 @@ def get_bundle_state_details(bundle):
         'run': {
             'created': 'Bundle has been created but its contents have not been populated yet.',
             'staged': 'Bundle’s dependencies are all ready. Waiting for the bundle to be assigned to a worker to be run.',
-            'starting': 'Bundle has been assigned to a worker and waiting for worker to start the bundle.',
-            'preparing': 'Waiting for worker to download bundle dependencies and Docker image to run the bundle.',
+            'starting': 'Bundle has been assigned to a worker. Waiting for worker to start the bundle.',
             'finalizing': 'Bundle command has finished executing, cleaning up on the worker.',
             'ready': 'Bundle command has finished executing successfully, and results have been uploaded to the server.',
             'failed': 'Bundle has failed.',
@@ -399,7 +399,8 @@ def get_bundle_state_details(bundle):
         },
     }
 
-    # if the bundle is `running`, return the `run_status`
-    if state == 'running':
-        return metadata.get('run_status', '')
+    # TODO: make sure preparing always has a status
+
+    if state == 'preparing' or state == 'running':
+        return run_status
     return state_details_by_type[type][state]

--- a/codalab/lib/bundle_util.py
+++ b/codalab/lib/bundle_util.py
@@ -372,8 +372,8 @@ def get_bundle_state_details(bundle):
     """
     metadata = bundle.get('metadata', {})
     run_status = metadata.get('run_status')
-    state = bundle.get('state')
     type = bundle.get('bundle_type')
+    state = bundle.get('state')
     state_details_by_type = {
         'dataset': {
             'created': 'Bundle has been created but its contents have not been uploaded yet.',

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -921,6 +921,7 @@ class BundleModel(object):
             bundle_update = {
                 'state': State.PREPARING,
                 'metadata': {
+                    'run_status': 'Waiting for worker to download bundle dependencies and Docker image to run the bundle.',
                     'started': start_time,
                     'last_updated': start_time,
                     'remote': remote,

--- a/codalab/worker/docker_image_manager.py
+++ b/codalab/worker/docker_image_manager.py
@@ -133,19 +133,37 @@ class DockerImageManager(ImageManager):
         Returns: None
 
         """
+
+        # TODO: split to helper
+        # TODO: unit test
+        # TODO: code docs
+
+        def get_progress(image_info):
+            progress_detail = image_info.get('progressDetail', {})
+            total = progress_detail.get('total')
+            current = progress_detail.get('current')
+
+            if total and current:
+                percentage = current * 100 / total
+                progress = image_info.get('progress')
+
+                if progress:
+                    progress = progress.split(']')[
+                        -1
+                    ].strip()  # e.g. '[========>    ]  20.32MB/28.54MB' -> '20.32MB/28.54MB'
+                    return '%s (%d%% done)' % (progress, percentage)
+                return '(%d%% done)' % percentage
+            return ''
+
         logger.debug('Downloading Docker image %s', image_spec)
         try:
             for line in self._docker.api.pull(image_spec, stream=True, decode=True):
-                self._downloading[image_spec]['status'] = ''
-                # Set the status to the percent completed
-                if (
-                    line['status'] == 'Downloading'
-                    and 'total' in line['progressDetail']
-                    and 'current' in line['progressDetail']
-                ):
-                    self._downloading[image_spec]['status'] = '(%d%%)' % (
-                        line['progressDetail']['current'] * 100 / line['progressDetail']['total']
-                    )
+                status = line['status']
+                if status == 'Downloading' or status == 'Extracting':
+                    progress = get_progress(line)
+                    self._downloading[image_spec]['status'] = '%s %s' % (status, progress)
+                else:
+                    self._downloading[image_spec]['status'] = status
 
             logger.debug('Download for Docker image %s complete', image_spec)
             self._downloading[image_spec]['success'] = True

--- a/codalab/worker/docker_image_manager.py
+++ b/codalab/worker/docker_image_manager.py
@@ -135,10 +135,9 @@ class DockerImageManager(ImageManager):
         logger.debug('Downloading Docker image %s', image_spec)
         try:
             for line in self._docker.api.pull(image_spec, stream=True, decode=True):
-                status = line['status']
-                if status == 'Downloading' or status == 'Extracting':
+                if line['status'] == 'Downloading' or line['status'] == 'Extracting':
                     progress = docker_utils.parse_image_progress(line)
-                    self._downloading[image_spec]['status'] = '%s %s' % (status, progress)
+                    self._downloading[image_spec]['status'] = '%s %s' % (line['status'], progress)
                 else:
                     self._downloading[image_spec]['status'] = ''
 

--- a/codalab/worker/docker_utils.py
+++ b/codalab/worker/docker_utils.py
@@ -39,6 +39,36 @@ MEMORY_LIMIT_ERROR_REGEX = (
 logger = logging.getLogger(__name__)
 
 
+def parse_image_progress(image_info={}):
+    """
+    As a docker image is being pulled, we have access to a stream of image info.
+    This helper takes in image info and returns a consise progress string.
+
+    Example Input:
+    image_info = {
+        progressDetail: { current: 20320000, total: 28540000 }
+        progress: '[===============>     ]  20.32MB/28.54MB'
+    }
+
+    Example Return:
+    '20.32MB/28.54MB (71% done)'
+    """
+    progress_detail = image_info.get('progressDetail', {})
+    current = progress_detail.get('current')
+    total = progress_detail.get('total')
+
+    if total and current:
+        percentage = current * 100 / total
+        progress = image_info.get('progress')
+
+        if progress:
+            progress_parts = progress.split(']')
+            concise_progress = progress_parts[-1].strip()
+            return '%s (%d%% done)' % (concise_progress, percentage)
+        return '(%d%% done)' % percentage
+    return ''
+
+
 def wrap_exception(message):
     def decorator(f):
         def wrapper(*args, **kwargs):

--- a/codalab/worker/worker_run_state.py
+++ b/codalab/worker/worker_run_state.py
@@ -297,7 +297,7 @@ class RunStateMachine(StateTransitioner):
         image_state = self.image_manager.get(docker_image)
         if image_state.stage == DependencyStage.DOWNLOADING:
             status_messages.append(
-                'Pulling docker image %s %s' % (docker_image, image_state.message)
+                'Pulling docker image %s. %s' % (docker_image, image_state.message)
             )
             dependencies_ready = False
         elif image_state.stage == DependencyStage.FAILED:

--- a/docs/Bundle-Lifecycle.md
+++ b/docs/Bundle-Lifecycle.md
@@ -43,7 +43,7 @@ bundles. Each bundle transitions through various states during its lifecycle.
 | - | - |
 | **created** | Bundle has been created but its contents have not been populated yet. |
 | **staged** | Bundle’s dependencies are all ready. Waiting for the bundle to be assigned to a worker to be run. |
-| **starting** | Bundle has been assigned to a worker and waiting for worker to start the bundle. |
+| **starting** | Bundle has been assigned to a worker. Waiting for worker to start the bundle. |
 | **preparing** | Waiting for worker to download bundle dependencies and Docker image to run the bundle. |
 | **running** | Bundle command is being executed in a Docker container or results are being uploaded. |
 | **finalizing** | Bundle command has finished executing, cleaning up on the worker. |

--- a/frontend/src/components/worksheets/BundleDetail/BundleFieldTable/BundleStateRow.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/BundleFieldTable/BundleStateRow.jsx
@@ -36,11 +36,14 @@ class BundleStateTable extends React.Component {
 
     getTime(state) {
         const bundle = this.props.bundle;
+        let time;
         if (state === 'preparing') {
-            return bundle.time_preparing?.value;
+            time = bundle.time_preparing?.value;
+        } else if (state === 'running') {
+            time = bundle.time_running?.value || bundle.time?.value;
         }
-        if (state === 'running') {
-            return bundle.time_running?.value || bundle.time?.value;
+        if (time && time !== '0s') {
+            return time;
         }
     }
 


### PR DESCRIPTION
### Reasons for making this change

Currently we show a static status for bundles that are in the `preparing` state. However there is useful information that is appended to `run_status` for bundles that are `preparing`, so we should show `run_status` for `preparing` bundles.

This change enables `run_status` to be shown to the user when a bundle is in the `preparing` state. It also refines the progress messaging that is appended to `run_status` when a docker image is being pulled.

### Related issues

https://github.com/codalab/codalab-worksheets/issues/4186
https://github.com/codalab/codalab-worksheets/issues/4113

### Screenshots

#### Docker image is being downloaded

![downloading-sample](https://user-images.githubusercontent.com/25855750/185491045-2b04573f-026c-4bc8-bf9c-cec7f7bb602f.png)

#### Docker image is being extracted

![extracting-sample](https://user-images.githubusercontent.com/25855750/185491071-c1e7508f-d9c2-4ccc-88c1-7a398b9ca565.png)

### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
