### PR TITLE
Provides an option not to ignore patterns like .git, hidden files and…

### DIFF
--- a/codalab/migration.py
+++ b/codalab/migration.py
@@ -118,8 +118,7 @@ class Migration:
         )
 
         if is_dir:
-            source_fileobj = zip_util.tar_gzip_directory(
-                bundle_location, exclude_patterns=None)
+            source_fileobj = zip_util.tar_gzip_directory(bundle_location, exclude_patterns=None)
             source_ext = ".tar.gz"
             unpack = True
         else:

--- a/codalab/migration.py
+++ b/codalab/migration.py
@@ -118,7 +118,8 @@ class Migration:
         )
 
         if is_dir:
-            source_fileobj = zip_util.tar_gzip_directory(bundle_location)
+            source_fileobj = zip_util.tar_gzip_directory(
+                bundle_location, exclude_patterns=None)
             source_ext = ".tar.gz"
             unpack = True
         else:
@@ -164,7 +165,7 @@ class Migration:
         new_location = self.get_bundle_location(bundle_uuid)
         if is_dir:
             # For dirs, check the folder contains same files
-            with OpenFile(new_location, gzipped=True) as f:
+            with OpenFile(new_location, gzipped=True, exclude_patterns=None) as f:
                 new_file_list = tarfile.open(fileobj=f, mode='r:gz').getnames()
                 new_file_list.sort()
 

--- a/codalab/worker/file_util.py
+++ b/codalab/worker/file_util.py
@@ -21,7 +21,7 @@ import tempfile
 # from ratarmountcore import SQLiteIndexedTar, FileInfo
 from ratarmountcore import FileInfo
 from codalab.lib.beam.SQLiteIndexedTar import SQLiteIndexedTar  # type: ignore
-from typing import IO, cast, List
+from typing import IO, List, Optional, cast
 
 NONE_PLACEHOLDER = '<none>'
 
@@ -240,9 +240,11 @@ class OpenFile(object):
     path: str
     mode: str
     gzipped: bool
-    exclude_patterns: List[str] | None
+    exclude_patterns: Optional[List[str]]
 
-    def __init__(self, path: str, mode='rb', gzipped=False, exclude_patterns=ALWAYS_IGNORE_PATTERNS):
+    def __init__(
+        self, path: str, mode='rb', gzipped=False, exclude_patterns=ALWAYS_IGNORE_PATTERNS
+    ):
         """Initialize OpenFile.
 
         Args:

--- a/codalab/worker/file_util.py
+++ b/codalab/worker/file_util.py
@@ -21,7 +21,7 @@ import tempfile
 # from ratarmountcore import SQLiteIndexedTar, FileInfo
 from ratarmountcore import FileInfo
 from codalab.lib.beam.SQLiteIndexedTar import SQLiteIndexedTar  # type: ignore
-from typing import IO, cast
+from typing import IO, cast, List
 
 NONE_PLACEHOLDER = '<none>'
 
@@ -50,7 +50,7 @@ def get_path_exists(path):
 def tar_gzip_directory(
     directory_path,
     follow_symlinks=False,
-    exclude_patterns=None,
+    exclude_patterns=ALWAYS_IGNORE_PATTERNS,
     exclude_names=None,
     ignore_file=None,
 ):
@@ -79,7 +79,6 @@ def tar_gzip_directory(
     if not exclude_patterns:
         exclude_patterns = []
 
-    exclude_patterns.extend(ALWAYS_IGNORE_PATTERNS)
     for pattern in exclude_patterns:
         args.append('--exclude=' + pattern)
 
@@ -241,8 +240,9 @@ class OpenFile(object):
     path: str
     mode: str
     gzipped: bool
+    exclude_patterns: List[str] | None
 
-    def __init__(self, path: str, mode='rb', gzipped=False):
+    def __init__(self, path: str, mode='rb', gzipped=False, exclude_patterns=ALWAYS_IGNORE_PATTERNS):
         """Initialize OpenFile.
 
         Args:
@@ -255,6 +255,7 @@ class OpenFile(object):
         self.path = path
         self.mode = mode
         self.gzipped = gzipped
+        self.exclude_patterns = exclude_patterns
 
     def __enter__(self) -> IO[bytes]:
         linked_bundle_path = parse_linked_bundle_url(self.path)
@@ -296,7 +297,7 @@ class OpenFile(object):
             if os.path.isdir(self.path):
                 if not self.gzipped:
                     raise IOError("Directories must be gzipped.")
