### PR TITLE
Multireaderfilestream Redesign

### DIFF
--- a/codalab/lib/beam/MultiReaderFileStream.py
+++ b/codalab/lib/beam/MultiReaderFileStream.py
@@ -53,7 +53,8 @@ class MultiReaderFileStream(BytesIO):
         
         with self._lock:
             # Calculate how many new bytes need to be read
-            new_bytes_needed = num_bytes - (max(self._pos) - self._pos[index])
+            new_pos = self._pos[index] + num_bytes
+            new_bytes_needed = new_pos - max(self._pos)
             if new_bytes_needed > 0:
                 self._fill_buf_bytes(new_bytes_needed)
 

--- a/codalab/lib/beam/MultiReaderFileStream.py
+++ b/codalab/lib/beam/MultiReaderFileStream.py
@@ -7,7 +7,7 @@ class MultiReaderFileStream(BytesIO):
     """
     NUM_READERS = 2
     LOOKBACK_LENGTH = 33554432
-    MAX_THRESHOLD = LOOKBACK_LENGTH * 4
+    MAX_THRESHOLD = LOOKBACK_LENGTH * 2
 
     def __init__(self, fileobj):
         self._buffer = bytes()

--- a/codalab/lib/beam/MultiReaderFileStream.py
+++ b/codalab/lib/beam/MultiReaderFileStream.py
@@ -134,7 +134,10 @@ class MultiReaderFileStream(BytesIO):
         return s
 
     def seek(self, index: int, offset: int, whence=SEEK_SET):
-        pass
-
+        if whence == SEEK_END:
+            super().seek(offset, whence)
+        else:
+            pass
+            
     def close(self):
         self.__input.close()

--- a/codalab/lib/beam/MultiReaderFileStream.py
+++ b/codalab/lib/beam/MultiReaderFileStream.py
@@ -61,7 +61,7 @@ class MultiReaderFileStream(BytesIO):
             # NOTE: it's possible for diff < 0 if seek backwards occur
             if diff > 0:
                 self._buffer = self._buffer[diff:]
-                self._buffer_pos += diff
+                self._buffer_start_pos += diff
         return s
 
     def peek(self, index: int, num_bytes: int):   # type: ignore
@@ -76,7 +76,7 @@ class MultiReaderFileStream(BytesIO):
                 self._fill_buf_bytes(new_bytes_needed)
 
             # Get the bytes in the buffer that correspond to the read function call
-            buffer_index = self._pos[index] - self._buffer_pos
+            buffer_index = self._pos[index] - self._buffer_start_pos
             s = self._buffer[buffer_index:buffer_index + num_bytes]
 
         return s

--- a/codalab/lib/beam/MultiReaderFileStream.py
+++ b/codalab/lib/beam/MultiReaderFileStream.py
@@ -1,21 +1,82 @@
 from io import BytesIO
 from threading import Lock
+import time
 
 from codalab.worker.un_gzip_stream import BytesBuffer
 
+import heapq
 
-class MultiReaderFileStream(BytesIO):
+class MinMaxHeap:
+    def __init__(self):
+        self.heap = []
+        self.item_index = {}  # Dictionary to store indices of elements
+        
+    def push(self, item):
+        heapq.heappush(self.heap, item)
+        index = len(self.heap) - 1
+        self.item_index[item] = index
+    
+    def pop(self):
+        if self.heap:
+            item = heapq.heappop(self.heap)
+            del self.item_index[item]
+            return item
+        else:
+            raise IndexError("pop from an empty heap")
+    
+    def update(self, old_item, new_item):
+        index = self.item_index.pop(old_item)
+        self.heap[index] = new_item
+        self.item_index[new_item] = index
+        heapq._siftup(self.heap, index)
+        heapq._siftdown(self.heap, 0, index)
+    
+    def min(self):
+        if self.heap:
+            return self.heap[0]
+    
+    def max(self):
+        if self.heap:
+            if len(self.heap) == 1:
+                return self.heap[0]
+            elif len(self.heap) == 2:
+                return self.heap[1]
+            else:
+                return max(self.heap[1], self.heap[2])
+    
+    def min_index(self):
+        if self.heap:
+            return self.item_index[self.min()]
+    
+    def max_index(self):
+        if self.heap:
+            return self.item_index[self.max()]
+        
+    def get_at_index(self, index):
+        if index < len(self.heap):
+            return self.heap[index]
+        else:
+            raise IndexError("Index out of range")
+
+class MultiReaderFileStream2(BytesIO):
     """
