### PR TITLE
Add better error message for incorrect worksheet name.

### DIFF
--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -799,7 +799,11 @@ class BundleCLI(object):
                     client, base_worksheet_uuid, parsed_spec
                 )
             except ValueError:
-                raise UsageError('Invalid spec: "{}"'.format(spec))
+                raise UsageError(
+                    "'{}' worksheet could not be found. Use 'cl wls' command to search for worksheets.".format(
+                        spec
+                    )
+                )
         return client, worksheet_uuid
 
     @staticmethod

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -800,7 +800,7 @@ class BundleCLI(object):
                 )
             except ValueError:
                 raise UsageError(
-                    "'{}' worksheet could not be found. Use 'cl wls' command to search for worksheets.".format(
+                    "'{}' worksheet not found. Use the 'cl wls' command to search for worksheets.".format(
                         spec
                     )
                 )

--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -794,16 +794,7 @@ class BundleCLI(object):
                 base_worksheet_uuid = None
             else:
                 _, base_worksheet_uuid = self.manager.get_current_worksheet_uuid()
-            try:
-                worksheet_uuid = self.resolve_worksheet_uuid(
-                    client, base_worksheet_uuid, parsed_spec
-                )
-            except ValueError:
-                raise UsageError(
-                    "'{}' worksheet not found. Use the 'cl wls' command to search for worksheets.".format(
-                        spec
-                    )
-                )
+            worksheet_uuid = self.resolve_worksheet_uuid(client, base_worksheet_uuid, parsed_spec)
         return client, worksheet_uuid
 
     @staticmethod


### PR DESCRIPTION
### Reasons for making this change

This change allows the correct error to surface for users who type in an incorrect password.

Currently the "incorrect password" error is being masked by the CLI.

### Related issues

https://github.com/codalab/codalab-worksheets/issues/4188

### Screenshots

https://user-images.githubusercontent.com/25855750/199907174-4d83efba-9755-4745-863c-0261a9a1a425.mp4

### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [ ] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [ ] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
