### PR TITLE
Fix StressTestRunner cleanup()

### DIFF
--- a/tests/stress/stress_test.py
+++ b/tests/stress/stress_test.py
@@ -141,7 +141,7 @@ class StressTestRunner:
 
     def run(self):
         print('Cleaning up stress test files from other runs...')
-        cleanup(self._cl, self._TAG, should_wait=True)
+        self.cleanup()
 
         print('Running stress tests...')
         self._start_heartbeat()


### PR DESCRIPTION
Addresses #4540.

The old cleanup function didn't take the `bypass_wait` argument from the `stress_test.py` script into account. It led to annoying cases where cleanup would continue indefinitely due to issues with bundles that never finished even when the user specified `stress_test.py`.

This fixes that by calling the proper cleanup function