### PR TITLE
Allow users to bulk-select all bundles in a table in worksheet view

### DIFF
--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -237,10 +237,7 @@ class Worksheet extends React.Component {
             ) {
                 return;
             }
-            if (!(uuid in bundlesCount)) {
-                bundlesCount[uuid] = 0;
-            }
-            bundlesCount[uuid] += 1;
+            bundlesCount[uuid] = 1;
             let checkedBundles = this.state.checkedBundles;
             if (!(uuid in checkedBundles)) {
                 checkedBundles[uuid] = {};
@@ -262,7 +259,7 @@ class Worksheet extends React.Component {
             ) {
                 return;
             }
-            if (this.state.uuidBundlesCheckedCount[uuid] >= 1) {
+            if (this.state.uuidBundlesCheckedCount[uuid] === 1) {
                 delete this.state.uuidBundlesCheckedCount[uuid];
                 delete this.state.checkedBundles[uuid];
             } else {

--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -262,7 +262,7 @@ class Worksheet extends React.Component {
             ) {
                 return;
             }
-            if (this.state.uuidBundlesCheckedCount[uuid] === 1) {
+            if (this.state.uuidBundlesCheckedCount[uuid] >= 1) {
                 delete this.state.uuidBundlesCheckedCount[uuid];
                 delete this.state.checkedBundles[uuid];
             } else {

--- a/frontend/src/components/worksheets/items/TableItem/TableItem.js
+++ b/frontend/src/components/worksheets/items/TableItem/TableItem.js
@@ -42,7 +42,7 @@ class TableItem extends React.Component<{
             indeterminateCheckState: false,
             curSchemaNames: this.props.item.using_schemas.join(' '),
             openSchemaTextBox: false,
-            tableSelected: false,
+            tableIsSelected: false,
         };
         this.copyCheckedBundleRows = this.copyCheckedBundleRows.bind(this);
         this.showCheckedBundleRowsContents = this.showCheckedBundleRowsContents.bind(this);
@@ -61,6 +61,7 @@ class TableItem extends React.Component<{
             childrenCheckState: childrenStatus,
             indeterminateCheckState: false,
             checked: false,
+            tableIsSelected: false,
         });
     };
 
@@ -137,10 +138,10 @@ class TableItem extends React.Component<{
 
     toggleTableSelect = () => {
         const bundles = this.props.item.bundles_spec.bundle_infos;
-        const tableSelected = !this.state.tableSelected;
+        const tableIsSelected = !this.state.tableIsSelected;
 
         // update the table checkbox state
-        this.setState({ tableSelected });
+        this.setState({ tableIsSelected });
 
         // update the checkbox state for each bundle row
         bundles.forEach((bundle, i) => {
@@ -148,10 +149,10 @@ class TableItem extends React.Component<{
             this.props.handleCheckBundle(
                 bundle.uuid,
                 identifier,
-                tableSelected,
+                tableIsSelected,
                 this.refreshCheckBox,
             );
-            this.childrenCheck(i, tableSelected);
+            this.childrenCheck(i, tableIsSelected);
         });
     };
 
@@ -213,7 +214,7 @@ class TableItem extends React.Component<{
                                 checkedIcon={<CheckBoxIcon fontSize='small' />}
                                 classes={{ root: classes.tableCheckbox }}
                                 onChange={this.toggleTableSelect}
-                                checked={this.state.tableSelected}
+                                checked={this.state.tableIsSelected}
                             />
                             <Tooltip title={'Change the schemas of this table'}>
                                 <IconButton>
@@ -256,7 +257,7 @@ class TableItem extends React.Component<{
                     worksheetUUID={worksheetUUID}
                     item={rowItem}
                     rowIndex={rowIndex}
-                    focused={this.state.tableSelected || rowFocused}
+                    focused={this.state.tableIsSelected || rowFocused}
                     focusIndex={this.props.focusIndex}
                     setFocus={setFocus}
                     showNewRerun={this.props.showNewRerun}

--- a/frontend/src/components/worksheets/items/TableItem/TableItem.js
+++ b/frontend/src/components/worksheets/items/TableItem/TableItem.js
@@ -145,7 +145,7 @@ class TableItem extends React.Component<{
 
         // update the checkbox state for each bundle row
         bundles.forEach((bundle, i) => {
-            const identifier = Math.random() * 10000;
+            const identifier = Math.random() * 10000; // see handleCheckBundle() for identifier implementation details
             this.props.handleCheckBundle(
                 bundle.uuid,
                 identifier,

--- a/frontend/src/components/worksheets/items/TableItem/TableItem.js
+++ b/frontend/src/components/worksheets/items/TableItem/TableItem.js
@@ -2,6 +2,9 @@
 import React, { useEffect } from 'react';
 import classNames from 'classnames';
 import { withStyles } from '@material-ui/core';
+import Checkbox from '@material-ui/core/Checkbox';
+import CheckBoxOutlineBlankIcon from '@material-ui/icons/CheckBoxOutlineBlank';
+import CheckBoxIcon from '@material-ui/icons/CheckBox';
 import Table from '@material-ui/core/Table';
 import TableHead from '@material-ui/core/TableHead';
 import TableCell from './TableCell';
@@ -39,6 +42,7 @@ class TableItem extends React.Component<{
             indeterminateCheckState: false,
             curSchemaNames: this.props.item.using_schemas.join(' '),
             openSchemaTextBox: false,
+            tableSelected: false,
         };
         this.copyCheckedBundleRows = this.copyCheckedBundleRows.bind(this);
         this.showCheckedBundleRowsContents = this.showCheckedBundleRowsContents.bind(this);
@@ -131,6 +135,26 @@ class TableItem extends React.Component<{
         });
     };
 
+    toggleTableSelect = () => {
+        const bundles = this.props.item.bundles_spec.bundle_infos;
+        const tableSelected = !this.state.tableSelected;
+
+        // update the table checkbox state
+        this.setState({ tableSelected });
+
+        // update the checkbox state for each bundle row
+        bundles.forEach((bundle, i) => {
+            const identifier = Math.random() * 10000;
+            this.props.handleCheckBundle(
+                bundle.uuid,
+                identifier,
+                tableSelected,
+                this.refreshCheckBox,
+            );
+            this.childrenCheck(i, tableSelected);
+        });
+    };
+
     // BULK OPERATION RELATED CODE ABOVE
 
     updateRowIndex = (rowIndex) => {
@@ -150,6 +174,7 @@ class TableItem extends React.Component<{
             this.showCheckedBundleRowsContents,
         );
         let tableClassName = this.props.focused ? 'table focused' : 'table';
+        let checkboxVariant = this.props.focused || this.state.hovered ? 'action' : 'disabled';
         let item = this.props.item;
         let bundleInfos = item.bundles_spec.bundle_infos;
         let headerItems = item.header;
@@ -169,7 +194,7 @@ class TableItem extends React.Component<{
                     style={
                         index === 0
                             ? {
-                                  paddingLeft: editPermission ? '30px' : '70px',
+                                  paddingLeft: editPermission ? '6px' : '70px',
                                   paddingBottom: 0,
                                   paddingTop: 0,
                               }
@@ -177,18 +202,32 @@ class TableItem extends React.Component<{
                     }
                 >
                     {editPermission && index === 0 && (
-                        <Tooltip title={'Change the schemas of this table'}>
-                            <IconButton>
-                                <ViewListIcon
-                                    style={{ padding: '0px', height: 15 }}
-                                    onClick={() => {
-                                        this.setState({
-                                            openSchemaTextBox: !this.state.openSchemaTextBox,
-                                        });
-                                    }}
-                                />
-                            </IconButton>
-                        </Tooltip>
+                        <>
+                            <Checkbox
+                                icon={
+                                    <CheckBoxOutlineBlankIcon
+                                        color={checkboxVariant}
+                                        fontSize='small'
+                                    />
+                                }
+                                checkedIcon={<CheckBoxIcon fontSize='small' />}
+                                classes={{ root: classes.tableCheckbox }}
+                                onChange={this.toggleTableSelect}
+                                checked={this.state.tableSelected}
+                            />
+                            <Tooltip title={'Change the schemas of this table'}>
+                                <IconButton>
+                                    <ViewListIcon
+                                        style={{ padding: '0px', height: 15 }}
+                                        onClick={() => {
+                                            this.setState({
+                                                openSchemaTextBox: !this.state.openSchemaTextBox,
+                                            });
+                                        }}
+                                    />
+                                </IconButton>
+                            </Tooltip>
+                        </>
                     )}
                     {item}
                     {showStateTooltip && <BundleStateTooltip />}
@@ -217,7 +256,7 @@ class TableItem extends React.Component<{
                     worksheetUUID={worksheetUUID}
                     item={rowItem}
                     rowIndex={rowIndex}
-                    focused={rowFocused}
+                    focused={this.state.tableSelected || rowFocused}
                     focusIndex={this.props.focusIndex}
                     setFocus={setFocus}
                     showNewRerun={this.props.showNewRerun}
@@ -378,6 +417,9 @@ const styles = () => ({
         zIndex: 1,
         color: '#000000',
         height: 26,
+    },
+    tableCheckbox: {
+        paddingRight: 2,
     },
 });
 


### PR DESCRIPTION
### Reasons for making this change

I create / delete a lot of bundles during development. This feature makes that process easier. (Not sure if regular users need to be able to bulk-delete bundles with ease but it's def a nice feature for development purposes).

### Related issues

https://github.com/codalab/codalab-worksheets/issues/4223

### Screenshots

https://user-images.githubusercontent.com/25855750/197941297-34540cc1-b06a-4674-820c-f19943c9a200.mp4


### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [ ] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [ ] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
