### PR TITLE
Fix metadata error - duplicate values by adding transactions

### DIFF
--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -1300,8 +1300,8 @@ class BundleModel(object):
                     logger.error(f"metadata_update_clause: {metadata_update_clause}")
                     logger.error(f"metadata_update_values: {metadata_update_values}")
                     logger.error(f"metadata_update: {metadata_update}")
-                    connection.execute(cl_bundle_metadata.insert(), metadata_update_values)
                     connection.execute(cl_bundle_metadata.delete().where(metadata_update_clause))
+                    self.do_multirow_insert(connection, cl_bundle_metadata, metadata_update_values)
                 if metadata_delete_keys:
                     connection.execute(cl_bundle_metadata.delete().where(metadata_delete_clause))
             except UnicodeError:

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -1294,8 +1294,11 @@ class BundleModel(object):
                 if update:
                     connection.execute(cl_bundle.update().where(clause).values(update))
                 if metadata_update:
-                    connection.execute(cl_bundle_metadata.delete().where(metadata_update_clause))
-                    self.do_multirow_insert(connection, cl_bundle_metadata, metadata_update_values)
+                    with connection.begin():
+                        connection.execute(
+                            cl_bundle_metadata.delete().where(metadata_update_clause)
+                        )
+                        connection.execute(cl_bundle_metadata.insert(), metadata_update_values)
                 if metadata_delete_keys:
                     connection.execute(cl_bundle_metadata.delete().where(metadata_delete_clause))
             except UnicodeError:

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -157,8 +157,7 @@ class BundleModel(object):
         #   - Some dialects do not support multiple inserts in a single statement,
         #     which we deal with by using the DBAPI execute_many pattern.
         if values:
-            with connection.begin():
-                connection.execute(table.insert(), values)
+            connection.execute(table.insert(), values)
 
     @staticmethod
     def make_clause(key, value):
@@ -1291,14 +1290,17 @@ class BundleModel(object):
         # Perform the actual updates and deletes.
         def do_update(connection):
             try:
+                logger.error(update)
+                logger.error(metadata_update)
                 if update:
+                    logger.error("ABOUT TO UPDATE!")
+                    logger.error(clause)
                     connection.execute(cl_bundle.update().where(clause).values(update))
                 if metadata_update:
-                    with connection.begin():
-                        connection.execute(
-                            cl_bundle_metadata.delete().where(metadata_update_clause)
-                        )
-                        connection.execute(cl_bundle_metadata.insert(), metadata_update_values)
+                    logger.error(metadata_update_clause)
+                    logger.error(metadata_update_values)
+                    connection.execute(cl_bundle_metadata.insert(), metadata_update_values)
+                    connection.execute(cl_bundle_metadata.delete().where(metadata_update_clause))
                 if metadata_delete_keys:
                     connection.execute(cl_bundle_metadata.delete().where(metadata_delete_clause))
             except UnicodeError:

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -1291,15 +1291,8 @@ class BundleModel(object):
         def do_update(connection):
             try:
                 if update:
-                    logger.error("ABOUT TO UPDATE!")
-                    logger.error(f"update clause: {clause}")
-                    logger.error(f"The acutal update: {update}")
                     connection.execute(cl_bundle.update().where(clause).values(update))
                 if metadata_update:
-                    logger.error("ABOUT TO UPDATE METADATA!")
-                    logger.error(f"metadata_update_clause: {metadata_update_clause}")
-                    logger.error(f"metadata_update_values: {metadata_update_values}")
-                    logger.error(f"metadata_update: {metadata_update}")
                     connection.execute(cl_bundle_metadata.delete().where(metadata_update_clause))
                     self.do_multirow_insert(connection, cl_bundle_metadata, metadata_update_values)
                 if metadata_delete_keys:

--- a/codalab/model/bundle_model.py
+++ b/codalab/model/bundle_model.py
@@ -1290,15 +1290,16 @@ class BundleModel(object):
         # Perform the actual updates and deletes.
         def do_update(connection):
             try:
-                logger.error(update)
-                logger.error(metadata_update)
                 if update:
                     logger.error("ABOUT TO UPDATE!")
-                    logger.error(clause)
+                    logger.error(f"update clause: {clause}")
+                    logger.error(f"The acutal update: {update}")
                     connection.execute(cl_bundle.update().where(clause).values(update))
                 if metadata_update:
-                    logger.error(metadata_update_clause)
-                    logger.error(metadata_update_values)
+                    logger.error("ABOUT TO UPDATE METADATA!")
+                    logger.error(f"metadata_update_clause: {metadata_update_clause}")
+                    logger.error(f"metadata_update_values: {metadata_update_values}")
+                    logger.error(f"metadata_update: {metadata_update}")
                     connection.execute(cl_bundle_metadata.insert(), metadata_update_values)
                     connection.execute(cl_bundle_metadata.delete().where(metadata_update_clause))
                 if metadata_delete_keys:

--- a/codalab/objects/metadata.py
+++ b/codalab/objects/metadata.py
@@ -5,6 +5,10 @@ and validates the metadata before returning.
 '''
 from codalab.common import UsageError
 from codalab.lib import formatting
+import logging
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.WARNING)
 
 
 class Metadata(object):
@@ -86,7 +90,7 @@ class Metadata(object):
                 metadata_dict[key].append(value)
             else:
                 if metadata_dict.get(key):
-                    raise UsageError(
+                    logger.warning(
                         'Got duplicate values {} and {} for key {}. metadata dict is {}, rows are {}'.format(
                             metadata_dict[key], value, key, metadata_dict, rows
                         )


### PR DESCRIPTION
Fix https://github.com/codalab/codalab-worksheets/issues/4488 by:
- adding transactions when bundle metadata is updated
- properly deal with existing duplicate values (pick the latest one) -- we no longer throw an error, we just show a warning now.