-    FileStream that support multiple readers
+    FileStream that support multiple readers and seeks backwards
     """
     NUM_READERS = 2
+    LOOKBACK_LENGTH = 33554432
+    MAX_THRESHOLD = LOOKBACK_LENGTH * 4
 
     def __init__(self, fileobj):
-        self._bufs = [BytesBuffer() for _ in range(0, self.NUM_READERS)]
-        self._pos = [0 for _ in range(0, self.NUM_READERS)]
+        self._buffer = bytes()
+        self._buffer_pos = 0 # position in the fileobj (min reader position - LOOKBACK LENGTH)
+        self._size = 0 # size of bytes (for convenience)
+        self._pos = MinMaxHeap() # position of each reader
         self._fileobj = fileobj
-        self._lock = Lock()  # lock to ensure one does not concurrently read self._fileobj / write to the buffers.
+        self._lock = Lock()  # lock to ensure one does not concurrently read self._fileobj / write to the buffer.
 
+        for i in range(0, self.NUM_READERS):
+            self._pos.push(0)
+            assert self._pos.get_at_index(i) == 0
         class FileStreamReader(BytesIO):
             def __init__(s, index):
                 s._index = index
@@ -28,22 +89,22 @@ class MultiReaderFileStream(BytesIO):
 
         self.readers = [FileStreamReader(i) for i in range(0, self.NUM_READERS)]
 
-    def _fill_buf_bytes(self, index: int, num_bytes=None):
+    def _fill_buf_bytes(self, num_bytes=None):
         with self._lock:
-            while num_bytes is None or len(self._bufs[index]) < num_bytes:
-                s = self._fileobj.read(num_bytes)
-                if not s:
-                    break
-                for i in range(0, self.NUM_READERS):
-                    self._bufs[i].write(s)
+            s = self._fileobj.read(num_bytes)
+            if not s:
+                return
+            self._buffer += s
 
-    def read(self, index: int, num_bytes=None):  # type: ignore
+    def read(self, index: int, num_bytes=0):  # type: ignore
         """Read the specified number of bytes from the associated file.
         index: index that specifies which reader is reading.
         """
         self._fill_buf_bytes(index, num_bytes)
-        if num_bytes is None:
-            num_bytes = len(self._bufs[index])
+        # if num_bytes is None:
+        #     num_bytes = len(self._bufs[index])
+        while (self._pos[index] + num_bytes) - self._buffer_pos > self.MAX_THRESHOLD:
+            time.sleep(.1) # 100 ms
         s = self._bufs[index].read(num_bytes)
         self._pos[index] += len(s)
         return s

--- a/codalab/lib/beam/MultiReaderFileStream.py
+++ b/codalab/lib/beam/MultiReaderFileStream.py
@@ -50,7 +50,7 @@ class MultiReaderFileStream(BytesIO):
             if new_bytes_needed > 0:
                 self._fill_buf_bytes(new_bytes_needed)
         while (self._pos[index] + num_bytes) - self._buffer_pos > self.MAX_THRESHOLD:
-            time.sleep(.1) # 100 ms
+            time.sleep(10) # 100 ms
 
         with self._lock:
             old_position = self._pos[index] - self._buffer_pos

--- a/codalab/lib/beam/MultiReaderFileStream.py
+++ b/codalab/lib/beam/MultiReaderFileStream.py
@@ -24,10 +24,11 @@ class MinMaxHeap:
         else:
             raise IndexError("pop from an empty heap")
     
-    def update(self, old_item, new_item):
-        index = self.item_index.pop(old_item)
+    def update(self, index, new_item):
+        old_item = self.heap[index]
         self.heap[index] = new_item
         self.item_index[new_item] = index
+        del self.item_index[old_item]
         heapq._siftup(self.heap, index)
         heapq._siftdown(self.heap, 0, index)
     

--- a/codalab/lib/beam/MultiReaderFileStream.py
+++ b/codalab/lib/beam/MultiReaderFileStream.py
@@ -25,10 +25,8 @@ class MinMaxHeap:
             raise IndexError("pop from an empty heap")
     
     def update(self, index, new_item):
-        old_item = self.heap[index]
         self.heap[index] = new_item
         self.item_index[new_item] = index
-        del self.item_index[old_item]
         heapq._siftup(self.heap, index)
         heapq._siftdown(self.heap, 0, index)
     
@@ -71,13 +69,14 @@ class MultiReaderFileStream(BytesIO):
         self._buffer = bytes()
         self._buffer_pos = 0 # start position of buffer in the fileobj (min reader position - LOOKBACK LENGTH)
         self._size = 0 # size of bytes (for convenience)
-        self._pos = MinMaxHeap() # position of each reader
+        # self._pos = MinMaxHeap() # position of each reader
+        self._pos = [0 for _ in range(self.NUM_READERS)] # position of each reader
         self._fileobj = fileobj
         self._lock = Lock()  # lock to ensure one does not concurrently read self._fileobj / write to the buffer.
 
-        for i in range(0, self.NUM_READERS):
-            self._pos.push(0)
-            assert self._pos.get_at_index(i) == 0
+        # for i in range(0, self.NUM_READERS):
+        #     self._pos.push(0)
+        #     assert self._pos.get_at_index(i) == 0
         class FileStreamReader(BytesIO):
             def __init__(s, index):
                 s._index = index
@@ -88,7 +87,7 @@ class MultiReaderFileStream(BytesIO):
             def peek(s, num_bytes):
                 return self.peek(s._index, num_bytes)
             
-            def seek(s, offset, whence):
+            def seek(s, offset, whence=SEEK_SET):
                 return self.seek(s._index, offset, whence)
 
         self.readers = [FileStreamReader(i) for i in range(0, self.NUM_READERS)]
@@ -105,39 +104,51 @@ class MultiReaderFileStream(BytesIO):
         """Read the specified number of bytes from the associated file.
         index: index that specifies which reader is reading.
         """
-        self._fill_buf_bytes(index, num_bytes)
+        # Calculate how many new bytes need to be read
+        print("READING HERE with num_bytes, index, self._buffer_pos, self._size: ", num_bytes, index, self._buffer_pos, self._size)
+        num_bytes -= max(self._pos) - self._pos[index]
+        if num_bytes > 0:
+            print("new num bytes: ", num_bytes)
+            self._fill_buf_bytes(num_bytes)
         # if num_bytes is None:
         #     num_bytes = len(self._bufs[index])
-        while (self._pos.get_at_index(index) + num_bytes) - self._buffer_pos > self.MAX_THRESHOLD:
+        while (self._pos[index] + num_bytes) - self._buffer_pos > self.MAX_THRESHOLD:
+            print("SLEEPING")
             time.sleep(.1) # 100 ms
 
-        old_position = self._pos.get_at_index(index)
-        s = self._buffer[old_position:old_position + num_bytes]
+        with self._lock:
+            old_position = self._pos[index]
+            s = self._buffer[old_position:old_position + num_bytes]
 
-        # Modify position
-        new_position = old_position + len(s)
-        self._pos.update(index, new_position) 
+            # Modify position
+            self._pos[index] += len(s)
 
-        # Update buffer if this reader is the minimum reader
-        diff = (self._pos.min() - self.LOOKBACK_LENGTH) - self._buffer_pos # calculated min position of buffer minus current min position of buffer
-        # NOTE: it's possible for diff < 0 if seek backwards occur
-        if diff > 0:
-            self._buffer = self._buffer[diff:]
-            self._buffer_pos += diff
-            self._size -= diff
+            # Update buffer if this reader is the minimum reader
+            diff = (min(self._pos) - self.LOOKBACK_LENGTH) - self._buffer_pos # calculated min position of buffer minus current min position of buffer
+            # NOTE: it's possible for diff < 0 if seek backwards occur
+            print("DIFF: ", diff)
+            if diff > 0:
+                self._buffer = self._buffer[diff:]
+                self._buffer_pos += diff
+                self._size -= diff
 
+            print("Length of return: ", len(s))
         return s
 
     def peek(self, index: int, num_bytes):   # type: ignore
-        self._fill_buf_bytes(index, num_bytes)
-        s = self._bufs[index].peek(num_bytes)
-        return s
+        pass
+        # self._fill_buf_bytes(index, num_bytes)
+        # s = self._bufs[index].peek(num_bytes)
+        # return s
 
     def seek(self, index: int, offset: int, whence=SEEK_SET):
+        print("SEEKING SEEKING SEEKING")
+        print(index, offset)
         if whence == SEEK_END:
             super().seek(offset, whence)
         else:
-            pass
+            assert offset >= self._buffer_pos
+            self._pos[index] = offset
             
     def close(self):
         self.__input.close()

--- a/codalab/lib/beam/MultiReaderFileStream.py
+++ b/codalab/lib/beam/MultiReaderFileStream.py
@@ -80,7 +80,8 @@ class MultiReaderFileStream(BytesIO):
         
         with self._lock:
             # Calculate how many new bytes need to be read
-            new_bytes_needed = num_bytes - (max(self._pos) - self._pos[index])
+            new_pos = self._pos[index] + num_bytes
+            new_bytes_needed = new_pos - max(self._pos)
             if new_bytes_needed > 0:
                 self._fill_buf_bytes(new_bytes_needed)
         

--- a/codalab/lib/beam/MultiReaderFileStream.py
+++ b/codalab/lib/beam/MultiReaderFileStream.py
@@ -1,62 +1,6 @@
 from io import BytesIO, SEEK_SET, SEEK_END
 from threading import Lock
 import time
-
-from codalab.worker.un_gzip_stream import BytesBuffer
-
-import heapq
-
-class MinMaxHeap:
-    def __init__(self):
-        self.heap = []
-        self.item_index = {}  # Dictionary to store indices of elements
-        
-    def push(self, item):
-        heapq.heappush(self.heap, item)
-        index = len(self.heap) - 1
-        self.item_index[item] = index
-    
-    def pop(self):
-        if self.heap:
-            item = heapq.heappop(self.heap)
-            del self.item_index[item]
-            return item
-        else:
-            raise IndexError("pop from an empty heap")
-    
-    def update(self, index, new_item):
-        self.heap[index] = new_item
-        self.item_index[new_item] = index
-        heapq._siftup(self.heap, index)
-        heapq._siftdown(self.heap, 0, index)
-    
-    def min(self):
-        if self.heap:
-            return self.heap[0]
-    
-    def max(self):
-        if self.heap:
-            if len(self.heap) == 1:
-                return self.heap[0]
-            elif len(self.heap) == 2:
-                return self.heap[1]
-            else:
-                return max(self.heap[1], self.heap[2])
-    
-    def min_index(self):
-        if self.heap:
-            return self.item_index[self.min()]
-    
-    def max_index(self):
-        if self.heap:
-            return self.item_index[self.max()]
-        
-    def get_at_index(self, index: int):
-        if index < len(self.heap):
-            return self.heap[index]
-        else:
-            raise IndexError("Index out of range")
-
 class MultiReaderFileStream(BytesIO):
     """
     FileStream that support multiple readers and seeks backwards
