### PR TITLE
Bump version to 1.5.9

### DIFF
--- a/codalab/common.py
+++ b/codalab/common.py
@@ -29,7 +29,7 @@ from codalab.lib.beam.filesystems import (
 
 # Increment this on master when ready to cut a release.
 # http://semver.org/
-CODALAB_VERSION = '1.5.8'
+CODALAB_VERSION = '1.5.9'
 BINARY_PLACEHOLDER = '<binary>'
 URLOPEN_TIMEOUT_SECONDS = int(os.environ.get('CODALAB_URLOPEN_TIMEOUT_SECONDS', 5 * 60))
 

--- a/docs/REST-API-Reference.md
+++ b/docs/REST-API-Reference.md
@@ -1,6 +1,6 @@
 # REST API Reference
 
-_version 1.5.8_
+_version 1.5.9_
 
 This reference and the REST API itself is still under heavy development and is
 subject to change at any time. Feedback through our GitHub issues is appreciated!

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -1,5 +1,5 @@
 // Should match codalab/common.py#CODALAB_VERSION
-export const CODALAB_VERSION = '1.5.8';
+export const CODALAB_VERSION = '1.5.9';
 
 // Name Regex to match the backend in spec_utils.py
 export const NAME_REGEX = /^[a-zA-Z_][a-zA-Z0-9_.-]*$/i;

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import sys
 
 
 # should match codalab/common.py#CODALAB_VERSION
-CODALAB_VERSION = "1.5.8"
+CODALAB_VERSION = "1.5.9"
 
 
 class Install(install):


### PR DESCRIPTION
## Frontend
- Show error message for private bundles. (#4241)
- Remove min-height from worksheet content area (#4244) 
- Simplify isLoading logic in MainContent component (#4243)
- Add preparing and finalizing text to upload progress. (#4248)
- Fix mutateMetadata. (#4249)
- Sync bundle row state and bundle detail state (#4246) 
- Prevent worksheet reloads during command execution. (#4253)
- Add error handling for editable bundle fields. (#4254)
- Disable editing for certain fields once bundle reaches starting state (#4252)
- Improve bundle view responsiveness. (#4260)
- Only show [uploaded] summary for dataset bundles that are ready. (#4247)

## Backend
- Fix staged_status and add it to bundle state details (#4242)
- Bypass server upload for GCS (#4119)

## Dev
- Use minikube instead of kind for local k8s (#4214)

## Full Changelog 
https://github.com/codalab/codalab-worksheets/compare/v1.5.7...rc1.5.9