-                return tar_gzip_directory(self.path)
+                return tar_gzip_directory(self.path, exclude_patterns=self.exclude_patterns)
             if self.gzipped:
                 raise IOError(
                     "Gzipping local files from disk from OpenFile is not yet supported. Please use file_util.gzip_file instead."

--- a/codalab/worker/file_util.py
+++ b/codalab/worker/file_util.py
@@ -98,7 +98,7 @@ def tar_gzip_directory(
 def zip_directory(
     directory_path,
     follow_symlinks=False,
-    exclude_patterns=None,
+    exclude_patterns=ALWAYS_IGNORE_PATTERNS,
     exclude_names=None,
     ignore_file=None,
 ):
@@ -134,7 +134,6 @@ def zip_directory(
         if not exclude_patterns:
             exclude_patterns = []
 
-        exclude_patterns.extend(ALWAYS_IGNORE_PATTERNS)
         for pattern in exclude_patterns:
             args.append(f'--exclude=*{pattern}*')
 

--- a/tests/unit/worker/file_util_test.py
+++ b/tests/unit/worker/file_util_test.py
@@ -407,8 +407,7 @@ class ArchiveTestBase:
         self.assertNotIn('__MACOSX', output_dir_entries)
         self.assertFalse(os.path.exists(os.path.join(output_dir, 'dir', '__MACOSX')))
         self.assertFalse(os.path.exists(os.path.join(output_dir, 'dir', '._ignored2')))
-
-
+        
 class TarArchiveTest(ArchiveTestBase, unittest.TestCase):
     """Archive test for tar/gzip methods."""
 
@@ -417,6 +416,21 @@ class TarArchiveTest(ArchiveTestBase, unittest.TestCase):
 
     def unarchive(self, *args, **kwargs):
         return un_tar_directory(*args, **kwargs)
+
+    def test_do_not_always_ignore(self):
+        temp_dir = tempfile.mkdtemp()
+        self.addCleanup(lambda: remove_path(temp_dir))
+        output_dir = os.path.join(temp_dir, 'output')
+
+        self.unarchive(self.archive(IGNORE_TEST_DIR, exclude_patterns=None), output_dir, 'gz')
+        output_dir_entries = os.listdir(output_dir)
+        self.assertNotIn('._ignored', output_dir_entries)
+        self.assertIn('dir', output_dir_entries)
+        self.assertIn('__MACOSX', output_dir_entries)
+        self.assertTrue(os.path.exists(os.path.join(output_dir, 'dir', '__MACOSX')))
+        self.assertTrue(os.path.exists(os.path.join(output_dir, 'dir', '._ignored2')))
+
+
 
 
 class ZipArchiveTest(ArchiveTestBase, unittest.TestCase):

--- a/tests/unit/worker/file_util_test.py
+++ b/tests/unit/worker/file_util_test.py
@@ -429,7 +429,6 @@ class TarArchiveTest(ArchiveTestBase, unittest.TestCase):
         self.assertIn('dir', output_dir_entries)
         self.assertIn('__MACOSX', output_dir_entries)
         self.assertTrue(os.path.exists(os.path.join(output_dir, 'dir', '__MACOSX')))
-        self.assertTrue(os.path.exists(os.path.join(output_dir, 'dir', '._ignored2')))
 
 
 class ZipArchiveTest(ArchiveTestBase, unittest.TestCase):

--- a/tests/unit/worker/file_util_test.py
+++ b/tests/unit/worker/file_util_test.py
@@ -407,7 +407,8 @@ class ArchiveTestBase:
         self.assertNotIn('__MACOSX', output_dir_entries)
         self.assertFalse(os.path.exists(os.path.join(output_dir, 'dir', '__MACOSX')))
         self.assertFalse(os.path.exists(os.path.join(output_dir, 'dir', '._ignored2')))
-        
+
+
 class TarArchiveTest(ArchiveTestBase, unittest.TestCase):
     """Archive test for tar/gzip methods."""
 
@@ -429,8 +430,6 @@ class TarArchiveTest(ArchiveTestBase, unittest.TestCase):
         self.assertIn('__MACOSX', output_dir_entries)
         self.assertTrue(os.path.exists(os.path.join(output_dir, 'dir', '__MACOSX')))
         self.assertTrue(os.path.exists(os.path.join(output_dir, 'dir', '._ignored2')))
-
-
 
 
 class ZipArchiveTest(ArchiveTestBase, unittest.TestCase):


### PR DESCRIPTION
… MACOSX files.

### Reasons for making this change

Needed for the blob storage migration, because once upon a time these files were uploaded as part of bundles. Omitting them will cause discrepancy in bundles after the migration.

### Related issues

fixes #4575

### Checklist

* [NA] I've added a screenshot of the changes, if this is a frontend change
* [Y] I've added and/or updated tests, if this is a backend change
* [Y] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [NA] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
