### PR TITLE
Fix Flaky CI - Make

### DIFF
--- a/codalab/lib/bundle_cli.py
+++ b/codalab/lib/bundle_cli.py
@@ -1709,19 +1709,15 @@ class BundleCLI(object):
         # Add new bundle's location. If user specify the storage using `--store`, the bundle will be added to that storage.
         # Otherwise, the new MakeBundle will be added to default storage, which is set by the rest server.
         destination_bundle_store = metadata.get('store')
-        if destination_bundle_store is not None:
-            bundle_store_uuid = None
-
-            # 1) Read destination store from --store if user has specified it
-            if destination_bundle_store:
-                storage_info = client.fetch_one(
-                    'bundle_stores',
-                    params={
-                        'name': destination_bundle_store,
-                        'include': ['uuid', 'storage_type', 'url'],
-                    },
-                )
-                bundle_store_uuid = storage_info['uuid']
+        if destination_bundle_store:
+            storage_info = client.fetch_one(
+                'bundle_stores',
+                params={
+                    'name': destination_bundle_store,
+                    'include': ['uuid', 'storage_type', 'url'],
+                },
+            )
+            bundle_store_uuid = storage_info['uuid']
 
             # Do not need to bypass server for MakeBundle. Directly make bundle on server.
             params = {'need_bypass': False}

--- a/codalab/server/bundle_manager.py
+++ b/codalab/server/bundle_manager.py
@@ -329,7 +329,7 @@ class BundleManager(object):
             logger.info('Finished making bundle %s', bundle.uuid)
             self._model.update_bundle(bundle, {'state': State.READY})
         except Exception as e:
-            logger.info('Failing bundle %s: %s', bundle.uuid, str(e))
+            logger.info('Failing bundle %s\n %s', bundle.uuid, traceback.format_exc())
             self._model.update_bundle(
                 bundle,
                 {


### PR DESCRIPTION
Fix flaky test for Make (to address #4433)

I believe what's happening is that there's a race condition in the CLI code for Make.

**Race Condition Explanation**

The test that's failing in the example given is this one [here](https://github.com/codalab/codalab-worksheets/blame/master/tests/cli/test_cli.py#L1567) (uploading local files to Azure Blob storage). The error is `azure.core.exceptions.ResourceNotFoundError: Operation returned an invalid status 'The specified blob does not exist.'
ErrorCode:BlobNotFound`, which occurs because of the following error: `Not found: azfs://devstoreaccount1/bundles/0x5982329733ef43c8aadfa08b21a3a29d/contents.gz`. Interestingly, that's actually the UUID of the make bundle (in the bundle manager logs, we see this line: `2023-04-05 22:28:00,662 Staging 0x5982329733ef43c8aadfa08b21a3a29d
2023-04-05 22:28:00,677 Making bundle 0x5982329733ef43c8aadfa08b21a3a29d
2023-04-05 22:28:01,201 Failing bundle 0x5982329733ef43c8aadfa08b21a3a29d: [Errno 2] Not found: azfs://devstoreaccount1/bundles/0x5982329733ef43c8aadfa08b21a3a29d/contents.gz`).

This happens because: the ['make'](https://github.com/codalab/codalab-worksheets/blob/master/codalab/lib/bundle_cli.py#L1676) command in the bundle CLI, we see that the make bundle is first [created](https://github.com/codalab/codalab-worksheets/blob/master/codalab/lib/bundle_cli.py#L1703)  -- meaning that the rest server will add it to the database as a MAKE bundle -- and then bundle location for it [is added](https://github.com/codalab/codalab-worksheets/blob/master/codalab/lib/bundle_cli.py#L1728) slightly later. My thinking right now is that there's a race condition wherein the `bundle-manager` starts making the bundle in the interval between when it's added to the database and when the bundle location is added.

**Possible Solutions**
- Have a new bundle type that isn't something the bundle manager will pick up. Update to type MakeBundle after checking if location needs to be added?
- Others?