### PR TITLE
Provide download link for bundles.

### DIFF
--- a/frontend/src/components/DownloadLink.jsx
+++ b/frontend/src/components/DownloadLink.jsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import { withStyles } from '@material-ui/core';
+import Link from '@material-ui/core/Link';
+
+class DownloadLink extends React.Component {
+    constructor(props) {
+        super(props);
+    }
+
+    render() {
+        const { classes, href } = this.props;
+        return (
+            <Link classes={{ root: classes.downloadLink }} href={href}>
+                <span className='glyphicon glyphicon-download-alt' />
+            </Link>
+        );
+    }
+}
+
+const styles = (theme) => ({
+    downloadLink: {
+        display: 'inline-block',
+        padding: '8px 11px',
+        fontSize: 14,
+        border: '1px solid rgba(49, 131, 200, 0.5)',
+        borderRadius: '4px',
+        color: theme.color.primary.base,
+        transition:
+            'background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms', // mimic MUI button transition
+        '&:hover': {
+            color: theme.color.primary.base, // override defaults
+            border: `1px solid ${theme.color.primary.base}`,
+            backgroundColor: 'rgba(49, 131, 200, 0.08)',
+            textDecoration: 'none',
+        },
+        '&:focus': {
+            color: theme.color.primary.base, // override defaults
+        },
+    },
+});
+
+export default withStyles(styles)(DownloadLink);

--- a/frontend/src/components/worksheets/BundleDetail/BundleActions.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/BundleActions.jsx
@@ -5,6 +5,7 @@ import IconButton from '@material-ui/core/IconButton';
 import CloseIcon from '@material-ui/icons/Close';
 import Button from '@material-ui/core/Button';
 import Snackbar from '@material-ui/core/Snackbar';
+import DownloadLink from '../../DownloadLink';
 import { buildTerminalCommand } from '../../../util/worksheet_utils';
 import { executeCommand } from '../../../util/apiWrapper';
 
@@ -96,9 +97,10 @@ class BundleActions extends React.Component<{
             state !== 'starting' &&
             state !== 'created' &&
             state !== 'staged';
+        const showDownloadLink = isRunBundle ? isDownloadableRunBundle : true;
 
         return (
-            <div>
+            <div className={classes.ctaContainer}>
                 {isRunBundle && editPermission && (
                     <>
                         <Snackbar
@@ -117,35 +119,31 @@ class BundleActions extends React.Component<{
                         >
                             Kill
                         </Button>
-                        <Button variant='contained' color='primary' onClick={this.rerun}>
+                        <Button
+                            classes={{ root: classes.rerunButton }}
+                            variant='contained'
+                            color='primary'
+                            onClick={this.rerun}
+                        >
                             Rerun
                         </Button>
                     </>
                 )}
-                <Button
-                    classes={{ root: classes.downloadButton }}
-                    style={!isRunBundle || !editPermission ? { marginLeft: 0 } : {}}
-                    disabled={isRunBundle ? !isDownloadableRunBundle : false}
-                    variant='outlined'
-                    color='primary'
-                    onClick={() => {
-                        window.open(bundleDownloadUrl, '_blank');
-                    }}
-                >
-                    <span className='glyphicon glyphicon-download-alt' />
-                </Button>
+                {showDownloadLink && <DownloadLink href={bundleDownloadUrl} />}
             </div>
         );
     }
 }
 
 const styles = () => ({
+    ctaContainer: {
+        display: 'flex',
+    },
     killButton: {
         minWidth: 50,
     },
-    downloadButton: {
-        minWidth: 'auto',
-        padding: '10px 11px',
+    rerunButton: {
+        marginRight: 14,
     },
     snackbar: {
         marginBottom: 40,


### PR DESCRIPTION
### Reasons for making this change

Currently when you right-click the bundle download button, there is no option to copy the bundle download URL. This feature would be useful for people who want to download a bundle programmatically for whatever reason.

This change updates the bundle download button to be an `a` tag under the hood (as opposed to a `button` tag) which enables the right-click -> copy url functionality.

### Related issues

https://github.com/codalab/codalab-worksheets/issues/4262

### Screenshots

#### Right-Click Before

![Screen Shot 2022-10-11 at 7 33 55 PM](https://user-images.githubusercontent.com/25855750/195236054-de8f5569-9b4a-441b-b735-4b8fbbdfab84.png)

#### Right-Click After

![Screen Shot 2022-10-11 at 7 33 09 PM](https://user-images.githubusercontent.com/25855750/195235980-14c9b858-3346-49c4-b19f-bf5b9bf4398c.png)

### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [ ] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [ ] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
