### PR TITLE
Makes zipping and unzipping work for empty folders for migration.

### DIFF
--- a/codalab/worker/file_util.py
+++ b/codalab/worker/file_util.py
@@ -125,8 +125,9 @@ def zip_directory(
             # zip needs to be used with relative paths, so that the final directory structure
             # is correct -- https://stackoverflow.com/questions/11249624/zip-stating-absolute-paths-but-only-keeping-part-of-them.
             '.',
+            # -i . is needed for empty folders; -i ./\* so zip recursively.
             '-i',
-            '.',
+            './\*',
         ]
 
         if ignore_file:

--- a/codalab/worker/file_util.py
+++ b/codalab/worker/file_util.py
@@ -126,7 +126,7 @@ def zip_directory(
             # is correct -- https://stackoverflow.com/questions/11249624/zip-stating-absolute-paths-but-only-keeping-part-of-them.
             '.',
             '-i',
-            '.'
+            '.',
         ]
 
         if ignore_file:

--- a/tests/unit/worker/file_util_test.py
+++ b/tests/unit/worker/file_util_test.py
@@ -408,16 +408,6 @@ class ArchiveTestBase:
         self.assertFalse(os.path.exists(os.path.join(output_dir, 'dir', '__MACOSX')))
         self.assertFalse(os.path.exists(os.path.join(output_dir, 'dir', '._ignored2')))
 
-
-class TarArchiveTest(ArchiveTestBase, unittest.TestCase):
-    """Archive test for tar/gzip methods."""
-
-    def archive(self, *args, **kwargs):
-        return tar_gzip_directory(*args, **kwargs)
-
-    def unarchive(self, *args, **kwargs):
-        return un_tar_directory(*args, **kwargs)
-
     def test_do_not_always_ignore(self):
         temp_dir = tempfile.mkdtemp()
         self.addCleanup(lambda: remove_path(temp_dir))
@@ -429,6 +419,16 @@ class TarArchiveTest(ArchiveTestBase, unittest.TestCase):
         self.assertIn('dir', output_dir_entries)
         self.assertIn('__MACOSX', output_dir_entries)
         self.assertTrue(os.path.exists(os.path.join(output_dir, 'dir', '__MACOSX')))
+
+
+class TarArchiveTest(ArchiveTestBase, unittest.TestCase):
+    """Archive test for tar/gzip methods."""
+
+    def archive(self, *args, **kwargs):
+        return tar_gzip_directory(*args, **kwargs)
+
+    def unarchive(self, *args, **kwargs):
+        return un_tar_directory(*args, **kwargs)
 
 
 class ZipArchiveTest(ArchiveTestBase, unittest.TestCase):
@@ -443,10 +443,6 @@ class ZipArchiveTest(ArchiveTestBase, unittest.TestCase):
 
     def unarchive(self, *args, **kwargs):
         return unzip_directory(*args, **kwargs)
-
-    def test_empty(self):
-        # zip doesn't create files when it's supposed to create an empty zip file.
-        pass
 
     def test_exclude_ignore(self):
         # TODO(Ashwin): make zip files properly work with exclude ignore.


### PR DESCRIPTION
### Reasons for making this change

Needed for azure blob migration.

### Related issues

Fixes #4573.

### Checklist

* [NA] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [NA] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
