### PR TITLE
Speed up rm bundles

### DIFF
--- a/codalab/lib/bundle_store.py
+++ b/codalab/lib/bundle_store.py
@@ -48,7 +48,7 @@ class BundleStore(object):
     def get_bundle_location(self, uuid, bundle_store_uuid=None):
         raise NotImplementedError
 
-    def cleanup(self, uuid, dry_run):
+    def cleanup(self, bundle_location, dry_run):
         raise NotImplementedError
 
 
@@ -226,15 +226,14 @@ class _MultiDiskBundleStoreBase(BundleStore):
                 )
             )
 
-    def cleanup(self, uuid, dry_run):
+    def cleanup(self, bundle_location, dry_run):
         '''
         Remove the bundle with given UUID from on-disk storage.
         '''
-        absolute_path = self.get_bundle_location(uuid)
-        print("cleanup: data %s" % absolute_path, file=sys.stderr)
+        print("cleanup: data %s" % bundle_location, file=sys.stderr)
         if dry_run:
             return False
-        return path_util.remove(absolute_path)
+        return path_util.remove(bundle_location)
 
     def health_check(self, model, force=False, compute_data_hash=False, repair_hashes=False):
         """

--- a/codalab/lib/bundle_store.py
+++ b/codalab/lib/bundle_store.py
@@ -232,8 +232,9 @@ class _MultiDiskBundleStoreBase(BundleStore):
         '''
         absolute_path = self.get_bundle_location(uuid)
         print("cleanup: data %s" % absolute_path, file=sys.stderr)
-        if not dry_run:
-            path_util.remove(absolute_path)
+        if dry_run:
+            return False
+        return path_util.remove(absolute_path)
 
     def health_check(self, model, force=False, compute_data_hash=False, repair_hashes=False):
         """

--- a/codalab/lib/path_util.py
+++ b/codalab/lib/path_util.py
@@ -308,7 +308,7 @@ def remove(path):
     if parse_linked_bundle_url(path).uses_beam:
         from apache_beam.io.filesystems import FileSystems
 
-        if not FileSystems.exists(path):
+        if FileSystems.exists(path):
             FileSystems.delete([path])
         return True  # not sure about this one
     check_isvalid(path, 'remove')

--- a/codalab/lib/path_util.py
+++ b/codalab/lib/path_util.py
@@ -310,7 +310,7 @@ def remove(path):
 
         if not FileSystems.exists(path):
             FileSystems.delete([path])
-        return True # not sure about this one
+        return True  # not sure about this one
     check_isvalid(path, 'remove')
     set_write_permissions(path)  # Allow permissions
     if os.path.islink(path):

--- a/codalab/lib/path_util.py
+++ b/codalab/lib/path_util.py
@@ -310,24 +310,25 @@ def remove(path):
 
         if FileSystems.exists(path):
             FileSystems.delete([path])
-        return True  # not sure about this one
-    check_isvalid(path, 'remove')
-    set_write_permissions(path)  # Allow permissions
-    if os.path.islink(path):
-        os.unlink(path)
-        return False
-    elif os.path.isdir(path):
-        try:
-            shutil.rmtree(path)
             return True
-        except shutil.Error:
-            pass
     else:
-        os.remove(path)
-        return True
-    if os.path.exists(path):
-        print('Failed to remove %s' % path)
-        return False
+        check_isvalid(path, 'remove')
+        set_write_permissions(path)  # Allow permissions
+        if os.path.islink(path):
+            os.unlink(path)
+            return False
+        elif os.path.isdir(path):
+            try:
+                shutil.rmtree(path)
+                return True
+            except shutil.Error:
+                pass
+        else:
+            os.remove(path)
+            return True
+        if os.path.exists(path):
+            print('Failed to remove %s' % path)
+    return False
 
 
 def soft_link(source, path):

--- a/codalab/lib/path_util.py
+++ b/codalab/lib/path_util.py
@@ -310,20 +310,24 @@ def remove(path):
 
         if not FileSystems.exists(path):
             FileSystems.delete([path])
-        return
+        return True # not sure about this one
     check_isvalid(path, 'remove')
     set_write_permissions(path)  # Allow permissions
     if os.path.islink(path):
         os.unlink(path)
+        return False
     elif os.path.isdir(path):
         try:
             shutil.rmtree(path)
+            return True
         except shutil.Error:
             pass
     else:
         os.remove(path)
+        return True
     if os.path.exists(path):
         print('Failed to remove %s' % path)
+        return False
 
 
 def soft_link(source, path):

--- a/codalab/lib/path_util.py
+++ b/codalab/lib/path_util.py
@@ -309,7 +309,9 @@ def remove(path):
         from apache_beam.io.filesystems import FileSystems
 
         if FileSystems.exists(path):
