### PR TITLE
Clarify test

### DIFF
--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -2369,8 +2369,7 @@ def test_kill(ctx):
     uuid = _run_command([cl, 'run', 'while true; do sleep 100; done'])
     wait_until_state(uuid, State.RUNNING)
     check_equals(uuid, _run_command([cl, 'kill', uuid]))
-    _run_command([cl, 'wait', uuid], 1)
-    _run_command([cl, 'wait', uuid], 1)
+    wait_until_state(uuid, State.KILLED)
     check_equals(str(['kill']), get_info(uuid, 'actions'))
 
 


### PR DESCRIPTION
Clarify `kill` test to specify what we're actually waiting for. `run_command([cl, 'wait', uuid], 1)` is a bit confusing.