### PR TITLE
Add dynamic codalab status report to on-call worksheets.

### DIFF
--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -1215,7 +1215,15 @@ class BundleCLI(object):
     @Commands.command(
         'workers',
         help=['Display information about workers that you have connected to the CodaLab instance.'],
-        arguments=(),
+        arguments=(
+            Commands.Argument(
+                '-c',
+                '--condensed',
+                help='Show a condensed worker list (worker IDs only).',
+                action='store_true',
+                default=False,
+            ),
+        ),
     )
     def do_workers_command(self, args):
         client = self.manager.current_client()
@@ -1261,7 +1269,11 @@ class BundleCLI(object):
                 }
             )
 
-        self.print_table(columns, data)
+        if args.condensed:
+            for worker in data:
+                print(worker['worker_id'], file=self.stdout)
+        else:
+            self.print_table(columns, data)
 
     @Commands.command(
         'upload',

--- a/docs/CLI-Reference.md
+++ b/docs/CLI-Reference.md
@@ -494,6 +494,8 @@ Usage: `cl <command> <arguments>`
 ## Commands for managing server
 ### workers
     Display information about workers that you have connected to the CodaLab instance.
+    Arguments:
+      -c, --condensed  Show a condensed worker list (worker IDs only).
 
 ### bs-add-partition
     Add another partition for storage (MultiDiskBundleStore only)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2453,6 +2453,11 @@
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
       "dev": true
     },
+    "@popperjs/core": {
+      "version": "2.11.6",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
+      "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw=="
+    },
     "@semantic-ui-react/event-stack": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@semantic-ui-react/event-stack/-/event-stack-3.1.1.tgz",
@@ -5698,7 +5703,7 @@
     "clone": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg=="
     },
     "clone-deep": {
       "version": "0.2.4",
@@ -6775,6 +6780,11 @@
         }
       }
     },
+    "date-fns": {
+      "version": "2.29.3",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
+      "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA=="
+    },
     "debounce": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.0.tgz",
@@ -6841,7 +6851,7 @@
     "defaults": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+      "integrity": "sha512-s82itHOnYrN0Ib8r+z7laQz3sdE+4FP3d9Q7VLO7U+KRT+CR0GsWuyHxzdAY82I7cXv0G/twrqomTJLOssO5HA==",
       "requires": {
         "clone": "^1.0.2"
       }
@@ -15175,6 +15185,45 @@
         "prop-types": "^15.5.8"
       }
     },