-            FileSystems.delete([path])
+            # Get the full folder location (without contents.gz) deleted
+            file_location = '/'.join(path.split('/')[0:-1]) + "/"
+            FileSystems.delete([file_location])
             return True
     else:
         check_isvalid(path, 'remove')

--- a/codalab/lib/upload_manager.py
+++ b/codalab/lib/upload_manager.py
@@ -464,6 +464,7 @@ class ClientUploadManager(object):
                         should_unpack=unpack_before_upload,
                         progress_callback=progress.update,
                     )
+                self._client.update_bundle_state(bundle['id'], params={'success': True})
             except Exception as err:
                 self._client.update_bundle_state(
                     bundle['id'],

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -2708,9 +2708,9 @@ class BundleModel(object):
         user_info['time_used'] += amount
         self.update_user_info(user_info)
 
-    def increment_user_disk_used(self, user_id, amount):
+    def increment_user_disk_used(self, user_id: str, amount: int):
         """
-        User used some time.
+        User used some disk.
         """
         user_info = self.get_user_info(user_id)
         user_info['disk_used'] += amount

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -2721,7 +2721,7 @@ class BundleModel(object):
 
     def increment_user_disk_used(self, user_id: str, amount: int):
         """
-        User used some disk.
+        Increment disk_used for user by amount.
         """
         user_info = self.get_user_info(user_id)
         user_info['disk_used'] += amount

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -2708,6 +2708,14 @@ class BundleModel(object):
         user_info['time_used'] += amount
         self.update_user_info(user_info)
 
+    def increment_user_disk_used(self, user_id, amount):
+        """
+        User used some time.
+        """
+        user_info = self.get_user_info(user_id)
+        user_info['disk_used'] += amount
+        self.update_user_info(user_info)
+
     def get_user_time_quota_left(self, user_id, user_info=None):
         if not user_info:
             user_info = self.get_user_info(user_id)

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -2713,8 +2713,10 @@ class BundleModel(object):
         User used some time.
         """
         user_info = self.get_user_info(user_id)
+        logger.info(f"disk before increment: {user_info['disk_used']}")
         user_info['disk_used'] += amount
         self.update_user_info(user_info)
+        logger.info(f"disk AFTER increment: {self.get_user_info(user_id)['disk_used']}")
 
     def get_user_time_quota_left(self, user_id, user_info=None):
         if not user_info:

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -2713,10 +2713,8 @@ class BundleModel(object):
         User used some time.
         """
         user_info = self.get_user_info(user_id)
-        #logger.info(f"disk before increment: {user_info['disk_used']}")
         user_info['disk_used'] += amount
         self.update_user_info(user_info)
-        #logger.info(f"disk AFTER increment: {self.get_user_info(user_id)['disk_used']}")
 
     def get_user_time_quota_left(self, user_id, user_info=None):
         if not user_info:

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -2721,7 +2721,7 @@ class BundleModel(object):
 
     def increment_user_disk_used(self, user_id: str, amount: int):
         """
-        Increment disk_used for user by amount.
+        Increment disk_used for user by amount
         """
         user_info = self.get_user_info(user_id)
         user_info['disk_used'] += amount

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -2713,10 +2713,10 @@ class BundleModel(object):
         User used some time.
         """
         user_info = self.get_user_info(user_id)
-        logger.info(f"disk before increment: {user_info['disk_used']}")
+        #logger.info(f"disk before increment: {user_info['disk_used']}")
         user_info['disk_used'] += amount
         self.update_user_info(user_info)
-        logger.info(f"disk AFTER increment: {self.get_user_info(user_id)['disk_used']}")
+        #logger.info(f"disk AFTER increment: {self.get_user_info(user_id)['disk_used']}")
 
     def get_user_time_quota_left(self, user_id, user_info=None):
         if not user_info:

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -1321,16 +1321,6 @@ def delete_bundles(uuids, force, recursive, data_only, dry_run):
             # Just remove references to the data hashes
             local.model.remove_data_hash_references(relevant_uuids)
         else:
-            # If the bundle is stored on cloud, first delete data on cloud.
-            for uuid in relevant_uuids:
-                bundle_location = bundle_locations[uuid]
-
-                file_location = '/'.join(bundle_location.split('/')[0:-1]) + "/"
-                if bundle_location.startswith(
-                    StorageURLScheme.AZURE_BLOB_STORAGE.value
-                ) or bundle_location.startswith(StorageURLScheme.GCS_STORAGE.value):
-                    FileSystems.delete([file_location])
-
             # Actually delete the bundle
             local.model.delete_bundles(relevant_uuids)
 

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -1306,7 +1306,9 @@ def delete_bundles(uuids, force, recursive, data_only, dry_run):
             )
 
     bundle_data_sizes = local.model.get_bundle_metadata(relevant_uuids, 'data_size')
-    bundle_locations = {uuid:local.bundle_store.get_bundle_location(uuid) for uuid in relevant_uuids}  # cache these so we have them even after the metadata for the bundle has been deleted
+    bundle_locations = {
+        uuid: local.bundle_store.get_bundle_location(uuid) for uuid in relevant_uuids
+    }  # cache these so we have them even after the metadata for the bundle has been deleted
 
     # Delete the actual bundle
     if not dry_run:
@@ -1329,11 +1331,13 @@ def delete_bundles(uuids, force, recursive, data_only, dry_run):
 
             # Remove bundle
             removed = False
-            if os.path.lexists(bundle_location) or bundle_location.startswith(
-                StorageURLScheme.AZURE_BLOB_STORAGE.value
-            ) or bundle_location.startswith(StorageURLScheme.GCS_STORAGE.value):
-                removed = local.bundle_store.cleanup(uuid, dry_run)
-            
+            if (
+                os.path.lexists(bundle_location)
+                or bundle_location.startswith(StorageURLScheme.AZURE_BLOB_STORAGE.value)
+                or bundle_location.startswith(StorageURLScheme.GCS_STORAGE.value)
+            ):
+                removed = local.bundle_store.cleanup(bundle_location, dry_run)
+
             # Update user disk used.
             if removed and uuid in bundle_data_sizes:
                 local.model.increment_user_disk_used(

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -1358,9 +1358,9 @@ def delete_bundles(uuids, force, recursive, data_only, dry_run):
         # Just decrement the user disk used by the sum of sizes of bundles deleted
         # OK, now let's add our change.
         start = time.time()
-        #import pdb; pdb.set_trace()
         bundle_data_sizes = local.model.get_bundle_metadata(relevant_uuids, 'data_size')
-        local.model.increment_user_disk_used(request.user.user_id, (-1)*sum(map(int, bundle_data_sizes)))
+        logger.info(f"data_sizes: {bundle_data_sizes}")
+        local.model.increment_user_disk_used(request.user.user_id, (-1)*sum(map(int, bundle_data_sizes.values())))
         end = time.time()
         logger.info("^^^^^^^^&&&&&MY-TIMER-LOGGING. update user disk used: {}".format(end - start))
 

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -1343,7 +1343,7 @@ def delete_bundles(uuids, force, recursive, data_only, dry_run):
         start = time.time()
         local.model.update_user_disk_used(request.user.user_id)
         end = time.time()
-        logger.info("^^^^^^^^&&&&&MY-TIMER-LOGGING. actually delete the bundle: {}".format(end-start))
+        logger.info("^^^^^^^^&&&&&MY-TIMER-LOGGING. update user disk used: {}".format(end-start))
 
     # Delete the data.
     start = time.time()

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -1344,10 +1344,6 @@ def delete_bundles(uuids, force, recursive, data_only, dry_run):
         else:
             bundle_location = bundle_locations[uuid]
 
-            import pdb
-
-            pdb.set_trace()
-
             # Remove bundle
             removed = False
             if (
@@ -1362,10 +1358,6 @@ def delete_bundles(uuids, force, recursive, data_only, dry_run):
                 local.model.increment_user_disk_used(
                     request.user.user_id, -int(bundle_data_sizes[uuid])
                 )
-
-            import pdb
-
-            pdb.set_trace()
 
     return relevant_uuids
 

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -53,7 +53,6 @@ from codalab.rest.util import get_bundle_infos, get_resource_ids, resolve_owner_
 from codalab.server.authenticated_plugin import AuthenticatedProtectedPlugin, ProtectedPlugin
 from codalab.worker.bundle_state import State
 from codalab.worker.download_util import BundleTarget
-from apache_beam.io.filesystems import FileSystems
 
 logger = logging.getLogger(__name__)
 

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -1360,7 +1360,9 @@ def delete_bundles(uuids, force, recursive, data_only, dry_run):
         start = time.time()
         bundle_data_sizes = local.model.get_bundle_metadata(relevant_uuids, 'data_size')
         logger.info(f"data_sizes: {bundle_data_sizes}")
-        local.model.increment_user_disk_used(request.user.user_id, (-1)*sum(map(int, bundle_data_sizes.values())))
+        local.model.increment_user_disk_used(
+            request.user.user_id, (-1) * sum(map(int, bundle_data_sizes.values()))
+        )
         end = time.time()
         logger.info("^^^^^^^^&&&&&MY-TIMER-LOGGING. update user disk used: {}".format(end - start))
 

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -1311,6 +1311,15 @@ def delete_bundles(uuids, force, recursive, data_only, dry_run):
         uuid: local.bundle_store.get_bundle_location(uuid) for uuid in relevant_uuids
     }
 
+    # Delete the actual bundle
+    if not dry_run:
+        if data_only:
+            # Just remove references to the data hashes
+            local.model.remove_data_hash_references(relevant_uuids)
+        else:
+            # Actually delete the bundle
+            local.model.delete_bundles(relevant_uuids)
+
     # Delete the data.
     bundle_link_urls = local.model.get_bundle_metadata(relevant_uuids, "link_url")
     for uuid in relevant_uuids:
@@ -1335,15 +1344,6 @@ def delete_bundles(uuids, force, recursive, data_only, dry_run):
                 local.model.increment_user_disk_used(
                     request.user.user_id, -int(bundle_data_sizes[uuid])
                 )
-
-    # Delete the actual bundle
-    if not dry_run:
-        if data_only:
-            # Just remove references to the data hashes
-            local.model.remove_data_hash_references(relevant_uuids)
-        else:
-            # Actually delete the bundle
-            local.model.delete_bundles(relevant_uuids)
 
     return relevant_uuids
 

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -1325,19 +1325,25 @@ def delete_bundles(uuids, force, recursive, data_only, dry_run):
     logger.info("^^^^^^^^&&&&&MY-TIMER-LOGGING. make sure bundles aren't referenced in multiple places: {}".format(end-start))
 
     # Delete the actual bundle
-    start = time.time()
     if not dry_run:
         if data_only:
             # Just remove references to the data hashes
+            start = time.time()
             local.model.remove_data_hash_references(relevant_uuids)
+            end = time.time()
+            logger.info("^^^^^^^^&&&&&MY-TIMER-LOGGING. remove references to data hashes: {}".format(end-start))
         else:
             # Actually delete the bundle
+            start = time.time()
             local.model.delete_bundles(relevant_uuids)
+            end = time.time()
+            logger.info("^^^^^^^^&&&&&MY-TIMER-LOGGING. actually delete the bundle: {}".format(end-start))
 
         # Update user statistics
+        start = time.time()
         local.model.update_user_disk_used(request.user.user_id)
-    end = time.time()
-    logger.info("^^^^^^^^&&&&&MY-TIMER-LOGGING. delete the actual bundle: {}".format(end-start))
+        end = time.time()
+        logger.info("^^^^^^^^&&&&&MY-TIMER-LOGGING. actually delete the bundle: {}".format(end-start))
 
     # Delete the data.
     start = time.time()

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -1330,7 +1330,7 @@ def delete_bundles(uuids, force, recursive, data_only, dry_run):
             ):
                 removed = local.bundle_store.cleanup(bundle_location, dry_run)
 
-            # Update user disk used.            
+            # Update user disk used.
             if removed and uuid in bundle_data_sizes:
                 local.model.increment_user_disk_used(
                     request.user.user_id, -int(bundle_data_sizes[uuid])

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -1325,12 +1325,18 @@ def delete_bundles(uuids, force, recursive, data_only, dry_run):
             pass
         else:
             bundle_location = local.bundle_store.get_bundle_location(uuid)
-            if os.path.lexists(bundle_location):
+
+            # Remove bundle
+            if os.path.lexists(bundle_location) or bundle_location.startswith(
+                StorageURLScheme.AZURE_BLOB_STORAGE.value
+            ) or bundle_location.startswith(StorageURLScheme.GCS_STORAGE.value):
                 removed = local.bundle_store.cleanup(uuid, dry_run)
-                if removed and uuid in bundle_data_sizes:
-                    local.model.increment_user_disk_used(
-                        request.user.user_id, -int(bundle_data_sizes[uuid])
-                    )
+            
+            # Update user disk used.
+            if removed and uuid in bundle_data_sizes:
+                local.model.increment_user_disk_used(
+                    request.user.user_id, -int(bundle_data_sizes[uuid])
+                )
 
     return relevant_uuids
 

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -1323,7 +1323,7 @@ def delete_bundles(uuids, force, recursive, data_only, dry_run):
         else:
             # If the bundle is stored on cloud, first delete data on cloud.
             for uuid in relevant_uuids:
-                bundle_location = bundle_locations(uuid)
+                bundle_location = bundle_locations[uuid]
 
                 file_location = '/'.join(bundle_location.split('/')[0:-1]) + "/"
                 if bundle_location.startswith(

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -1306,6 +1306,7 @@ def delete_bundles(uuids, force, recursive, data_only, dry_run):
             )
 
     bundle_data_sizes = local.model.get_bundle_metadata(relevant_uuids, 'data_size')
+    bundle_locations = {uuid:local.bundle_store.get_bundle_location(uuid) for uuid in relevant_uuids}  # cache these so we have them even after the metadata for the bundle has been deleted
 
     # Delete the actual bundle
     if not dry_run:
@@ -1324,9 +1325,10 @@ def delete_bundles(uuids, force, recursive, data_only, dry_run):
             # Don't physically delete linked bundles.
             pass
         else:
-            bundle_location = local.bundle_store.get_bundle_location(uuid)
+            bundle_location = bundle_locations[uuid]
 
             # Remove bundle
+            removed = False
             if os.path.lexists(bundle_location) or bundle_location.startswith(
                 StorageURLScheme.AZURE_BLOB_STORAGE.value
             ) or bundle_location.startswith(StorageURLScheme.GCS_STORAGE.value):

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -1323,7 +1323,7 @@ def delete_bundles(uuids, force, recursive, data_only, dry_run):
         else:
             # If the bundle is stored on cloud, first delete data on cloud.
             for uuid in relevant_uuids:
-                bundle_location = local.bundle_store.get_bundle_location(uuid)
+                bundle_location = bundle_locations(uuid)
 
                 file_location = '/'.join(bundle_location.split('/')[0:-1]) + "/"
                 if bundle_location.startswith(
@@ -1344,6 +1344,10 @@ def delete_bundles(uuids, force, recursive, data_only, dry_run):
         else:
             bundle_location = bundle_locations[uuid]
 
+            import pdb
+
+            pdb.set_trace()
+
             # Remove bundle
             removed = False
             if (
@@ -1358,6 +1362,10 @@ def delete_bundles(uuids, force, recursive, data_only, dry_run):
                 local.model.increment_user_disk_used(
                     request.user.user_id, -int(bundle_data_sizes[uuid])
                 )
+
+            import pdb
+
+            pdb.set_trace()
 
     return relevant_uuids
 

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -1329,7 +1329,8 @@ def delete_bundles(uuids, force, recursive, data_only, dry_run):
                 removed = local.bundle_store.cleanup(uuid, dry_run)
                 if removed and uuid in bundle_data_sizes:
                     local.model.increment_user_disk_used(
-                        request.user.user_id, -int(bundle_data_sizes[uuid]))
+                        request.user.user_id, -int(bundle_data_sizes[uuid])
+                    )
 
     return relevant_uuids
 

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -1358,7 +1358,7 @@ def delete_bundles(uuids, force, recursive, data_only, dry_run):
         # Just decrement the user disk used by the sum of sizes of bundles deleted
         # OK, now let's add our change.
         start = time.time()
-        import pdb; pdb.set_trace()
+        #import pdb; pdb.set_trace()
         bundle_data_sizes = local.model.get_bundle_metadata(relevant_uuids, 'data_size')
         local.model.increment_user_disk_used(request.user.user_id, (-1)*sum(map(int, bundle_data_sizes)))
         end = time.time()

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -1331,7 +1331,7 @@ def delete_bundles(uuids, force, recursive, data_only, dry_run):
                 removed = local.bundle_store.cleanup(bundle_location, dry_run)
 
             # Update user disk used.            
-            if removed:
+            if removed and uuid in bundle_data_sizes:
                 local.model.increment_user_disk_used(
                     request.user.user_id, -int(bundle_data_sizes[uuid])
                 )

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1322,10 +1322,10 @@ def test_rm(ctx):
     wait_until_state(uuid, State.READY)
     file_size = path_util.get_size(test_path('b.txt'))
     check_equals(
-        _run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used']), str(int(disk_used) + file_size)
+        str(int(disk_used) + file_size), _run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used'])
     )
     _run_command([cl, 'rm', uuid])
-    check_equals(_run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used']), disk_used)
+    check_equals(disk_used, _run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used']))
 
     # Make sure disk quota is adjusted correctly when --data-only is used.
     disk_used = _run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used'])
@@ -1333,7 +1333,7 @@ def test_rm(ctx):
     wait_until_state(uuid, State.READY)
     file_size = path_util.get_size(test_path('b.txt'))
     check_equals(
-        _run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used']), str(int(disk_used) + file_size)
+        _run_command(str(int(disk_used) + file_size), [cl, 'uinfo', 'codalab', '-f', 'disk_used']))
     )
     _run_command([cl, 'rm', '-d', uuid])
     check_equals(_run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used']), disk_used)

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1316,16 +1316,11 @@ def test_binary(ctx):
 
 @TestModule.register('rm')
 def test_rm(ctx):
-    test = _run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used'])
     # Check rm functions correctly
     uuid = _run_command([cl, 'upload', test_path('a.txt')])
-    test = _run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used'])
     _run_command([cl, 'add', 'bundle', uuid])  # Duplicate
-    test = _run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used'])
     _run_command([cl, 'rm', uuid])  # Can delete even though it exists twice on the same worksheet
-    test = _run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used'])
     _run_command([cl, 'rm', ''], expected_exit_code=1)  # Empty parameter should give an Usage error
-    test = _run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used'])
 
     # Make sure disk quota is adjusted correctly.
     disk_used = _run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used'])

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1316,11 +1316,16 @@ def test_binary(ctx):
 
 @TestModule.register('rm')
 def test_rm(ctx):
+    test = _run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used'])
     # Check rm functions correctly
     uuid = _run_command([cl, 'upload', test_path('a.txt')])
+    test = _run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used'])
     _run_command([cl, 'add', 'bundle', uuid])  # Duplicate
+    test = _run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used'])
     _run_command([cl, 'rm', uuid])  # Can delete even though it exists twice on the same worksheet
+    test = _run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used'])
     _run_command([cl, 'rm', ''], expected_exit_code=1)  # Empty parameter should give an Usage error
+    test = _run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used'])
 
     # Make sure disk quota is adjusted correctly.
     disk_used = _run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used'])

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1316,7 +1316,7 @@ def test_binary(ctx):
 
 @TestModule.register('rm')
 def test_rm(ctx):
-    # Let's add more tests here to see if the disk quota is doing what we expect.
+    # Make sure disk quota is adjusted correctly.
     disk_used = _run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used'])
     uuid = _run_command([cl, 'upload', test_path('b.txt')])
     wait_until_state(uuid, State.READY)
@@ -1331,7 +1331,7 @@ def test_rm(ctx):
         disk_used
     )
 
-    # Now, for -d
+    # Make sure disk quota is adjusted correctly when --data-only is used.
     disk_used = _run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used'])
     uuid = _run_command([cl, 'upload', test_path('b.txt')])
     wait_until_state(uuid, State.READY)
@@ -1351,7 +1351,24 @@ def test_rm(ctx):
         disk_used
     )
 
-    # TODO: Add one for symlinks as well!
+    # Make sure disk quota is adjusted correctly for symlinks is used.
+    disk_used = _run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used'])
+    uuid = _run_command([cl, 'upload', test_path('b.txt'), '--link'])
+    wait_until_state(uuid, State.READY)
+    check_equals(
+        _run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used']),
+        disk_used
+    )
+    _run_command([cl, 'rm', '-d', uuid])
+    check_equals(
+        _run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used']),
+        disk_used
+    )
+    _run_command([cl, 'rm', uuid])
+    check_equals(
+        _run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used']),
+        disk_used
+    )
 
 
     uuid = _run_command([cl, 'upload', test_path('a.txt')])

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1316,11 +1316,6 @@ def test_binary(ctx):
 
 @TestModule.register('rm')
 def test_rm(ctx):
-    uuid = _run_command([cl, 'upload', test_path('a.txt')])
-    _run_command([cl, 'add', 'bundle', uuid])  # Duplicate
-    _run_command([cl, 'rm', uuid])  # Can delete even though it exists twice on the same worksheet
-    _run_command([cl, 'rm', ''], expected_exit_code=1)  # Empty parameter should give an Usage error
-
     # Make sure disk quota is adjusted correctly.
     disk_used = _run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used'])
     uuid = _run_command([cl, 'upload', test_path('b.txt')])
@@ -1354,6 +1349,11 @@ def test_rm(ctx):
     check_equals(_run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used']), disk_used)
     _run_command([cl, 'rm', uuid])
     check_equals(_run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used']), disk_used)
+
+    uuid = _run_command([cl, 'upload', test_path('a.txt')])
+    _run_command([cl, 'add', 'bundle', uuid])  # Duplicate
+    _run_command([cl, 'rm', uuid])  # Can delete even though it exists twice on the same worksheet
+    _run_command([cl, 'rm', ''], expected_exit_code=1)  # Empty parameter should give an Usage error
 
 
 @TestModule.register('make')

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1316,11 +1316,6 @@ def test_binary(ctx):
 
 @TestModule.register('rm')
 def test_rm(ctx):
-    uuid = _run_command([cl, 'upload', test_path('a.txt')])
-    _run_command([cl, 'add', 'bundle', uuid])  # Duplicate
-    _run_command([cl, 'rm', uuid])  # Can delete even though it exists twice on the same worksheet
-    _run_command([cl, 'rm', ''], expected_exit_code=1)  # Empty parameter should give an Usage error
-
     # Make sure disk quota is adjusted correctly.
     disk_used = _run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used'])
     uuid = _run_command([cl, 'upload', test_path('b.txt')])
@@ -1354,6 +1349,11 @@ def test_rm(ctx):
     check_equals(disk_used, _run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used']))
     _run_command([cl, 'rm', uuid])
     check_equals(disk_used, _run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used']))
+
+    uuid = _run_command([cl, 'upload', test_path('a.txt')])
+    _run_command([cl, 'add', 'bundle', uuid])  # Duplicate
+    _run_command([cl, 'rm', uuid])  # Can delete even though it exists twice on the same worksheet
+    _run_command([cl, 'rm', ''], expected_exit_code=1)  # Empty parameter should give an Usage error
 
 
 @TestModule.register('make')

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1757,7 +1757,6 @@ def test_search_time(ctx):
 @TestModule.register('run')
 def test_run(ctx):
     # Test that bundle fails when run without sufficient time quota
-    """
     time_used = int(_run_command([cl, 'uinfo', 'codalab', '-f', 'time_used']))
     _run_command([cl, 'uedit', 'codalab', '--time-quota', str(time_used + 2)])
     uuid = _run_command([cl, 'run', 'sleep 100000'])
@@ -1770,7 +1769,6 @@ def test_run(ctx):
         get_info(uuid, 'failure_message'),
     )
     _run_command([cl, 'uedit', 'codalab', '--time-quota', ctx.time_quota])  # reset time quota
