### PR TITLE
Allow edu users to have more time quota and disk quota

### DIFF
--- a/codalab/lib/bundle_store.py
+++ b/codalab/lib/bundle_store.py
@@ -444,9 +444,11 @@ class MultiDiskBundleStore(_MultiDiskBundleStoreBase):
             assert len(bundle_locations) >= 1
         storage_type, is_dir = self._bundle_model.get_bundle_storage_info(uuid)
         import logging
-        logger = logging.getLogger(__name__)
-        logging.info(f"In get_bundle_location_full_info, {storage_type} {is_dir}")# None None
-        
+
+        logging.info(
+            f"In get_bundle_location_full_info, {storage_type} {is_dir} {uuid} {type(self._bundle_model)}"
+        )  # None None
+
         logging.info("bundle_locations: " + str(bundle_locations))
         if len(bundle_locations) >= 1:
             # Use the BundleLocations stored with the bundle, along with some

--- a/codalab/lib/bundle_store.py
+++ b/codalab/lib/bundle_store.py
@@ -443,13 +443,7 @@ class MultiDiskBundleStore(_MultiDiskBundleStoreBase):
         if bundle_store_uuid:
             assert len(bundle_locations) >= 1
         storage_type, is_dir = self._bundle_model.get_bundle_storage_info(uuid)
-        import logging
-
-        logging.info(
-            f"In get_bundle_location_full_info, {storage_type} {is_dir} {uuid} {type(self._bundle_model)}"
-        )  # None None
-
-        logging.info("bundle_locations: " + str(bundle_locations))
+        
         if len(bundle_locations) >= 1:
             # Use the BundleLocations stored with the bundle, along with some
             # precedence rules, to determine where the bundle is stored.

--- a/codalab/lib/bundle_store.py
+++ b/codalab/lib/bundle_store.py
@@ -443,6 +443,11 @@ class MultiDiskBundleStore(_MultiDiskBundleStoreBase):
         if bundle_store_uuid:
             assert len(bundle_locations) >= 1
         storage_type, is_dir = self._bundle_model.get_bundle_storage_info(uuid)
+        import logging
+        logger = logging.getLogger(__name__)
+        logging.info(f"In get_bundle_location_full_info, {storage_type} {is_dir}")# None None
+        
+        logging.info("bundle_locations: " + str(bundle_locations))
         if len(bundle_locations) >= 1:
             # Use the BundleLocations stored with the bundle, along with some
             # precedence rules, to determine where the bundle is stored.

--- a/codalab/lib/bundle_store.py
+++ b/codalab/lib/bundle_store.py
@@ -443,7 +443,7 @@ class MultiDiskBundleStore(_MultiDiskBundleStoreBase):
         if bundle_store_uuid:
             assert len(bundle_locations) >= 1
         storage_type, is_dir = self._bundle_model.get_bundle_storage_info(uuid)
-        
+
         if len(bundle_locations) >= 1:
             # Use the BundleLocations stored with the bundle, along with some
             # precedence rules, to determine where the bundle is stored.

--- a/codalab/lib/codalab_manager.py
+++ b/codalab/lib/codalab_manager.py
@@ -326,11 +326,13 @@ class CodaLabManager(object):
     @cached
     def default_user_info(self):
         info = self.config['server'].get(
-            'default_user_info', {'time_quota': '1y', 'disk_quota': '1t', 'parallel_run_quota': 3}
+            'default_user_info', {'time_quota': '1y', 'disk_quota': '1t', 'edu_time_quota': '1y', 'edu_disk_quota': '1t', 'parallel_run_quota': 3}
         )
         return {
             'time_quota': formatting.parse_duration(info['time_quota']),
             'disk_quota': formatting.parse_size(info['disk_quota']),
+            'edu_time_quota': formatting.parse_duration(info['edu_time_quota']),
+            'edu_disk_quota': formatting.parse_size(info['edu_disk_quota']),
             'parallel_run_quota': info['parallel_run_quota'],
         }
 