@@ -70,13 +14,9 @@ class MultiReaderFileStream(BytesIO):
         self._buffer_pos = 0 # start position of buffer in the fileobj (min reader position - LOOKBACK LENGTH)
         self._size = 0 # size of bytes (for convenience)
         # self._pos = MinMaxHeap() # position of each reader
-        self._pos = [0 for _ in range(self.NUM_READERS)] # position of each reader
+        self._pos = [0 for _ in range(self.NUM_READERS)] # position of each reader in the fileobj
         self._fileobj = fileobj
         self._lock = Lock()  # lock to ensure one does not concurrently read self._fileobj / write to the buffer.
-
-        # for i in range(0, self.NUM_READERS):
-        #     self._pos.push(0)
-        #     assert self._pos.get_at_index(i) == 0
         class FileStreamReader(BytesIO):
             def __init__(s, index):
                 s._index = index
@@ -93,31 +33,27 @@ class MultiReaderFileStream(BytesIO):
         self.readers = [FileStreamReader(i) for i in range(0, self.NUM_READERS)]
 
     def _fill_buf_bytes(self, num_bytes=None):
-        with self._lock:
-            s = self._fileobj.read(num_bytes)
-            if not s:
-                return
-            self._buffer += s
-            self._size += len(s)
+        # with self._lock:
+        s = self._fileobj.read(num_bytes)
+        if not s:
+            return
+        self._buffer += s
+        self._size += len(s)
 
     def read(self, index: int, num_bytes=0):  # type: ignore
         """Read the specified number of bytes from the associated file.
         index: index that specifies which reader is reading.
         """
         # Calculate how many new bytes need to be read