-    """
 
     name = random_name()
     uuid = _run_command([cl, 'run', 'echo hello', '-n', name])

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1316,6 +1316,11 @@ def test_binary(ctx):
 
 @TestModule.register('rm')
 def test_rm(ctx):
+    uuid = _run_command([cl, 'upload', test_path('a.txt')])
+    _run_command([cl, 'add', 'bundle', uuid])  # Duplicate
+    _run_command([cl, 'rm', uuid])  # Can delete even though it exists twice on the same worksheet
+    _run_command([cl, 'rm', ''], expected_exit_code=1)  # Empty parameter should give an Usage error
+
     # Make sure disk quota is adjusted correctly.
     disk_used = _run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used'])
     uuid = _run_command([cl, 'upload', test_path('b.txt')])
@@ -1333,27 +1338,22 @@ def test_rm(ctx):
     wait_until_state(uuid, State.READY)
     file_size = path_util.get_size(test_path('b.txt'))
     check_equals(
-        _run_command(str(int(disk_used) + file_size), [cl, 'uinfo', 'codalab', '-f', 'disk_used']))
+        str(int(disk_used) + file_size), _run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used'])
     )
     _run_command([cl, 'rm', '-d', uuid])
-    check_equals(_run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used']), disk_used)
+    check_equals(disk_used, _run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used']))
     _run_command([cl, 'rm', uuid])
-    check_equals(_run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used']), disk_used)
+    check_equals(disk_used, _run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used']))
 
     # Make sure disk quota is adjusted correctly for symlinks is used.
     disk_used = _run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used'])
     uuid = _run_command([cl, 'upload', test_path('b.txt'), '--link'])
     wait_until_state(uuid, State.READY)
-    check_equals(_run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used']), disk_used)
+    check_equals(disk_used, _run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used']))
     _run_command([cl, 'rm', '-d', uuid])
-    check_equals(_run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used']), disk_used)
+    check_equals(disk_used, _run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used']))
     _run_command([cl, 'rm', uuid])
-    check_equals(_run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used']), disk_used)
-
-    uuid = _run_command([cl, 'upload', test_path('a.txt')])
-    _run_command([cl, 'add', 'bundle', uuid])  # Duplicate
-    _run_command([cl, 'rm', uuid])  # Can delete even though it exists twice on the same worksheet
-    _run_command([cl, 'rm', ''], expected_exit_code=1)  # Empty parameter should give an Usage error
+    check_equals(disk_used, _run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used']))
 
 
 @TestModule.register('make')

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1316,6 +1316,12 @@ def test_binary(ctx):
 
 @TestModule.register('rm')
 def test_rm(ctx):
+    # Check rm functions correctly
+    uuid = _run_command([cl, 'upload', test_path('a.txt')])
+    _run_command([cl, 'add', 'bundle', uuid])  # Duplicate
+    _run_command([cl, 'rm', uuid])  # Can delete even though it exists twice on the same worksheet
+    _run_command([cl, 'rm', ''], expected_exit_code=1)  # Empty parameter should give an Usage error
+
     # Make sure disk quota is adjusted correctly.
     disk_used = _run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used'])
     uuid = _run_command([cl, 'upload', test_path('b.txt')])
@@ -1349,11 +1355,6 @@ def test_rm(ctx):
     check_equals(disk_used, _run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used']))
     _run_command([cl, 'rm', uuid])
     check_equals(disk_used, _run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used']))
-
-    uuid = _run_command([cl, 'upload', test_path('a.txt')])
-    _run_command([cl, 'add', 'bundle', uuid])  # Duplicate
-    _run_command([cl, 'rm', uuid])  # Can delete even though it exists twice on the same worksheet
-    _run_command([cl, 'rm', ''], expected_exit_code=1)  # Empty parameter should give an Usage error
 
 
 @TestModule.register('make')

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1316,20 +1316,21 @@ def test_binary(ctx):
 
 @TestModule.register('rm')
 def test_rm(ctx):
+    uuid = _run_command([cl, 'upload', test_path('a.txt')])
+    _run_command([cl, 'add', 'bundle', uuid])  # Duplicate
+    _run_command([cl, 'rm', uuid])  # Can delete even though it exists twice on the same worksheet
+    _run_command([cl, 'rm', ''], expected_exit_code=1)  # Empty parameter should give an Usage error
+
     # Make sure disk quota is adjusted correctly.
     disk_used = _run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used'])
     uuid = _run_command([cl, 'upload', test_path('b.txt')])
     wait_until_state(uuid, State.READY)
     file_size = path_util.get_size(test_path('b.txt'))
     check_equals(
-        _run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used']),
-        str(int(disk_used) + file_size)
+        _run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used']), str(int(disk_used) + file_size)
     )
     _run_command([cl, 'rm', uuid])
-    check_equals(
-        _run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used']),
-        disk_used
-    )
+    check_equals(_run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used']), disk_used)
 
     # Make sure disk quota is adjusted correctly when --data-only is used.
     disk_used = _run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used'])
@@ -1337,46 +1338,22 @@ def test_rm(ctx):
     wait_until_state(uuid, State.READY)
     file_size = path_util.get_size(test_path('b.txt'))
     check_equals(
-        _run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used']),
-        str(int(disk_used) + file_size)
+        _run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used']), str(int(disk_used) + file_size)
     )
     _run_command([cl, 'rm', '-d', uuid])
-    check_equals(
-        _run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used']),
-        disk_used
-    )
+    check_equals(_run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used']), disk_used)
     _run_command([cl, 'rm', uuid])
-    check_equals(
-        _run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used']),
-        disk_used
-    )
+    check_equals(_run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used']), disk_used)
 
     # Make sure disk quota is adjusted correctly for symlinks is used.
     disk_used = _run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used'])
     uuid = _run_command([cl, 'upload', test_path('b.txt'), '--link'])
     wait_until_state(uuid, State.READY)
-    check_equals(
-        _run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used']),
-        disk_used
-    )
+    check_equals(_run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used']), disk_used)
     _run_command([cl, 'rm', '-d', uuid])
-    check_equals(
-        _run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used']),
-        disk_used
-    )
+    check_equals(_run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used']), disk_used)
     _run_command([cl, 'rm', uuid])
-    check_equals(
-        _run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used']),
-        disk_used
-    )
-
-
-    uuid = _run_command([cl, 'upload', test_path('a.txt')])
-    _run_command([cl, 'add', 'bundle', uuid])  # Duplicate
-    _run_command([cl, 'rm', uuid])  # Can delete even though it exists twice on the same worksheet
-    _run_command([cl, 'rm', ''], expected_exit_code=1)  # Empty parameter should give an Usage error
-
-    
+    check_equals(_run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used']), disk_used)
 
 
 @TestModule.register('make')

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1757,7 +1757,6 @@ def test_search_time(ctx):
 @TestModule.register('run')
 def test_run(ctx):
     # Test that bundle fails when run without sufficient time quota
-<<<<<<< HEAD
     """
     time_used = int(_run_command([cl, 'uinfo', 'codalab', '-f', 'time_used']))
     _run_command([cl, 'uedit', 'codalab', '--time-quota', str(time_used + 2)])

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1319,10 +1319,11 @@ def test_rm(ctx):
     # Let's add more tests here to see if the disk quota is doing what we expect.
     disk_used = _run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used'])
     uuid = _run_command([cl, 'upload', test_path('b.txt')])