--- a/codalab/lib/codalab_manager.py
+++ b/codalab/lib/codalab_manager.py
@@ -326,7 +326,14 @@ class CodaLabManager(object):
     @cached
     def default_user_info(self):
         info = self.config['server'].get(
-            'default_user_info', {'time_quota': '1y', 'disk_quota': '1t', 'edu_time_quota': '1y', 'edu_disk_quota': '1t', 'parallel_run_quota': 3}
+            'default_user_info',
+            {
+                'time_quota': '1y',
+                'disk_quota': '1t',
+                'edu_time_quota': '1y',
+                'edu_disk_quota': '1t',
+                'parallel_run_quota': 3,
+            },
         )
         return {
             'time_quota': formatting.parse_duration(info['time_quota']),

--- a/codalab/lib/upload_manager.py
+++ b/codalab/lib/upload_manager.py
@@ -234,9 +234,6 @@ class BlobStorageUploader(Uploader):
             conn_str = os.environ.get('AZURE_STORAGE_CONNECTION_STRING', '')
             os.environ['AZURE_STORAGE_CONNECTION_STRING'] = bundle_conn_str
         try:
-            import time
-
-            time1 = time.time()
             bytes_uploaded = 0
             CHUNK_SIZE = 16 * 1024
             with FileSystems.create(
@@ -252,8 +249,6 @@ class BlobStorageUploader(Uploader):
                         should_resume = progress_callback(bytes_uploaded)
                         if not should_resume:
                             raise Exception('Upload aborted by client')
-            time2 = time.time()
-            print("upload time: ", time2 - time1)
             with FileSystems.open(
                 bundle_path, compression_type=CompressionTypes.UNCOMPRESSED
             ) as ttf, tempfile.NamedTemporaryFile(suffix=".sqlite") as tmp_index_file:

--- a/codalab/lib/upload_manager.py
+++ b/codalab/lib/upload_manager.py
@@ -234,6 +234,8 @@ class BlobStorageUploader(Uploader):
             conn_str = os.environ.get('AZURE_STORAGE_CONNECTION_STRING', '')
             os.environ['AZURE_STORAGE_CONNECTION_STRING'] = bundle_conn_str
         try:
+            import time
+            time1 = time.time()
             bytes_uploaded = 0
             CHUNK_SIZE = 16 * 1024
             with FileSystems.create(
@@ -249,7 +251,8 @@ class BlobStorageUploader(Uploader):
                         should_resume = progress_callback(bytes_uploaded)
                         if not should_resume:
                             raise Exception('Upload aborted by client')
-
+            time2 = time.time()
+            print("upload time: ", time2-time1)
             with FileSystems.open(
                 bundle_path, compression_type=CompressionTypes.UNCOMPRESSED
             ) as ttf, tempfile.NamedTemporaryFile(suffix=".sqlite") as tmp_index_file:

--- a/codalab/lib/upload_manager.py
+++ b/codalab/lib/upload_manager.py
@@ -235,6 +235,7 @@ class BlobStorageUploader(Uploader):
             os.environ['AZURE_STORAGE_CONNECTION_STRING'] = bundle_conn_str
         try:
             import time
+
             time1 = time.time()
             bytes_uploaded = 0
             CHUNK_SIZE = 16 * 1024
@@ -252,7 +253,7 @@ class BlobStorageUploader(Uploader):
                         if not should_resume:
                             raise Exception('Upload aborted by client')
             time2 = time.time()
-            print("upload time: ", time2-time1)
+            print("upload time: ", time2 - time1)
             with FileSystems.open(
                 bundle_path, compression_type=CompressionTypes.UNCOMPRESSED
             ) as ttf, tempfile.NamedTemporaryFile(suffix=".sqlite") as tmp_index_file:

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -3083,6 +3083,9 @@ class BundleModel(object):
                 )
                 .where(cl_bundle_location.c.bundle_uuid == bundle_uuid)
             ).fetchall()
+            import logging
+
+            logging.info(str(rows))
             return [
                 {
                     'bundle_store_uuid': row.uuid,

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -3092,9 +3092,6 @@ class BundleModel(object):
                 )
                 .where(cl_bundle_location.c.bundle_uuid == bundle_uuid)
             ).fetchall()
-            import logging
-
-            logging.info(str(rows))
             return [
                 {
                     'bundle_store_uuid': row.uuid,

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -2461,9 +2461,17 @@ class BundleModel(object):
             now = datetime.datetime.utcnow()
             user_id = user_id or '0x%s' % uuid4().hex
 
-            time_quota = self.default_user_info['edu_time_quota'] if email.endswith(".edu") else self.default_user_info['time_quota']
-            disk_quota = self.default_user_info['edu_disk_quota'] if email.endswith(".edu") else self.default_user_info['disk_quota']
-            
+            time_quota = (
+                self.default_user_info['edu_time_quota']
+                if email.endswith(".edu")
+                else self.default_user_info['time_quota']
+            )
+            disk_quota = (
+                self.default_user_info['edu_disk_quota']
+                if email.endswith(".edu")
+                else self.default_user_info['disk_quota']
+            )
+
             connection.execute(
                 cl_user.insert().values(
                     {

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -2455,6 +2455,9 @@ class BundleModel(object):
             now = datetime.datetime.utcnow()
             user_id = user_id or '0x%s' % uuid4().hex
 
+            time_quota = self.default_user_info['edu_time_quota'] if email.endswith(".edu") else self.default_user_info['time_quota']
+            disk_quota = self.default_user_info['edu_disk_quota'] if email.endswith(".edu") else self.default_user_info['disk_quota']
+            
             connection.execute(
                 cl_user.insert().values(
                     {
@@ -2470,10 +2473,10 @@ class BundleModel(object):
                         "has_access": has_access,
                         "is_verified": is_verified,
                         "password": User.encode_password(password, crypt_util.get_random_string()),
-                        "time_quota": self.default_user_info['time_quota'],
+                        "time_quota": time_quota,
                         "parallel_run_quota": self.default_user_info['parallel_run_quota'],
                         "time_used": time_used,
-                        "disk_quota": self.default_user_info['disk_quota'],
+                        "disk_quota": disk_quota,
                         "disk_used": disk_used,
                         "affiliation": affiliation,
                         "url": None,

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -486,7 +486,7 @@ def _add_bundle_location(bundle_uuid: str):
         default_bundle_store = local.model.get_bundle_store(
             request.user.user_id, name=default_store_name
         )
-        if default_bundle_store['storage_type'] in (StorageType.AZURE_BLOB_STORAGE.value,):
+        if default_bundle_store['storage_type'] in (StorageType.AZURE_BLOB_STORAGE.value,StorageType.GCS_STORAGE.value,):
             local.model.add_bundle_location(
                 new_location['bundle_uuid'], default_bundle_store['uuid']
             )
@@ -1325,6 +1325,7 @@ def delete_bundles(uuids, force, recursive, data_only, dry_run):
         bundle_link_url = bundle_link_urls.get(uuid)
         logging.info(f"bundle_link_url: {bundle_link_url}") #none
 
+        logging.info(f"Type pf bundle_store: {type(local.bundle_store)}")
         bundle_location = local.bundle_store.get_bundle_location(uuid)
         logging.info(f"bundle_location: {bundle_location}") #none
 

--- a/codalab_service.py
+++ b/codalab_service.py
@@ -249,6 +249,8 @@ CODALAB_ARGUMENTS = [
     # User
     CodalabArg(name='user_disk_quota', help='How much space a user can use', default='100g'),
     CodalabArg(name='user_time_quota', help='How much total time a user can use', default='100y'),
+    CodalabArg(name='edu_user_disk_quota', help='How much space a user with edu email can use', default='100g'),
+    CodalabArg(name='edu_user_time_quota', help='How much total time a user with edu email can use', default='100y'),
     CodalabArg(
         name='user_parallel_run_quota',
         help='How many simultaneous runs a user can have',
@@ -903,6 +905,8 @@ class CodalabServiceManager(object):
                     ('server/support_email', self.args.support_email),  # Use support_email
                     ('server/default_user_info/disk_quota', self.args.user_disk_quota),
                     ('server/default_user_info/time_quota', self.args.user_time_quota),
+                    ('server/default_user_info/edu_disk_quota', self.args.edu_user_disk_quota),
+                    ('server/default_user_info/edu_time_quota', self.args.edu_user_time_quota),
                     (
                         'server/default_user_info/parallel_run_quota',
                         self.args.user_parallel_run_quota,

--- a/codalab_service.py
+++ b/codalab_service.py
@@ -249,8 +249,16 @@ CODALAB_ARGUMENTS = [
     # User
     CodalabArg(name='user_disk_quota', help='How much space a user can use', default='100g'),
     CodalabArg(name='user_time_quota', help='How much total time a user can use', default='100y'),
-    CodalabArg(name='edu_user_disk_quota', help='How much space a user with edu email can use', default='100g'),
-    CodalabArg(name='edu_user_time_quota', help='How much total time a user with edu email can use', default='100y'),
+    CodalabArg(
+        name='edu_user_disk_quota',
+        help='How much space a user with edu email can use',
+        default='100g',
+    ),
+    CodalabArg(
+        name='edu_user_time_quota',
+        help='How much total time a user with edu email can use',
+        default='100y',
+    ),
     CodalabArg(
         name='user_parallel_run_quota',
         help='How many simultaneous runs a user can have',


### PR DESCRIPTION
### Reasons for making this change
To solve issue #4302.
Add two new environment variables to set edu email user's quota.  CODALAB_EDU_USER_DISK_QUOTA, CODALAB_EDU_USER_TIME_QUOTA.

```
  CODALAB_EDU_USER_DISK_QUOTA: 60g
  CODALAB_EDU_USER_TIME_QUOTA: 10d
```


### Related issues
#4302 
<!-- Add a reference to issues resolved, if applicable (for example, "fixes #1"). -->

### Screenshots

<!-- Add screenshots, if necessary. If this is a substantial frontend / user flow change, consider recording
a user flow GIF using a tool such as [LICEcap](https://www.cockos.com/licecap/). -->

### Checklist

* [ ] I've added a screenshot of the changes, if this is a frontend change
* [ ] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
