### PR TITLE
Enable bundle permissions UI to update in real-time

### DIFF
--- a/frontend/src/components/worksheets/BundleDetail/BundleDetail.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/BundleDetail.jsx
@@ -99,10 +99,10 @@ const BundleDetail = ({
             include: 'owner,group_permissions,host_worksheets',
         }).toString();
 
-    const { dataMetadata, errorMetadata, mutateMetadata } = useSWR(urlMetadata, fetcherMetadata, {
+    const { mutate: mutateMetadata } = useSWR(urlMetadata, fetcherMetadata, {
         revalidateOnMount: true,
         refreshInterval: refreshInterval,
-        onSuccess: (response, key, config) => {
+        onSuccess: (response) => {
             // Normalize JSON API doc into simpler object
             const bundleInfo = new JsonApiDataStore().sync(response);
             bundleInfo.editableMetadataFields = response.data.meta.editable_metadata_keys;
@@ -234,7 +234,7 @@ const BundleDetail = ({
                 <BundleDetailSideBar
                     bundleInfo={bundleInfo}
                     onUpdate={onUpdate}
-                    onMetaDataChange={mutateMetadata}
+                    onMetadataChange={mutateMetadata}
                     expanded={sidebarExpanded}
                     hidePageLink={hideBundlePageLink}
                 />

--- a/frontend/src/components/worksheets/BundleDetail/BundleDetailSideBar.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/BundleDetailSideBar.jsx
@@ -48,7 +48,7 @@ class BundleDetailSideBar extends React.Component {
     }
 
     render() {
-        const { bundleInfo, classes, hidePageLink, onUpdate, onMetaDataChange } = this.props;
+        const { bundleInfo, classes, hidePageLink, onUpdate, onMetadataChange } = this.props;
         const { expandPermissons, showMoreDetail } = this.state;
         const bundle = formatBundle(bundleInfo);
         const bundleType = bundle.bundle_type.value;
@@ -111,7 +111,7 @@ class BundleDetailSideBar extends React.Component {
                             <BundlePermissions
                                 bundleInfo={bundleInfo}
                                 onClick={() => this.toggleExpandPermissions()}
-                                onChange={onMetaDataChange || function() {}}
+                                onChange={onMetadataChange}
                                 showDialog={expandPermissons}
                             />
                         }


### PR DESCRIPTION
### Reasons for making this change

This change fixes the `mutateMetadata` function that is being passed into `BundleDetail`. The permissions components rely on `mutateMetadata` in order to update permissions UI in real-time (see screen recording below).

### Related issues

https://github.com/codalab/codalab-worksheets/issues/4206

### Screenshots

#### Before (prod)

https://user-images.githubusercontent.com/25855750/189242601-e45c3fde-8d57-4fb6-aca8-98b431605402.mp4

#### After (local)

https://user-images.githubusercontent.com/25855750/189242591-5a85ab99-8b05-44ba-a736-cf0a87fc3519.mp4

### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [ ] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [ ] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
