### PR TITLE
Make time quota test easier to run locally

### DIFF
--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1725,7 +1725,7 @@ def test_run(ctx):
     time_used = int(_run_command([cl, 'uinfo', 'codalab', '-f', 'time_used']))
     _run_command([cl, 'uedit', 'codalab', '--time-quota', str(time_used + 2)])
     uuid = _run_command([cl, 'run', 'sleep 100000'])
-    wait_until_state(uuid, State.KILLED, timeout_seconds=60)
+    wait_until_state(uuid, State.KILLED, timeout_seconds=120)
     check_equals(
         'Kill requested: User time quota exceeded. To apply for more quota,'
         ' please visit the following link: '

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1722,7 +1722,8 @@ def test_search_time(ctx):
 @TestModule.register('run')
 def test_run(ctx):
     # Test that bundle fails when run without sufficient time quota
-    _run_command([cl, 'uedit', 'codalab', '--time-quota', '2'])
+    time_used = int(_run_command([cl, 'uinfo', 'codalab', '-f', 'time_used']))
+    _run_command([cl, 'uedit', 'codalab', '--time-quota', str(time_used + 2)])
     uuid = _run_command([cl, 'run', 'sleep 100000'])
     wait_until_state(uuid, State.KILLED, timeout_seconds=60)
     check_equals(


### PR DESCRIPTION
### Reasons for making this change

The test for checking that bundles fail when they go over time quota works in Github Actions, but is annoying to execute locally. This PR fixes that issue.