### PR TITLE
Fix ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   format:
     name: Format
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python 3.7
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.6
       - run: npm ci
         working-directory: ./frontend
       - run: npm run check-ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   format:
     name: Format
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python 3.7
         uses: actions/setup-python@v1
         with:
-          python-version: 3.6
+          python-version: 3.7
       - run: npm ci
         working-directory: ./frontend
       - run: npm run check-ci
@@ -378,7 +378,7 @@ jobs:
 
   test_backend_default_bundle_store_azure:
     name: Test backend - use azure as default bundle store 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: [build]
     strategy:
       matrix:
@@ -392,7 +392,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.6
       - uses: actions/cache@v2
         with:
           path: ~/.cache/pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-20.04, macos-latest]
         exclude:
           - os: macos-latest
             python-version: 3.6
@@ -392,7 +392,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
         with:
-          python-version: 3.6
+          python-version: 3.7
       - uses: actions/cache@v2
         with:
           path: ~/.cache/pip


### PR DESCRIPTION
### Reasons for making this change

CI is temporarily broken due to issue with Ubuntu-latest version not having support for python3.6 in python-setup Github Action. See issue here: https://github.com/actions/setup-python/issues/544