-        print("READING HERE with num_bytes, index, self._buffer_pos, self._size: ", num_bytes, index, self._buffer_pos, self._size)
-        num_bytes -= max(self._pos) - self._pos[index]
-        if num_bytes > 0:
-            print("new num bytes: ", num_bytes)
-            self._fill_buf_bytes(num_bytes)
-        # if num_bytes is None:
-        #     num_bytes = len(self._bufs[index])
+        with self._lock:
+            new_bytes_needed = num_bytes - (max(self._pos) - self._pos[index])
+            if new_bytes_needed > 0:
+                self._fill_buf_bytes(new_bytes_needed)
         while (self._pos[index] + num_bytes) - self._buffer_pos > self.MAX_THRESHOLD:
-            print("SLEEPING")
             time.sleep(.1) # 100 ms
 
         with self._lock:
-            old_position = self._pos[index]
+            old_position = self._pos[index] - self._buffer_pos
             s = self._buffer[old_position:old_position + num_bytes]
 
             # Modify position
@@ -126,13 +62,10 @@ class MultiReaderFileStream(BytesIO):
             # Update buffer if this reader is the minimum reader
             diff = (min(self._pos) - self.LOOKBACK_LENGTH) - self._buffer_pos # calculated min position of buffer minus current min position of buffer
             # NOTE: it's possible for diff < 0 if seek backwards occur
-            print("DIFF: ", diff)
             if diff > 0:
                 self._buffer = self._buffer[diff:]
                 self._buffer_pos += diff
                 self._size -= diff
-
-            print("Length of return: ", len(s))
         return s
 
     def peek(self, index: int, num_bytes):   # type: ignore
@@ -142,8 +75,6 @@ class MultiReaderFileStream(BytesIO):
         # return s
 
     def seek(self, index: int, offset: int, whence=SEEK_SET):
-        print("SEEKING SEEKING SEEKING")
-        print(index, offset)
         if whence == SEEK_END:
             super().seek(offset, whence)
         else:

--- a/codalab/lib/upload_manager.py
+++ b/codalab/lib/upload_manager.py
@@ -255,6 +255,7 @@ class BlobStorageUploader(Uploader):
             conn_str = os.environ.get('AZURE_STORAGE_CONNECTION_STRING', '')
             os.environ['AZURE_STORAGE_CONNECTION_STRING'] = bundle_conn_str
         try:
+            # Chunk size set to 1MiB for performance
             CHUNK_SIZE = 1024 * 1024
 
             def upload_file_content():

--- a/codalab/lib/upload_manager.py
+++ b/codalab/lib/upload_manager.py
@@ -260,7 +260,7 @@ class BlobStorageUploader(Uploader):
 
             def upload_file_content():
                 iteration = 0
