### PR TITLE
Simplify `isLoading` logic in `MainContent` component

### DIFF
--- a/codalab/server/bundle_manager.py
+++ b/codalab/server/bundle_manager.py
@@ -167,11 +167,11 @@ class BundleManager(object):
                 ]
                 failure_message = ''
                 if failed_uuids:
-                    failure_message += ' Parent bundles failed: %s' % ', '.join(failed_uuids)
+                    failure_message += 'Parent bundles failed: %s ' % ', '.join(failed_uuids)
                 if killed_uuids:
-                    failure_message += ' Parent bundles were killed: %s' % ', '.join(killed_uuids)
+                    failure_message += 'Parent bundles were killed: %s ' % ', '.join(killed_uuids)
                 if failure_message:
-                    failure_message += ' (Please use the --allow-failed-dependencies flag to depend on results of failed or killed bundles)'
+                    failure_message += '(Please use the --allow-failed-dependencies flag to depend on results of failed or killed bundles) '
                     bundles_to_fail.append((bundle, failure_message))
                     continue
 
@@ -368,9 +368,9 @@ class BundleManager(object):
         for bundle in active_bundles:
             failure_message = None
             if not workers.is_running(bundle.uuid):
-                failure_message = 'No worker claims bundle'
+                failure_message = 'No worker claims bundle.'
             if now - bundle.metadata.last_updated > self._worker_timeout_seconds:
-                failure_message = 'Worker offline'
+                failure_message = 'Worker offline.'
             if failure_message is not None:
                 logger.info('Bringing bundle offline %s: %s', bundle.uuid, failure_message)
                 self._model.transition_bundle_worker_offline(bundle)

--- a/frontend/src/components/worksheets/BundleDetail/BundleDetail.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/BundleDetail.jsx
@@ -246,7 +246,6 @@ const BundleDetail = ({
                 stdout={stdout}
                 stderr={stderr}
                 fileContents={fileContents}
-                fetchingContent={fetchingContent}
                 contentType={contentType}
                 expanded={contentExpanded}
             />

--- a/frontend/src/components/worksheets/BundleDetail/MainContent.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/MainContent.jsx
@@ -2,7 +2,6 @@
 import * as React from 'react';
 import Grid from '@material-ui/core/Grid';
 import { withStyles } from '@material-ui/core/styles';
-import { FINAL_BUNDLE_STATES } from '../../../constants';
 import { FileBrowserLite } from '../../FileBrowser/FileBrowser';
 import CollapseButton from '../../CollapseButton';
 import CodeSnippet from '../../CodeSnippet';
@@ -69,8 +68,8 @@ class MainContent extends React.Component<{
         const stdoutUrl = '/rest/bundles/' + uuid + '/contents/blob/stdout';
         const stderrUrl = '/rest/bundles/' + uuid + '/contents/blob/stderr';
         const failureMessage = metadata.failure_message;
-        const inFinalState = FINAL_BUNDLE_STATES.includes(state);
-        const isLoading = !inFinalState || !contentType;
+        const inErrorState = ['killed', 'failed'].includes(state);
+        const isLoading = !contentType && !inErrorState;
 
         return (
             <div className={classes.outter}>

--- a/frontend/src/components/worksheets/BundleDetail/MainContent.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/MainContent.jsx
@@ -55,19 +55,6 @@ class MainContent extends React.Component<{
         return runStates.includes(bundleInfo.state);
     }
 
-    isLoading() {
-        const { bundleInfo, fetchingContent, contentType, stderr, stdout } = this.props;
-        const state = bundleInfo.state;
-        const inFinalState = FINAL_BUNDLE_STATES.includes(state);
-        if (!inFinalState) {
-            return true;
-        }
-        if (state === 'killed') {
-            return false;
-        }
-        return !stderr && !stdout && !contentType && fetchingContent;
-    }
-
     render() {
         const {
             bundleInfo,
@@ -78,12 +65,12 @@ class MainContent extends React.Component<{
             stderr,
             stdout,
         } = this.props;
-        const uuid = bundleInfo.uuid;
+        const { command, metadata, state, uuid } = bundleInfo || {};
         const stdoutUrl = '/rest/bundles/' + uuid + '/contents/blob/stdout';
         const stderrUrl = '/rest/bundles/' + uuid + '/contents/blob/stderr';
-        const command = bundleInfo.command;
-        const failureMessage = bundleInfo.metadata.failure_message;
-        const isLoading = this.isLoading();
+        const failureMessage = metadata.failure_message;
+        const inFinalState = FINAL_BUNDLE_STATES.includes(state);
+        const isLoading = !inFinalState || !contentType;
 
         return (
             <div className={classes.outter}>


### PR DESCRIPTION
### Reasons for making this change

A few weeks ago, I hastily added an `isLoading()` function to the `MainContent` component as a quick patch. This change simplifies that cumbersome logic. 

### Related issues

https://github.com/codalab/codalab-worksheets/issues/4215

### Screenshots

https://user-images.githubusercontent.com/25855750/188035967-67f134a7-adc3-44bd-b4b6-453923c40560.mp4


### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [ ] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [ ] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
