### PR TITLE
PR

### DIFF
--- a/codalab/common.py
+++ b/codalab/common.py
@@ -29,7 +29,7 @@ from codalab.lib.beam.filesystems import (
 
 # Increment this on master when ready to cut a release.
 # http://semver.org/
-CODALAB_VERSION = '1.7.0'
+CODALAB_VERSION = '1.7.1'
 BINARY_PLACEHOLDER = '<binary>'
 URLOPEN_TIMEOUT_SECONDS = int(os.environ.get('CODALAB_URLOPEN_TIMEOUT_SECONDS', 5 * 60))
 

--- a/docs/CLI-Reference.md
+++ b/docs/CLI-Reference.md
@@ -111,6 +111,12 @@ Usage: `cl <command> <arguments>`
       -i, --dry-run         Perform a dry run (just show what will be done without doing it).
       -w, --worksheet-spec  Operate on this worksheet ([(<alias>|<address>)::](<uuid>|<name>)).
 
+### ancestors
+    Prints out the nested dependencies of a bundle.
+    Arguments:
+      bundle_spec           [[(<alias>|<address>)::](<uuid>|<name>)//](<uuid>|<name>|^<index>)
+      -w, --worksheet-spec  Operate on this worksheet ([(<alias>|<address>)::](<uuid>|<name>)).
+
 ### search (s)
     Search for bundles on a CodaLab instance (returns 10 results by default).
       search <keyword> ... <keyword>         : Name or uuid contains each <keyword>.

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -1,5 +1,5 @@
 // Should match codalab/common.py#CODALAB_VERSION
-export const CODALAB_VERSION = '1.7.0';
+export const CODALAB_VERSION = '1.7.1';
 
 // Name Regex to match the backend in spec_utils.py
 export const NAME_REGEX = /^[a-zA-Z_][a-zA-Z0-9_.-]*$/i;

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ setuptools>=40.0.0
 argcomplete==1.12.3
 indexed_gzip==1.7.0
 ratarmountcore==0.1.3
-PyYAML==5.4
+PyYAML==5.3.1
 psutil==5.7.2
 six==1.15.0
 SQLAlchemy==1.3.19

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import sys
 
 
 # should match codalab/common.py#CODALAB_VERSION
-CODALAB_VERSION = "1.7.0"
+CODALAB_VERSION = "1.7.1"
 
 
 class Install(install):


### PR DESCRIPTION
### Reasons for making this change
Implementing a new Codalab CLI command, `cl ancestors` that will recursively print out all ancestors/dependencies of some given bundle spec. 

### Related issues
* My local CLI was segfaulting incessantly on every CLI call after the functions had ran for some reason.
* Needed to update version to 1.7.1 to work with remote
* Needed to downgrade PyYAML to 5.3.1 for it to pip install correctly (Probably a me issue with python)
* I've added a test, but did not test it locally since I didn't have the local Docker containers running, so its just a rough outline of a test that could potentially not work.

### Screenshots
<img width="716" alt="Screenshot 2023-09-13 at 11 01 56 PM" src="https://github.com/codalab/codalab-worksheets/assets/61605392/f6e2679a-bda1-4963-b30d-f03675e07642">


### Checklist

* [ ] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
