### PR TITLE
Remove min-height from worksheet content area

### DIFF
--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -2047,7 +2047,6 @@ const styles = (theme) => ({
         marginTop: NAVBAR_HEIGHT,
     },
     worksheetOuter: {
-        minHeight: 600, // Worksheet height
         margin: '32px auto', // Center page horizontally
         backgroundColor: 'white', // Paper color
         border: `2px solid ${theme.color.grey.light}`,

--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -2045,8 +2045,10 @@ const styles = (theme) => ({
     worksheetDesktop: {
         backgroundColor: theme.color.grey.lightest,
         marginTop: NAVBAR_HEIGHT,
+        height: 'calc(100% - 20px)',
     },
     worksheetOuter: {
+        minHeight: '100%', // Worksheet height
         margin: '32px auto', // Center page horizontally
         backgroundColor: 'white', // Paper color
         border: `2px solid ${theme.color.grey.light}`,


### PR DESCRIPTION
### Reasons for making this change

This change prevents unwanted scrolling for worksheets that don't have enough content to take up the height of the viewport.

### Related issues

https://github.com/codalab/codalab-worksheets/issues/4218

### Screenshots (prod vs. local)

https://user-images.githubusercontent.com/25855750/188047978-fa5be624-3f37-4d47-b447-a64bca98f0cc.mp4


### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [ ] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [ ] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
