### PR TITLE
update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ apache-beam[azure]==2.38.0
 # (https://github.com/apache/beam/blob/master/sdks/python/setup.py).
 cachetools>=3.1.0,<5
 google-apitools>=0.5.31,<0.5.32
-google-auth>=1.18.0,<3
+google-auth==2.23.0
 
 # Remaining requirements
 bottle==0.12.20
@@ -45,3 +45,4 @@ websockets==9.1
 kubernetes==12.0.1
 google-cloud-storage==2.0.0
 httpio==0.3.0
+msrest==0.6.21


### PR DESCRIPTION
### Reasons for making this change

On Sept 28, google-auth generated a new release 2.32.2 (found [here](https://pypi.org/project/google-auth/#history:~:text=THIS%20VERSION-,2.23.2,Sep%2028%2C%202023,-2.23.1)). This change broke codalab, as we did not have the version pinned in our requirements.txt. This change pins google-auth to 2.23.0 and also specifies a version for package msrest.

### Related issues

No related issues

### Checklist

* [ ] I've added a screenshot of the changes, if this is a frontend change
* [ ] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [ ] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
