### PR TITLE
Return empty state_details for deprecated bundle types.

### DIFF
--- a/codalab/lib/bundle_util.py
+++ b/codalab/lib/bundle_util.py
@@ -398,6 +398,9 @@ def get_bundle_state_details(bundle):
             'worker_offline': 'The worker where the bundle is running on is offline, and the worker might or might not come back online.',
         },
     }
+
+    # We can remove the defensive checks below once program bundles are converted to dataset bundles.
+    # Related Issue: https://github.com/codalab/codalab-worksheets/issues/4235
     state_details = state_details_by_type.get(type, {}).get(state, '')
 
     if state == 'preparing' or state == 'running':

--- a/codalab/lib/bundle_util.py
+++ b/codalab/lib/bundle_util.py
@@ -375,7 +375,7 @@ def get_bundle_state_details(bundle):
     type = bundle.get('bundle_type')
     state = bundle.get('state')
     state_details_by_type = {
-        'dataset': {
+        'dataset': {  # uploaded
             'created': 'Bundle has been created but its contents have not been uploaded yet.',
             'uploading': 'Bundle contents are being uploaded.',
             'ready': 'Bundle has finished uploading successfully, and is ready to be used for further runs.',
@@ -398,7 +398,8 @@ def get_bundle_state_details(bundle):
             'worker_offline': 'The worker where the bundle is running on is offline, and the worker might or might not come back online.',
         },
     }
+    state_details = state_details_by_type.get(type, {}).get(state, '')
 
     if state == 'preparing' or state == 'running':
         return run_status
-    return state_details_by_type[type][state]
+    return state_details

--- a/tests/unit/lib/bundle_util_test.py
+++ b/tests/unit/lib/bundle_util_test.py
@@ -3,6 +3,14 @@ from codalab.lib.bundle_util import get_bundle_state_details
 
 
 class GetBundleStateDetailsTest(unittest.TestCase):
+    def test_deprecated_bundle(self):
+        """
+        Returns an empty string for deprecated bundle types.
+        """
+        deprecated_bundle = {'bundle_type': 'program', 'state': 'ready'}
+        state_details = get_bundle_state_details(deprecated_bundle)
+        self.assertEqual(state_details, '')
+
     def test_running_bundle(self):
         """
         Returns `run_status` if state is `running`.


### PR DESCRIPTION
### Reasons for making this change

There are old worksheets that contain `program` bundles. This bundle type has been deprecated. However, we should not throw an internal error if an old worksheet contains this type of bundle. 

This change updates the `get_bundle_state_details` function to return an empty string for deprecated bundle types.

### Related issues

https://github.com/codalab/codalab-worksheets/issues/4228
https://github.com/codalab/codalab-worksheets/issues/4235

### Screenshots

<!-- Add screenshots, if necessary. If this is a substantial frontend / user flow change, consider recording
a user flow GIF using a tool such as [LICEcap](https://www.cockos.com/licecap/). -->

### Checklist

* [ ] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [ ] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
