### PR TITLE
Replace google.com with recaptcha.net

### DIFF
--- a/codalab/rest/account.py
+++ b/codalab/rest/account.py
@@ -78,6 +78,7 @@ def do_signup():
     if not token:
         errors.append('Google reCAPTCHA token is missing.')
     else:
+        # URL from https://developers.google.com/recaptcha/docs/faq#can-i-use-recaptcha-globally
         url = 'https://www.recaptcha.net/recaptcha/api/siteverify'
         data = {
             'secret': os.environ['CODALAB_RECAPTCHA_SECRET_KEY'],

--- a/codalab/rest/account.py
+++ b/codalab/rest/account.py
@@ -78,7 +78,7 @@ def do_signup():
     if not token:
         errors.append('Google reCAPTCHA token is missing.')
     else:
-        url = 'https://www.google.com/recaptcha/api/siteverify'
+        url = 'https://www.recaptcha.net/recaptcha/api/siteverify'
         data = {
             'secret': os.environ['CODALAB_RECAPTCHA_SECRET_KEY'],
             'response': token,

--- a/frontend/src/components/SignUp.js
+++ b/frontend/src/components/SignUp.js
@@ -5,6 +5,13 @@ import ContentWrapper from './ContentWrapper';
 import queryString from 'query-string';
 import ReCAPTCHA from 'react-google-recaptcha';
 
+// Set global properties used by reCaptcha
+// See: https://www.npmjs.com/package/react-google-recaptcha#global-properties-used-by-recaptcha
+window.recaptchaOptions = {
+    // Use recaptcha.net to avoid blocks on google.com
+    useRecaptchaNet: true,
+};
+
 export const SignUpSuccess = (props) => {
     const { email } = queryString.parse(props.location.search);
     return (


### PR DESCRIPTION
### Reasons for making this change

This allows reCaptcha to be usable from within China. Refer to the [reCaptcha documentation](https://developers.google.com/recaptcha/docs/faq#can-i-use-recaptcha-globally).

### Related issues

- Addresses #3698
- Addresses #4278 

### Screenshots

Accounts page is unchanged.

### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
