### PR TITLE
Add time quota request form in documentations

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -40,9 +40,11 @@ If you have used up your disk quota and want to reduce your disk usage, here are
 - If you have intermediate bundles whose contents you don't need, you can use `cl rm -d <bundle>` to delete only the contents of the bundle but keep the metadata.  This way, you keep the provenance and can regenerate this bundle in the future.
 - If there are selected files that you wish to keep in a bundle, you can use `cl make <bundle>/<important-file>` to make a new bundle that only has a copy of the desired file and then you can do `cl rm -d <bundle>` to remove all the other files in that bundle.
 
-### How do I request more disk quota?
+### How do I request more disk quota or time quota?
 
-If you have tried the steps above and still need more disk quota, please fill out this [form](https://docs.google.com/forms/d/e/1FAIpQLSdS22MaLyE1kx0JL-w2a8f8IasDyc36H_ZuidNBVAE_afMCpw/viewform).
+If you have tried the steps above and still need more **disk quota**, please fill out this [form](https://docs.google.com/forms/d/e/1FAIpQLSdS22MaLyE1kx0JL-w2a8f8IasDyc36H_ZuidNBVAE_afMCpw/viewform).
+
+If you are running out of **time quota**, please fill out this [form](https://docs.google.com/forms/d/e/1FAIpQLSebCBrglB7z2R7OeHJ_NsVWcUcHVMAW4AQnFxNt0YvTS-rDNA/viewform).
 
 ### How do I upload large bundles?
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -42,9 +42,7 @@ If you have used up your disk quota and want to reduce your disk usage, here are
 
 ### How do I request more disk quota or time quota?
 
-If you have tried the steps above and still need more **disk quota**, please fill out this [form](https://docs.google.com/forms/d/e/1FAIpQLSdS22MaLyE1kx0JL-w2a8f8IasDyc36H_ZuidNBVAE_afMCpw/viewform).
-
-If you are running out of **time quota**, please fill out this [form](https://docs.google.com/forms/d/e/1FAIpQLSebCBrglB7z2R7OeHJ_NsVWcUcHVMAW4AQnFxNt0YvTS-rDNA/viewform).
+If you have tried the steps above and still need more **disk quota** or **time quota**, please fill out this [form](https://docs.google.com/forms/d/e/1FAIpQLSebCBrglB7z2R7OeHJ_NsVWcUcHVMAW4AQnFxNt0YvTS-rDNA/viewform).
 
 ### How do I upload large bundles?
 


### PR DESCRIPTION
### Reasons for making this change
Need to add time quota request form when user run out of time quota.

This google form is created using codalab.worksheets@gmail.com. 
Edit Form: https://docs.google.com/forms/d/18FwwqhQocXu6ph7N0wy2f15Bg7k16EFLy_W_xvSE9Ww/edit
View Form: https://docs.google.com/forms/d/e/1FAIpQLSebCBrglB7z2R7OeHJ_NsVWcUcHVMAW4AQnFxNt0YvTS-rDNA/viewform
Responses: https://docs.google.com/spreadsheets/d/1XTaee-SVBQ9Mb9GXtr5jg3X6GgA4dNz9pvMfP_Nw0fs/edit?resourcekey=undefined#gid=128169651

Will create a new PR in deployment and oncall repo, which will add the link to grant more

### Related issues
#4295 
<!-- Add a reference to issues resolved, if applicable (for example, "fixes #1"). -->

### Screenshots

<!-- Add screenshots, if necessary. If this is a substantial frontend / user flow change, consider recording
a user flow GIF using a tool such as [LICEcap](https://www.cockos.com/licecap/). -->

### Checklist

* [ ] I've added a screenshot of the changes, if this is a frontend change
* [ ] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [ ] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
