### PR TITLE
Bump version to 1.6.3

### DIFF
--- a/codalab/common.py
+++ b/codalab/common.py
@@ -29,7 +29,7 @@ from codalab.lib.beam.filesystems import (
 
 # Increment this on master when ready to cut a release.
 # http://semver.org/
-CODALAB_VERSION = '1.6.2'
+CODALAB_VERSION = '1.6.3'
 BINARY_PLACEHOLDER = '<binary>'
 URLOPEN_TIMEOUT_SECONDS = int(os.environ.get('CODALAB_URLOPEN_TIMEOUT_SECONDS', 5 * 60))
 

--- a/docs/REST-API-Reference.md
+++ b/docs/REST-API-Reference.md
@@ -1,6 +1,6 @@
 # REST API Reference
 
-_version 1.6.2_
+_version 1.6.3_
 
 This reference and the REST API itself is still under heavy development and is
 subject to change at any time. Feedback through our GitHub issues is appreciated!

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -1,5 +1,5 @@
 // Should match codalab/common.py#CODALAB_VERSION
-export const CODALAB_VERSION = '1.6.2';
+export const CODALAB_VERSION = '1.6.3';
 
 // Name Regex to match the backend in spec_utils.py
 export const NAME_REGEX = /^[a-zA-Z_][a-zA-Z0-9_.-]*$/i;

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import sys
 
 
 # should match codalab/common.py#CODALAB_VERSION
-CODALAB_VERSION = "1.6.2"
+CODALAB_VERSION = "1.6.3"
 
 
 class Install(install):


### PR DESCRIPTION
# Release notes

## Frontend

- Fix web cli scrolling (#4415)
- Bump jszip from 3.7.0 to 3.8.0 in /frontend (#4376) 

## CLI

- Fix CI - upgrade apache beam to version 2.38.0 (#4452)

## Backend

- Allow ".edu.cn" accounts to have more time and disk quota (#4440)
- Added changes to track disk quota usage (#4307)

## Dev / docs / CI

- None