+    "react-datepicker": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-4.8.0.tgz",
+      "integrity": "sha512-u69zXGHMpxAa4LeYR83vucQoUCJQ6m/WBsSxmUMu/M8ahTSVMMyiyQzauHgZA2NUr9y0FUgOAix71hGYUb6tvg==",
+      "requires": {
+        "@popperjs/core": "^2.9.2",
+        "classnames": "^2.2.6",
+        "date-fns": "^2.24.0",
+        "prop-types": "^15.7.2",
+        "react-onclickoutside": "^6.12.0",
+        "react-popper": "^2.2.5"
+      },
+      "dependencies": {
+        "prop-types": {
+          "version": "15.8.1",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+          "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.13.1"
+          }
+        },
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        },
+        "react-popper": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.3.0.tgz",
+          "integrity": "sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==",
+          "requires": {
+            "react-fast-compare": "^3.0.1",
+            "warning": "^4.0.2"
+          }
+        }
+      }
+    },
     "react-dev-utils": {
       "version": "10.2.1",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-10.2.1.tgz",
@@ -15513,6 +15562,11 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "react-onclickoutside": {
+      "version": "6.12.2",
+      "resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-6.12.2.tgz",
+      "integrity": "sha512-NMXGa223OnsrGVp5dJHkuKxQ4czdLmXSp5jSV9OqiCky9LOpPATn3vLldc+q5fK3gKbEHvr7J1u0yhBh/xYkpA=="
     },
     "react-overlays": {
       "version": "0.9.1",
@@ -18607,7 +18661,7 @@
     "wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
       "requires": {
         "defaults": "^1.0.3"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,6 +36,7 @@
     "react-circular-progressbar": "^2.0.3",
     "react-cookie": "^4.0.3",
     "react-copy-to-clipboard": "^5.0.2",
+    "react-datepicker": "^4.8.0",
     "react-dom": "^16.13.1",
     "react-google-recaptcha": "^2.1.0",
     "react-helmet": "^6.1.0",

--- a/frontend/src/components/StatusReport/index.jsx
+++ b/frontend/src/components/StatusReport/index.jsx
@@ -76,11 +76,9 @@ class StatusReport extends React.Component {
 
         // failed bundle count
         promises.push(
-            executeCommand(`cl search .after=${isoDate} state=failed .count`, uuid).then(
-                (resp) => {
-                    report.failedBundleCount = resp.output;
-                },
-            ),
+            executeCommand(`cl search .after=${isoDate} state=failed .count`, uuid).then((resp) => {
+                report.failedBundleCount = resp.output;
+            }),
         );
 
         // active worker list

--- a/frontend/src/components/StatusReport/index.jsx
+++ b/frontend/src/components/StatusReport/index.jsx
@@ -76,7 +76,7 @@ class StatusReport extends React.Component {
 
         // failed bundle count
         promises.push(
-            executeCommand(`cl search .after=${isoDate}  state=failed .count`, uuid).then(
+            executeCommand(`cl search .after=${isoDate} state=failed .count`, uuid).then(
                 (resp) => {
                     report.failedBundleCount = resp.output;
                 },

--- a/frontend/src/components/StatusReport/index.jsx
+++ b/frontend/src/components/StatusReport/index.jsx
@@ -43,12 +43,7 @@ class StatusReport extends React.Component {
     }
 
     fetchReport(date) {
-        const formattedDate = date.toISOString();
-        const newUserCommand = `cl uls .joined_after=${formattedDate} .count`;
-        const activeUserCommand = `cl uls .active_after=${formattedDate} .count`;
-        const newBundleCommand = `cl search .after=${formattedDate} .count`;
-        const failedBundleCommand = `cl search .after=${formattedDate}  state=failed .count`;
-        const activeWorkersCommand = `cl workers -c`;
+        const isoDate = date.toISOString();
         const uuid = this.props.worksheetUUID;
         const promises = [];
         const report = {};
@@ -58,31 +53,43 @@ class StatusReport extends React.Component {
             reportIsErroring: false,
         });
 
+        // new user count
         promises.push(
-            executeCommand(newUserCommand, uuid).then((resp) => {
+            executeCommand(`cl uls .joined_after=${isoDate} .count`, uuid).then((resp) => {
                 report.newUserCount = resp.output;
             }),
         );
+
+        // active user count
         promises.push(
-            executeCommand(activeUserCommand, uuid).then((resp) => {
+            executeCommand(`cl uls .active_after=${isoDate} .count`, uuid).then((resp) => {
                 report.activeUserCount = resp.output;
             }),
         );
+
+        // new bundle count
         promises.push(
-            executeCommand(newBundleCommand, uuid).then((resp) => {
+            executeCommand(`cl search .after=${isoDate} .count`, uuid).then((resp) => {
                 report.newBundleCount = resp.output;
             }),
         );
+
+        // failed bundle count
         promises.push(
-            executeCommand(failedBundleCommand, uuid).then((resp) => {
-                report.failedBundleCount = resp.output;
-            }),
+            executeCommand(`cl search .after=${isoDate}  state=failed .count`, uuid).then(
+                (resp) => {
+                    report.failedBundleCount = resp.output;
+                },
+            ),
         );
+
+        // active worker list
         promises.push(
-            executeCommand(activeWorkersCommand, uuid).then((resp) => {
+            executeCommand(`cl workers -c`, uuid).then((resp) => {
                 report.activeWorkers = resp.output;
             }),
         );
+
         Promise.all(promises)
             .then(() => {
                 this.setState({
@@ -117,8 +124,7 @@ class StatusReport extends React.Component {
         const { classes } = this.props;
         const { reportIsLoading, reportIsErroring, reportDate, report } = this.state;
         const errorText = 'Error: Unable to fetch status report.';
-        const helpText =
-            'Use the date picker below to select your report date range. Results will reflect activity between the selected date and now.';
+        const helpText = 'Report results will reflect activity between the selected date and now.';
         const tableRows = [
             this.createRowData('New User Count', report.newUserCount),
             this.createRowData('Active User Count', report.activeUserCount),
@@ -149,7 +155,7 @@ class StatusReport extends React.Component {
                         <Table>
                             <TableHead classes={{ root: classes.row }}>
                                 <TableCell>
-                                    Query [since {reportDate.toLocaleDateString()}]
+                                    Query [{reportDate.toLocaleDateString()} - Now]
                                 </TableCell>
                                 <TableCell>Data</TableCell>
                             </TableHead>

--- a/frontend/src/components/StatusReport/index.jsx
+++ b/frontend/src/components/StatusReport/index.jsx
@@ -1,0 +1,198 @@
+import React from 'react';
+import DatePicker from 'react-datepicker';
+import { withStyles } from '@material-ui/core/styles';
+import Paper from '@material-ui/core/Paper';
+import Table from '@material-ui/core/Table';
+import TableBody from '@material-ui/core/TableBody';
+import TableCell from '@material-ui/core/TableCell';
+import TableContainer from '@material-ui/core/TableBody';
+import TableRow from '@material-ui/core/TableRow';
+import TableHead from '@material-ui/core/TableHead';
+import { executeCommand } from '../../util/apiWrapper';
+import Loading from '../Loading';
+import ErrorMessage from '../worksheets/ErrorMessage';
+import HelpTooltip from '../HelpTooltip';
+import 'react-datepicker/dist/react-datepicker.css';
+
+/**
+ * This component renders a status report that programatically answers common
+ * questions about CodaLab's user activity such as:
+ *
+ * How many new users joined?
+ * How many users are active?
+ * How many workers are up?
+ * How many new bundles have been created?
+ * How many bundles have failed?
+ */
+class StatusReport extends React.Component {
+    constructor(props) {
+        super(props);
+        this.handleDateChange = this.handleDateChange.bind(this);
+        this.state = {
+            reportDate: new Date(),
+            reportIsLoading: true,
+            reportIsErroring: false,
+            report: {
+                newUserCount: '',
+                activeUserCount: '',
+                newBundleCount: '',
+                failedBundleCount: '',
+                activeWorkers: '',
+            },
+        };
+    }
+
+    fetchReport(date) {
+        const formattedDate = date.toISOString();
+        const newUserCommand = `cl uls .joined_after=${formattedDate} .count`;
+        const activeUserCommand = `cl uls .active_after=${formattedDate} .count`;
+        const newBundleCommand = `cl search .after=${formattedDate} .count`;
+        const failedBundleCommand = `cl search .after=${formattedDate}  state=failed .count`;
+        const activeWorkersCommand = `cl workers -c`;
+        const uuid = this.props.worksheetUUID;
+        const promises = [];
+        const report = {};
+
+        this.setState({
+            reportIsLoading: true,
+            reportIsErroring: false,
+        });
+
+        promises.push(
+            executeCommand(newUserCommand, uuid).then((resp) => {
+                report.newUserCount = resp.output;
+            }),
+        );
+        promises.push(
+            executeCommand(activeUserCommand, uuid).then((resp) => {
+                report.activeUserCount = resp.output;
+            }),
+        );
+        promises.push(
+            executeCommand(newBundleCommand, uuid).then((resp) => {
+                report.newBundleCount = resp.output;
+            }),
+        );
+        promises.push(
+            executeCommand(failedBundleCommand, uuid).then((resp) => {
+                report.failedBundleCount = resp.output;
+            }),
+        );
+        promises.push(
+            executeCommand(activeWorkersCommand, uuid).then((resp) => {
+                report.activeWorkers = resp.output;
+            }),
+        );
+        Promise.all(promises)
+            .then(() => {
+                this.setState({
+                    reportIsLoading: false,
+                    reportIsErroring: false,
+                    report,
+                });
+            })
+            .catch(() => {
+                this.setState({
+                    reportIsLoading: false,
+                    reportIsErroring: true,
+                });
+            });
+    }
+
+    handleDateChange(date) {
+        this.setState({ reportDate: date });
+        this.fetchReport(date);
+    }
+
+    createRowData(query, data) {
+        const dataList = data.split('\n');
+        return { query, data: dataList };
+    }
+
+    componentDidMount() {
+        this.fetchReport(new Date()); // initial report
+    }
+
+    render() {
+        const { classes } = this.props;
+        const { reportIsLoading, reportIsErroring, reportDate, report } = this.state;
+        const errorText = 'Error: Unable to fetch status report.';
+        const helpText =
+            'Use the date picker below to select your report date range. Results will reflect activity between the selected date and now.';
+        const tableRows = [
+            this.createRowData('New User Count', report.newUserCount),
+            this.createRowData('Active User Count', report.activeUserCount),
+            this.createRowData('New Bundle Count', report.newBundleCount),
+            this.createRowData('Failed Bundle Count', report.failedBundleCount),
+            this.createRowData('Active Worker IDs', report.activeWorkers),
+        ];
+
+        return (
+            <div className={classes.reportContainer}>
+                <h1>Status Report</h1>
+                <div className={classes.subheading}>
+                    <h4>Report Start Date</h4>
+                    <HelpTooltip className={classes.tooltip} title={helpText} />
+                </div>
+                <DatePicker
+                    selected={reportDate}
+                    onChange={this.handleDateChange}
+                    className={classes.datePicker}
+                    popperClassName={classes.popper}
+                    dateFormat={'M/d/yyyy'}
+                    showPopperArrow={false}
+                />
+                {reportIsLoading && <Loading />}
+                {reportIsErroring && <ErrorMessage message={errorText} noMargin />}
+                {!reportIsLoading && !reportIsErroring && (
+                    <TableContainer component={Paper}>
+                        <Table>
+                            <TableHead classes={{ root: classes.row }}>
+                                <TableCell>
+                                    Query [since {reportDate.toLocaleDateString()}]
+                                </TableCell>
+                                <TableCell>Data</TableCell>
+                            </TableHead>
+                            <TableBody>
+                                {tableRows.map((row) => (
+                                    <TableRow classes={{ root: classes.row }}>
+                                        <TableCell>{row.query}</TableCell>
+                                        <TableCell>
+                                            {row.data.map((data) => (
+                                                <div>{data}</div>
+                                            ))}
+                                        </TableCell>
+                                    </TableRow>
+                                ))}
+                            </TableBody>
+                        </Table>
+                    </TableContainer>
+                )}
+            </div>
+        );
+    }
+}
+
+const styles = () => ({
+    reportContainer: {
+        marginBottom: 35,
+    },
+    subheading: {
+        display: 'flex',
+    },
+    tooltip: {
+        fontSize: 13,
+        padding: 4,
+    },
+    datePicker: {
+        marginBottom: 20,
+    },
+    popper: {
+        zIndex: 10,
+    },
+    row: {
+        height: 30,
+    },
+});
+
+export default withStyles(styles)(StatusReport);

--- a/frontend/src/components/worksheets/ErrorMessage.js
+++ b/frontend/src/components/worksheets/ErrorMessage.js
@@ -3,13 +3,14 @@ import Grid from '@material-ui/core/Grid';
 
 class ErrorMessage extends React.Component {
     render() {
+        const margin = this.props.noMargin ? '' : '100px 0 80px';
         return (
             <Grid
                 container
                 direction='column'
                 justify='center'
                 alignItems='center'
-                style={{ margin: '100px 0 80px' }}
+                style={{ margin }}
             >
                 <Grid className='alert alert-danger alert-dismissable'>
                     <Grid item style={{ fontSize: '16px', marginLeft: 10 }}>

--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -9,6 +9,7 @@ import {
     addUTCTimeZone,
 } from '../../../util/worksheet_utils';
 import * as Mousetrap from '../../../util/ws_mousetrap_fork';
+import StatusReport from '../../StatusReport';
 import WorksheetItemList from '../WorksheetItemList';
 import InformationModal from '../InformationModal/InformationModal';
 import WorksheetHeader from './WorksheetHeader';
@@ -62,11 +63,21 @@ class Worksheet extends React.Component {
         let localWorksheetWidthPreference = window.localStorage.getItem(
             LOCAL_STORAGE_WORKSHEET_WIDTH,
         );
+        // uuids for the "What's Running on CodaLab?" worksheets.
+        const statusWorksheetUUIDs = [
+            '0x870c3781d520468694758e665bba7345', // local (testing)
+            '0xa590fd1b68944a1a95c1c40c4931dc7b', // prod
+            '0xc347c4ebc5644a71b24343523bf76e7b', // stanford
+            '0xa590fd1b68944a1a95c1c40c4931dc7b', // dev
+        ];
+        const uuid = this.props.match.params['uuid'];
+
         this.state = {
             ws: {
-                uuid: this.props.match.params['uuid'],
+                uuid,
                 info: null,
             },
+            showStatusReport: statusWorksheetUUIDs.includes(uuid),
             version: 0, // Increment when we refresh
             escCount: 0, // Increment when the user presses esc keyboard shortcut, a hack to allow esc shortcut to work
             activeComponent: 'itemList', // Where the focus is (terminal, itemList)
@@ -1731,6 +1742,7 @@ class Worksheet extends React.Component {
             showInformationModal,
             showWorksheetContent,
             showWorksheetContainer,
+            showStatusReport,
         } = this.state;
 
         this.setupEventHandlers();
@@ -1975,6 +1987,11 @@ class Worksheet extends React.Component {
                                                 id='worksheet_content'
                                                 className={editableClassName + ' worksheet_content'}
                                             >
+                                                {showStatusReport && (
+                                                    <StatusReport
+                                                        worksheetUUID={this.state.ws.uuid}
+                                                    />
+                                                )}
                                                 {worksheetDisplay}
                                                 {/* Show error dialog if bulk bundle execution failed*/}
                                                 {this.state.BulkBundleDialog}

--- a/frontend/src/components/worksheets/Worksheet/Worksheet.js
+++ b/frontend/src/components/worksheets/Worksheet/Worksheet.js
@@ -63,7 +63,7 @@ class Worksheet extends React.Component {
         let localWorksheetWidthPreference = window.localStorage.getItem(
             LOCAL_STORAGE_WORKSHEET_WIDTH,
         );
-        // uuids for the "What's Running on CodaLab?" worksheets.
+        // uuids for the "What's Running on CodaLab?" worksheets
         const statusWorksheetUUIDs = [
             '0x870c3781d520468694758e665bba7345', // local (testing)
             '0xa590fd1b68944a1a95c1c40c4931dc7b', // prod


### PR DESCRIPTION
### Reasons for making this change

Each week, the on-call team member has to manually run several queries on the prod codalab instance and the stanford codalab instance in order to fill out the [on-call template](https://docs.google.com/document/d/1ID_bRUuV1oaDQ2dsxIJ_ZFBLqJJnmN-qlOB0HTqooE4/edit#heading=h.dj0kmok9a06e).

This changes adds a dynamic status report to the "What's Running on CodaLab?" worksheets across all environments so that the on-call member doesn't have to run each query manually.

### Related issues

https://github.com/codalab/codalab-worksheets/issues/4200

### Screenshots

https://user-images.githubusercontent.com/25855750/200739927-f091873e-a171-445c-8632-cc88a8d4c66b.mp4

### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [ ] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
