### PR TITLE
Updates the store field in codalab worksheet UI to display real bundle location.

### DIFF
--- a/frontend/src/components/worksheets/BundleDetail/BundleDetail.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/BundleDetail.jsx
@@ -112,12 +112,11 @@ const BundleDetail = ({
             setBundleInfo(bundleInfo);
             setMetadataErrors([]);
 
-            fetchBundleStores(uuid)
-                .then((response) => {
-                    const bundleStore = response.data[0].attributes.name;
-                    bundleInfo.bundleStore = bundleStore;
-                    setBundleInfo(bundleInfo);
-                });
+            fetchBundleStores(uuid).then((response) => {
+                const bundleStore = response.data[0].attributes.name;
+                bundleInfo.bundleStore = bundleStore;
+                setBundleInfo(bundleInfo);
+            });
         },
     });
 

--- a/frontend/src/components/worksheets/BundleDetail/BundleDetail.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/BundleDetail.jsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import { JsonApiDataStore } from 'jsonapi-datastore';
 import { findDOMNode } from 'react-dom';
 import useSWR from 'swr';
-import { apiWrapper, fetchFileSummary } from '../../../util/apiWrapper';
+import { apiWrapper, fetchBundleStores, fetchFileSummary } from '../../../util/apiWrapper';
 
 import ConfigPanel from '../ConfigPanel';
 import ErrorMessage from '../ErrorMessage';
@@ -111,6 +111,13 @@ const BundleDetail = ({
             bundleInfo.metadataTypes = response.data.meta.metadata_type;
             setBundleInfo(bundleInfo);
             setMetadataErrors([]);
+
+            fetchBundleStores(uuid)
+                .then((response) => {
+                    const bundleStore = response.data[0].attributes.name;
+                    bundleInfo.bundleStore = bundleStore;
+                    setBundleInfo(bundleInfo);
+                });
         },
     });
 

--- a/frontend/src/components/worksheets/BundleDetail/BundleDetailSideBar.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/BundleDetailSideBar.jsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { withStyles } from '@material-ui/core';
+import { fetchBundleStores } from '../../../util/apiWrapper';
 import { formatBundle } from '../../../util/worksheet_utils';
 import { FINAL_BUNDLE_STATES } from '../../../constants';
 import CollapseButton from '../../CollapseButton';
@@ -48,6 +49,9 @@ class BundleDetailSideBar extends React.Component {
         const showOwner = !bundle.is_anonymous.value;
         const showDependencies = !!bundle.dependencies?.value?.length;
         const showHostWorksheets = !!bundle.host_worksheets?.value.length;
+
+        let bundleStoreResponse = await fetchBundleStores(uuid);
+        const bundleStore = bundleStoreResponse.data[0].attributes.name;
 
         return (
             <div className={classes.sidebar}>
@@ -109,7 +113,7 @@ class BundleDetailSideBar extends React.Component {
                     {(showRunFields || showDatasetFields) && (
                         <BundleFieldRow
                             label='Store'
-                            field={bundle.store}
+                            field={bundleStore}
                             onChange={(store) => onUpdate({ store })}
                         />
                     )}

--- a/frontend/src/components/worksheets/BundleDetail/BundleDetailSideBar.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/BundleDetailSideBar.jsx
@@ -50,9 +50,6 @@ class BundleDetailSideBar extends React.Component {
         const showDependencies = !!bundle.dependencies?.value?.length;
         const showHostWorksheets = !!bundle.host_worksheets?.value.length;
 
-        let bundleStoreResponse = await fetchBundleStores(uuid);
-        const bundleStore = bundleStoreResponse.data[0].attributes.name;
-
         return (
             <div className={classes.sidebar}>
                 {showPageLink && (
@@ -113,8 +110,8 @@ class BundleDetailSideBar extends React.Component {
                     {(showRunFields || showDatasetFields) && (
                         <BundleFieldRow
                             label='Store'
-                            field={bundleStore}
-                            onChange={(store) => onUpdate({ store })}
+                            field={bundle.bundleStore}
+                            onChange={(bundleStore) => onUpdate({ bundleStore })}
                         />
                     )}
                 </BundleFieldTable>

--- a/frontend/src/components/worksheets/BundleDetail/BundleDetailSideBar.jsx
+++ b/frontend/src/components/worksheets/BundleDetail/BundleDetailSideBar.jsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { withStyles } from '@material-ui/core';
-import { fetchBundleStores } from '../../../util/apiWrapper';
 import { formatBundle } from '../../../util/worksheet_utils';
 import { FINAL_BUNDLE_STATES } from '../../../constants';
 import CollapseButton from '../../CollapseButton';


### PR DESCRIPTION
### Reasons for making this change

Previously the UI uses metadata.store, which is a parameter user optionally specifies when a bundle is created. However, this is not necessarily where the bundle is ultimately stored and can be empty, which is confusing.
![Screenshot from 2024-04-23 11-56-38](https://github.com/codalab/codalab-worksheets/assets/14281098/8f1e1b3e-ef93-4308-bd86-8729045ae4bf)


### Related issues

<!-- Add a reference to issues resolved, if applicable (for example, "fixes #1"). -->

### Screenshots

<!-- Add screenshots, if necessary. If this is a substantial frontend / user flow change, consider recording
a user flow GIF using a tool such as [LICEcap](https://www.cockos.com/licecap/). -->

### Checklist

* [x] I've added a screenshot of the changes, if this is a frontend change
* [ ] I've added and/or updated tests, if this is a backend change
* [x] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [ ] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
