### PR TITLE
Remove python 3.6 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,11 +36,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
         os: [ubuntu-20.04, macos-latest]
-        exclude:
-          - os: macos-latest
-            python-version: 3.6
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
@@ -406,7 +403,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.6
+          python-version: 3.7
       - uses: actions/cache@v3
         with:
           path: ~/.cache/pip


### PR DESCRIPTION
Python 3.6 is EOL (https://endoflife.date/python) so we don't need to test it on GitHub Actions anymore.