### PR TITLE
Revert "Include ws-server as something NGINX depends on"

### DIFF
--- a/docker_config/compose_files/docker-compose.yml
+++ b/docker_config/compose_files/docker-compose.yml
@@ -357,7 +357,6 @@ services:
     depends_on:
       - frontend
       - rest-server
-      - ws-server
     ports:
       - ${CODALAB_HTTP_PORT}:80
     volumes:


### PR DESCRIPTION
Reverts codalab/codalab-worksheets#4322