### PR TITLE
Fix GPU Discovery.

### DIFF
--- a/codalab/worker/docker_utils.py
+++ b/codalab/worker/docker_utils.py
@@ -152,7 +152,11 @@ class DockerRuntime(Runtime):
             docker.errors.ImageNotFound if the CUDA image cannot be pulled
             docker.errors.APIError if another server error occurs
         """
-        cuda_image = 'nvidia/cuda:12.2.0-devel-ubuntu22.04'
+
+        # Note: Do NOT update the NVIDIA image to use a CUDA version higher than
+        # that supported by the NLP machines. Otherwise, Slurm Batch Worker
+        # Manager will no longer function.
+        cuda_image = 'nvidia/cuda:11.5.2-base-ubuntu20.04'
         nvidia_command = 'nvidia-smi --query-gpu=index,uuid --format=csv,noheader'
         if use_docker:
             self.client.images.pull(cuda_image)

--- a/codalab/worker/main.py
+++ b/codalab/worker/main.py
@@ -450,13 +450,17 @@ def parse_gpuset_args(arg):
 
     try:
         all_gpus = DockerRuntime().get_nvidia_devices()  # Dict[GPU index: GPU UUID]
-    except DockerException:
+    except DockerException as e:
+        logger.error(e)
+        logger.error("Setting all_gpus to be empty...")
         all_gpus = {}
     # Docker socket can't be used
     except requests.exceptions.ConnectionError:
         try:
             all_gpus = DockerRuntime().get_nvidia_devices(use_docker=False)
-        except SingularityError:
+        except SingularityError as e:
+            logger.error(e)
+            logger.error("Setting all_gpus to be empty...")
             all_gpus = {}
 
     if arg == 'ALL':


### PR DESCRIPTION
Recently, the [image](https://github.com/codalab/codalab-worksheets/blob/v1.6.3/codalab/worker/docker_utils.py#L155) we used to run `nvidia-smi` to to GPU discovery was deprecated. To address this, a [PR](https://github.com/codalab/codalab-worksheets/commit/ad2435e5329b6bf1103a71e22f2b79d3c5cd4a00) was made to update the image; however, this broke GPU discovery since the `nvidia-smi` output changed (it now included a header).

This PR does the following:
(1) Fix GPU discovery so that GPU workers will now be able to run
(2) Use a smaller NVIDIA/CUDA image
(3) Downgrade the CUDA version.

Regarding (2), the official [NVIDIA Dockerhub page](https://hub.docker.com/r/nvidia/cuda) includes the following blurb at the time this PR was created:
```
Overview of Images
Three flavors of images are provided:

base: Includes the CUDA runtime (cudart)
runtime: Builds on the base and includes the [CUDA math libraries](https://developer.nvidia.com/gpu-accelerated-libraries), and [NCCL](https://developer.nvidia.com/nccl). A runtime image that also includes [cuDNN](https://developer.nvidia.com/cudnn) is available.
devel: Builds on the runtime and includes headers, development tools for building CUDA images. These images are particularly useful for multi-stage builds.
```
Thus, the base image is the smallest. Since we need only run `nvidia-smi`, which is supported by all three images, it is best to use the smallest possible image to minimize download and container startup times.


Regarding (3), at the time of this PR, the Stanford NLP machines use CUDA version 11.5. Using an image with CUDA 12.2 yields an error since the machines do not support that version of CUDA. Thus, I downgraded the version.
