### PR TITLE
DO NOT MERGE

### DIFF
--- a/docs/CLI-Reference.md
+++ b/docs/CLI-Reference.md
@@ -100,6 +100,12 @@ Usage: `cl <command> <arguments>`
       -n, --index           Specifies which occurrence (1, 2, ...) of the bundle to detach, counting from the end.
       -w, --worksheet-spec  Operate on this worksheet ([(<alias>|<address>)::](<uuid>|<name>)).
 
+### ancestors (a)
+    Print bundle ancestors. Multiple bundles can be provided and will have ancestors printed separately.
+    Arguments:
+      bundle_spec           [[(<alias>|<address>)::](<uuid>|<name>)//](<uuid>|<name>|^<index>)
+      -w, --worksheet-spec  Operate on this worksheet ([(<alias>|<address>)::](<uuid>|<name>)).
+
 ### rm
     Remove a bundle (permanent!).
     Arguments:

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1300,6 +1300,16 @@ def test_binary(ctx):
     _run_command([cl, 'info', '--verbose', uuid])
 
 
+@TestModule.register('ancestors')
+def test_ancestors(ctx):
+    uuid_a = _run_command([cl, 'upload', test_path('a.txt')])
+    uuid_b = _run_command([cl, 'upload', test_path('b.txt')])
+    uuid_cl_run = _run_command([cl, 'run', f':{uuid_a}', f':{uuid_b}', 'echo hello'])
+
+    expected = f"-run-echo({uuid_cl_run})\n" f"  -{'a.txt'}({uuid_a})\n" f"  -{'b.txt'}({uuid_b})"
+    check_equals(expected, _run_command([cl, 'ancestors', uuid_cl_run]))
+
+
 @TestModule.register('rm')
 def test_rm(ctx):
     uuid = _run_command([cl, 'upload', test_path('a.txt')])


### PR DESCRIPTION
Adds a new command to the CLI that prints out the name and UUID of the current bundle and its ancestors in the bundle dependency graph.

### Reasons for making this change

Users want an easy way to view the bundle dependency graph through the CLI.

### Related issues

This is a takehome assignment that is referenced [here](https://gist.github.com/percyliang/5bf88a5c054b9689b61c79b81bd16ff4).

### Checklist

* [x ] I've added a screenshot of the changes, if this is a frontend change
* [x ] I've added and/or updated tests, if this is a backend change
* [x ] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x ] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
