### PR TITLE
Hardcodes the golden data path.

### DIFF
--- a/tests/ui/ui_tester.py
+++ b/tests/ui/ui_tester.py
@@ -306,6 +306,8 @@ class UITester(ABC):
         return output_dir
 
     def _get_browser_name(self):
+        if self.browser.capabilities['browserName'] == 'chrome-headless-shell':
+            return 'chrome'
         return self.browser.capabilities['browserName']
 
 


### PR DESCRIPTION
### Reasons for making this change

Chrome has changed its browser name to chrome-headless-shell which is part of the golden data directory. Our golden data is stored in path chrome/. For now, hard code the golden data path.

### Related issues

<!-- Add a reference to issues resolved, if applicable (for example, "fixes #1"). -->

### Screenshots

<!-- Add screenshots, if necessary. If this is a substantial frontend / user flow change, consider recording
a user flow GIF using a tool such as [LICEcap](https://www.cockos.com/licecap/). -->

### Checklist

* [ ] I've added a screenshot of the changes, if this is a frontend change
* [ ] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [ ] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