-                ITERATIONS_PER_DISK_CHECK = 2000
+                ITERATIONS_PER_DISK_CHECK = 32
                 bytes_uploaded = 0
 
                 with FileSystems.create(

--- a/codalab/lib/upload_manager.py
+++ b/codalab/lib/upload_manager.py
@@ -255,7 +255,7 @@ class BlobStorageUploader(Uploader):
             conn_str = os.environ.get('AZURE_STORAGE_CONNECTION_STRING', '')
             os.environ['AZURE_STORAGE_CONNECTION_STRING'] = bundle_conn_str
         try:
-            CHUNK_SIZE = 16 * 1024
+            CHUNK_SIZE = 1024 * 1024
 
             def upload_file_content():
                 iteration = 0

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,3 +45,4 @@ websockets==9.1
 kubernetes==12.0.1
 google-cloud-storage==2.0.0
 httpio==0.3.0
+memory_profiler==0.61.0

--- a/tests/unit/beam/multireaderfilestream_test.py
+++ b/tests/unit/beam/multireaderfilestream_test.py
@@ -11,6 +11,10 @@ CHUNKSIZE = FILESIZE/10
 
 class MultiReaderFileStreamTest(unittest.TestCase):
     def test_reader_distance(self):
+        """
+        This test verifies that both readers in the Multireaderfilestream
+        are within the limits defined in the class
+        """
         with tempfile.NamedTemporaryFile(delete=True) as f:
             f.seek(FILESIZE - 1)
             f.write(b"\0")
@@ -38,13 +42,13 @@ class MultiReaderFileStreamTest(unittest.TestCase):
             # Sleep a little for thread 1 to start reading
             time.sleep(3)
 
-            # Assert that the first reader has not read past the Maximum threshold
+            # Assert that the first reader has not read past the maximum threshold
             self.assertGreater(70000000, m_stream._pos[0])
 
             t2.start()
 
             # Sleep a little for thread 2 to start reading
-            time.sleep(3)
+            time.sleep(1)
 
             # Assert that the first reader is at 100000000, second reader is at 40000000
             self.assertEqual(100000000, m_stream._pos[0])
@@ -54,12 +58,16 @@ class MultiReaderFileStreamTest(unittest.TestCase):
             self.assertEqual(6445568, m_stream._buffer_pos)
 
             # Assert that the buffer is length 100000000 - 6445568 
-            self.assertEqual(93554432, m_stream._size)
+            self.assertEqual(93554432, len(m_stream._buffer))
 
             t1.join()
             t2.join()
     
-    def test_seek(self):
+    def test_backwards_seek(self):
+        """
+        This test verifies that a backwards seek within the lookback length
+        defined in the Multireaderfilestream class behaves as expected
+        """
         with tempfile.NamedTemporaryFile(delete=True) as f:
             f.seek(FILESIZE - 1)
             f.write(b"\0")
@@ -105,6 +113,11 @@ class MultiReaderFileStreamTest(unittest.TestCase):
 
 
     def test_toofar_seek(self):
+        """
+        This test verifies that a backwards seek past the lookback length
+        defined in the Multireaderfilestream class behaves as expected with
+        an AssertionError
+        """
         with tempfile.NamedTemporaryFile(delete=True) as f:
             f.seek(FILESIZE - 1)
             f.write(b"\0")
@@ -124,7 +137,7 @@ class MultiReaderFileStreamTest(unittest.TestCase):
             def thread2():
                 # This reader will only read 4/10 of the file, then seek to the beginning
                 for _ in range(4):
-                    status = reader_2.read(CHUNKSIZE)
+                    reader_2.read(CHUNKSIZE)
                 
                 try:
                     reader_2.seek(0)

--- a/tests/unit/beam/multireaderfilestream_test.py
+++ b/tests/unit/beam/multireaderfilestream_test.py
@@ -10,12 +10,6 @@ FILESIZE = 100000000
 CHUNKSIZE = FILESIZE/10
 
 class MultiReaderFileStreamTest(unittest.TestCase):
-    def write_file_of_size(self, size: int, file_path: str):
-        with open(file_path, "wb") as f:
-            f.seek(size - 1)
-            f.write(b"\0")
-
-
     def test_reader_distance(self):
         with tempfile.NamedTemporaryFile(delete=True) as f:
             f.seek(FILESIZE - 1)

--- a/tests/unit/beam/multireaderfilestream_test.py
+++ b/tests/unit/beam/multireaderfilestream_test.py
@@ -1,0 +1,148 @@
+import tempfile
+import time
+import unittest
+
+from threading import Thread
+
+from codalab.lib.beam.MultiReaderFileStream import MultiReaderFileStream
+
+FILESIZE = 100000000
+CHUNKSIZE = FILESIZE/10
+
+class MultiReaderFileStreamTest(unittest.TestCase):
+    def write_file_of_size(self, size: int, file_path: str):
+        with open(file_path, "wb") as f:
+            f.seek(size - 1)
+            f.write(b"\0")
+
+
+    def test_reader_distance(self):
+        with tempfile.NamedTemporaryFile(delete=True) as f:
+            f.seek(FILESIZE - 1)
+            f.write(b"\0")
+
+            m_stream = MultiReaderFileStream(f)
+            reader_1 = m_stream[0]
+            reader_2 = m_stream[1]
+
+            def thread1():
+                while True:
+                    status = reader_1.read(CHUNKSIZE)
+                    if not status:
+                        break
+
+            def thread2():
+                # This reader will only read 4/10 of the file
+                for _ in range(4):
+                    status = reader_2.read(CHUNKSIZE)
+
+            t1 = Thread(target=thread1)
+            t2 = Thread(target=thread2)
+
+            t1.start()
+
+            # Sleep a little for thread 1 to start reading
+            time.sleep(3)
+
+            # Assert that the first reader has not read past the Maximum threshold
+            self.assertGreater(70000000, m_stream._pos[0])
+
+            t2.start()
+
+            # Sleep a little for thread 2 to start reading
+            time.sleep(3)
+
+            # Assert that the first reader is at 100000000, second reader is at 40000000
+            self.assertEqual(100000000, m_stream._pos[0])
+            self.assertEqual(40000000, m_stream._pos[1])
+
+            # Assert that the buffer is at 6445568 (40000000 - LOOKBACK_LENGTH)
+            self.assertEqual(6445568, m_stream._buffer_pos)
+
+            # Assert that the buffer is length 100000000 - 6445568 
+            self.assertEqual(93554432, m_stream._size)
+
+            t1.join()
+            t2.join()
+    
+    def test_seek(self):
+        with tempfile.NamedTemporaryFile(delete=True) as f:
+            f.seek(FILESIZE - 1)
+            f.write(b"\0")
+
+            m_stream = MultiReaderFileStream(f)
+            reader_1 = m_stream[0]
+            reader_2 = m_stream[1]
+
+            result = None
+
+            def thread1():
+                while True:
+                    status = reader_1.read(CHUNKSIZE)
+                    if not status:
+                        break
+
+            def thread2():
+                # This reader will only read 4/10 of the file, then seek to 10000000 and read another 4/10 of the file
+                for _ in range(4):
+                    reader_2.read(CHUNKSIZE)
+                
+                try:
+                    reader_2.seek(10000000)
+                except AssertionError as e: 
+                    result = e
+
+                for _ in range(4):
+                    reader_2.read(CHUNKSIZE)
+
+            t1 = Thread(target=thread1)
+            t2 = Thread(target=thread2)
+            t1.start()
+            t2.start()
+
+            t1.join()
+            t2.join()
+
+            self.assertIsNone(result)
+
+            # Check that reader 2 is at 50000000 and buffer position is correct
+            self.assertEqual(50000000, m_stream._pos[1])
+            self.assertEqual(16445568, m_stream._buffer_pos)
+
+
+    def test_toofar_seek(self):
+        with tempfile.NamedTemporaryFile(delete=True) as f:
+            f.seek(FILESIZE - 1)
+            f.write(b"\0")
+
+            m_stream = MultiReaderFileStream(f)
+            reader_1 = m_stream[0]
+            reader_2 = m_stream[1]
+
+            result = None
+
+            def thread1():
+                while True:
+                    status = reader_1.read(CHUNKSIZE)
+                    if not status:
+                        break
+
+            def thread2():
+                # This reader will only read 4/10 of the file, then seek to the beginning
+                for _ in range(4):
+                    status = reader_2.read(CHUNKSIZE)
+                
+                try:
+                    reader_2.seek(0)
+                except AssertionError as e: 
+                    result = e
+
+            t1 = Thread(target=thread1)
+            t2 = Thread(target=thread2)
+            t1.start()
+            t2.start()
+
+            t1.join()
+            t2.join()
+
+            self.assertIsInstance(result, AssertionError)

--- a/tests/unit/beam/multireaderfilestream_test.py
+++ b/tests/unit/beam/multireaderfilestream_test.py
@@ -16,8 +16,8 @@ class MultiReaderFileStreamTest(unittest.TestCase):
             f.write(b"\0")
 
             m_stream = MultiReaderFileStream(f)
-            reader_1 = m_stream[0]
-            reader_2 = m_stream[1]
+            reader_1 = m_stream.readers[0]
+            reader_2 = m_stream.readers[1]
 
             def thread1():
                 while True:
@@ -65,8 +65,8 @@ class MultiReaderFileStreamTest(unittest.TestCase):
             f.write(b"\0")
 
             m_stream = MultiReaderFileStream(f)
-            reader_1 = m_stream[0]
-            reader_2 = m_stream[1]
+            reader_1 = m_stream.readers[0]
+            reader_2 = m_stream.readers[1]
 
             result = None
 
@@ -110,8 +110,8 @@ class MultiReaderFileStreamTest(unittest.TestCase):
             f.write(b"\0")
 
             m_stream = MultiReaderFileStream(f)
-            reader_1 = m_stream[0]
-            reader_2 = m_stream[1]
+            reader_1 = m_stream.readers[0]
+            reader_2 = m_stream.readers[1]
 
             result = None
 

--- a/tests/unit/beam/multireaderfilestream_test.py
+++ b/tests/unit/beam/multireaderfilestream_test.py
@@ -40,7 +40,7 @@ class MultiReaderFileStreamTest(unittest.TestCase):
             t1.start()
 
             # Sleep a little for thread 1 to start reading
-            time.sleep(3)
+            time.sleep(.5)
 
             # Assert that the first reader has not read past the maximum threshold
             self.assertGreater(70000000, m_stream._pos[0])
@@ -48,7 +48,7 @@ class MultiReaderFileStreamTest(unittest.TestCase):
             t2.start()
 
             # Sleep a little for thread 2 to start reading
-            time.sleep(1)
+            time.sleep(.5)
 
             # Assert that the first reader is at 100000000, second reader is at 40000000
             self.assertEqual(100000000, m_stream._pos[0])

--- a/tests/unit/lib/upload_manager_test.py
+++ b/tests/unit/lib/upload_manager_test.py
@@ -196,7 +196,7 @@ class UploadManagerTestBase(TestBase):
             interval=0.1,
             timeout=1
         )
