### PR TITLE
Add ANSI coloring to stdout on frontend.

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3949,6 +3949,11 @@
       "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
       "dev": true
     },
+    "anser": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/anser/-/anser-1.4.10.tgz",
+      "integrity": "sha512-hCv9AqTQ8ycjpSd3upOJd7vFwW1JaoYQ7tpham03GJ1ca8/65rqn0RpaWpItOAd6ylW9wAw6luXYPJIyPFVOww=="
+    },
     "ansi-colors": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
@@ -3979,6 +3984,15 @@
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "requires": {
         "color-convert": "^1.9.0"
+      }
+    },
+    "ansi-to-react": {
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/ansi-to-react/-/ansi-to-react-6.1.6.tgz",
+      "integrity": "sha512-+HWn72GKydtupxX9TORBedqOMsJRiKTqaLUKW8txSBZw9iBpzPKLI8KOu4WzwD4R7hSv1zEspobY6LwlWvwZ6Q==",
+      "requires": {
+        "anser": "^1.4.1",
+        "escape-carriage": "^1.3.0"
       }
     },
     "anymatch": {
@@ -7425,6 +7439,11 @@
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.0.2.tgz",
       "integrity": "sha512-gPYAU37hYCUhW5euPeR+Y74F7BL+IBsV93j5cvGriSaD1aG6MGsqsV1yamRdrWrb2j3aiZvb0X+UBOWpx3JWtQ==",
       "dev": true
+    },
+    "escape-carriage": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/escape-carriage/-/escape-carriage-1.3.0.tgz",
+      "integrity": "sha512-ATWi5MD8QlAGQOeMgI8zTp671BG8aKvAC0M7yenlxU4CRLGO/sKthxVUyjiOFKjHdIo+6dZZUNFgHFeVEaKfGQ=="
     },
     "escape-html": {
       "version": "1.0.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "@material-ui/icons": "^3.0.2",
     "@material-ui/styles": "^4.11.2",
     "@sentry/react": "^6.3.5",
+    "ansi-to-react": "^6.1.6",
     "await-semaphore": "^0.1.3",
     "axios": "^0.21.2",
     "bootstrap": "^3.4.1",

--- a/frontend/src/components/CodeSnippet.jsx
+++ b/frontend/src/components/CodeSnippet.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Ansi from 'ansi-to-react';
 import { withStyles } from '@material-ui/core/styles';
 import Grid from '@material-ui/core/Grid';
 import Copy from './Copy';
@@ -19,19 +20,22 @@ class CodeSnippet extends React.Component {
         const { classes, code, copyMessage, expanded, href } = this.props;
         const maxHeight = expanded ? 'none' : 300;
         const marginBottom = this.props.noMargin ? 0 : 16;
+
         return (
             <Grid item xs={12}>
                 <div className={classes.snippet} style={{ maxHeight, marginBottom }}>
-                    <div className={classes.codeContainer}>{code}</div>
-                    {copyMessage && <Copy message={copyMessage} text={code} />}
-                    {href && <NewWindowLink href={href} />}
+                    <div className={classes.codeContainer}>
+                        <Ansi>{code}</Ansi>
+                    </div>
+                    {copyMessage && <Copy message={copyMessage} text={code} fill='white' />}
+                    {href && <NewWindowLink style={{ color: 'white' }} href={href} />}
                 </div>
             </Grid>
         );
     }
 }
 
