### PR TITLE
Include ws-server as something NGINX depends on

### DIFF
--- a/docker_config/compose_files/docker-compose.yml
+++ b/docker_config/compose_files/docker-compose.yml
@@ -357,6 +357,7 @@ services:
     depends_on:
       - frontend
       - rest-server
+      - ws-server
     ports:
       - ${CODALAB_HTTP_PORT}:80
     volumes:


### PR DESCRIPTION
### Reasons for making this change

The NGINX service in the Docker compose must also depend on the ws-server. Otherwise, NGINX container fails with error:
[emerg] 1#1: host not found in upstream "backend" in /etc/nginx/nginx.conf:137
nginx: [emerg] host not found in upstream "backend" in /etc/nginx/nginx.conf:137