-        self.assertEqual(max(memory_usage) < 100000000, True)
+        self.assertEqual(max(mem_usage) < 100000000, True)
 
     def write_string_to_file(self, string, file_path):
         with open(file_path, 'w') as f:

--- a/tests/unit/lib/upload_manager_test.py
+++ b/tests/unit/lib/upload_manager_test.py
@@ -19,6 +19,7 @@ from tests.unit.server.bundle_manager import TestBase
 
 urlopen_real = urllib.request.urlopen
 LARGE_FILE_SIZE = 16777216 #16MB
+EXTRA_LARGE_FILE_SIZE = 134217728 #128MB for Memory Profiling Only
 
 class UploadManagerTestBase(TestBase):
     """A class that contains the base for an UploadManager test. Subclasses
@@ -89,6 +90,7 @@ class UploadManagerTestBase(TestBase):
         source = os.path.join(self.temp_dir, 'source_dir')
         os.mkdir(source)
         self.write_file_of_size(10, os.path.join(source, 'file'))
+        self.do_upload(('source.tar.gz', tar_gzip_directory(source)))
         self.assertEqual(['file'], sorted(self.listdir()))
         self.assertEqual([10], self.check_file_size())
 
@@ -185,6 +187,10 @@ class UploadManagerTestBase(TestBase):
         # This test hits the real GitHub repository. If the contents of README.md at https://github.com/codalab/test
         # change, then update this test.
         self.check_file_equals_string('testfile.md', '# test\nUsed for testing\n')
+
+    def test_upload_memory(self):
+        self.write_file_of_size(LARGE_FILE_SIZE, os.path.join(self.temp_dir, 'bigfile'))
+        self.do_upload(('bigfile', os.path.join(self.temp_dir, 'bigfile')))
 
     def write_string_to_file(self, string, file_path):
         with open(file_path, 'w') as f:

--- a/tests/unit/lib/upload_manager_test.py
+++ b/tests/unit/lib/upload_manager_test.py
@@ -10,6 +10,7 @@ import urllib
 from apache_beam.io.filesystem import CompressionTypes
 from apache_beam.io.filesystems import FileSystems
 from io import BytesIO
+from memory_profiler import memory_usage
 from typing import IO, cast
 from unittest.mock import MagicMock
 from urllib.response import addinfourl
@@ -190,7 +191,12 @@ class UploadManagerTestBase(TestBase):
 
     def test_upload_memory(self):
         self.write_file_of_size(LARGE_FILE_SIZE, os.path.join(self.temp_dir, 'bigfile'))
-        self.do_upload(('bigfile', os.path.join(self.temp_dir, 'bigfile')))
+        mem_usage = memory_usage(
+            (self.do_upload(('bigfile', os.path.join(self.temp_dir, 'bigfile'))), ),
+            interval=0.1,
+            timeout=1
+        )
+        self.assertEqual(max(memory_usage) < 40000000, True)
 
     def write_string_to_file(self, string, file_path):
         with open(file_path, 'w') as f:

--- a/tests/unit/lib/upload_manager_test.py
+++ b/tests/unit/lib/upload_manager_test.py
@@ -50,7 +50,7 @@ class UploadManagerTestBase(TestBase):
         with FileSystems.open(
             self.bundle_location, compression_type=CompressionTypes.UNCOMPRESSED
         ) as f, tarfile.open(fileobj=f, mode='r:gz') as tf:
-            return [tarinfo.size for tarinfo in tf]
+            return [tarinfo.size for tarinfo in tf.getmembers()]
 
     @property
     def bundle_location(self):

--- a/tests/unit/lib/upload_manager_test.py
+++ b/tests/unit/lib/upload_manager_test.py
@@ -196,7 +196,7 @@ class UploadManagerTestBase(TestBase):
             interval=0.1,
             timeout=1
         )
-        self.assertEqual(max(memory_usage) < 40000000, True)
+        self.assertEqual(max(memory_usage) < 90000000, True)
 
     def write_string_to_file(self, string, file_path):
         with open(file_path, 'w') as f:

--- a/tests/unit/lib/upload_manager_test.py
+++ b/tests/unit/lib/upload_manager_test.py
@@ -93,7 +93,7 @@ class UploadManagerTestBase(TestBase):
         self.write_file_of_size(10, os.path.join(source, 'file'))
         self.do_upload(('source.tar.gz', tar_gzip_directory(source)))
         self.assertEqual(['file'], sorted(self.listdir()))
-        self.assertEqual([10], self.check_file_size())
+        self.assertEqual([0, 10], self.check_file_size())
 
     def test_large_fileobj_tar_gz(self):
         """