+    wait_until_state(uuid, State.READY)
     file_size = path_util.get_size(test_path('b.txt'))
     check_equals(
         _run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used']),
-        disk_used + file_size
+        str(int(disk_used) + file_size)
     )
     _run_command([cl, 'rm', uuid])
     check_equals(
@@ -1333,10 +1334,11 @@ def test_rm(ctx):
     # Now, for -d
     disk_used = _run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used'])
     uuid = _run_command([cl, 'upload', test_path('b.txt')])
+    wait_until_state(uuid, State.READY)
     file_size = path_util.get_size(test_path('b.txt'))
     check_equals(
         _run_command([cl, 'uinfo', 'codalab', '-f', 'disk_used']),
-        disk_used + file_size
+        str(int(disk_used) + file_size)
     )
     _run_command([cl, 'rm', '-d', uuid])
     check_equals(

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1722,6 +1722,7 @@ def test_search_time(ctx):
 @TestModule.register('run')
 def test_run(ctx):
     # Test that bundle fails when run without sufficient time quota
+    """
     _run_command([cl, 'uedit', 'codalab', '--time-quota', '2'])
     uuid = _run_command([cl, 'run', 'sleep 100000'])
     wait_until_state(uuid, State.KILLED, timeout_seconds=60)
@@ -1733,6 +1734,7 @@ def test_run(ctx):
         get_info(uuid, 'failure_message'),
     )
     _run_command([cl, 'uedit', 'codalab', '--time-quota', ctx.time_quota])  # reset time quota
+    """
 
     name = random_name()
     uuid = _run_command([cl, 'run', 'echo hello', '-n', name])


### PR DESCRIPTION
### Reasons for making this change

Speed up rm bundles since it's very slow on the Stanford instance (and is slow in general on any instance that has lots of bundles).

### Related issues

#4217
