### PR TITLE
Improve bundle view responsiveness.

### DIFF
--- a/frontend/src/components/CodeSnippet.jsx
+++ b/frontend/src/components/CodeSnippet.jsx
@@ -22,7 +22,7 @@ class CodeSnippet extends React.Component {
         return (
             <Grid item xs={12}>
                 <div className={classes.snippet} style={{ maxHeight, marginBottom }}>
-                    <div>{code}</div>
+                    <div className={classes.codeContainer}>{code}</div>
                     {copyMessage && <Copy message={copyMessage} text={code} />}
                     {href && <NewWindowLink href={href} />}
                 </div>
@@ -36,11 +36,16 @@ const styles = (theme) => ({
         display: 'flex',
         justifyContent: 'space-between',
         fontFamily: 'monospace',
+        fontSize: 14,
         padding: 10,
         flexShrink: 1,
         overflow: 'auto',
+        overflowWrap: 'anywhere',
         whiteSpace: 'pre-wrap',
         backgroundColor: theme.color.grey.lightest,
+    },
+    codeContainer: {
+        paddingRight: 10,
     },
 });
 

--- a/frontend/src/components/Copy/index.jsx
+++ b/frontend/src/components/Copy/index.jsx
@@ -38,7 +38,7 @@ class Copy extends React.Component {
     );
 
     render() {
-        const { classes, message, text } = this.props;
+        const { classes, message, text, style } = this.props;
         if (!message || !text) {
             return null;
         }
@@ -46,7 +46,11 @@ class Copy extends React.Component {
         return (
             <>
                 <CopyToClipboard text={text}>
-                    <div className={classes.copyIconContainer} onClick={this.handleOpenSnackbar}>
+                    <div
+                        className={classes.copyIconContainer}
+                        style={style}
+                        onClick={this.handleOpenSnackbar}
+                    >
                         <CopyIcon />
                     </div>
                 </CopyToClipboard>
@@ -67,7 +71,6 @@ const styles = () => ({
     copyIconContainer: {
         width: 12,
         minWidth: 12,
-        marginLeft: 10,
         cursor: 'pointer',
     },
     snackbar: {

--- a/frontend/src/components/worksheets/BundleDetail/BundleFieldTable/BundleFieldRow.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/BundleFieldTable/BundleFieldRow.jsx
@@ -69,7 +69,13 @@ class BundleFieldRow extends React.Component {
                             <Typography noWrap={noWrap} classes={{ root: valueClass }}>
                                 {value}
                             </Typography>
-                            {allowCopy && <Copy message={`${label} Copied!`} text={value} />}
+                            {allowCopy && (
+                                <Copy
+                                    style={{ marginLeft: 10 }}
+                                    message={`${label} Copied!`}
+                                    text={value}
+                                />
+                            )}
                         </div>
                     )}
                 </td>

--- a/frontend/src/components/worksheets/ConfigPanel/ConfigPanel.jsx
+++ b/frontend/src/components/worksheets/ConfigPanel/ConfigPanel.jsx
@@ -73,6 +73,9 @@ const styles = (theme) => ({
         flexGrow: 1,
         flexWrap: 'nowrap',
         maxWidth: '100%',
+        [theme.breakpoints.down('sm')]: {
+            flexDirection: 'column',
+        },
     },
     content: {
         justifyContent: 'flex-start',
@@ -82,6 +85,11 @@ const styles = (theme) => ({
         overflow: 'auto',
         flexGrow: 1,
         maxWidth: '90%',
+        [theme.breakpoints.down('sm')]: {
+            order: 2,
+            maxWidth: 'none',
+            width: '100%',
+        },
     },
     sidebar: {
         backgroundColor: theme.color.grey.lighter,
@@ -90,6 +98,11 @@ const styles = (theme) => ({
         overflow: 'auto',
         minWidth: '400px',
         flexGrow: 1,
+        [theme.breakpoints.down('sm')]: {
+            order: 1,
+            minWidth: 'none',
+            width: '100%',
+        },
     },
     buttons: {
         '& button': {


### PR DESCRIPTION
### Reasons for making this change

Unwanted horizontal scrolling can be observed when bundle content (like command, stdout, stderr, etc) has long lines (see sample screen recording below). This change prevents that unwanted scrolling. 

I have also added css that collapses the bundle view at the `600px` breakpoint, ordering the bundle sidebar above the bundle content. This prevents the bundle view from becoming squished.

### Related issues

https://github.com/codalab/codalab-worksheets/issues/4216

### Screenshots

#### Before [prod]

https://user-images.githubusercontent.com/25855750/192422773-b58eec00-0a83-4bfe-9464-cd1b094b8184.mp4

#### After [local]

https://user-images.githubusercontent.com/25855750/192422788-13d3823f-b2c1-4d6c-a028-dff6ab90e09a.mp4

### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [ ] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [ ] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
