### PR TITLE
Fix Flaky CI - Mimic

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,6 +32,7 @@ selenium==3.141.0
 requests==2.25.0
 azure-storage-blob==12.4.0
 azure-core==1.8.0
+msrest==0.6.21
 sentry-sdk==1.11.1
 requests-oauthlib==1.1.0
 oauthlib==2.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,6 @@ selenium==3.141.0
 requests==2.25.0
 azure-storage-blob==12.4.0
 azure-core==1.8.0
-msrest==0.6.21
 sentry-sdk==1.11.1
 requests-oauthlib==1.1.0
 oauthlib==2.1.0

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -305,6 +305,7 @@ def data_hash(uuid, worksheet=None):
     """Temporarily download bundle contents.
     Return a hash of those contents.
     """
+    _run_command([cl, 'wait', uuid])
     path = temp_path(uuid)
     if not os.path.exists(path):
         # Download the bundle to that path.

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -302,10 +302,9 @@ def recursive_ls(path):
 
 
 def data_hash(uuid, worksheet=None):
+    """Temporarily download bundle contents.
+    Return a hash of those contents.
     """
-        Temporarily download bundle contents.
-        Return a hash of those contents.
-        """
     path = temp_path(uuid)
     if not os.path.exists(path):
         # Download the bundle to that path.
@@ -316,10 +315,8 @@ def data_hash(uuid, worksheet=None):
     sha1 = hashlib.sha1()
     files = recursive_ls(path)[1]
     for f in files:
-        try:
-            sha1.update(open(f, 'r').read().encode())
-        except Exception as e:
-            raise Exception("file name: {}. exception: {}".format(f, e))
+        sha1.update(open(f, 'r').read().encode())
+    #os.removedir(path)
     return sha1.hexdigest()
 
 
@@ -2388,11 +2385,6 @@ def test_write(ctx):
     check_equals(str(['write\tmessage\thello world']), get_info(uuid, 'actions'))
 
 
-"""
-This we'll have ot think about how to migrate...
-"""
-
-
 @TestModule.register('mimic')
 def test_mimic(ctx):
     simple_name = random_name()
@@ -2437,6 +2429,10 @@ def test_mimic(ctx):
     new_named_input_uuid = _run_command([cl, 'upload', test_path('b.txt')])
 
     # Try running macro with numbered and named inputs
+    # Here is where mimic is failing.
+    # Not sure why...
+    # Plan should be to try and run this command, run data_hash, see what happens
+    # We can read the commands run and re-create them and see what's going on!
     macro_out_uuid = _run_command(
         [
             cl,

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -317,7 +317,7 @@ def data_hash(uuid, worksheet=None):
     files = recursive_ls(path)[1]
     for f in files:
         sha1.update(open(f, 'r').read().encode())
-    #os.removedir(path)
+    shutil.rmtree(path)
     return sha1.hexdigest()
 
 
@@ -2430,10 +2430,6 @@ def test_mimic(ctx):
     new_named_input_uuid = _run_command([cl, 'upload', test_path('b.txt')])
 
     # Try running macro with numbered and named inputs
-    # Here is where mimic is failing.
-    # Not sure why...
-    # Plan should be to try and run this command, run data_hash, see what happens
-    # We can read the commands run and re-create them and see what's going on!
     macro_out_uuid = _run_command(
         [
             cl,


### PR DESCRIPTION
Addresses one part of issue #4433 by addressing the flakiness of the Mimic test.

What happened was, after we removed the data hash, we had to write code in the test_cli.py file to produce something equivalent for tests that relied on having a check that the contents of two bundles were the same. To do this, we download the bundle and then hash the files in the directories in a function in the test_cli.py file.

However, that function did not `wait` on the uuid of the bundle being data hashed, and so sometimes the downloaded contents wouldn't match the contents of the bundle being mimicked, thereby causing occasional failures.

(Note: This is still a hypothesis. I could not reproduce the issue locally but could on CI, but I have re-run the mimic CI test many times after this change and it has yet to fail.)
