### PR TITLE
increase timeouts range in both worker and bundle-manager to help all…

### DIFF
--- a/codalab/rest/workers.py
+++ b/codalab/rest/workers.py
@@ -25,7 +25,7 @@ def checkin(worker_id):
     Waits for a message for the worker for WAIT_TIME_SECS seconds. Returns the
     message or None if there isn't one.
     """
-    WAIT_TIME_SECS = 3.0
+    WAIT_TIME_SECS = 5.0
 
     # Old workers might not have all the fields, so allow subsets to be missing.
     socket_id = local.worker_model.worker_checkin(

--- a/codalab/server/bundle_manager.py
+++ b/codalab/server/bundle_manager.py
@@ -355,7 +355,7 @@ class BundleManager(object):
                 worker['socket_id'],
                 worker['worker_id'],
                 {'type': 'mark_finalized', 'uuid': bundle.uuid},
-                0.2,
+                1,
             ):
                 logger.info(
                     'Acknowledged finalization of run bundle {} on worker {}'.format(


### PR DESCRIPTION
In a previous [PR](https://github.com/codalab/codalab-worksheets/pull/4406), I adjusted the incorrect timeout in the bundle-manager. I correct that here and increase the timeout for the worker on its checkin.