### PR TITLE
Stress Test Minor Patch

### DIFF
--- a/tests/stress/stress_test.py
+++ b/tests/stress/stress_test.py
@@ -141,7 +141,7 @@ class StressTestRunner:
 
     def run(self):
         print('Cleaning up stress test files from other runs...')
-        cleanup(self._cl, StressTestRunner._TAG, should_wait=True)
+        cleanup(self._cl, self._TAG, should_wait=True)
 
         print('Running stress tests...')
         self._start_heartbeat()


### PR DESCRIPTION
This is a minor patch to the stress test to fix an issue arising from a recent change I made where a value which no longer exists is referenced, thereby yielding `AttributeError: type object 'StressTestRunner' has no attribute '_TAG'`