### PR TITLE
Bump version to 1.5.11

### DIFF
--- a/codalab/common.py
+++ b/codalab/common.py
@@ -29,7 +29,7 @@ from codalab.lib.beam.filesystems import (
 
 # Increment this on master when ready to cut a release.
 # http://semver.org/
-CODALAB_VERSION = '1.5.9'
+CODALAB_VERSION = '1.5.11'
 BINARY_PLACEHOLDER = '<binary>'
 URLOPEN_TIMEOUT_SECONDS = int(os.environ.get('CODALAB_URLOPEN_TIMEOUT_SECONDS', 5 * 60))
 

--- a/docs/REST-API-Reference.md
+++ b/docs/REST-API-Reference.md
@@ -1,6 +1,6 @@
 # REST API Reference
 
-_version 1.5.9_
+_version 1.5.11_
 
 This reference and the REST API itself is still under heavy development and is
 subject to change at any time. Feedback through our GitHub issues is appreciated!

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -1,5 +1,5 @@
 // Should match codalab/common.py#CODALAB_VERSION
-export const CODALAB_VERSION = '1.5.9';
+export const CODALAB_VERSION = '1.5.11';
 
 // Name Regex to match the backend in spec_utils.py
 export const NAME_REGEX = /^[a-zA-Z_][a-zA-Z0-9_.-]*$/i;

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import sys
 
 
 # should match codalab/common.py#CODALAB_VERSION
-CODALAB_VERSION = "1.5.9"
+CODALAB_VERSION = "1.5.11"
 
 
 class Install(install):


### PR DESCRIPTION
## Frontend
-  Provide download link for bundles. (https://github.com/codalab/codalab-worksheets/pull/4281)
-  Allow users to bulk-select all bundles in a table in worksheet view (#4289)
## Backend
-  Fix/4196 speed up search bundles (https://github.com/codalab/codalab-worksheets/pull/4273)(https://github.com/codalab/codalab-worksheets/commit/efd99ac7789af8b09ab15586808e6c0d7a250109)
- Fix Azure bypass-server upload to Azure timeout issue (https://github.com/codalab/codalab-worksheets/pull/4275)
- adding changes to check time quota for running jobs. (#4283)
## Dev
- Test installing codalab CLI on mac as well (https://github.com/codalab/codalab-worksheets/pull/4270)
- Add time quota request form in documentations (#4296)