### PR TITLE
Dependency manager: don't release un-acquired lock

### DIFF
--- a/codalab/worker/dependency_manager.py
+++ b/codalab/worker/dependency_manager.py
@@ -73,8 +73,8 @@ class NFSLock:
         try:
             self._lock.unlock()
         except NotLockedError:
-            # Safe to re-attempt to release a lock
-            pass
+            # Lock is not acquired, so we don't need to release
+            return
         self._r_lock.release()
 
     def __enter__(self):


### PR DESCRIPTION
Fixes https://github.com/codalab/codalab-worksheets/issues/4092. We had assumed this is a safe operation, but it actually isn't.