### PR TITLE
Bump to v1.5.8

### DIFF
--- a/codalab/common.py
+++ b/codalab/common.py
@@ -27,7 +27,7 @@ from codalab.lib.beam.filesystems import (
 
 # Increment this on master when ready to cut a release.
 # http://semver.org/
-CODALAB_VERSION = '1.5.7'
+CODALAB_VERSION = '1.5.8'
 BINARY_PLACEHOLDER = '<binary>'
 URLOPEN_TIMEOUT_SECONDS = int(os.environ.get('CODALAB_URLOPEN_TIMEOUT_SECONDS', 5 * 60))
 

--- a/docs/REST-API-Reference.md
+++ b/docs/REST-API-Reference.md
@@ -1,6 +1,6 @@
 # REST API Reference
 
-_version 1.5.7_
+_version 1.5.8_
 
 This reference and the REST API itself is still under heavy development and is
 subject to change at any time. Feedback through our GitHub issues is appreciated!

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -1,5 +1,5 @@
 // Should match codalab/common.py#CODALAB_VERSION
-export const CODALAB_VERSION = '1.5.7';
+export const CODALAB_VERSION = '1.5.8';
 
 // Name Regex to match the backend in spec_utils.py
 export const NAME_REGEX = /^[a-zA-Z_][a-zA-Z0-9_.-]*$/i;

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import sys
 
 
 # should match codalab/common.py#CODALAB_VERSION
-CODALAB_VERSION = "1.5.7"
+CODALAB_VERSION = "1.5.8"
 
 
 class Install(install):


### PR DESCRIPTION
## Frontend
* Truncate `remote` field and make it copyable by @leilenah in https://github.com/codalab/codalab-worksheets/pull/4232
* Return empty state_details for deprecated bundle types. by @leilenah in https://github.com/codalab/codalab-worksheets/pull/4229

## Backend
* Incompatible variable type fixed by @luca-digrazia in https://github.com/codalab/codalab-worksheets/pull/4198
* Allow passing empty --worker-tag to worker managers by @epicfaace in https://github.com/codalab/codalab-worksheets/pull/4121
* Fix typo for --preemptible arg to workers by @epicfaace in https://github.com/codalab/codalab-worksheets/pull/4157

## Full Changelog 
https://github.com/codalab/codalab-worksheets/compare/v1.5.7...v1.5.8