@@ -104,7 +104,7 @@ class UploadManagerTestBase(TestBase):
         self.write_file_of_size(LARGE_FILE_SIZE, os.path.join(source, 'bigfile'))
         self.write_string_to_file('testing', os.path.join(source, 'README'))
         self.do_upload(('source.tar.gz', tar_gzip_directory(source)))
-        self.assertEqual(['bigfile', 'README'], sorted(self.listdir()))
+        self.assertEqual(['README', 'bigfile'], sorted(self.listdir()))
 
     def test_large_fileobj_tar_gz2(self):
         """
@@ -116,7 +116,7 @@ class UploadManagerTestBase(TestBase):
         self.write_file_of_size(LARGE_FILE_SIZE, os.path.join(source, 'bigfile2'))
         self.do_upload(('source.tar.gz', tar_gzip_directory(source)))
         self.assertEqual(['bigfile', 'bigfile2'], sorted(self.listdir()))
-        self.assertEqual([LARGE_FILE_SIZE, LARGE_FILE_SIZE], self.check_file_size())
+        self.assertEqual([0, LARGE_FILE_SIZE, LARGE_FILE_SIZE], self.check_file_size())
 
     def test_fileobj_tar_gz_should_not_simplify_archives(self):
         source = os.path.join(self.temp_dir, 'source_dir')

--- a/tests/unit/lib/upload_manager_test.py
+++ b/tests/unit/lib/upload_manager_test.py
@@ -196,7 +196,7 @@ class UploadManagerTestBase(TestBase):
             interval=0.1,
             timeout=1
         )
-        self.assertEqual(max(memory_usage) < 90000000, True)
+        self.assertEqual(max(memory_usage) < 100000000, True)
 
     def write_string_to_file(self, string, file_path):
         with open(file_path, 'w') as f:


### PR DESCRIPTION
### Reasons for making this change

The previous Multireaderfilestream design did not allow for backwards seeks, which causes uploads of directories above a certain size to break (~15MB). This was due to the process of reading directory bundles requiring seeks backwards up to a limit of 20MiB. The new design doesn't use BytesBuffers, but rather stores raw bytes, from 32MiB before the slowest reader, up to a maximum of 64MiB after the slowest reader. If a faster reader tries to read past this threshold, it will sleep until it is allowed to read more. 

#### Added Tests

**UPLOAD TESTS**

test_fileobj_tar_gz: basic directory bundle test, did not exist previously. Checks that a basic directory has the correct files and file sizes.

test_large_fileobj_tar_gz: Tests a large directory bundle past the size threshold limit of the previous Multireaderfilestream design. Checks that all files are uploaded.

test_large_fileobj_tar_gz2:  Tests a large directory bundle past the size threshold limit of the previous Multireaderfilestream design, with multiple large files. Checks that all files are uploaded and that sizes of files are correct.

test_upload_memory: Tests that the memory usage of the Multireaderfilestream uploading is expected at < 100MB

Manual speed test: Achieves faster than previous speeds with larger 1MB chunk sizes on upload, modified from 16KB

**MRFS TESTS**

test_reader_distance: Tests that 2 readers are always within the expected thresholds.

test_seek: Tests that backwards seeks within lookback range are working as expected.

test_toofar_seek: Tests that backwards seeks that go too far raise errors.

### Related issues

<!-- Add a reference to issues resolved, if applicable (for example, "fixes #1"). -->

### Screenshots

<!-- Add screenshots, if necessary. If this is a substantial frontend / user flow change, consider recording
a user flow GIF using a tool such as [LICEcap](https://www.cockos.com/licecap/). -->

### Checklist

* [ ] I've added a screenshot of the changes, if this is a frontend change
* [x] I've added and/or updated tests, if this is a backend change
* [ ] I've run the [pre-commit.sh](https://github.com/codalab/codalab-worksheets/blob/master/pre-commit.sh) script
* [x] I've updated [docs](https://github.com/codalab/codalab-worksheets/tree/master/docs), if needed
