### PR TITLE
Bump version to 1.6.1

### DIFF
--- a/codalab/common.py
+++ b/codalab/common.py
@@ -29,7 +29,7 @@ from codalab.lib.beam.filesystems import (
 
 # Increment this on master when ready to cut a release.
 # http://semver.org/
-CODALAB_VERSION = '1.6.0'
+CODALAB_VERSION = '1.6.1'
 BINARY_PLACEHOLDER = '<binary>'
 URLOPEN_TIMEOUT_SECONDS = int(os.environ.get('CODALAB_URLOPEN_TIMEOUT_SECONDS', 5 * 60))
 

--- a/docs/REST-API-Reference.md
+++ b/docs/REST-API-Reference.md
@@ -1,6 +1,6 @@
 # REST API Reference
 
-_version 1.6.0_
+_version 1.6.1_
 
 This reference and the REST API itself is still under heavy development and is
 subject to change at any time. Feedback through our GitHub issues is appreciated!

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -1,5 +1,5 @@
 // Should match codalab/common.py#CODALAB_VERSION
-export const CODALAB_VERSION = '1.6.0';
+export const CODALAB_VERSION = '1.6.1';
 
 // Name Regex to match the backend in spec_utils.py
 export const NAME_REGEX = /^[a-zA-Z_][a-zA-Z0-9_.-]*$/i;

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import sys
 
 
 # should match codalab/common.py#CODALAB_VERSION
-CODALAB_VERSION = "1.6.0"
+CODALAB_VERSION = "1.6.1"
 
 
 class Install(install):


### PR DESCRIPTION
# Release notes
## Frontend
None

## CLI
None

## Backend
Fix/4285 limit disk on parallel upload #4329 
Dependency manager: don't release un-acquired lock #4359 
Add Access-Control-Allow-Origin response header #4367 
Speed up disk quota computation #4354
[Fix/4392 remove data hash (](https://github.com/codalab/codalab-worksheets/commit/d33626f22cf957cae297942e8e98bae6d39840d2)
[Fix division by zero error when time quota is set to 0 (](https://github.com/codalab/codalab-worksheets/commit/dd9c4425897439a4c3f81bd00f421802b3d0d0c1)
[Clean up worker comments (](https://github.com/codalab/codalab-worksheets/commit/5955017a477ccb18009fd82440ee5b3b0564a3b1)
[Fix Stress Tests (](https://github.com/codalab/codalab-worksheets/commit/7833e8e981268ebabd7e9219e917d87f6c672270)
increase timeouts range in both worker and bundle-manager to help stress tests finish #4421

## Dev / docs / CI
Update Worker-Managers.md #4371 