### PR TITLE
Automatically reload REST server when file changes are detected

### DIFF
--- a/codalab/bin/server.py
+++ b/codalab/bin/server.py
@@ -35,7 +35,6 @@ class ClFileWatcherEventHandler(FileSystemEventHandler):
 
 def run_server_with_watch():
     modified_argv = list(sys.argv)
-    modified_argv[0] = 'cl'
     modified_argv.remove('--watch')
     event_handler = ClFileWatcherEventHandler(modified_argv)
     # Listen to root dir (/codalab/bin/../../)

--- a/docker_config/compose_files/docker-compose.dev.yml
+++ b/docker_config/compose_files/docker-compose.dev.yml
@@ -11,6 +11,7 @@ services:
     stdin_open: true
     tty: true
   rest-server:
+    command: cl-server --watch
     stdin_open: true
     tty: true
     volumes:

--- a/docs/Server-Setup.md
+++ b/docs/Server-Setup.md
@@ -103,8 +103,8 @@ Start the CodaLab service as follows:
 
     ./codalab_service.py start -bd
 
-If you modify the frontend, you can do so without restarting.  If you would
-like to modify the rest server, bundle manager, or worker, then you can edit
+If you modify the frontend or the rest server, you can do so without restarting.
+If you would like to modify the bundle manager, or worker, then you can edit
 the code and then start only that single Docker container.  For example, for
 the worker, the command would be:
 


### PR DESCRIPTION
### Reasons for making this change

The REST server will automatically reload when file changes are detected when the service is started in development mode i.e. `./codalab_service.py start -bd`. This eliminates the need to restart the REST server manually.

### Related issues

Fixes #1182
Fixes #4199

### Checklist

* [ ] I've added a screenshot of the changes, if this is a frontend change
* [ ] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
