### PR TITLE
Add Access-Control-Allow-Origin response header

### DIFF
--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -916,7 +916,7 @@ def _fetch_bundle_contents_blob(uuid, path=''):
     - `Content-Disposition: inline; filename=<bundle name or target filename>`
     - `Content-Type: <guess of mimetype based on file extension>`
     - `Content-Encoding: [gzip|identity]`
-    - `Access-Control-Allow-Origin: *` (only sent if the bundle is public)
+    - `Access-Control-Allow-Origin: *`
     - `Target-Type: file`
     - `X-CodaLab-Target-Size: <size of the target>`
 
@@ -924,7 +924,7 @@ def _fetch_bundle_contents_blob(uuid, path=''):
     - `Content-Disposition: attachment; filename=<bundle or directory name>.tar.gz`
     - `Content-Type: application/gzip`
     - `Content-Encoding: identity`
-    - `Access-Control-Allow-Origin: *` (only sent if the bundle is public)
+    - `Access-Control-Allow-Origin: *`
     - `Target-Type: directory`
     - `X-CodaLab-Target-Size: <size of the target>`
 

--- a/codalab/rest/bundles.py
+++ b/codalab/rest/bundles.py
@@ -916,6 +916,7 @@ def _fetch_bundle_contents_blob(uuid, path=''):
     - `Content-Disposition: inline; filename=<bundle name or target filename>`
     - `Content-Type: <guess of mimetype based on file extension>`
     - `Content-Encoding: [gzip|identity]`
+    - `Access-Control-Allow-Origin: *` (only sent if the bundle is public)
     - `Target-Type: file`
     - `X-CodaLab-Target-Size: <size of the target>`
 
@@ -923,6 +924,7 @@ def _fetch_bundle_contents_blob(uuid, path=''):
     - `Content-Disposition: attachment; filename=<bundle or directory name>.tar.gz`
     - `Content-Type: application/gzip`
     - `Content-Encoding: identity`
+    - `Access-Control-Allow-Origin: *` (only sent if the bundle is public)
     - `Target-Type: directory`
     - `X-CodaLab-Target-Size: <size of the target>`
 
@@ -1038,6 +1040,7 @@ def _fetch_bundle_contents_blob(uuid, path=''):
         response.set_header('Content-Disposition', 'inline; filename="%s"' % filename)
     else:
         response.set_header('Content-Disposition', 'attachment; filename="%s"' % filename)
+    response.set_header('Access-Control-Allow-Origin', '*')
     response.set_header('Target-Type', target_info['type'])
     if target_info['type'] == 'file':
         size = target_info['size']

--- a/docs/REST-API-Reference.md
+++ b/docs/REST-API-Reference.md
@@ -678,7 +678,7 @@ HTTP Response headers (for single-file targets):
 - `Content-Disposition: inline; filename=<bundle name or target filename>`
 - `Content-Type: <guess of mimetype based on file extension>`
 - `Content-Encoding: [gzip|identity]`
-- `Access-Control-Allow-Origin: *` (only sent if the bundle is public)
+- `Access-Control-Allow-Origin: *`
 - `Target-Type: file`
 - `X-CodaLab-Target-Size: <size of the target>`
 
@@ -686,7 +686,7 @@ HTTP Response headers (for directories):
 - `Content-Disposition: attachment; filename=<bundle or directory name>.tar.gz`
 - `Content-Type: application/gzip`
 - `Content-Encoding: identity`
-- `Access-Control-Allow-Origin: *` (only sent if the bundle is public)
+- `Access-Control-Allow-Origin: *`
 - `Target-Type: directory`
 - `X-CodaLab-Target-Size: <size of the target>`
 
@@ -731,7 +731,7 @@ HTTP Response headers (for single-file targets):
 - `Content-Disposition: inline; filename=<bundle name or target filename>`
 - `Content-Type: <guess of mimetype based on file extension>`
 - `Content-Encoding: [gzip|identity]`
-- `Access-Control-Allow-Origin: *` (only sent if the bundle is public)
+- `Access-Control-Allow-Origin: *`
 - `Target-Type: file`
 - `X-CodaLab-Target-Size: <size of the target>`
 
@@ -739,7 +739,7 @@ HTTP Response headers (for directories):
 - `Content-Disposition: attachment; filename=<bundle or directory name>.tar.gz`
 - `Content-Type: application/gzip`
 - `Content-Encoding: identity`