-const styles = (theme) => ({
+const styles = () => ({
     snippet: {
         display: 'flex',
         justifyContent: 'space-between',
@@ -39,13 +43,16 @@ const styles = (theme) => ({
         fontSize: 14,
         padding: 10,
         flexShrink: 1,
-        overflow: 'auto',
-        overflowWrap: 'anywhere',
         whiteSpace: 'pre-wrap',
-        backgroundColor: theme.color.grey.lightest,
+        borderRadius: '4px',
+        backgroundColor: 'black',
+        opacity: '0.80',
     },
     codeContainer: {
         paddingRight: 10,
+        overflow: 'auto',
+        overflowWrap: 'anywhere',
+        color: 'white',
     },
 });
 

--- a/frontend/src/components/Copy/index.jsx
+++ b/frontend/src/components/Copy/index.jsx
@@ -38,7 +38,7 @@ class Copy extends React.Component {
     );
 
     render() {
-        const { classes, message, text, style } = this.props;
+        const { classes, fill, message, text, style } = this.props;
         if (!message || !text) {
             return null;
         }
@@ -51,7 +51,7 @@ class Copy extends React.Component {
                         style={style}
                         onClick={this.handleOpenSnackbar}
                     >
-                        <CopyIcon />
+                        <CopyIcon fill={fill} />
                     </div>
                 </CopyToClipboard>
                 <Snackbar

--- a/frontend/src/components/NewWindowLink.jsx
+++ b/frontend/src/components/NewWindowLink.jsx
@@ -12,14 +12,15 @@ class NewWindowLink extends React.Component {
     }
 
     render() {
-        const { classes, className, href } = this.props;
+        const { classes, href, style } = this.props;
 
         if (!href) {
             return null;
         }
         return (
             <a
-                className={`${classes.link} ${className}`}
+                className={classes.link}
+                style={style}
                 href={href}
                 target='_blank'
                 rel='noopener noreferrer'

--- a/frontend/src/components/worksheets/BundleDetail/BundleDetailSideBar.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/BundleDetailSideBar.jsx
@@ -52,7 +52,10 @@ class BundleDetailSideBar extends React.Component {
         return (
             <div className={classes.sidebar}>
                 {showPageLink && (
-                    <NewWindowLink className={classes.pageLink} href={`/bundles/${uuid}`} />
+                    <NewWindowLink
+                        style={{ position: 'absolute', right: -1 }}
+                        href={`/bundles/${uuid}`}
+                    />
                 )}
                 <BundleFieldTable>
                     <BundleStateRow bundle={bundle} />
@@ -265,10 +268,6 @@ class BundleDetailSideBar extends React.Component {
 const styles = () => ({
     sidebar: {
         position: 'relative',
-    },
-    pageLink: {
-        position: 'absolute',
-        right: -1,
     },
     collapseBtn: {
         marginTop: 5,

--- a/frontend/src/components/worksheets/BundleDetail/MainContent.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/MainContent.jsx
@@ -76,7 +76,7 @@ class MainContent extends React.Component<{
                 <Grid container>
                     {/** Failure components ================================================================= */}
                     {failureMessage && (
-                        <Grid classes={{ container: classes.failureContainer }} container>
+                        <Grid container>
                             <CollapseButton
                                 label='Failure Message'
                                 collapsed={this.state.showFailureMessage}
@@ -179,12 +179,9 @@ class MainContent extends React.Component<{
     }
 }
 
-const styles = (theme) => ({
+const styles = () => ({
     outter: {
         flex: 1,
-    },
-    failureContainer: {
-        color: theme.color.red.base,
     },
 });
 

--- a/frontend/src/css/overrides.scss
+++ b/frontend/src/css/overrides.scss
@@ -35,3 +35,13 @@ iframe {
 .ui.category.search > .results .category > .name {
     font-family: 'Roboto', 'Helvetica Neue', sans-serif !important;
 }
+
+// override ansi-to-react styles
+code {
+    color: inherit;
+    font-family: inherit;
+    font-size: inherit;
+    background: transparent;
+    padding: 0;
+    border-radius: 0;
+}


### PR DESCRIPTION
### Reasons for making this change

If ANSI colors are included in stdout or stderr, we should apply those colors to the stderr / stdout string. This will make stdout / stderr easier to read in the web view.

### Related issues

https://github.com/codalab/codalab-worksheets/issues/4180

### Screenshots

##### Before Change

![Screen Shot 2022-10-04 at 8 16 35 PM](https://user-images.githubusercontent.com/25855750/193973532-0281f8a2-4ff0-40f6-97ff-a22968e56bef.png)

##### After Change

![Screen Shot 2022-10-04 at 8 16 02 PM](https://user-images.githubusercontent.com/25855750/193973515-99195fc7-c4c4-4eef-ac9b-d36c7820c5c7.png)

### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [ ] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [ ] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
