### PR TITLE
Show error message for private bundles.

### DIFF
--- a/frontend/src/components/worksheets/BundleDetail/BundleDetail.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/BundleDetail.jsx
@@ -52,13 +52,11 @@ const BundleDetail = ({
     // If info is not available yet, fetch
     // If bundle is in a state that is possible to transition to a different state, fetch data
     // we have ignored ready|failed|killed states here
-    const refreshInterval =
-        !bundleInfo ||
-        bundleInfo.state.match(
-            'uploading|created|staged|making|starting|preparing|running|finalizing|worker_offline',
-        )
-            ? 4000
-            : 0;
+    const refreshInterval = bundleInfo?.state?.match(
+        'uploading|created|staged|making|starting|preparing|running|finalizing|worker_offline',
+    )
+        ? 4000
+        : 0;
 
     useEffect(() => {
         const timer = setInterval(() => {
@@ -214,7 +212,7 @@ const BundleDetail = ({
     }
 
     if (bundleInfo.bundle_type === 'private') {
-        return <div>Detail not available for this bundle</div>;
+        return <ErrorMessage message='Error: Bundle Access Denied' />;
     }
 
     return (


### PR DESCRIPTION
### Reasons for making this change

Currently, if a user doesn't have access to view a bundle, they see a blank page with no indication that they don't have permission to view the bundle.

This change adds an error message to the bundle view that will be surfaced to the user if they don't have permission to view a bundle.

### Related issues

https://github.com/codalab/codalab-worksheets/issues/4240

### Screenshots

![Screen Shot 2022-08-29 at 3 02 05 PM](https://user-images.githubusercontent.com/25855750/187307153-304fc02e-9ec7-40d3-8d21-365cffb00d49.png)

### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [ ] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [ ] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