-- `Access-Control-Allow-Origin: *` (only sent if the bundle is public)
+- `Access-Control-Allow-Origin: *`
 - `Target-Type: directory`
 - `X-CodaLab-Target-Size: <size of the target>`
 

--- a/docs/REST-API-Reference.md
+++ b/docs/REST-API-Reference.md
@@ -667,6 +667,7 @@ Query parameters:
 - `support_redirect`: Set to 1 if the client supports bypassing the server
   and redirecting to another URL (such as Blob Storage). If so, the Target-Type and
   X-CodaLab-Target-Size headers will not be present in the response.
+
   If this endpoint is called from a web browser (`Referer` header is set), this parameter
   defaults to 1. Otherwise, it defaults to 0, meant for compatibility
   with older clients / CLI versions that depend on the Target-Type and
@@ -719,6 +720,7 @@ Query parameters:
 - `support_redirect`: Set to 1 if the client supports bypassing the server
   and redirecting to another URL (such as Blob Storage). If so, the Target-Type and
   X-CodaLab-Target-Size headers will not be present in the response.
+
   If this endpoint is called from a web browser (`Referer` header is set), this parameter
   defaults to 1. Otherwise, it defaults to 0, meant for compatibility
   with older clients / CLI versions that depend on the Target-Type and

--- a/docs/REST-API-Reference.md
+++ b/docs/REST-API-Reference.md
@@ -667,7 +667,6 @@ Query parameters:
 - `support_redirect`: Set to 1 if the client supports bypassing the server
   and redirecting to another URL (such as Blob Storage). If so, the Target-Type and
   X-CodaLab-Target-Size headers will not be present in the response.
-
   If this endpoint is called from a web browser (`Referer` header is set), this parameter
   defaults to 1. Otherwise, it defaults to 0, meant for compatibility
   with older clients / CLI versions that depend on the Target-Type and
@@ -678,6 +677,7 @@ HTTP Response headers (for single-file targets):
 - `Content-Disposition: inline; filename=<bundle name or target filename>`
 - `Content-Type: <guess of mimetype based on file extension>`
 - `Content-Encoding: [gzip|identity]`
+- `Access-Control-Allow-Origin: *` (only sent if the bundle is public)
 - `Target-Type: file`
 - `X-CodaLab-Target-Size: <size of the target>`
 
@@ -685,6 +685,7 @@ HTTP Response headers (for directories):
 - `Content-Disposition: attachment; filename=<bundle or directory name>.tar.gz`
 - `Content-Type: application/gzip`
 - `Content-Encoding: identity`
+- `Access-Control-Allow-Origin: *` (only sent if the bundle is public)
 - `Target-Type: directory`
 - `X-CodaLab-Target-Size: <size of the target>`
 
@@ -718,7 +719,6 @@ Query parameters:
 - `support_redirect`: Set to 1 if the client supports bypassing the server
   and redirecting to another URL (such as Blob Storage). If so, the Target-Type and
   X-CodaLab-Target-Size headers will not be present in the response.
-
   If this endpoint is called from a web browser (`Referer` header is set), this parameter
   defaults to 1. Otherwise, it defaults to 0, meant for compatibility
   with older clients / CLI versions that depend on the Target-Type and
@@ -729,6 +729,7 @@ HTTP Response headers (for single-file targets):
 - `Content-Disposition: inline; filename=<bundle name or target filename>`
 - `Content-Type: <guess of mimetype based on file extension>`
 - `Content-Encoding: [gzip|identity]`
+- `Access-Control-Allow-Origin: *` (only sent if the bundle is public)
 - `Target-Type: file`
 - `X-CodaLab-Target-Size: <size of the target>`
 
@@ -736,6 +737,7 @@ HTTP Response headers (for directories):
 - `Content-Disposition: attachment; filename=<bundle or directory name>.tar.gz`
 - `Content-Type: application/gzip`
 - `Content-Encoding: identity`
+- `Access-Control-Allow-Origin: *` (only sent if the bundle is public)
 - `Target-Type: directory`
 - `X-CodaLab-Target-Size: <size of the target>`
 


### PR DESCRIPTION
### Reasons for making this change

This allows websites not hosted CodaLab to make `XMLHttpRequests` to fetch files from CodaLab bundles.

### Related issues

Addresses #4365

### Checklist

* [ ] I've added a screenshot of the changes, if this is a frontend change
* [ ] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [ ] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
