### PR TITLE
Truncate `remote` field and make it copyable

### DIFF
--- a/frontend/src/components/worksheets/BundleDetail/BundleActions.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/BundleActions.jsx
@@ -87,14 +87,15 @@ class BundleActions extends React.Component<{
 
     render() {
         const { bundleInfo, classes, editPermission } = this.props;
+        const state = bundleInfo.state;
         const bundleDownloadUrl = '/rest/bundles/' + bundleInfo.uuid + '/contents/blob/';
         const isRunBundle = bundleInfo.bundle_type === 'run' && bundleInfo.metadata;
-        const isKillableBundle = bundleInfo.state === 'running' || bundleInfo.state === 'preparing';
+        const isKillableBundle = state === 'running' || state === 'preparing' || state === 'staged';
         const isDownloadableRunBundle =
-            bundleInfo.state !== 'preparing' &&
-            bundleInfo.state !== 'starting' &&
-            bundleInfo.state !== 'created' &&
-            bundleInfo.state !== 'staged';
+            state !== 'preparing' &&
+            state !== 'starting' &&
+            state !== 'created' &&
+            state !== 'staged';
 
         return (
             <div>

--- a/frontend/src/components/worksheets/BundleDetail/BundleDetailSideBar.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/BundleDetailSideBar.jsx
@@ -53,7 +53,6 @@ class BundleDetailSideBar extends React.Component {
         const bundle = formatBundle(bundleInfo);
         const bundleType = bundle.bundle_type.value;
         const uuid = bundle.uuid.value;
-        const remote = bundle.remote?.value;
         const time = bundle.time?.value;
         const exclusions = bundle.exclude_patterns;
         const state = bundle.state.value;

--- a/frontend/src/components/worksheets/BundleDetail/BundleDetailSideBar.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/BundleDetailSideBar.jsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { withStyles } from '@material-ui/core';
-import { formatBundle, shorten_uuid } from '../../../util/worksheet_utils';
+import { formatBundle } from '../../../util/worksheet_utils';
 import { FINAL_BUNDLE_STATES } from '../../../constants';
 import CollapseButton from '../../CollapseButton';
 import NewWindowLink from '../../NewWindowLink';
@@ -78,9 +78,9 @@ class BundleDetailSideBar extends React.Component {
                     <BundleFieldRow
                         label='UUID'
                         description="Click the copy icon to copy the bundle's full UUID."
-                        value={`${shorten_uuid(uuid)}...`}
-                        copyValue={uuid}
+                        field={bundle.uuid}
                         allowCopy
+                        noWrap
                     />
                     <BundleFieldRow
                         label='Name'
@@ -123,13 +123,7 @@ class BundleDetailSideBar extends React.Component {
                         description='Size of this bundle in bytes (data_size).'
                         value={bundle.data_size?.value || '--'}
                     />
-                    <BundleFieldRow
-                        label='Remote'
-                        field={bundle.remote}
-                        value={remote && `${shorten_uuid(remote)}...`}
-                        copyValue={remote}
-                        allowCopy
-                    />
+                    <BundleFieldRow label='Remote' field={bundle.remote} allowCopy noWrap />
                     <BundleFieldRow
                         label='Store'
                         field={bundle.store}
@@ -287,7 +281,7 @@ const styles = () => ({
     },
     pageLink: {
         position: 'absolute',
-        right: 0,
+        right: -1,
     },
     collapseBtn: {
         marginTop: 5,

--- a/frontend/src/components/worksheets/BundleDetail/BundleDetailSideBar.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/BundleDetailSideBar.jsx
@@ -53,6 +53,7 @@ class BundleDetailSideBar extends React.Component {
         const bundle = formatBundle(bundleInfo);
         const bundleType = bundle.bundle_type.value;
         const uuid = bundle.uuid.value;
+        const remote = bundle.remote?.value;
         const time = bundle.time?.value;
         const exclusions = bundle.exclude_patterns;
         const state = bundle.state.value;
@@ -122,7 +123,13 @@ class BundleDetailSideBar extends React.Component {
                         description='Size of this bundle in bytes (data_size).'
                         value={bundle.data_size?.value || '--'}
                     />
-                    <BundleFieldRow label='Remote' field={bundle.remote} />
+                    <BundleFieldRow
+                        label='Remote'
+                        field={bundle.remote}
+                        value={remote && `${shorten_uuid(remote)}...`}
+                        copyValue={remote}
+                        allowCopy
+                    />
                     <BundleFieldRow
                         label='Store'
                         field={bundle.store}

--- a/frontend/src/components/worksheets/BundleDetail/BundleFieldTable/BundleFieldRow.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/BundleFieldTable/BundleFieldRow.jsx
@@ -60,7 +60,6 @@ class BundleFieldRow extends React.Component {
         const label = this.props.label || field.name;
         const description = this.props.description || field.description;
         const value = this.props.value || field.value;
-        const copyValue = this.props.copyValue || value;
 
         if (hideRow) {
             return null;
@@ -98,7 +97,7 @@ class BundleFieldRow extends React.Component {
                     ) : (
                         <div className={classes.dataContainer}>
                             <Typography noWrap={noWrap}>{value}</Typography>
-                            {allowCopy && <Copy message={`${label} Copied!`} text={copyValue} />}
+                            {allowCopy && <Copy message={`${label} Copied!`} text={value} />}
                         </div>
                     )}
                 </td>


### PR DESCRIPTION
### Reasons for making this change

The `remote` field is often long. The user doesn't need to be able to read the whole field, as it is usually a UUID. This changes truncates that uuid and makes it copyable (just like we do for the bundle's uuid).

This change also allows staged bundles to be killed from the bundle content CTAs.

### Related issues

https://github.com/codalab/codalab-worksheets/issues/4230

### Screenshots

#### Before
![Screen Shot 2022-08-22 at 5 49 32 PM](https://user-images.githubusercontent.com/25855750/186045495-e741125e-d9d0-4cf7-b76b-2deb3e5aefae.png)

#### After

![Screen Shot 2022-08-23 at 8 09 50 PM](https://user-images.githubusercontent.com/25855750/186312480-04dda857-32ff-49f3-a221-377b13a09acd.png)

![Screen Shot 2022-08-23 at 8 08 59 PM](https://user-images.githubusercontent.com/25855750/186312500-a09110f9-74d2-44a6-8a2d-713055e2b99b.png)


### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [ ] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [ ] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
