### PR TITLE
Add preparing and finalizing text to upload progress.

### DIFF
--- a/frontend/src/components/worksheets/NewUpload/NewUpload.jsx
+++ b/frontend/src/components/worksheets/NewUpload/NewUpload.jsx
@@ -214,9 +214,20 @@ class NewUpload extends React.Component<{
         this.setState({ numeratorComplete: 0, denominatorComplete: 0, uploading: false });
     };
 
+    getUploadingText(percentComplete) {
+        if (percentComplete === 0) {
+            return 'preparing...';
+        }
+        if (percentComplete === 100) {
+            return 'finalizing...';
+        }
+        return `${percentComplete}% uploaded`;
+    }
+
     render() {
         const { classes } = this.props;
         const { percentComplete, uploading } = this.state;
+        const uploadingText = this.getUploadingText(percentComplete);
 
         return (
             <React.Fragment>
@@ -244,7 +255,7 @@ class NewUpload extends React.Component<{
                         className={classes.progress}
                         variant='determinate'
                         value={percentComplete}
-                        text={`${percentComplete}% uploaded`}
+                        text={uploadingText}
                         styles={buildStyles({
                             textSize: '12px',
                         })}


### PR DESCRIPTION
### Reasons for making this change

It can be confusing to a user if upload UI hangs at `0%` or `100%`. This is not really an issue with small files, but can happen if the user is trying to upload a large file.

This change adds a `preparing` and `finalizing` indicator to the upload progress UI.

### Related issues

https://github.com/codalab/codalab-worksheets/issues/4137
https://github.com/codalab/codalab-worksheets/issues/4177

### Screenshots

#### Before (prod)

https://user-images.githubusercontent.com/25855750/189028802-e2cb20cc-fbce-4e98-b7a2-03a718bfc467.mp4

#### After (local)

https://user-images.githubusercontent.com/25855750/189028821-5d0e3eec-17b0-4e45-a5ef-d72b1b49c9af.mp4

### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [ ] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [ ] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
