### PR TITLE
Rc1.5.13

### DIFF
--- a/codalab/common.py
+++ b/codalab/common.py
@@ -29,7 +29,7 @@ from codalab.lib.beam.filesystems import (
 
 # Increment this on master when ready to cut a release.
 # http://semver.org/
-CODALAB_VERSION = '1.5.12'
+CODALAB_VERSION = '1.5.13'
 BINARY_PLACEHOLDER = '<binary>'
 URLOPEN_TIMEOUT_SECONDS = int(os.environ.get('CODALAB_URLOPEN_TIMEOUT_SECONDS', 5 * 60))
 

--- a/docs/REST-API-Reference.md
+++ b/docs/REST-API-Reference.md
@@ -1,6 +1,6 @@
 # REST API Reference
 
-_version 1.5.12_
+_version 1.5.13_
 
 This reference and the REST API itself is still under heavy development and is
 subject to change at any time. Feedback through our GitHub issues is appreciated!

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -1,5 +1,5 @@
 // Should match codalab/common.py#CODALAB_VERSION
-export const CODALAB_VERSION = '1.5.12';
+export const CODALAB_VERSION = '1.5.13';
 
 // Name Regex to match the backend in spec_utils.py
 export const NAME_REGEX = /^[a-zA-Z_][a-zA-Z0-9_.-]*$/i;

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import sys
 
 
 # should match codalab/common.py#CODALAB_VERSION
-CODALAB_VERSION = "1.5.12"
+CODALAB_VERSION = "1.5.13"
 
 
 class Install(install):


### PR DESCRIPTION
## Frontend

## Backend
- Delete bundle content stored in Azure/GCS when deleting a bundle (#4308)
- Allow edu users to have more time quota and disk quota (#4303)
- Use websockets to make on-demand worker file previews faster as well as some other fixes (#4096, #4324, #4338)
- Support kubernetes runtime (#4316)

## Dev
-  Fix CI (#4320)
- Make time quota test easier to run locally (#4313)