### PR TITLE
Add error handle code for stale file handler when `cl upload`

### DIFF
--- a/codalab/worker/file_util.py
+++ b/codalab/worker/file_util.py
@@ -531,18 +531,17 @@ def get_path_size(path, exclude_names=[], ignore_nonexistent_path=False):
             return 0
         # Raise the FileNotFoundError
         raise
-    
+
     # Detect and ignore Stale file handler. Please see: https://www.baeldung.com/linux/stale-file-handles
     try:
         os.listdir(path)
     except OSError:
         if ignore_nonexistent_path:
-            #If we have trouble list the dir, return the size of this path as 0
+            # If we have trouble list the dir, return the size of this path as 0
             # Do not raise error and just ignore the stale file handler/
             return 0
         else:
             raise
-        
 
     if not os.path.islink(path) and os.path.isdir(path):
         for child in os.listdir(path):

--- a/codalab/worker/file_util.py
+++ b/codalab/worker/file_util.py
@@ -534,7 +534,8 @@ def get_path_size(path, exclude_names=[], ignore_nonexistent_path=False):
 
     # Detect and ignore Stale file handler. Please see: https://www.baeldung.com/linux/stale-file-handles
     try:
-        os.listdir(path)
+        if not os.path.islink(path) and os.path.isdir(path):
+            os.listdir(path)
     except OSError:
         if ignore_nonexistent_path:
             # If we have trouble list the dir, return the size of this path as 0

--- a/codalab/worker/file_util.py
+++ b/codalab/worker/file_util.py
@@ -531,6 +531,19 @@ def get_path_size(path, exclude_names=[], ignore_nonexistent_path=False):
             return 0
         # Raise the FileNotFoundError
         raise
+    
+    # Detect and ignore Stale file handler. Please see: https://www.baeldung.com/linux/stale-file-handles
+    try:
+        os.listdir(path)
+    except OSError:
+        if ignore_nonexistent_path:
+            #If we have trouble list the dir, return the size of this path as 0
+            # Do not raise error and just ignore the stale file handler/
+            return 0
+        else:
+            raise
+        
+
     if not os.path.islink(path) and os.path.isdir(path):
         for child in os.listdir(path):
             if child not in exclude_names:

--- a/codalab/worker/file_util.py
+++ b/codalab/worker/file_util.py
@@ -540,6 +540,7 @@ def get_path_size(path, exclude_names=[], ignore_nonexistent_path=False):
             if ignore_nonexistent_path:
                 # If we have trouble list the dir, return the size of this path as 0
                 # Do not raise error and just ignore the stale file handler/
+                logging.warning(f"Error when list the child path. Ignore the files under path: {path}")
                 return 0
             raise
         else:

--- a/codalab/worker/file_util.py
+++ b/codalab/worker/file_util.py
@@ -540,7 +540,9 @@ def get_path_size(path, exclude_names=[], ignore_nonexistent_path=False):
             if ignore_nonexistent_path:
                 # If we have trouble list the dir, return the size of this path as 0
                 # Do not raise error and just ignore the stale file handler/
-                logging.warning(f"Error when list the child path. Ignore the files under path: {path}")
+                logging.warning(
+                    f"Error when list the child path. Ignore the files under path: {path}"
+                )
                 return 0
             raise
         else:

--- a/codalab/worker/file_util.py
+++ b/codalab/worker/file_util.py
@@ -551,7 +551,7 @@ def get_path_size(path, exclude_names=[], ignore_nonexistent_path=False):
                     except UnicodeDecodeError:
                         full_child_path = os.path.join(path.decode('utf-8'), child.decode('utf-8'))
                     result += get_path_size(full_child_path, ignore_nonexistent_path=True)
-            return result
+    return result
 
 
 def remove_path(path):

--- a/codalab/worker/file_util.py
+++ b/codalab/worker/file_util.py
@@ -535,7 +535,14 @@ def get_path_size(path, exclude_names=[], ignore_nonexistent_path=False):
     # Detect and ignore Stale file handler. Please see: https://www.baeldung.com/linux/stale-file-handles
     try:
         if not os.path.islink(path) and os.path.isdir(path):
-            os.listdir(path)
+            for child in os.listdir(path):
+                if child not in exclude_names:
+                    try:
+                        full_child_path = os.path.join(path, child)
+                    except UnicodeDecodeError:
+                        full_child_path = os.path.join(path.decode('utf-8'), child.decode('utf-8'))
+                    result += get_path_size(full_child_path, ignore_nonexistent_path=True)
+        return result
     except OSError:
         if ignore_nonexistent_path:
             # If we have trouble list the dir, return the size of this path as 0
@@ -543,16 +550,6 @@ def get_path_size(path, exclude_names=[], ignore_nonexistent_path=False):
             return 0
         else:
             raise
-
-    if not os.path.islink(path) and os.path.isdir(path):
-        for child in os.listdir(path):
-            if child not in exclude_names:
-                try:
-                    full_child_path = os.path.join(path, child)
-                except UnicodeDecodeError:
-                    full_child_path = os.path.join(path.decode('utf-8'), child.decode('utf-8'))
-                result += get_path_size(full_child_path, ignore_nonexistent_path=True)
-    return result
 
 
 def remove_path(path):


### PR DESCRIPTION
### Reasons for making this change
When uploading from nlp machine, we might meet **stale file handler**(https://www.baeldung.com/linux/stale-file-handles) generated by other process. Add some code to just ignore those stale file handlers.
<!-- Add a reason for making this change here. -->
For stale file handlers, we can not even `ls` them. 
![image](https://user-images.githubusercontent.com/40016222/200201534-911986ee-8598-4ba4-9633-074ebe02f2c7.png)


### Related issues

<!-- Add a reference to issues resolved, if applicable (for example, "fixes #1"). -->

### Screenshots

<!-- Add screenshots, if necessary. If this is a substantial frontend / user flow change, consider recording
a user flow GIF using a tool such as [LICEcap](https://www.cockos.com/licecap/). -->

### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [ ] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
